### PR TITLE
[fix] use plugin-google-gtag

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -82,7 +82,7 @@ const config = {
                 theme: {
                     customCss: require.resolve('./src/scss/custom.scss'),
                 },
-                googleAnalytics: {
+                gtag: {
                     trackingID: 'G-DT7W9E9722',
                     anonymizeIP: true,
                 },


### PR DESCRIPTION
Google Analytics 4 need to using plugin-google-gtag