### PR TITLE
Modify the Duplicate model document error in the data-module directory

### DIFF
--- a/docs/data-table/data-model.md
+++ b/docs/data-table/data-model.md
@@ -329,7 +329,7 @@ CREATE TABLE IF NOT EXISTS example_db.expamle_tbl
     `op_id` BIGINT COMMENT "operater id",
     `op_time` DATETIME COMMENT "operate time"
 )
-DUPLICATE KEY(`timestamp`, `type`)
+DUPLICATE KEY(`timestamp`, `type`, `error_code`)
 DISTRIBUTED BY HASH(`type`) BUCKETS 1
 PROPERTIES (
 "replication_allocation" = "tag.location.default: 1"

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-table/data-model.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-table/data-model.md
@@ -335,7 +335,7 @@ CREATE TABLE IF NOT EXISTS example_db.expamle_tbl
     `op_id` BIGINT COMMENT "负责人id",
     `op_time` DATETIME COMMENT "处理时间"
 )
-DUPLICATE KEY(`timestamp`, `type`)
+DUPLICATE KEY(`timestamp`, `type`, `error_code`)
 DISTRIBUTED BY HASH(`type`) BUCKETS 1
 PROPERTIES (
 "replication_allocation" = "tag.location.default: 1"


### PR DESCRIPTION
When creating the table of the Duplicate model, specify the SortKet of error_code as Yes, but when creating the table later, the DUPLICATE KEY does not contain the error_code field, only the timestamp and type fields exist. Please check whether to add this field.