### PR TITLE
[typo](docs) mix of SSD and HDD disks should specify the storage directory only

### DIFF
--- a/docs/admin-manual/config/be-config.md
+++ b/docs/admin-manual/config/be-config.md
@@ -1164,6 +1164,7 @@ Shard size of StoragePageCache, the value must be power of two. It's recommended
 * Type: string
 
 * Description: data root path, separate by ';'.you can specify the storage medium of each root path, HDD or SSD. you can add capacity limit at the end of each root path, separate by ','
+  If the user does not use a mix of SSD and HDD disks, they do not need to configure the configuration methods in Example 1 and Example 2 below, but only need to specify the storage directory; they also do not need to modify the default storage media configuration of FE.  
 
     eg.1: `storage_root_path=/home/disk1/doris.HDD;/home/disk2/doris.SSD;/home/disk2/doris`
 

--- a/docs/install/install-deploy.md
+++ b/docs/install/install-deploy.md
@@ -191,7 +191,8 @@ See the section on `lower_case_table_names` variables in [Variables](../advanced
 
 * Modify all BE configurations
 
-  Modify be/conf/be.conf. Mainly configure `storage_root_path`: data storage directory. The default is be/storage, this directory needs to be **created manually** by. In multi directories case, using `;` separation (do not add `;` after the last directory).
+  Modify be/conf/be.conf. Mainly configure `storage_root_path`: data storage directory. The default is be/storage, this directory needs to be **created manually** by. In multi directories case, using `;` separation (do not add `;` after the last directory).  
+  If the user does not use a mix of SSD and HDD disks, they do not need to configure the configuration methods in Example 1 and Example 2 below, but only need to specify the storage directory; they also do not need to modify the default storage media configuration of FE.  
 
     eg.1: 
 


### PR DESCRIPTION
In document, add a notice that mix of SSD and HDD disks should specify the storage directory only