### PR TITLE
(styles) markdown use default font-weight 400

### DIFF
--- a/src/scss/components/markdown.scss
+++ b/src/scss/components/markdown.scss
@@ -1,6 +1,5 @@
 .markdown {
     color: #4c4e4d;
-    font-weight: 200;
     padding-left: 1rem;
     h1,
     h2,


### PR DESCRIPTION
- (styles) markdown use default font-weight 400