### PR TITLE
[fix] releasenote 2.0.0 use github issue url

### DIFF
--- a/src/constant/download.data.ts
+++ b/src/constant/download.data.ts
@@ -324,7 +324,7 @@ export function getAllRelease(locale: string) {
         {
             version: '2.0.0 ( Latest )',
             date: '2023-08-11',
-            note: '/docs/dev/releasenotes/release-2.0.0',
+            note: 'https://github.com/apache/doris/issues/22647',
             download: [
                 {
                     cpu: 'X64 ( avx2 )',

--- a/src/constant/newsletter.data.ts
+++ b/src/constant/newsletter.data.ts
@@ -7,7 +7,7 @@ export const NEWSLETTER_DATA = [
     {
         tag: 'Release Notes',
         title: 'Apache Doris Announced the Official Release of Version 2.0.0 ! ',
-        to: '/docs/dev/releasenotes/release-2.0.0',
+        to: 'https://github.com/apache/doris/issues/22647',
         hot: true,
     },
     {

--- a/src/pages/download/index.tsx
+++ b/src/pages/download/index.tsx
@@ -285,7 +285,7 @@ export default function Download(): JSX.Element {
                                         {currentLocale === 'zh-CN' ? (
                                             <div className="notice-text">
                                                 详细升级注意事项请参考
-                                                <Link to="/docs/dev/releasenotes/release-2.0.0">
+                                                <Link to="https://github.com/apache/doris/issues/22647">
                                                     2.0.0 Release Note
                                                 </Link>
                                                 以及
@@ -303,7 +303,7 @@ export default function Download(): JSX.Element {
                                         ) : (
                                             <div className="notice-text">
                                                 For detailed upgrade precautions, please refer to the{' '}
-                                                <Link to="/docs/dev/releasenotes/release-2.0.0">2.0.0</Link>
+                                                <Link to="https://github.com/apache/doris/issues/22647">2.0.0</Link>
                                                 and the
                                                 <Link to="/docs/dev/install/standard-deployment">deployment</Link> and
                                                 cluster


### PR DESCRIPTION
[fix] releasenote 2.0.0 use github issue url