### PR TITLE
(typo) use 2.0.1 in download page

### DIFF
--- a/src/pages/download/index.tsx
+++ b/src/pages/download/index.tsx
@@ -303,7 +303,7 @@ export default function Download(): JSX.Element {
                                         ) : (
                                             <div className="notice-text">
                                                 For detailed upgrade precautions, please refer to the{' '}
-                                                <Link to="https://github.com/apache/doris/issues/22647">2.0.0</Link>
+                                                <Link to="https://github.com/apache/doris/issues/23640">2.0.1</Link>
                                                 and the
                                                 <Link to="/docs/dev/install/standard-deployment">deployment</Link> and
                                                 cluster


### PR DESCRIPTION
- [(typo) use 2.0.1 in download page](https://github.com/apache/doris-website/commit/8d72e35fee02ca73ef168170065851f4afad0ce6)