### PR TITLE
[home](fix) Update link of what is Apache Doris on home page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -175,7 +175,7 @@ export default function Home(): JSX.Element {
                     }
                     footer={
                         <More
-                            link="docs/dev/get-starting/what-is-apache-doris"
+                            link="docs/get-starting/what-is-apache-doris"
                             text={
                                 <Translate id="homepage.more" description="more link">
                                     More


### PR DESCRIPTION
Update link of what is Apache Doris on home page

<img width="1037" alt="image" src="https://github.com/apache/doris-website/assets/139741991/1c6902a8-3127-4912-b77a-f909bf04f0a4">

<img width="696" alt="image" src="https://github.com/apache/doris-website/assets/139741991/110bb67f-0234-4a1d-ad50-8dcca5259fa0">
