### PR TITLE
[Feature] Support CREATE DB COMMENT (#16678)

### DIFF
--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-DATABASE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-DATABASE.md
@@ -38,6 +38,7 @@ grammar:
 
 ```sql
 CREATE DATABASE [IF NOT EXISTS] db_name
+    [COMMENT "db comment"]
     [PROPERTIES ("key"="value", ...)];
 ````
 
@@ -68,10 +69,15 @@ CREATE DATABASE [IF NOT EXISTS] db_name
    );
    ````
 
+3. Create a new database db_test with comment
+   ```sql
+   CREATE DATABASE db_test COMMENT "this is test comment";
+   ````
+
 ### Keywords
 
 ````text
-CREATE, DATABASE
+CREATE, DATABASE, COMMENT
 ````
 
 ### Best Practice

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-DATABASE.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-DATABASE.md
@@ -70,9 +70,22 @@ illustrate:
     +-----------+------------------------------------------------------------------------------------+                         
     1 row in set (0.01 sec)  
     ```
-   
+
+3. View the creation of the test database in doris(with comment)
+
+    ```sql
+    mysql> SHOW CREATE DATABASE test;
+    +----------+--------------------------------------------------+
+    | Database | Create Database                                  |
+    +----------+--------------------------------------------------+
+    | test     | CREATE DATABASE `test`                           |
+    |          | COMMENT "this is comment"                        |
+    +----------+--------------------------------------------------+
+    1 row in set (0.00 sec)
+    ````
+
 ### Keywords
 
-     SHOW, CREATE, DATABASE
+     SHOW, CREATE, DATABASE, COMMENT
 
 ### Best Practice

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-DATABASE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-DATABASE.md
@@ -38,6 +38,7 @@ CREATE DATABASE
 
 ```sql
 CREATE DATABASE [IF NOT EXISTS] db_name
+    [COMMENT "db comment"]
     [PROPERTIES ("key"="value", ...)];
 ```
 
@@ -68,10 +69,15 @@ CREATE DATABASE [IF NOT EXISTS] db_name
    );
    ```
 
+3. 新建带注释的数据库 db_test
+   ```sql
+   CREATE DATABASE db_test COMMENT "this is test comment";
+   ````
+
 ### Keywords
 
 ```text
-CREATE, DATABASE
+CREATE, DATABASE, COMMENT
 ```
 
 ### Best Practice

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-DATABASE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-DATABASE.md
@@ -69,6 +69,21 @@ SHOW CREATE DATABASE db_name;
     +-----------+------------------------------------------------------------------------------------+                         
     1 row in set (0.01 sec)  
     ```
+
+
+3. 查看doris中test数据库的创建情况（带有库注释）
+
+    ```sql
+    mysql> SHOW CREATE DATABASE test;
+    +----------+--------------------------------------------------+
+    | Database | Create Database                                  |
+    +----------+--------------------------------------------------+
+    | test     | CREATE DATABASE `test`                           |
+    |          | COMMENT "this is comment"                        |
+    +----------+--------------------------------------------------+
+    1 row in set (0.00 sec)
+    ````
+
 ### Keywords
 
     SHOW, CREATE, DATABASE


### PR DESCRIPTION
When create a database, add support for comment, which explains something about the database so that people who see it know what it is and what it does. CREATE DATABASE [IF NOT EXISTS] db_name COMMENT database_comment [PROPERTIES ("key"="value", ...)]; Add database's comment to the result of the SHOW CREATE DATABASE statement.