### PR TITLE
[doc](fix) add caution for `group_concat` and `lateral view`

### DIFF
--- a/docs/query/query-data/lateral-view.md
+++ b/docs/query/query-data/lateral-view.md
@@ -31,7 +31,7 @@ Used in conjunction with generator functions such as `EXPLODE`, will generate a 
 ## Grammar
 
 ```sql
-LATERAL VIEW  generator_function ( expression [, ...] ) [ table_identifier ] AS column_identifier [, ...]
+LATERAL VIEW  generator_function ( expression [, ...] ) table_identifier AS column_identifier [, ...]
 ```
 
 ## Parameters
@@ -42,7 +42,7 @@ LATERAL VIEW  generator_function ( expression [, ...] ) [ table_identifier ] AS 
 
 - table_identifier
 
-   Alias for `generator_function`, which is optional.
+   Alias for `generator_function`.
 
 - column_identifier
 

--- a/docs/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -33,8 +33,11 @@ under the License.
 
 This function is an aggregation function similar to sum (), and group_concat links multiple rows of results in the result set to a string. The second parameter, sep, is a connection symbol between strings, which can be omitted. This function usually needs to be used with group by statements.
 
-<version since="1.2"></version>
 Support Order By for sorting multi-row results, sorting and aggregation columns can be different.
+
+:::caution
+`group_concat` don't support using `distinct` with `order by` together.
+:::
 
 ### example
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/query/query-data/lateral-view.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/query/query-data/lateral-view.md
@@ -31,7 +31,7 @@ under the License.
 ## 语法
 
 ```sql
-LATERAL VIEW generator_function ( expression [, ...] ) [ table_identifier ] AS column_identifier [, ...]
+LATERAL VIEW generator_function ( expression [, ...] ) table_identifier AS column_identifier [, ...]
 ```
 
 ## 参数
@@ -42,7 +42,7 @@ LATERAL VIEW generator_function ( expression [, ...] ) [ table_identifier ] AS c
 
 - table_identifier
 
-  `generator_function` 的别名，它是可选项。
+  `generator_function` 的别名。
 
 - column_identifier
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -33,8 +33,11 @@ under the License.
 
 该函数是类似于 sum() 的聚合函数，group_concat 将结果集中的多行结果连接成一个字符串。第二个参数 sep 为字符串之间的连接符号，该参数可以省略。该函数通常需要和 group by 语句一起使用。
 
-<version since="1.2"></version>
 支持Order By进行多行结果的排序，排序和聚合列可不同。
+
+:::caution
+`group_concat`暂不支持`distinct`和`order by`一起用。
+:::
 
 ### example
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/advanced/lateral-view.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/advanced/lateral-view.md
@@ -31,7 +31,7 @@ under the License.
 ## 语法
 
 ```sql
-LATERAL VIEW generator_function ( expression [, ...] ) [ table_identifier ] AS column_identifier [, ...]
+LATERAL VIEW generator_function ( expression [, ...] ) table_identifier AS column_identifier [, ...]
 ```
 
 ## 参数
@@ -42,7 +42,7 @@ LATERAL VIEW generator_function ( expression [, ...] ) [ table_identifier ] AS c
 
 - table_identifier
 
-  `generator_function` 的别名，它是可选项。
+  `generator_function` 的别名。
 
 - column_identifier
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-functions/aggregate-functions/group_concat.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-functions/aggregate-functions/group_concat.md
@@ -33,8 +33,11 @@ under the License.
 
 该函数是类似于 sum() 的聚合函数，group_concat 将结果集中的多行结果连接成一个字符串。第二个参数 sep 为字符串之间的连接符号，该参数可以省略。该函数通常需要和 group by 语句一起使用。
 
-<version since="1.2"></version>
 支持Order By进行多行结果的排序，排序和聚合列可不同。
+
+:::caution
+`group_concat`暂不支持`distinct`和`order by`一起用。
+:::
 
 ### example
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/query/query-data/lateral-view.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/query/query-data/lateral-view.md
@@ -31,7 +31,7 @@ under the License.
 ## 语法
 
 ```sql
-LATERAL VIEW generator_function ( expression [, ...] ) [ table_identifier ] AS column_identifier [, ...]
+LATERAL VIEW generator_function ( expression [, ...] ) table_identifier AS column_identifier [, ...]
 ```
 
 ## 参数
@@ -42,7 +42,7 @@ LATERAL VIEW generator_function ( expression [, ...] ) [ table_identifier ] AS c
 
 - table_identifier
 
-  `generator_function` 的别名，它是可选项。
+  `generator_function` 的别名。
 
 - column_identifier
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -33,8 +33,11 @@ under the License.
 
 该函数是类似于 sum() 的聚合函数，group_concat 将结果集中的多行结果连接成一个字符串。第二个参数 sep 为字符串之间的连接符号，该参数可以省略。该函数通常需要和 group by 语句一起使用。
 
-<version since="1.2"></version>
 支持Order By进行多行结果的排序，排序和聚合列可不同。
+
+:::caution
+`group_concat`暂不支持`distinct`和`order by`一起用。
+:::
 
 ### example
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/query/query-data/lateral-view.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/query/query-data/lateral-view.md
@@ -31,7 +31,7 @@ under the License.
 ## 语法
 
 ```sql
-LATERAL VIEW generator_function ( expression [, ...] ) [ table_identifier ] AS column_identifier [, ...]
+LATERAL VIEW generator_function ( expression [, ...] ) table_identifier AS column_identifier [, ...]
 ```
 
 ## 参数
@@ -42,7 +42,7 @@ LATERAL VIEW generator_function ( expression [, ...] ) [ table_identifier ] AS c
 
 - table_identifier
 
-  `generator_function` 的别名，它是可选项。
+  `generator_function` 的别名。
 
 - column_identifier
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -33,8 +33,11 @@ under the License.
 
 该函数是类似于 sum() 的聚合函数，group_concat 将结果集中的多行结果连接成一个字符串。第二个参数 sep 为字符串之间的连接符号，该参数可以省略。该函数通常需要和 group by 语句一起使用。
 
-<version since="1.2"></version>
 支持Order By进行多行结果的排序，排序和聚合列可不同。
+
+:::caution
+`group_concat`暂不支持`distinct`和`order by`一起用。
+:::
 
 ### example
 

--- a/versioned_docs/version-1.2/advanced/lateral-view.md
+++ b/versioned_docs/version-1.2/advanced/lateral-view.md
@@ -31,7 +31,7 @@ Used in conjunction with generator functions such as `EXPLODE`, will generate a 
 ## Grammar
 
 ```sql
-LATERAL VIEW  generator_function ( expression [, ...] ) [ table_identifier ] AS column_identifier [, ...]
+LATERAL VIEW  generator_function ( expression [, ...] ) table_identifier AS column_identifier [, ...]
 ```
 
 ## Parameters
@@ -42,7 +42,7 @@ LATERAL VIEW  generator_function ( expression [, ...] ) [ table_identifier ] AS 
 
 - table_identifier
 
-   Alias for `generator_function`, which is optional.
+   Alias for `generator_function`.
 
 - column_identifier
 

--- a/versioned_docs/version-1.2/sql-manual/sql-functions/aggregate-functions/group_concat.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-functions/aggregate-functions/group_concat.md
@@ -33,8 +33,11 @@ under the License.
 
 This function is an aggregation function similar to sum (), and group_concat links multiple rows of results in the result set to a string. The second parameter, sep, is a connection symbol between strings, which can be omitted. This function usually needs to be used with group by statements.
 
-<version since="1.2"></version>
 Support Order By for sorting multi-row results, sorting and aggregation columns can be different.
+
+:::caution
+`group_concat` don't support using `distinct` with `order by` together.
+:::
 
 ### example
 

--- a/versioned_docs/version-2.0/query/query-data/lateral-view.md
+++ b/versioned_docs/version-2.0/query/query-data/lateral-view.md
@@ -31,7 +31,7 @@ Used in conjunction with generator functions such as `EXPLODE`, will generate a 
 ## Grammar
 
 ```sql
-LATERAL VIEW  generator_function ( expression [, ...] ) [ table_identifier ] AS column_identifier [, ...]
+LATERAL VIEW  generator_function ( expression [, ...] ) table_identifier AS column_identifier [, ...]
 ```
 
 ## Parameters
@@ -42,7 +42,7 @@ LATERAL VIEW  generator_function ( expression [, ...] ) [ table_identifier ] AS 
 
 - table_identifier
 
-   Alias for `generator_function`, which is optional.
+   Alias for `generator_function`.
 
 - column_identifier
 

--- a/versioned_docs/version-2.0/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -33,8 +33,11 @@ under the License.
 
 This function is an aggregation function similar to sum (), and group_concat links multiple rows of results in the result set to a string. The second parameter, sep, is a connection symbol between strings, which can be omitted. This function usually needs to be used with group by statements.
 
-<version since="1.2"></version>
 Support Order By for sorting multi-row results, sorting and aggregation columns can be different.
+
+:::caution
+`group_concat` don't support using `distinct` with `order by` together.
+:::
 
 ### example
 

--- a/versioned_docs/version-2.1/query/query-data/lateral-view.md
+++ b/versioned_docs/version-2.1/query/query-data/lateral-view.md
@@ -31,7 +31,7 @@ Used in conjunction with generator functions such as `EXPLODE`, will generate a 
 ## Grammar
 
 ```sql
-LATERAL VIEW  generator_function ( expression [, ...] ) [ table_identifier ] AS column_identifier [, ...]
+LATERAL VIEW  generator_function ( expression [, ...] ) table_identifier AS column_identifier [, ...]
 ```
 
 ## Parameters
@@ -42,7 +42,7 @@ LATERAL VIEW  generator_function ( expression [, ...] ) [ table_identifier ] AS 
 
 - table_identifier
 
-   Alias for `generator_function`, which is optional.
+   Alias for `generator_function`.
 
 - column_identifier
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -33,8 +33,11 @@ under the License.
 
 This function is an aggregation function similar to sum (), and group_concat links multiple rows of results in the result set to a string. The second parameter, sep, is a connection symbol between strings, which can be omitted. This function usually needs to be used with group by statements.
 
-<version since="1.2"></version>
 Support Order By for sorting multi-row results, sorting and aggregation columns can be different.
+
+:::caution
+`group_concat` don't support using `distinct` with `order by` together.
+:::
 
 ### example
 


### PR DESCRIPTION
1. group_concat: don't support using `distinct` with `order by` together.
2. table_identifier is required in lateral view syntax