### PR TITLE
[doc](batch-delete) remove outdated contents

### DIFF
--- a/docs/admin-manual/config/fe-config.md
+++ b/docs/admin-manual/config/fe-config.md
@@ -871,16 +871,6 @@ MasterOnly：false
 
 The time interval of the latest partitioned version of the table refers to the time interval between the data update and the current version. It is generally set to 900 seconds, which distinguishes offline and real-time import
 
-#### `enable_batch_delete_by_default`
-
-Default：false
-
-IsMutable：true
-
-MasterOnly：true
-
-Whether to add a delete sign column when create unique table
-
 #### `max_allowed_in_element_num_of_delete`
 
 Default：1024

--- a/docs/data-operate/delete/batch-delete-manual.md
+++ b/docs/data-operate/delete/batch-delete-manual.md
@@ -68,16 +68,6 @@ When FE parses the query, `DORIS_DELETE_SIGN` is removed when it encounters * an
 
     When Base Compaction is performed, the rows marked for deletion are deleted to reduce the space occupied by the data.
 
-## Enable Batch Delete Support
-
-There are two forms of enabling Batch Delete support:
-
-1. Batch Delete is supported by adding `enable_batch_delete_by_default=true` in the FE configuration file for all new tables created after restarting FE;
-
-2. For tables that do not have the above FE configuration changed or for existing tables that do not support Batch Delete, the following statement can be used: `ALTER TABLE tablename ENABLE FEATURE "BATCH_DELETE"` to enable Batch Delete. This is essentially a schema change operation, which returns immediately and can be confirmed by `showing alter table column`.
-
-Then how to determine whether a table supports Batch Delete, you can set a session variable to show hidden columns `SET show_hidden_columns=true`, and after that use `desc tablename`, if there is a `DORIS_DELETE_SIGN` column in the output then it is supported, if there is not then it is not supported.
-
 ## Syntax Description
 
 The syntax design of the import is mainly to add a column mapping that specifies the field of the delete marker column, and it is necessary to add a column to the imported data. The syntax of various import methods is as follows:

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/config/fe-config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/config/fe-config.md
@@ -872,16 +872,6 @@ http 请求处理/api/upload 任务的最大线程池
 
 缓存结果时上一版本的最小间隔，该参数区分离线更新和实时更新
 
-#### `enable_batch_delete_by_default`
-
-默认值：false
-
-是否可以动态配置：true
-
-是否为 Master FE 节点独有的配置项：true
-
-创建唯一表时是否添加删除标志列，具体原理参照官方文档：操作手册->数据导入->批量删除
-
 #### `max_allowed_in_element_num_of_delete`
 
 默认值：1024

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/delete/batch-delete-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/delete/batch-delete-manual.md
@@ -65,16 +65,6 @@ FE 解析查询时，遇到 * 等扩展时去掉`DORIS_DELETE_SIGN`，并且默�
 
     Base Compaction 时要将标记为删除的行的删掉，以减少数据占用的空间。
 
-## 启用批量删除支持
-
-启用批量删除支持有以下两种形式：
-
-1. 通过在 FE 配置文件中增加`enable_batch_delete_by_default=true` 重启 fe 后新建表的都支持批量删除，此选项默认为 true；
-
-2. 对于没有更改上述 FE 配置或对于已存在的不支持批量删除功能的表，可以使用如下语句： `ALTER TABLE tablename ENABLE FEATURE "BATCH_DELETE"` 来启用批量删除。本操作本质上是一个 schema change 操作，操作立即返回，可以通过`show alter table column` 来确认操作是否完成。
-
-那么如何确定一个表是否支持批量删除，可以通过设置一个 session variable 来显示隐藏列 `SET show_hidden_columns=true` ，之后使用`desc tablename`，如果输出中有`DORIS_DELETE_SIGN` 列则支持，如果没有则不支持。
-
 ## 语法说明
 
 导入的语法设计方面主要是增加一个指定删除标记列的字段的 column 映射，并且需要在导入的数据中增加一列，各种导入方式设置的语法如下

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/delete/batch-delete-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/delete/batch-delete-manual.md
@@ -65,16 +65,6 @@ FE 解析查询时，遇到 * 等扩展时去掉`DORIS_DELETE_SIGN`，并且默�
 
     Base Compaction 时要将标记为删除的行的删掉，以减少数据占用的空间。
 
-## 启用批量删除支持
-
-启用批量删除支持有以下两种形式：
-
-1. 通过在 FE 配置文件中增加`enable_batch_delete_by_default=true` 重启 fe 后新建表的都支持批量删除，此选项默认为 true；
-
-2. 对于没有更改上述 FE 配置或对于已存在的不支持批量删除功能的表，可以使用如下语句： `ALTER TABLE tablename ENABLE FEATURE "BATCH_DELETE"` 来启用批量删除。本操作本质上是一个 schema change 操作，操作立即返回，可以通过`show alter table column` 来确认操作是否完成。
-
-那么如何确定一个表是否支持批量删除，可以通过设置一个 session variable 来显示隐藏列 `SET show_hidden_columns=true` ，之后使用`desc tablename`，如果输出中有`DORIS_DELETE_SIGN` 列则支持，如果没有则不支持。
-
 ## 语法说明
 
 导入的语法设计方面主要是增加一个指定删除标记列的字段的 column 映射，并且需要在导入的数据中增加一列，各种导入方式设置的语法如下

--- a/versioned_docs/version-2.1/data-operate/delete/batch-delete-manual.md
+++ b/versioned_docs/version-2.1/data-operate/delete/batch-delete-manual.md
@@ -68,16 +68,6 @@ When FE parses the query, `DORIS_DELETE_SIGN` is removed when it encounters * an
 
     When Base Compaction is performed, the rows marked for deletion are deleted to reduce the space occupied by the data.
 
-## Enable Batch Delete Support
-
-There are two forms of enabling Batch Delete support:
-
-1. Batch Delete is supported by adding `enable_batch_delete_by_default=true` in the FE configuration file for all new tables created after restarting FE;
-
-2. For tables that do not have the above FE configuration changed or for existing tables that do not support Batch Delete, the following statement can be used: `ALTER TABLE tablename ENABLE FEATURE "BATCH_DELETE"` to enable Batch Delete. This is essentially a schema change operation, which returns immediately and can be confirmed by `showing alter table column`.
-
-Then how to determine whether a table supports Batch Delete, you can set a session variable to show hidden columns `SET show_hidden_columns=true`, and after that use `desc tablename`, if there is a `DORIS_DELETE_SIGN` column in the output then it is supported, if there is not then it is not supported.
-
 ## Syntax Description
 
 The syntax design of the import is mainly to add a column mapping that specifies the field of the delete marker column, and it is necessary to add a column to the imported data. The syntax of various import methods is as follows:


### PR DESCRIPTION
batch delete is supported as a default feature since 0.15, we don't need the contents about "How to Enable Batch Delete Support" in our documents, remove the in the docs of master and version 2.1

remove the outdated config `enable_batch_delete_by_default` as well, related doris PR: https://github.com/apache/doris/pull/36485