### PR TITLE
[fix](render) use `shell` to replace `Bash`

### DIFF
--- a/benchmark/ssb.md
+++ b/benchmark/ssb.md
@@ -116,7 +116,7 @@ Execute the following script to download and compile the [ssb-tools](https://git
 
 ```shell
 sh bin/build-ssb-dbgen.sh
-````
+```
 
 After successful installation, the `dbgen` binary will be generated under the `ssb-dbgen/` directory.
 
@@ -126,7 +126,7 @@ Execute the following script to generate the SSB dataset:
 
 ```shell
 sh bin/gen-ssb-data.sh -s 1000
-````
+```
 
 > Note 1: Check the script help via `sh gen-ssb-data.sh -h`.
 >
@@ -163,7 +163,7 @@ export DB='ssb'
 
 ```shell
 sh bin/create-ssb-tables.sh -s 1000
-````
+```
 
 Or copy the table creation statements in [create-ssb-tables.sql](https://github.com/apache/incubator-doris/tree/master/tools/ssb-tools/ddl/create-ssb-tables-sf1000.sql) and [ create-ssb-flat-table.sql](https://github.com/apache/incubator-doris/tree/master/tools/ssb-tools/ddl/create-ssb-flat-tables-sf1000.sql) and then execute them in the MySQL client.
 

--- a/blog/How-We-Increased-Database-Query-Concurrency-by-20-Times.md
+++ b/blog/How-We-Increased-Database-Query-Concurrency-by-20-Times.md
@@ -199,7 +199,7 @@ The following example demonstrates how to use a prepared statement in JDBC:
 
 1. Set a JDBC URL and enable prepared statement at the server end.
 
-```Bash
+```shell
 url = jdbc:mysql://127.0.0.1:9030/ycsb?useServerPrepStmts=true
 ```
 

--- a/blog/from-presto-trino-clickhouse-and-hive-to-apache-doris-sql-convertor-for-easy-migration.md
+++ b/blog/from-presto-trino-clickhouse-and-hive-to-apache-doris-sql-convertor-for-easy-migration.md
@@ -135,13 +135,13 @@ Follow these steps to deploy the visual conversion interface:
 
 3. Create a network for the image
 
-```Bash
+```shell
 docker network create app_network
 ```
 
 4. Decompress the package
 
-```Bash
+```shell
 tar xzvf doris-sql-convertor-1.0.1.tar.gz
 
 cd doris-sql-convertor
@@ -149,7 +149,7 @@ cd doris-sql-convertor
 
 5. Edit the environment variables
    
-```Bash
+```shell
 FLASK_APP=server/app.py
 FLASK_DEBUG=1
 API_HOST=http://doris-sql-convertor-api:5000
@@ -161,7 +161,7 @@ WEB_TAG=latest
 
 6. Start it up
 
-```Bash
+```shell
 sh start.sh
 ```
 

--- a/blog/inverted-index-accelerates-text-searches-by-40-time-apache-doris.md
+++ b/blog/inverted-index-accelerates-text-searches-by-40-time-apache-doris.md
@@ -92,7 +92,7 @@ PROPERTIES (
    - [amazon_reviews_2015](https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/amazon_reviews_2015.snappy.parquet)
 4. Execute the following commands to load the datasets
 
-```Bash
+```shell
 curl --location-trusted -u root: -T amazon_reviews_2010.snappy.parquet -H "format:parquet" http://${BE_IP}:${BE_PORT}/api/${DB}/amazon_reviews/_stream_load
 curl --location-trusted -u root: -T amazon_reviews_2011.snappy.parquet -H "format:parquet" http://${BE_IP}:${BE_PORT}/api/${DB}/amazon_reviews/_stream_load
 curl --location-trusted -u root: -T amazon_reviews_2012.snappy.parquet -H "format:parquet" http://${BE_IP}:${BE_PORT}/api/${DB}/amazon_reviews/_stream_load

--- a/blog/job-scheduler-for-task-automation.md
+++ b/blog/job-scheduler-for-task-automation.md
@@ -115,7 +115,7 @@ CREATE JOB my_job ON SCHEDULER EVERY 1 DAY STARTS '2025-01-01 00:00:00' ENDS '20
 
 For example, to asynchronously execute data loading from `db2.tbl2` to `db1.tbl1`, simply create a one-time job for it and schedule it at `current_timestamp`.
 
-```Bash
+```shell
 CREATE JOB my_job ON SCHEDULE AT current_timestamp DO INSERT INTO db1.tbl1 SELECT * FROM db2.tbl2;
 ```
 
@@ -153,7 +153,7 @@ PROPERTIES (
 
 **Step 2**: Create a catalog in Doris to map to the data in MySQL
 
-```Bash
+```shell
 CREATE CATALOG activity PROPERTIES (
     "type"="jdbc",
     "user"="root",

--- a/blog/log-analysis-elasticsearch-vs-apache-doris.md
+++ b/blog/log-analysis-elasticsearch-vs-apache-doris.md
@@ -301,7 +301,7 @@ Notes:
 - `http header "load_to_single_tablet:true"`: write to one tablet each time
 - For the data writing clients, we recommend a batch size of 100MB~1GB. Future versions will enable Group Commit at the server end and reduce batch size from clients.
 
-```Bash
+```shell
 curl \
 --location-trusted \
 -u username:password \

--- a/blog/ssb.md
+++ b/blog/ssb.md
@@ -145,7 +145,7 @@ Execute the following script to download and compile the [ssb-dbgen](https://git
 
 ```shell
 sh build-ssb-dbgen.sh
-````
+```
 
 After successful installation, the `dbgen` binary will be generated under the `ssb-dbgen/` directory.
 
@@ -155,7 +155,7 @@ Execute the following script to generate the SSB dataset:
 
 ```shell
 sh gen-ssb-data.sh -s 100 -c 100
-````
+```
 
 > Note 1: Check the script help via `sh gen-ssb-data.sh -h`.
 >
@@ -196,7 +196,7 @@ export DB="ssb"
 
 ```shell
 sh create-ssb-tables.sh
-````
+```
 
 Or copy the table creation statements in [create-ssb-tables.sql](https://github.com/apache/incubator-doris/tree/master/tools/ssb-tools/ddl/create-ssb-tables.sql) and [ create-ssb-flat-table.sql](https://github.com/apache/incubator-doris/tree/master/tools/ssb-tools/ddl/create-ssb-flat-table.sql) and then execute them in the MySQL client.
 

--- a/common_docs_zh/ecosystem/doris-streamloader.md
+++ b/common_docs_zh/ecosystem/doris-streamloader.md
@@ -51,7 +51,7 @@ under the License.
 
 ## 使用方法
 
-```bash
+```shell
 
 doris-streamloader --source_file={FILE_LIST} --url={FE_OR_BE_SERVER_URL}:{PORT} --header={STREAMLOAD_HEADER} --db={TARGET_DATABASE} --table={TARGET_TABLE}
 
@@ -110,7 +110,7 @@ doris-streamloader --source_file={FILE_LIST} --url={FE_OR_BE_SERVER_URL}:{PORT} 
 
 用法举例：
 
-```bash
+```shell
 doris-streamloader --source_file="data.csv" --url="http://localhost:8330" --header="column_separator:|?columns:col1,col2" --db="testdb" --table="testtbl"
 ```
 

--- a/common_docs_zh/gettingStarted/quick-start.md
+++ b/common_docs_zh/gettingStarted/quick-start.md
@@ -39,7 +39,7 @@ under the License.
 
 从 doris.apache.org 下载相应的 Apache Doris 安装包，并且解压。
 
-```Bash
+```shell
 # 下载 Apache Doris 二进制安装包
 server1:~ doris$ wget https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-2.0.12-bin-x64.tar.gz
 
@@ -71,7 +71,7 @@ JAVA_HOME=/home/doris/jdk8
 
 在 apache-doris/fe 下，运行下面命令启动 FE。
 
-```Bash
+```shell
 # 将 FE 启动成后台运行模式，这样确保退出终端后，进程依旧运行。
 server1:apache-doris/fe doris$ ./bin/start_fe.sh --daemon
 ```
@@ -95,7 +95,7 @@ JAVA_HOME=/home/doris/jdk8
 
 在 apache-doris/be 下，运行下面命令启动 BE。
 
-```Bash
+```shell
 # 将 BE 启动成后台运行模式，这样确保退出终端后，进程依旧运行。
 server1:apache-doris/be doris$ ./bin/start_be.sh --daemon
 ```
@@ -106,7 +106,7 @@ server1:apache-doris/be doris$ ./bin/start_be.sh --daemon
 
 解压刚才下载的 MySQL 客户端，在 `bin/` 目录下可以找到 `mysql` 命令行工具。然后执行下面的命令连接 Apache Doris。
 
-```Bash
+```shell
 mysql -uroot -P9030 -h127.0.0.1
 ```
 
@@ -160,7 +160,7 @@ Root 用户和 Admin 用户都属于 Apache Doris 安装完默认存在的 2 个
 
 使用 Admin 账户连接 Apache Doris FE。
 
-```Bash
+```shell
 mysql -uadmin -P9030 -h127.0.0.1
 ```
 
@@ -199,7 +199,7 @@ PROPERTIES ('replication_num' = '1');
 
 通过 Stream Load 方式将上面保存到文件中的数据导入到刚才创建的表里。
 
-```Bash
+```shell
 curl  --location-trusted -u admin:admin_password -T data.csv -H "column_separator:," http://127.0.0.1:8030/api/demo/mytable/_stream_load
 ```
 
@@ -211,7 +211,7 @@ curl  --location-trusted -u admin:admin_password -T data.csv -H "column_separato
 
 执行成功之后我们可以看到下面的返回信息：
 
-```Bash
+```shell
 {                                                     
     "TxnId": 30,                                  
     "Label": "a56d2861-303a-4b50-9907-238fea904363",        
@@ -262,7 +262,7 @@ mysql> select * from mytable;
 
 在 apache-doris/fe 下，运行下面命令停止 FE。
 
-```Bash
+```shell
 server1:apache-doris/fe doris$ ./bin/stop_fe.sh
 ```
 
@@ -270,6 +270,6 @@ server1:apache-doris/fe doris$ ./bin/stop_fe.sh
 
 在 apache-doris/be 下，运行下面命令停止 BE。
 
-```Bash
+```shell
 server1:apache-doris/be doris$ ./bin/stop_be.sh
 ```

--- a/common_docs_zh/gettingStarted/tutorials/log-storage-analysis.md
+++ b/common_docs_zh/gettingStarted/tutorials/log-storage-analysis.md
@@ -366,7 +366,7 @@ output {
 
 3. 按照下方命令运行 Logstash，采集日志并输出至 Apache Doris。
 
-```Bash  
+```shell  
 ./bin/logstash -f logstash_demo.conf
 ```
 
@@ -441,7 +441,7 @@ output {
 
 3. 按照下方命令运行 Filebeat，采集日志并输出至 Apache Doris。
 
-```Bash  
+```shell  
 chmod +x filebeat-doris-1.0.0  
 ./filebeat-doris-1.0.0 -c filebeat_demo.yml
 ```
@@ -488,7 +488,7 @@ SHOW ROUTINE LOAD;
 
 除了对接常用的日志采集器以外，你也可以自定义程序，通过 HTTP API Stream Load 将日志数据导入 Apache Doris。参考以下代码：
 
-```Bash  
+```shell
 curl   
 --location-trusted   
 -u username:password   

--- a/community/developer-guide/docker-dev.md
+++ b/community/developer-guide/docker-dev.md
@@ -84,7 +84,7 @@ RUN wget https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -
 
 run build command
 
-```bash
+```shell
 docker build -t doris .
 ```
 
@@ -98,7 +98,7 @@ if you are developing on windows, mounting may cause cross-filesystem access pro
 
 `--cap-add SYS_PTRACE` parameter allows dockers to use ptrace, making it easier for us to use ptrace and gdb remote debugging functions.
 
-```bash
+```shell
 docker run -it --cap-add SYS_PTRACE doris:latest /bin/bash
 ```
 
@@ -110,7 +110,7 @@ plugins=(git zsh-autosuggestions zsh-syntax-highlighting)
 
 create directory and download doris
 
-```bash
+```shell
 su <your user>
 mkdir code && cd code
 git clone https://github.com/apache/doris.git
@@ -124,7 +124,7 @@ Note:
 
 use the following command first time compiling
 
-```bash
+```shell
 sh build.sh --clean --be --fe --ui
 ```
 
@@ -132,7 +132,7 @@ it is because build-env-for-0.15.0 version image upgraded thrift(0.9 -> 0.13), s
 
 compile Doris
 
-```bash
+```shell
 sh build.sh
 ```
 
@@ -140,26 +140,26 @@ sh build.sh
 
 manually create `meta_dir` metadata storage location, default value is `${DORIS_HOME}/doris-meta`
 
-```bash
+```shell
 mkdir meta_dir
 ```
 
 launch FE
 
-```bash
+```shell
 cd output/fe
 sh bin/start_fe.sh --daemon
 ```
 
 launch BE
 
-```bash
+```shell
 cd output/be
 sh bin/start_be.sh --daemon
 ```
 
 mysql-client connect
 
-```bash
+```shell
 mysql -h 127.0.0.1 -P 9030 -u root
 ```

--- a/community/developer-guide/fe-vscode-dev.md
+++ b/community/developer-guide/fe-vscode-dev.md
@@ -77,7 +77,7 @@ Other articles have already explained:
 
 In order to debug, you need to add debugging parameters when fe starts, such as 
 
-```bash
+```shell
 -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
 ```
 

--- a/community/how-to-contribute/docs-format-specification.md
+++ b/community/how-to-contribute/docs-format-specification.md
@@ -123,6 +123,8 @@ The Tab key and the Space key are commonly used for alignment. Therefore, the fo
 
 - Set the tab size to be equivalent to four half-width spaces in Markdown editors, such as Visual Studio Code.
 
+- Indentation may affect document rendering results, **which is subject to correct rendering by rich text editors such as vscode (e.g., code blocks within a multi-level indentation structure sometimes still require 0-level indentation to render correctly)**.
+
 ### 02 Numbered Lists and Bullet Points
 
 Numbered lists typically emphasize the priority order between items. When using numbered lists and bullet points, the following guidelines should be followed:
@@ -155,38 +157,38 @@ Link descriptions are not advisable to repeatedly use phrases such as "see detai
 
 ### 04 Code blocks
 
-- You can create fenced code blocks by placing triple backticks ````` before and after the code block. We recommend placing a blank line before and after code blocks to make the raw formatting easier to read.
+- You can create fenced code blocks by placing triple backticks(\```) before and after the code block. We recommend placing a blank line before and after code blocks to make the raw formatting easier to read.
 
 - You can add an optional language identifier to enable syntax highlighting in your fenced code block: 
 
 | Language   | Syntax Higlighting       |
 | :--------- | :----------------------- |
-| Shell      | ```shell``` or ```bash``` |
-| Python     | ```python```              |
-| JSON       | ```json```                |
-| XML        | ```xml```                 |
-| SQL        | ```sql```                 |
-| YAML       | ```yaml``` or ```yml```      |
-| Markdown   | ```markdown``` or```md```  |
-| JavaScript | ```js``` or ```javascript``` |
-| Java       | ```java```                |
-| C++        | ```cpp```                |
-| C          | ```c```                   |
-| Ruby       | ```ruby```                |
-| HTML       | ```html```                |
-| CSS        | ````css`                 |
-| PHP        | ```php```                 |
+| Shell      | \```shell```             |
+| Python     | \```python```              |
+| JSON       | \```json```                |
+| XML        | \```xml```                 |
+| SQL        | \```sql```                 |
+| YAML       | \```yaml\``` or \```yml```      |
+| Markdown   | \```markdown\``` or\```md```  |
+| JavaScript | \```js\``` or \```javascript``` |
+| Java       | \```java```                |
+| C++        | \```cpp```                |
+| C          | \```c```                   |
+| Ruby       | \```ruby```                |
+| HTML       | \```html```                |
+| CSS        | \```css```                 |
+| PHP        | \```php```                 |
 
-- When using the ```bash` code block, it is recommended to separate the command and the output results. Here is an example:
+- When using the ```shell` code block, it is recommended to separate the command and the output results. Here is an example:
   - Use the following command to view the service
   
-   ```Bash
+   ```shell
     kubectl get pod --namespace doris
     ```
 
   - The output result
   
-   ```Bash
+   ```shell
     NAME                     READY   STATUS    RESTARTS   AGE
     doriscluster-helm-fe-0   1/1     Running   0          1m39s
     doriscluster-helm-fe-1   1/1     Running   0          1m39s

--- a/community/release-and-verify/release-doris-sdk.md
+++ b/community/release-and-verify/release-doris-sdk.md
@@ -46,7 +46,7 @@ Create a branch in the code base: 1.0.0-release, and checkout to this branch.
 
 Execute the following command to start generating release tags:
 
-```bash
+```shell
 mvn release:clean
 mvn release:prepare -DpushChanges=false
 ```

--- a/community/release-and-verify/release-doris-shade.md
+++ b/community/release-and-verify/release-doris-shade.md
@@ -46,7 +46,7 @@ Create a branch in the code base: 1.0.0-release, and checkout to this branch.
 
 Execute the following command to start generating release tags:
 
-```bash
+```shell
 mvn release:clean
 mvn release:prepare -DpushChanges=false
 ```

--- a/docs/admin-manual/auth/certificate.md
+++ b/docs/admin-manual/auth/certificate.md
@@ -39,7 +39,7 @@ In addition to the Doris default certificate file, you can also generate a custo
 
 1. Generate the CA, server-side, and client-side keys and certificates:
 
-```bash
+```shell
 # Generate the CA certificate
 openssl genrsa 2048 > ca-key.pem
 openssl req -new -x509 -nodes -days 3600 \
@@ -64,13 +64,13 @@ openssl x509 -req -in client-req.pem -days 3600 \
 
 2. Verify the created certificates:
 
-```bash
+```shell
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
 3. Combine your key and certificate in a PKCS#12 (P12) bundle. You can also specify a certificate format (PKCS12 by default). You can modify the conf/fe.conf configuration file and add parameter ssl_trust_store_type to specify the certificate format.
 
-```bash
+```shell
 # Package the CA key and certificate
 openssl pkcs12 -inkey ca-key.pem -in ca.pem -export -out ca_certificate.p12
 

--- a/docs/admin-manual/auth/ldap.md
+++ b/docs/admin-manual/auth/ldap.md
@@ -108,7 +108,7 @@ Client-side LDAP authentication requires the mysql client-side explicit authenti
 
 * Set the environment variable LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN to value 1.
   For example, in a linux or max environment you can use the command:
-  ```bash
+  ```shell
   echo "export LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN=1" >> ～/.bash_profile && source ～/.bash_profile
   ```
 
@@ -168,12 +168,12 @@ For example:
 Doris account exists: jack@'172.10.1.10', password: 123456  
 LDAP user node presence attribute: uid: jack user password: abcdef  
 The jack@'172.10.1.10' account can be logged into by logging into Doris using the following command:
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
 Login will fail with the following command:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 
@@ -181,7 +181,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 
 LDAP user node presence attribute: uid: jack User password: abcdef  
 Use the following command to create a temporary user and log in to jack@'%', the temporary user has basic privileges DatabasePrivs: Select_priv, Doris will delete the temporary user after the user logs out and logs in:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
@@ -189,7 +189,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 
 Doris account exists: jack@'172.10.1.10', password: 123456  
 Login to the account using the Doris password, successfully:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 

--- a/docs/admin-manual/cluster-management/load-balancing.md
+++ b/docs/admin-manual/cluster-management/load-balancing.md
@@ -486,7 +486,7 @@ IP: 172.31.7.119
 
 ### Install dependencies
 
-```bash
+```shell
 sudo apt-get install build-essential
 sudo apt-get install libpcre3 libpcre3-dev 
 sudo apt-get install zlib1g-dev
@@ -495,7 +495,7 @@ sudo apt-get install openssl libssl-dev
 
 ### Install Nginx
 
-```bash
+```shell
 sudo wget http://nginx.org/download/nginx-1.18.0.tar.gz
 sudo tar zxvf nginx-1.18.0.tar.gz
 cd nginx-1.18.0
@@ -507,13 +507,13 @@ sudo make && make install
 
 Here is a new configuration file
 
-```bash
+```shell
 vim /usr/local/nginx/conf/default.conf
 ```
 
 Then add the following in it
 
-```bash
+```shell
 events {  
 worker_connections 1024;  
 }  
@@ -537,7 +537,7 @@ stream {
 
 Start the specified configuration file
 
-```bash
+```shell
 cd /usr/local/nginx
 /usr/local/nginx/sbin/nginx -c conf.d/default.conf
 ```

--- a/docs/admin-manual/data-admin/ccr.md
+++ b/docs/admin-manual/data-admin/ccr.md
@@ -70,7 +70,7 @@ enable_feature_binlog=true
 
 ​Build CCR syncer
 
-```Bash
+```shell
 git clone https://github.com/selectdb/ccr-syncer
 cd ccr-syncer   
 bash build.sh <-j NUM_OF_THREAD> <--output SYNCER_OUTPUT_DIR>
@@ -81,7 +81,7 @@ cd SYNCER_OUTPUT_DIR# Contact the Doris community for a free CCR binary package
 Start and stop syncer
 
 
-```Bash
+```shell
 # Start
 cd bin && sh start_syncer.sh --daemon
    
@@ -91,7 +91,7 @@ sh stop_syncer.sh
 
 5. Enable binlog in the source cluster.
 
-```Bash
+```shell
 -- If you want to synchronize the entire database, you can execute the following script:
 vim shell/enable_db_binlog.sh
 Modify host, port, user, password, and db in the source cluster
@@ -103,7 +103,7 @@ ALTER TABLE enable_binlog SET ("binlog.enable" = "true");
 
 6. Launch a synchronization task to the syncer
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -129,7 +129,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Parameter description:
 
-```Bash
+```shell
 name: name of the CCR synchronization task, should be unique
 host, port: host and mysql(jdbc) port for the master FE for the corresponding cluster
 user, password: the credentials used by the syncer to initiate transactions, fetch data, etc.
@@ -271,7 +271,7 @@ Stop the syncer according to the process number in the pid file under the defaul
 
 The file structure can be seen under the output path after compilation:
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -306,7 +306,7 @@ Follow the default configurations.
 
 Specify the directory where the pid file is located. The above three stopping methods all depend on the directory where the pid file is located for execution.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --pid_dir /path/to/pids
 ```
 
@@ -318,7 +318,7 @@ The default value is `SYNCER_OUTPUT_DIR/bin`.
 
 Stop the syncer corresponding to host: port in the pid_dir path.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --host 127.0.0.1 --port 9190
 ```
 
@@ -328,7 +328,7 @@ The default value of host is 127.0.0.1, and the default value of port is empty. 
 
 Stop the syncer corresponding to the specified pid file name in the pid_dir path.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 ```
 
@@ -338,7 +338,7 @@ The file names should be wrapped in `" "` and separated with spaces.
 
 **Template for requests**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d {json_body} http://ccr_syncer_host:ccr_syncer_port/operator
 ```
 
@@ -362,7 +362,7 @@ or
 
 Create CCR tasks
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -398,7 +398,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 View the synchronization progress.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/get_lag
@@ -410,7 +410,7 @@ The job_name is the name specified when create_ccr.
 
 Pause synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/pause 
@@ -420,7 +420,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Resume synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/resume
@@ -430,7 +430,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Delete synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/delete
@@ -440,7 +440,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 View version information.
 
-```Bash
+```shell
 curl http://ccr_syncer_host:ccr_syncer_port/version
 
 # > return
@@ -451,7 +451,7 @@ curl http://ccr_syncer_host:ccr_syncer_port/version
 
 View job status.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/job_status
@@ -470,7 +470,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 No sync. Users can swap the source and target clusters.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/desync
@@ -480,7 +480,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 List all created tasks.
 
-```Bash
+```shell
 curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
 {"success":true,"jobs":["ccr_db_table_alias"]}
@@ -492,7 +492,7 @@ curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
 The file structure can be seen under the output path after compilation:
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -509,7 +509,7 @@ output_dir
 
 **Usage**
 
-```Bash
+```shell
 bash bin/enable_db_binlog.sh -h host -p port -u user -P password -d db
 ```
 
@@ -556,7 +556,7 @@ Minimum required version: V2.0.3
 
 BE-side configuration parameter
 
-```Bash
+```shell
 download_binlog_rate_limit_kbs=1024 # This configuration limits the size to 1MB. It applies to all binlogs, including local snapshots, in a single BE.
 ```
 

--- a/docs/admin-manual/log-management/fe-log.md
+++ b/docs/admin-manual/log-management/fe-log.md
@@ -131,7 +131,7 @@ The Debug level log of FE can be enabled by modifying the configuration file or 
 
    You can also modify the log level at runtime through the following API. No need to restart the FE node.
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?add_verbose=org.apache.doris.catalog.Catalog
    ```
 
@@ -154,7 +154,7 @@ The Debug level log of FE can be enabled by modifying the configuration file or 
 
    You can also close Debug log through the following API:
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?del_verbose=org.apache.doris.catalog.Catalog
    ```
 

--- a/docs/admin-manual/memory-management/memory-analysis/memory-log-analysis.md
+++ b/docs/admin-manual/memory-management/memory-analysis/memory-log-analysis.md
@@ -30,7 +30,11 @@ The process memory logs in `be/log/be.INFO` are mainly divided into two categori
 
 The process memory status of Doris BE will be printed in the `log/be.INFO` log every time the process memory increases or decreases by 256 MB. In addition, when the process memory is insufficient, the process memory status will also be printed along with other logs.
 
-``` os physical memory 375.81 GB. process memory used 4.09 GB(= 3.49 GB[vm/rss] - 410.44 MB[tc/jemalloc_cache] + 1 GB[reserved] + 0B[waiting_refresh]), limit 3.01 GB, soft limit 2.71 GB. sys available memory 134.41 GB(= 1 35.41 GB[proc/available] - 1 GB[reserved] - 0B[waiting_refresh]), low water mark 3.20 GB, warning water mark 6.40 GB. ```` 1. `os physical memory 375.81 GB` refers to the system physical memory 375.81 GB.
+```
+os physical memory 375.81 GB. process memory used 4.09 GB(= 3.49 GB[vm/rss] - 410.44 MB[tc/jemalloc_cache] + 1 GB[reserved] + 0B[waiting_refresh]), limit 3.01 GB, soft limit 2.71 GB. sys available memory 134.41 GB(= 1 35.41 GB[proc/available] - 1 GB[reserved] - 0B[waiting_refresh]), low water mark 3.20 GB, warning water mark 6.40 GB.
+```
+
+1. `os physical memory 375.81 GB` refers to the system physical memory 375.81 GB.
 
 2. `process memory used 4.09 GB (= 3.49 GB [vm/rss] - 410.44 MB [tc/jemalloc_cache] + 1 GB [reserved] + 0B [waiting_refresh])`
 - Currently we think that the BE process uses 4.09 GB of memory, and the actual physical memory used by the BE process `vm/rss` is 3.49 GB,

--- a/docs/compute-storage-decoupled/before-deployment.md
+++ b/docs/compute-storage-decoupled/before-deployment.md
@@ -171,7 +171,7 @@ Adjust the FoundationDB configurations based on different hardware specification
 
 This is an example `foundationdb.conf` configuration file for a machine with 8 CPU cores, 32 GB of memory, and a 500 GB SSD data disk. Ensure that the `datadir` and `logdir` paths are set correctly. The data disk is typically mounted at `/mnt`:
 
-```Bash
+```shell
 # foundationdb.conf
 ##
 ## Configuration file for FoundationDB server processes
@@ -257,7 +257,7 @@ On the primary machine, update the `ip` in the `/etc/foundationdb/fdb.cluster` f
 
 Then, restart the FoundationDB service to apply the changes:
 
-```Bash
+```shell
 # for service
 user@host$ sudo service foundationdb restart
 
@@ -306,7 +306,7 @@ Replace `/etc/foundationdb/foundationdb.conf` and `/etc/foundationdb/fdb.cluster
 
 Then, restart FoundationDB service on the local machine.
 
-```Bash
+```shell
 # for service
 user@host$ sudo service foundationdb restart
 
@@ -395,7 +395,7 @@ All nodes must have OpenJDK 17 installed. You can download the installation pack
 
 Then, simply extract the downloaded OpenJDK package directly to the installation path:
 
-```Bash
+```shell
 tar xf openjdk-17.0.1_linux-x64_bin.tar.gz  -C /opt/
 
 # Before starting Meta Service or Recycler

--- a/docs/compute-storage-decoupled/compilation-and-deployment.md
+++ b/docs/compute-storage-decoupled/compilation-and-deployment.md
@@ -30,13 +30,13 @@ Compilation in the compute-storage decoupled mode is similar to that in the comp
 
 Similar to the compute-storage coupled mode, you can use the built-in `build.sh` script to compile Doris in the compute-storage decoupled mode. Add the `--cloud` parameter for compilation of the new Meta Service module (The binary name for it is `doris_cloud`). 
 
-```Bash
+```shell
 sh build.sh --fe --be --cloud 
 ```
 
 Unlike the compute-storage coupled mode, you will find an `ms` directory in the `output` directory after compiling in the compute-storage decoupled mode.
 
-```Bash
+```shell
 output
 ├── be
 ├── fe
@@ -61,7 +61,7 @@ The version information of `doris_cloud` can be checked in two ways. If one meth
 - `bin/start.sh --version`
 - `lib/doris_cloud --version`
 
-```Bash
+```shell
 $ lib/doris_cloud --version
 version:{doris_cloud-0.0.0-debug} code_version:{commit=b9c1d057f07dd874ad32501ff43701247179adcb time=2024-03-24 20:44:50 +0800} build_info:{initiator=gavinchou@VM-10-7-centos build_at=2024-03-24 20:44:50 +0800 build_on=NAME="TencentOS Server" VERSION="3.1 (Final)" }
 ```
@@ -85,7 +85,7 @@ The `brpc_listen_port = 5000` above is the default port for Meta Service. `fdb_c
 
 **Example**
 
-```Bash
+```shell
 cat /etc/foundationdb/fdb.cluster
 
 DO NOT EDIT!
@@ -108,7 +108,7 @@ The `brpc_listen_port = 5100` above is the default port for Recycler. `fdb_clust
 
 **Example**
 
-```Bash
+```shell
 cat /etc/foundationdb/fdb.cluster
 
 DO NOT EDIT!

--- a/docs/compute-storage-decoupled/creating-cluster.md
+++ b/docs/compute-storage-decoupled/creating-cluster.md
@@ -81,7 +81,7 @@ To create a Doris cluster in the compute-storage decoupled mode using HDFS as th
 
 **Example**
 
-```Bash
+```shell
 curl -s "127.0.0.1:5000/MetaService/http/create_instance?token=greedisgood9999" -d \
 '{
   "instance_id": "sample_instance_id",
@@ -356,7 +356,7 @@ Users/Roles with the `USAGE_PRIV` privilege for a specific storage vault can per
 
 **Example**
 
-```Bash
+```shell
 grant usage_priv on storage vault my_storage_vault to user1
 ```
 
@@ -375,7 +375,7 @@ Only the Admin user has the privilege to execute the `REVOKE` statement, which i
 
 **Example**
 
-```Bash
+```shell
 revoke usage_priv on storage vault my_storage_vault from user1
 ```
 
@@ -404,7 +404,7 @@ The parameter list for the `add_cluster` interface is as follows:
 
 This is an example of adding one FE:
 
-```Bash
+```shell
 # Add FE
 curl '127.0.0.1:5000/MetaService/http/add_cluster?token=greedisgood9999' -d '{
     "instance_id":"sample_instance_id",
@@ -467,7 +467,7 @@ Users can adjust the number of compute clusters and the number of nodes within e
 
 This is an example of adding a compute cluster that consists of 1 BE node.
 
-```Bash
+```shell
 # 172.19.0.11
 # Add BE
 curl '127.0.0.1:5000/MetaService/http/add_cluster?token=greedisgood9999' -d '{

--- a/docs/compute-storage-decoupled/file-cache.md
+++ b/docs/compute-storage-decoupled/file-cache.md
@@ -66,7 +66,7 @@ To apply the TTL strategy for a table, set the TTL strategy in the PROPERTIES of
 
 - `file_cache_ttl_seconds`: The expected time (measured in seconds) for newly imported data to be retained in the cache.
 
-```Bash
+```shell
 CREATE TABLE IF NOT EXISTS customer (
   C_CUSTKEY     INTEGER NOT NULL,
   C_NAME        VARCHAR(25) NOT NULL,
@@ -208,7 +208,7 @@ A user has a total data volume of over 3TB, but the available cache capacity is 
 
 Under the LRU strategy, if a large table is queried and accessed, its data will replace that of the small table in the cache, causing performance fluctuations. To solve this, the user adopts a TTL strategy, setting the TTL time of the dimension table and fact table to 1 year and 1 day, respectively. 
 
-```Bash
+```shell
 ALTER TABLE dimension_table set ("file_cache_ttl_seconds"="31536000");
 
 ALTER TABLE fact_table set ("file_cache_ttl_seconds"="86400");

--- a/docs/compute-storage-decoupled/managing-compute-cluster.md
+++ b/docs/compute-storage-decoupled/managing-compute-cluster.md
@@ -339,7 +339,7 @@ In a compute-storage decoupled architecture, the user can specify the database a
 USE { [catalog_name.]database_name[@cluster_name] | @cluster_name }
 ```
 
-If the name of the database or compute cluster contains a reserved keyword, the respective name needs to be enclosed within backticks ```` to denote it as a quoted identifier.
+If the name of the database or compute cluster contains a reserved keyword, the respective name needs to be enclosed within backticks \``` to denote it as a quoted identifier.
 
 **Example**
 

--- a/docs/compute-storage-decoupled/meta-service-api.md
+++ b/docs/compute-storage-decoupled/meta-service-api.md
@@ -60,7 +60,7 @@ This API is used to create an instance, which supports one or more storage vault
 
 - Syntax for a `create_instance` request using HDFS as the storage vault
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token> HTTP/1.1
 Content-Length: <ContentLength>
 Content-Type: text/plain
@@ -140,7 +140,7 @@ Content-Type: text/plain
 
 - Syntax for a `create_instance` request using object storage as the storage vault
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token HTTP/1.1
 Content-Length: <ContentLength>
 Content-Type: text/plain
@@ -183,7 +183,7 @@ Content-Type: text/plain
 
 - Example of a `create_instance` request using object storage as the storage vault
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=greedisgood9999 HTTP/1.1
 Content-Length: 441
 Content-Type: text/plain
@@ -248,7 +248,7 @@ This API is used to create an instance, which only supports one storage vault (m
 
 - Syntax
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token HTTP/1.1
 Content-Length: <ContentLength
 Content-Type: text/plain

--- a/docs/data-operate/delete/batch-delete-manual.md
+++ b/docs/data-operate/delete/batch-delete-manual.md
@@ -252,7 +252,7 @@ mysql DESC test;
 
 4. When the table has the sequence column, delete all data with the same key as the imported data
 
-    ```bash
+    ```shell
     curl --location-trusted -u root: -H "column_separator:," -H "columns: name, gender, age" -H "function_column.sequence_col: age" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
     ```
 

--- a/docs/data-operate/import/error-data-handling.md
+++ b/docs/data-operate/import/error-data-handling.md
@@ -112,7 +112,7 @@ When users use non-strict mode of Stream Load for partial column updates to inse
 18,9999999,2023-07-03 12:00:03
 ```
 
-```bash
+```shell
 curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:false" -H "column_separator:," -H "columns:id,balance,last_access_time" -T /tmp/test.csv http://host:port/api/db1/user_profile/_stream_load
 ```
 
@@ -120,7 +120,7 @@ One existing data record in the table will be updated, and two new data records 
 
 When users use strict mode of Stream Load for partial column updates to insert the above data into the table, the import will fail because strict mode is enabled and the keys (`(3)`, `(18)`) of the second and third rows are not present in the original table.
 
-``` bash
+```shell
 curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:true" -H "column_separator:," -H "columns:id,balance,last_access_time" -T /tmp/test.csv http://host:port/api/db1/user_profile/_stream_load
 ```
 
@@ -129,7 +129,7 @@ By default, strict mode is set to False, which means it is disabled. The method 
 
 [STREAM LOAD](./import-way/stream-load-manual.md)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "strict_mode: true" \
    -T 1.txt \
@@ -217,7 +217,7 @@ The default value of `max_filter_ratio` is 0, which means that if there is any e
 
 [Stream Load](./import-way/stream-load-manual.md)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "max_filter_ratio: 0.1" \
    -T 1.txt \

--- a/docs/data-operate/import/import-way/stream-load-manual.md
+++ b/docs/data-operate/import/import-way/stream-load-manual.md
@@ -117,7 +117,7 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 
    The Stream Load job can be submitted using the `curl` command.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "column_separator:," \
@@ -200,7 +200,7 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 
    The Stream Load job can be submitted using the `curl` command.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:124" \
     -H "Expect:100-continue" \
@@ -261,7 +261,7 @@ Users cannot manually cancel a Stream Load operation. A Stream Load job will be 
 
 The syntax for Stream Load is as follows:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
   -H "Expect:100-continue" [-H ""...] \
   -T <file_path> \
@@ -400,7 +400,7 @@ When performing Stream Load using the TVF `http_stream`, the Rest API URL differ
 
 Using curl for Stream Load in http_stream Mode:
 
-```Bash
+```shell
 curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -XPUT http://fe_host:http_port/api/_http_stream
 ```
 
@@ -408,7 +408,7 @@ Adding a SQL parameter in the header to replace the previous parameters such as 
 
 Example of load SQL:
 
-```Bash
+```shell
 insert into db.table (col, ...) select stream_col, ... from http_stream("property1"="value1");
 ```
 
@@ -455,7 +455,7 @@ Load job can tolerate a certain amount of data with formatting errors. The toler
 
 You can use the following command to specify a `max_filter_ratio` tolerance of 0.4 for creating a Stream Load job:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "max_filter_ratio:0.4" \
@@ -485,7 +485,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 Loading data from local files into partitions p1 and p2 of the table, allowing a 20% error rate.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:123" \
     -H "Expect:100-continue" \
@@ -513,7 +513,7 @@ Stream Load is based on the HTTP protocol for importing, which supports using pr
 
 The following example demonstrates this usage through a bash command pipeline. The imported data is generated streamingly by the program rather than from a local file.
 
-```Bash
+```shell
 seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -537,7 +537,7 @@ curl --location-trusted -u root -T test.csv  -H "label:1" -H "format:csv_with_na
 
 In stream load, there are three import types: APPEND, DELETE, and MERGE. These can be adjusted by specifying the parameter `merge_type`. If you want to specify that all data with the same key as the imported data should be deleted, you can use the following command:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: DELETE" \
@@ -580,7 +580,7 @@ After importing, the original table data will be deleted, resulting in the follo
 
 By specifying `merge_type` as MERGE, the imported data can be merged into the table. The MERGE semantics need to be used in combination with the DELETE condition, which means that data satisfying the DELETE condition is processed according to the DELETE semantics, and the rest is added to the table according to the APPEND semantics. The following operation represents deleting the row with `siteid` of 1, and adding the rest of the data to the table:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: MERGE" \
@@ -772,7 +772,7 @@ JSON data type:
 
 Command:
 
-```Bash
+```shell
 curl --location-trusted -u root -T test.json -H "label:1" -H "format:json" -H 'columns: id, order_code, create_time=CURRENT_TIMESTAMP()' http://host:port/api/testDb/testTbl/_stream_load
 ```
 

--- a/docs/data-operate/import/load-data-convert.md
+++ b/docs/data-operate/import/load-data-convert.md
@@ -60,7 +60,7 @@ WITH BROKER bos
 
 ### STREAM LOAD
 
-```bash
+```shell
 curl
 --location-trusted
 -u user:passwd
@@ -96,7 +96,7 @@ Stream load does not support preceding filtering.
 
 Example:
 
-```bash
+```shell
 curl
 --location-trusted
 -u user:passwd

--- a/docs/data-operate/import/load-data-format.md
+++ b/docs/data-operate/import/load-data-format.md
@@ -147,21 +147,21 @@ Currently only the following three JSON formats are supported:
 
    JSON format with Array as root node. Each element in the Array represents a row of data to be imported, usually an Object. An example is as follows:
 
-   ````json
+   ```json
    [
        { "id": 123, "city" : "beijing"},
        { "id": 456, "city" : "shanghai"},
        ...
    ]
-   ````
+   ```
 
-   ````json
+   ```json
    [
        { "id": 123, "city" : { "name" : "beijing", "region" : "haidian"}},
        { "id": 456, "city" : { "name" : "beijing", "region" : "chaoyang"}},
        ...
    ]
-   ````
+   ```
 
    This method is typically used for Stream Load import methods to represent multiple rows of data in a batch of imported data.
 
@@ -170,13 +170,13 @@ Currently only the following three JSON formats are supported:
 - A single row of data represented by Object
    JSON format with Object as root node. The entire Object represents a row of data to be imported. An example is as follows:
 
-   ````json
+   ```json
    { "id": 123, "city" : "beijing"}
-   ````
+   ```
  
-   ````json
+   ```json
    { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
-   ````
+   ```
  
    This method is usually used for the Routine Load import method, such as representing a message in Kafka, that is, a row of data.
 
@@ -184,11 +184,11 @@ Currently only the following three JSON formats are supported:
    
    A row of data represented by Object represents a row of data to be imported. The example is as follows:
  
-   ````json
+   ```json
    { "id": 123, "city" : "beijing"}
    { "id": 456, "city" : "shanghai"}
    ...
-   ````
+   ```
  
    This method is typically used for Stream Load import methods to represent multiple rows of data in a batch of imported data.
  
@@ -223,17 +223,17 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is as follows:
 
-  ````json
+  ```json
   { "id": 123, "city" : "beijing"}
-  ````
+  ```
 
   Then Doris will use `id`, `city` for matching, and get the final data `123` and `beijing`.
 
   If the JSON data is as follows:
 
-  ````json
+  ```json
   { "id": 123, "name" : "beijing"}
-  ````
+  ```
 
   Then use `id`, `city` for matching, and get the final data `123` and `null`.
 
@@ -241,13 +241,13 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   Specify a set of JSON Path in the form of a JSON data. Each element in the array represents a column to extract. An example is as follows:
 
-  ````json
+  ```json
   ["$.id", "$.name"]
-  ````
+  ```
 
-  ````json
+  ```json
   ["$.id.sub_id", "$.name[0]", "$.city[0]"]
-  ````
+  ```
 
   Doris will use the specified JSON Path for data matching and extraction.
 
@@ -257,21 +257,21 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
-  ````
+  ```
 
   JSON Path is `["$.city"]`. The matched elements are:
 
-  ````json
+  ```json
   { "name" : "beijing", "region" : "haidian" }
-  ````
+  ```
 
   The element will be converted to a string for subsequent import operations:
 
-  ````json
+  ```json
   "{'name':'beijing','region':'haidian'}"
-  ````
+  ```
 
 - match failed
 
@@ -279,41 +279,41 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "name" : "beijing"}
-  ````
+  ```
 
   JSON Path is `["$.id", "$.info"]`. The matched elements are `123` and `null`.
 
   Doris currently does not distinguish between null values represented in JSON data and null values produced when a match fails. Suppose the JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "name" : null }
-  ````
+  ```
 
   The same result would be obtained with the following two JSON Paths: `123` and `null`.
 
-  ````json
+  ```json
   ["$.id", "$.name"]
-  ````
+  ```
 
-  ````json
+  ```json
   ["$.id", "$.info"]
-  ````
+  ```
 
 - Exact match failed
 
   In order to prevent misoperation caused by some parameter setting errors. When Doris tries to match a row of data, if all columns fail to match, it considers this to be an error row. Suppose the Json data is:
 
-  ````json
+  ```json
   { "id": 123, "city" : "beijing" }
-  ````
+  ```
 
   If the JSON Path is written incorrectly as (or if the JSON Path is not specified, the columns in the table do not contain `id` and `city`):
 
-  ````json
+  ```json
   ["$.ad", "$.infa"]
-  ````
+  ```
 
   would cause the exact match to fail, and the line would be marked as an error line instead of yielding `null, null`.
 
@@ -325,65 +325,65 @@ In other words, it is equivalent to rearranging the columns of a JSON format dat
 
 Data content:
 
-````json
+```json
 {"k1": 1, "k2": 2}
-````
+```
 
 Table Structure:
 
-````
+```
 k2 int, k1 int
-````
+```
 
 Import statement 1 (take Stream Load as an example):
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -T example.json http:/ /127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 In import statement 1, only JSON Path is specified, and Columns is not specified. The role of JSON Path is to extract the JSON data in the order of the fields in the JSON Path, and then write it in the order of the table structure. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1   | k2   |
 +------+------+
 | 2    | 1    |
 +------+------+
-````
+```
 
 You can see that the actual k1 column imports the value of the "k2" column in the JSON data. This is because the field name in JSON is not equivalent to the field name in the table structure. We need to explicitly specify the mapping between the two.
 
 Import statement 2:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, k1 " -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Compared with the import statement 1, the Columns field is added here to describe the mapping relationship of the columns, in the order of `k2, k1`. That is, after extracting in the order of fields in JSON Path, specify the value of column k2 in the table for the first column, and the value of column k1 in the table for the second column. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1   |  k2  |
 +------+------+
 | 1    | 2    |
 +------+------+
-````
+```
 
 Of course, as with other imports, column transformations can be performed in Columns. An example is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, tmp_k1 , k1 = tmp_k1 * 100" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 The above example will import the value of k1 multiplied by 100. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1   | k2   |
 +------+------+
 | 100  | 2    |
 +------+------+
-````
+```
 
 Import statement 3:
 
@@ -396,7 +396,7 @@ k2 int, k1 int, k1_copy int
 
 If you want to assign a column field in JSON to several column fields in the table multiple times, you can specify the column multiple times in jsonPaths and specify the mapping order in sequence. An example is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\", \"$.k1\"]" -H "columns: k2,k1,k1_copy" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -427,7 +427,7 @@ k2 int, k1 int, k1_nested1 int, k1_nested2 int
 ```
 If you want to assign multi-level fields with the same name nested in json to different columns in the table, you can specify the column in jsonPaths and specify the mapping order in turn. An example are as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\",\"$.k3.k1\",\"$.k3.k1_nested.k1\" -H "columns: k2,k1,k1_nested1,k1_nested2" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -477,26 +477,26 @@ Doris supports extracting data specified in JSON through JSON root.
 
 Example data is as follows:
 
-````json
+```json
 [
     {"k1": 1, "k2": "a"},
     {"k1": 2},
     {"k1": 3, "k2": "c"}
 ]
-````
+```
 
 
 The table structure is: `k1 int null, k2 varchar(32) null default "x"`
 
 The import statement is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 The import results that users may expect are as follows, that is, for missing columns, fill in the default values.
 
-````text
+```text
 +------+------+
 | k1 | k2     |
 +------+------+
@@ -506,11 +506,11 @@ The import results that users may expect are as follows, that is, for missing co
 +------+------+
 |3     |c     |
 +------+------+
-````
+```
 
 But the actual import result is as follows, that is, for the missing column, NULL is added.
 
-````text
+```text
 +------+------+
 | k1 | k2     |
 +------+------+
@@ -520,13 +520,13 @@ But the actual import result is as follows, that is, for the missing column, NUL
 +------+------+
 |3     |c     |
 +------+------+
-````
+```
 
 This is because Doris doesn't know "the missing column is column k2 in the table" from the information in the import statement. If you want to import the above data according to the expected result, the import statement is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -H "jsonpaths: [\"$.k1\", \"$.k2\"]" - H "columns: k1, tmp_k2, k2 = ifnull(tmp_k2, 'x')" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 ### Application example
 
@@ -536,63 +536,63 @@ Because of the inseparability of the JSON format, when using Stream Load to impo
 
 Suppose the table structure is:
 
-````text
+```text
 id INT NOT NULL,
 city VARHCAR NULL,
 code INT NULL
-````
+```
 
 1. Import a single row of data 1
 
-````json
+```json
 {"id": 100, "city": "beijing", "code" : 1}
-````
+```
 
 - do not specify JSON Path
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Import result:
 
-````text
+```text
 100 beijing 1
-````
+```
 
 - Specify JSON Path
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Import result:
 
-````text
+```text
 100 beijing 1
-````
+```
 
 2. Import a single row of data 2
 
- ````json
+ ```json
 {"id": 100, "content": {"city": "beijing", "code": 1}}
-````
+```
 
 - Specify JSON Path
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\ "]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Import result:
 
-````text
+```text
 100 beijing 1
-````
+```
 
 3. Import multiple rows of data as Array
 
-````json
+```json
 [
     {"id": 100, "city": "beijing", "code" : 1},
     {"id": 101, "city": "shanghai"},
@@ -607,24 +607,24 @@ Import result:
         "code" : 6
     }
 ]
-````
+```
 
 - Specify JSON Path
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Import result:
 
-````text
+```text
 100 beijing 1
 101 shanghai NULL
 102 tianjin 3
 103 chongqing 4
 104 ["zhejiang","guangzhou"] 5
 105 {"order1":["guangzhou"]} 6
-````
+```
 
 4. Import multi-line data as multi-line Object
 
@@ -637,12 +637,12 @@ Import result:
 
 StreamLoad import:
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 Import result:
 	
-```bash
+```shell
 100     beijing                     1
 101     shanghai                    NULL
 102     tianjin                     3
@@ -653,20 +653,20 @@ Import result:
 
 The data is still the multi-line data in Example 3, and now it is necessary to add 1 to the `code` column in the imported data before importing.
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Import result:
 
-````text
+```text
 100 beijing 2
 101 shanghai NULL
 102 tianjin 4
 103 chongqing 5
 104 ["zhejiang","guangzhou"] 6
 105 {"order1":["guangzhou"]} 7
-````
+```
 
 6. Import Array by JSON
 Since the Rapidjson handles decimal and largeint numbers which will cause precision problems, 
@@ -680,7 +680,7 @@ we suggest you to use JSON string to import data to `array<decimal>` or `array<l
 {"k1": 40, "k2": ["10000000000000000000.1111111222222222"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_decimal.json http://localhost:8035/api/example_db/array_test_decimal/_stream_load
 ```
 
@@ -700,7 +700,7 @@ MySQL > select * from array_test_decimal;
 {"k1": 999, "k2": ["76959836937749932879763573681792701709", "26017042825937891692910431521038521227"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_largeint.json http://localhost:8035/api/example_db/array_test_largeint/_stream_load
 ```
 

--- a/docs/data-operate/transaction.md
+++ b/docs/data-operate/transaction.md
@@ -410,7 +410,7 @@ mysql> SELECT * FROM dt3;
 
 **1. Enable two-phase commit by setting `two_phase_commit:true` in the HTTP Header.**
 
-```Bash
+```shell
 curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt http://fe_host:http_port/api/{db}/{table}/_stream_load
 {
     "TxnId": 18036,
@@ -436,7 +436,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the Transaction ID:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18036" -H "txn_operation:commit" http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -446,7 +446,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the label:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:commit"  http://fe_host:http_port/api/{db}/{table}/_stream_load_2pc
   {
       "status": "Success",
@@ -458,7 +458,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the Transaction ID:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18037" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -468,7 +468,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the label:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",

--- a/docs/data-operate/update/unique-update-transaction.md
+++ b/docs/data-operate/update/unique-update-transaction.md
@@ -109,7 +109,7 @@ PROPERTIES (
 
 The syntax for stream load is to add the mapping of the hidden column `function_column.sequence_col` to the `source_sequence` in the header. Example:
 
-```Bash
+```shell
 curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -228,7 +228,7 @@ Load the following data:
 
 Here is an example using Stream Load:
 
-```Bash
+```shell
 curl --location-trusted -u root: -T testData http://host:port/api/test/test_table/_stream_load
 ```
 

--- a/docs/db-connect/database-connect.md
+++ b/docs/db-connect/database-connect.md
@@ -32,14 +32,14 @@ Download MySQL Client from the MySQL official website or use the pre-installed [
 
 Extract the downloaded MySQL client. In the `bin/` directory, find the `mysql` command-line tool. Execute the following command to connect to Doris:
 
-```Bash
+```shell
 # FE_IP represents the listening address of the FE node, while FE_QUERY_PORT represents the port of the MySQL protocol service of the FE. This corresponds to the query_port parameter in fe.conf and it defaults to 9030.
 mysql -h FE_IP -P FE_QUERY_PORT -u USER_NAME 
 ```
 
 After login, the following message will be displayed.
 
-```Bash
+```shell
 Welcome to the MySQL monitor.  Commands end with ; or \g.                               
 Your MySQL connection id is 236                                                         
 Server version: 5.7.99 Doris version doris-2.0.3-rc06-37d31a5                           

--- a/docs/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-access-cluster.md
+++ b/docs/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-access-cluster.md
@@ -35,13 +35,13 @@ Doris provides ClusterIP access mode by default on Kubernetes. No modification i
 
 After deploying the cluster, you can view the services exposed by Doris Operator through the following command:
 
-```bash
+```shell
 kubectl -n doris get svc
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                               AGE
 doriscluster-sample-be-internal   ClusterIP   None          <none>        9050/TCP                              9m
 doriscluster-sample-be-service    ClusterIP   10.1.68.128   <none>        9060/TCP,8040/TCP,9050/TCP,8060/TCP   9m
@@ -58,13 +58,13 @@ In the above results, FE and BE have two types of Services, with the suffixes in
 
 Use the following command to create a pod containing the mysql client in the current Kubernetes cluster:
 
-```bash
+```shell
 kubectl run mysql-client --image=mysql:5.7 -it --rm --restart=Never --namespace=doris -- /bin/bash
 ```
 
 In the container in the cluster, you can use the externally exposed service name with the suffix `service` to access the Doris cluster:
 
-```bash
+```shell
 ## Use service type pod name to access the Doris cluster
 mysql -uroot -P9030 -hdoriscluster-sample-fe-service
 ```
@@ -143,13 +143,13 @@ spec:
 
 After deploying the cluster, you can view the services exposed by Doris Operator through the following command:
 
-```bash
+```shell
 kubectl get service
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME TYPE CLUSTER-IP EXTERNAL-IP PORT(S) AGE
 kubernetes ClusterIP 10.152.183.1 <none> 443/TCP 169d
 doriscluster-sample-fe-internal ClusterIP None <none> 9030/TCP 2d
@@ -160,13 +160,13 @@ doriscluster-sample-be-service NodePort 10.152.183.244 <none> 9060:30940/TCP,804
 
 Doris's Query Port defaults to 9030, which is mapped to local port 31545 locally. When accessing the Doris cluster, you need to obtain the corresponding IP address, which can be viewed with the following command:
 
-```bash
+```shell
 kubectl get nodes -owide
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME   STATUS   ROLES           AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION          CONTAINER-RUNTIME
 r60    Ready    control-plane   14d   v1.28.2   192.168.88.60   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
 r61    Ready    <none>          14d   v1.28.2   192.168.88.61   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
@@ -176,7 +176,7 @@ r63    Ready    <none>          14d   v1.28.2   192.168.88.63   <none>        Ce
 
 In NodePort mode, you can access services in the Kubernetes cluster based on the host IP and port mapping of any node. In this example, you can use any node IP, 192.168.88.61, 192.168.88.62, 192.168.88.63, to access the Doris service. For example, in the following example, the node node 192.168.88.62 and the mapped query port port 31545 are used to access the cluster:
 
-```bash
+```shell
 mysql -h 192.168.88.62 -P 31545 -uroot
 ```
 
@@ -192,7 +192,7 @@ If you perform Stream Load inside Kubernetes, you can directly use the error add
 
 In the return result of the above example, you can directly obtain the return result through the curl command in the Pod in the same Kubernetes cluster:
 
-```bash
+```shell
 curl http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local:8040/api/_load_error_log?file=__shard_1/error_log_insert_stmt_af474190276a2e9c-49bb9d175b8e968e_af474190276a2e9c_49bb9d175b8e968e
 ```
 
@@ -243,7 +243,7 @@ Since the pod name returned by each stream load may be different, please delete 
 
 Follow the service in the above example, replace ${podName} in CR with doriscluster-sample-be-2, and replace ${ServiceType} with NodePort. Use the kubectl apply command to create the service service in the same namespace of the doris cluster.
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -251,13 +251,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 Use the following command to view the NodePort assigned by the above deployment Service:
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
 doriscluster-detail-error         NodePort    10.152.183.35    <none>        8040:31201/TCP     32s
 ```
@@ -266,13 +266,13 @@ The BE port accessed by `Stream Load` is 8040, and the host port (NodePort) corr
 
 Get the host address controlled by K8s:
 
-```bash
+```shell
 kubectl get node -owide
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME             STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION       CONTAINER-RUNTIME
 vm-10-8-centos   Ready    <none>   226d   v1.28.7   10.16.10.8    <none>        TencentOS Server 3.1 (Final)   5.4.119-19-0009.3    containerd://1.6.28
 vm-10-7-centos   Ready    <none>   19d    v1.28.7   10.16.10.7    <none>        TencentOS Server 3.1 (Final)   5.4.119-19.0009.25   containerd://1.6.28
@@ -298,7 +298,7 @@ http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluste
 
 The domain name address of the above address is `doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local`. Among the domain names used by pods deployed by `Doris Operator` on `Kubernetes`, the third level The domain name is the name of the pod. Replace {podName} in the above template with the real `pod` name, replace {serviceType} with `LoadBalancer`, and save the changes to the newly created `stream_load_get_error.yaml` file. Use the following command to deploy service:
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -306,13 +306,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 Use the following command to view the LoadBalaner address EXTERNAL-IP assigned by the above deployment Service. The following is a test instance in aws eks:
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                         TYPE          CLUSTER-IP       EXTERNAL-IP                                                              PORT(S)           AGE
 doriscluster-detail-error    LoadBalancer  172.20.183.136   ac4828493dgrftb884g67wg4tb68gyut-1137856348.us-east-1.elb.amazonaws.com  8040:32003/TCP    14s
 ```

--- a/docs/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-config-cluster.md
+++ b/docs/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-config-cluster.md
@@ -99,13 +99,13 @@ feSpec:
 
 Among them, the name of [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) needs to be specified in ${storageClassName}. You can use the following command to view the StorageClass supported in the current Kubernetes cluster:
 
-```bash
+```shell
 kubectl get sc
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                          PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
 openebs-hostpath              openebs.io/local               Delete          WaitForFirstConsumer   false                  212d
 openebs-device                openebs.io/local               Delete          WaitForFirstConsumer   false                  212d

--- a/docs/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-doris-cluster.md
+++ b/docs/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-doris-cluster.md
@@ -36,13 +36,13 @@ Deploying a cluster online requires the following steps:
 
 1. Create namespace:
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 2. Deploy Doris cluster
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -61,7 +61,7 @@ selectdb/doris.be-ubuntu:2.0.2
 
 Download the image locally and package it into a tar file
 
-```bash
+```shell
 ## download docker image
 docker pull selectdb/doris.fe-ubuntu:2.0.2
 docker pull selectdb/doris.be-ubuntu:2.0.2
@@ -73,7 +73,7 @@ docker save -o doris.be-ubuntu-v2.0.2.tar docker pull selectdb/doris.be-ubuntu:2
 
 Upload the image tar package to the server and execute the docker load command:
 
-```bash
+```shell
 ## load docker image
 docker load -i doris.fe-ubuntu-v2.0.2.tar
 docker load -i doris.be-ubuntu-v2.0.2.tar
@@ -81,13 +81,13 @@ docker load -i doris.be-ubuntu-v2.0.2.tar
 
 2. Create namespace:
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 3. Deploy Doris cluster
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -101,13 +101,13 @@ Before installation, you need to add a deployment warehouse. If it has been adde
 
 Install [doriscluster](https://artifacthub.io/packages/helm/doris/doris), using the default configuration this deployment only deploys 3 FE and 3 BE components, using the default `storageClass` to implement PV dynamic provisioning.
 
-```bash
+```shell
 helm install doriscluster doris-repo/doris
 ```
 
 If you need to customize resources and cluster shapes, please customize the resource configuration according to the annotations of each resource configuration in [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) and execute The following command:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-repo/doris
 ```
 
@@ -115,13 +115,13 @@ helm install -f values.yaml doriscluster doris-repo/doris
 
 You can check the pod deployment status through the `kubectl get pods` command. When the Pod of `doriscluster` is in `Running` state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -137,7 +137,7 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 Download `doris-{chart_version}.tgz` to install Doris Cluster chart. If you need to download the 2.0.6 version of the Doris cluster, you can use the following command:
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-2.0.6.tgz
 ```
 
@@ -145,13 +145,13 @@ wget https://charts.selectdb.com/doris-2.0.6.tgz
 
 Doris cluster can be installed through the `helm install` command.
 
-```bash
+```shell
 helm install doriscluster doris-1.4.0.tgz
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-1.4.0.tgz
 ```
 
@@ -159,13 +159,13 @@ helm install -f values.yaml doriscluster doris-1.4.0.tgz
 
 You can check the pod deployment status through the `kubectl get pods` command. When the Pod of `doriscluster` is in `Running` state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -181,13 +181,13 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 After the cluster deployment resources are delivered, you can check the cluster status by running the following command.
 
-```bash
+```shell
 kubectl get pods -n ${namespace}
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                       READY   STATUS    RESTARTS   AGE
 doriscluster-sample-fe-0   1/1     Running   0          20m
 doriscluster-sample-be-0   1/1     Running   0          19m
@@ -199,13 +199,13 @@ When the `STATUS` of all pods is in the `Running` state, and all containers in t
 
 Doris Operator will collect the status of cluster services and display them in the distributed resources. Doris Operator defines the abbreviation `dcr` for the `DorisCluster` type resource name, which can be replaced by the abbreviation when using the resource type to view the cluster status.
 
-```bash
+```shell
 kubectl get dcr
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                  FESTATUS    BESTATUS    CNSTATUS   BROKERSTATUS
 doriscluster-sample   available   available
 ```

--- a/docs/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-operator.md
+++ b/docs/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-operator.md
@@ -29,32 +29,32 @@ Doris Operator extends Kubernetes with Custom Resource Definition (CRD). The CRD
 
 Doris Cluster CRD can be deployed in a Kubernetes environment with the following command:
 
-```bash
+```shell
 kubectl create -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 ```
 
 If there is no external network, download the CRD file to your local computer first:
 
-```bash
+```shell
 wget https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 kubectl create -f ./doris.selectdb.com_dorisclusters.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 customresourcedefinition.apiextensions.k8s.io/dorisclusters.doris.selectdb.com created
 ```
 
 After the Doris Cluster CRD is created, you can view the created CRD with the following command.
 
-```bash
+```shell
 kubectl get crd | grep doris
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 ```
 
@@ -66,13 +66,13 @@ You can directly pull the Doris Operator template in the warehouse for quick dep
 
 Doris Operator can be deployed in a Kubernetes cluster using the following command:
 
-```bash
+```shell
 kubectl apply -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/operator/operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -91,13 +91,13 @@ The minimum requirements for deploying operator services are specified in the op
 
 After modifying the operator.yaml file, you can deploy the Doris Operator service using the following command:
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -113,13 +113,13 @@ deployment.apps/doris-operator created
 
 If the server is not connected to the external network, you need to download the corresponding operator image file first. Doris Operator uses the following images:
 
-```bash
+```shell
 selectdb/doris.k8s-operator:latest
 ```
 
 Run the following command on a server that can connect to the external network to download the image:
 
-```bash
+```shell
 ## download doris operator image
 docker pull selectdb/doris.k8s-operator:latest
 ## save the doris operator image as a tar package
@@ -128,7 +128,7 @@ docker save -o doris.k8s-operator-latest.tar selectdb/doris.k8s-operator:latest
 
 Place the packaged tar file into all Kubernetes nodes and run the following command to upload the image:
 
-```bash
+```shell
 docker load -i doris.k8s-operator-latest.tar
 ```
 
@@ -138,7 +138,7 @@ After downloading the operator.yaml file, you can modify the template according 
 
 Doris Operator is a stateless Deployment in the Kubernetes cluster. Items such as `limits`, `replica`, `label`, `namespace` and other items can be modified according to needs. If you need to specify a certain version of the doirs operator image, you can make the following modifications to the operator.yaml file after uploading the image:
 
-```bash
+```shell
 ...
 containers:
   - command:
@@ -158,13 +158,13 @@ containers:
 
 After modifying the Doris Operator template, you can use the apply command to deploy the Operator:
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -184,13 +184,13 @@ Helm Chart is an encapsulation of a series of YAML files that describe Kubernete
 
 Add the remote repository through the `repo add` command
 
-```bash
+```shell
 helm repo add doris-repo https://charts.selectdb.com
 ```
 
 Update the latest version of the chart through the `repo update` command
 
-```bash
+```shell
 helm repo update doris-repo
 ```
 
@@ -198,25 +198,25 @@ helm repo update doris-repo
 
 Doris Operator can be installed in the doris namespace using the default configuration through the `helm install` command.
 
-```bash
+```shell
 helm install operator doris-repo/doris-operator
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-repo/doris-operator
 ```
 
 Check the deployment status of Pods through the `kubectl get pods` command. When the Doris Operator's Pod is in the Running state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -229,7 +229,7 @@ If the server cannot connect to the external network, you need to download the c
 
 Download `doris-operator-{chart_version}.tgz` to install Doris Operator chart. If you need to download version 1.4.0 of Doris Operator, you can use the following command:
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 ```
 
@@ -237,25 +237,25 @@ wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 
 Doris Operator can be installed through the `helm install` command.
 
-```bash
+```shell
 helm install operator doris-operator-1.4.0.tgz
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-operator-1.4.0.tgz
 ```
 
 Check the deployment status of Pods through the `kubectl get pods` command. When the Doris Operator's Pod is in the Running state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -264,13 +264,13 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 After deploying the Operator service, you can check the service status through the following command.
 
-```bash
+```shell
 kubectl get pod -n doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-6f47594455-p5tp7   1/1     Running   0          11s
 ```

--- a/docs/install/cluster-deployment/k8s-deploy/install-env.md
+++ b/docs/install/cluster-deployment/k8s-deploy/install-env.md
@@ -39,7 +39,7 @@ under the License.
 
 When deploying a Doris cluster on Kubernetes, it is recommended to turn off the firewall configuration:
 
-```bash
+```shell
 systemctl stop firewalld
 systemctl disable firewalld
 ```
@@ -56,7 +56,7 @@ When deploying Doris, it is recommended to turn off the swap partition.
 
 The swap partition can be permanently shut down with the following command.
 
-```bash
+```shell
 echo "vm.swappiness = 0">> /etc/sysctl.conf
 swapoff -a && swapon -a
 sysctl -p
@@ -64,7 +64,7 @@ sysctl -p
 
 ### Set the maximum number of open file handles in the system
 
-```bash
+```shell
 vi /etc/security/limits.conf 
 * soft nofile 65536
 * hard nofile 65536
@@ -74,7 +74,7 @@ vi /etc/security/limits.conf
 
 Modify the virtual memory area to at least 2000000
 
-```bash
+```shell
 sysctl -w vm.max_map_count=2000000
 ```
 
@@ -82,7 +82,7 @@ sysctl -w vm.max_map_count=2000000
 
 When deploying Doris, it is recommended to turn off transparent huge pages.
 
-```bash
+```shell
 echo never > /sys/kernel/mm/transparent_hugepage/enabled
 echo never > /sys/kernel/mm/transparent_hugepage/defrag
 ```

--- a/docs/install/cluster-deployment/run-docker-cluster.md
+++ b/docs/install/cluster-deployment/run-docker-cluster.md
@@ -81,7 +81,7 @@ Download the [official binary package](https://doris.apache.org/zh-CN/download/)
 
 3. Write Dockerfile
 
-```Bash
+```shell
 # Choose a base image
 FROM openjdk:8u342-jdk
 

--- a/docs/install/cluster-deployment/standard-deployment.md
+++ b/docs/install/cluster-deployment/standard-deployment.md
@@ -296,7 +296,7 @@ This is a CIDR representation that specifies the IP used by the FE. In environme
 
 Start FE process by executing the following command
 
-```Bash
+```shell
 bin/start_fe.sh --daemon
 ```
 
@@ -359,7 +359,7 @@ ALTER SYSTEM ADD OBSERVER "<fe_ip_address>:<fe_edit_log_port>"
 
 Execute the following command to start FE Follower node and synchronize metadata automatically.
 
-```Bash
+```shell
 bin/start_fe.sh --helper <helper_fe_ip>:<fe_edit_log_port> --daemon
 ```
 
@@ -578,7 +578,7 @@ As a distributed database, Doris generally has many BE nodes. Doris adds BE node
 
 You can use the following command to check if the FE has started successfully.
 
-```Bash
+```shell
 # Retry the following command, if it returns "msg":"success"，the FE has started successfully.
 server1:apache-doris/fe doris$ curl http://127.0.0.1:8030/api/bootstrap
 {"msg":"success","code":0,"data":{"replayedJournalId":0,"queryPort":0,"rpcPort":0,"version":""},"count":0}

--- a/docs/install/source-install/compilation-mac.md
+++ b/docs/install/source-install/compilation-mac.md
@@ -98,7 +98,7 @@ cd output/fe/bin
 
 Download the pre-compiled third-party libraries from [Apache Doris Third Party Prebuilt](https://github.com/apache/doris-thirdparty/releases/tag/automation). Refer to the command below: 
 
-```Bash
+```shell
 cd thirdparty
 rm -rf installed
 

--- a/docs/install/source-install/compilation-with-docker.md
+++ b/docs/install/source-install/compilation-with-docker.md
@@ -38,7 +38,7 @@ Currently, this is not supported in the compute-storage decoupled mode.
 
 In CentOS, execute the following command: 
 
-```Bash
+```shell
 yum install docker
 ```
 
@@ -57,7 +57,7 @@ For different versions of Doris, you need to download different build images. Th
 
 Take Doris 2.0 as an example, download and check the correponding Docker image.
 
-```Bash
+```shell
 # Choose docker.io/apache/doris:build-env-for-2.0
 $ docker pull apache/doris:build-env-for-2.0
 
@@ -75,7 +75,7 @@ apache/doris    build-env-for-2.0    f29cf1979dba    3 days ago    3.3GB
 - For information about changes in the compilation image, please see [ChangeLog](https://github.com/apache/doris/blob/master/thirdparty/CHANGELOG.md).
 - The Docker compilation image includes both JDK 8 and JDK 17. You can check the default JDK version by running `java -version`, and switch between versions using the following commands. For versions earlier than 2.1 (inclusive), please use JDK 8. For versions later than 3.0 (inclusive) or the master branch, please use JDK 17.
 
-```Bash
+```shell
 # Switch to JDK 8
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0
 export PATH=$JAVA_HOME/bin/:$PATH

--- a/docs/install/source-install/compilation-with-ldb-toolchain.md
+++ b/docs/install/source-install/compilation-with-ldb-toolchain.md
@@ -118,7 +118,7 @@ The first step of compiling Doris source code is to first download third-party l
 
 1. **Enter the Doris source code directory and execute the following command to check if the compilation machine supports the AVX2 instruction set.**
 
-```Bash
+```shell
 $ cat /proc/cpuinfo | grep avx2
 ```
 

--- a/docs/lakehouse/database/es.md
+++ b/docs/lakehouse/database/es.md
@@ -120,7 +120,7 @@ For example, suppose there is an index `doc` containing the following data struc
 The array fields of this structure can be defined by using the following command to add the field property definition 
 to the `_meta.doris` property of the target index mapping.
 
-```bash
+```shell
 # ES 7.x and above
 curl -X PUT "localhost:9200/doc/_mapping?pretty" -H 'Content-Type:application/json' -d '
 {

--- a/docs/query/query-analysis/import-analysis.md
+++ b/docs/query/query-analysis/import-analysis.md
@@ -45,7 +45,7 @@ The execution process of a [Broker Load](../../data-operate/import/broker-load-m
 ┌────────────────┐
 │BrokerScanNode│
 └────────────────┘
-````
+```
 
 BrokerScanNode is mainly responsible for reading the source data and sending it to OlapTableSink, and OlapTableSink is responsible for sending data to the corresponding node according to the partition and bucketing rules, and the corresponding node is responsible for the actual data writing.
 
@@ -59,7 +59,7 @@ The user can open the session variable `is_report_success` with the following co
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Then submit a Broker Load import request and wait until the import execution completes. Doris will generate a Profile for this import. Profile contains the execution details of importing each subtask and Instance, which helps us analyze import bottlenecks.
 
@@ -105,7 +105,7 @@ WaitAndFetchResultTime: NULL
        FetchResultTime: 0ns
        WriteResultTime: 0ns
 WaitAndFetchResultTime: N/A
-````
+```
 
 This command will list all currently saved import profiles. Each line corresponds to one import. where the QueryId column is the ID of the import job. This ID can also be viewed through the SHOW LOAD statement. We can select the QueryId corresponding to the Profile we want to see to see the specific situation.
 
@@ -124,7 +124,7 @@ This command will list all currently saved import profiles. Each line correspond
    +-----------------------------------+------------+
    | 980014623046410a-af5d36f23381017f | 3m14s      |
    +-----------------------------------+------------+
-   ````
+   ```
 
 As shown in the figure above, it means that the import job `980014623046410a-af5d36f23381017f` has a total of one subtask, in which ActiveTime indicates the execution time of the longest instance in this subtask.
 
@@ -144,7 +144,7 @@ As shown in the figure above, it means that the import job `980014623046410a-af5
    | 980014623046410a-88e260f0c43031f4 | 10.81.85.89:9067 | 3m10s      |
    | 980014623046410a-88e260f0c43031f5 | 10.81.85.89:9067 | 3m14s      |
    +-----------------------------------+------------------+------------+
-   ````
+   ```
 
 This shows the time-consuming of four instances of the subtask 980014623046410a-af5d36f23381017f, and also shows the execution node where the instance is located.
 
@@ -195,7 +195,7 @@ This shows the time-consuming of four instances of the subtask 980014623046410a-
    │ - TotalReadThroughput: 30.39858627319336 MB/sec│
    │ - WaitScannerTime: 56s528ms │
    └------------------------------------------------- ----┘
-   ````
+   ```
 
 The figure above shows the specific profiles of each operator of Instance 980014623046410a-af5d36f23381017f in subtask 980014623046410a-88e260f0c43031f5.
 

--- a/docs/query/query-analysis/query-analytics.md
+++ b/docs/query/query-analysis/query-analytics.md
@@ -37,7 +37,7 @@ For example, if the user specifies a Join operator, the query planner needs to d
 
 Doris' query planning process is to first convert an SQL statement into a single-machine execution plan tree.
 
-````text
+```text
      ┌────┐
      │Sort│
      └────┘
@@ -53,11 +53,11 @@ Doris' query planning process is to first convert an SQL statement into a single
 ┌──────┐ ┌──────┐
 │Scan-1│ │Scan-2│
 └──────┘ └──────┘
-````
+```
 
 After that, the query planner will convert the single-machine query plan into a distributed query plan according to the specific operator execution mode and the specific distribution of data. The distributed query plan is composed of multiple fragments, each fragment is responsible for a part of the query plan, and the data is transmitted between the fragments through the ExchangeNode operator.
 
-````text
+```text
         ┌────┐
         │Sort│
         │F1 │
@@ -87,7 +87,7 @@ After that, the query planner will convert the single-machine query plan into a 
             │Scan-2│
             │F2 │
             └──────┘
-````
+```
 
 As shown above, we divided the stand-alone plan into two Fragments: F1 and F2. Data is transmitted between two Fragments through an ExchangeNode.
 
@@ -472,7 +472,7 @@ The user can open the session variable `is_report_success` with the following co
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Then execute the query, and Doris will generate a Profile of the query. Profile contains the specific execution of a query for each node, which helps us analyze query bottlenecks.
 
@@ -490,7 +490,7 @@ mysql> show query profile "/"\G
    EndTime: 2021-04-08 11:30:50
  TotalTime: 9ms
 QueryState: EOF
-````
+```
 
 This command will list all currently saved profiles. Each row corresponds to a query. We can select the QueryId corresponding to the Profile we want to see to see the specific situation.
 
@@ -669,7 +669,7 @@ This shows the execution nodes and time consumption of all three Instances on Fr
    │ - RowsReturnedRate: 0 │
    │ - SendersBlockedTotalTimer(*): 0ns │
    └────────────────────────────────────────────────────┘
-   ````
+   ```
 
    The above figure shows the specific profiles of each operator of Instance c257c52f93e149ee-ace8ac14e8c9ff03 in Fragment 1.
 

--- a/docs/query/query-variables/variables.md
+++ b/docs/query/query-variables/variables.md
@@ -587,19 +587,19 @@ Note that the comment must start with /*+ and can only follow the SELECT.
 
 	Default password expiration time. The default value is 0, which means no expiration. The unit is days. This parameter is only enabled if the user's password expiration property has a value of DEFAULT. like:
 
-   ````
+   ```
    CREATE USER user1 IDENTIFIED BY "12345" PASSWORD_EXPIRE DEFAULT;
    ALTER USER user1 PASSWORD_EXPIRE DEFAULT;
-   ````
+   ```
 
 * `password_history`
 
 	The default number of historical passwords. The default value is 0, which means no limit. This parameter is enabled only when the user's password history attribute is the DEFAULT value. like:
 
-   ````
+   ```
    CREATE USER user1 IDENTIFIED BY "12345" PASSWORD_HISTORY DEFAULT;
    ALTER USER user1 PASSWORD_HISTORY DEFAULT;
-   ````
+   ```
 
 * `validate_password_policy`
 

--- a/docs/sql-manual/sql-statements/Account-Management-Statements/CREATE-ROLE.md
+++ b/docs/sql-manual/sql-statements/Account-Management-Statements/CREATE-ROLE.md
@@ -36,7 +36,7 @@ The statement user creates a role
 
 ```sql
   CREATE ROLE role_name [comment];
-````
+```
 
 This statement creates an unprivileged role, which can be subsequently granted with the GRANT command.
 
@@ -46,7 +46,7 @@ This statement creates an unprivileged role, which can be subsequently granted w
 
     ```sql
     CREATE ROLE role1;
-    ````
+    ```
 
 2. Create a role with comment
 

--- a/docs/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
+++ b/docs/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
@@ -32,7 +32,7 @@ The statement user removes a role
 
 ```sql
   DROP ROLE [IF EXISTS] role1;
-````
+```
 
 Deleting a role does not affect the permissions of users who previously belonged to the role. It is only equivalent to decoupling the role from the user. The permissions that the user has obtained from the role will not change
 
@@ -42,7 +42,7 @@ Deleting a role does not affect the permissions of users who previously belonged
 
 ```sql
 DROP ROLE role1;
-````
+```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Account-Management-Statements/DROP-USER.md
+++ b/docs/sql-manual/sql-statements/Account-Management-Statements/DROP-USER.md
@@ -41,7 +41,7 @@ Delete a user
     
          user@'host'
          user@['domain']
-````
+```
 
   Delete the specified user identitiy.
 
@@ -51,7 +51,7 @@ Delete a user
 
     ```sql
     DROP USER 'jack'@'192.%'
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
+++ b/docs/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
@@ -47,7 +47,7 @@ GRANT privilege_list ON priv_level TO user_identity [ROLE role_name]
 GRANT privilege_list ON RESOURCE resource_name TO user_identity [ROLE role_name]
 
 GRANT role_list TO user_identity
-````
+```
 
 GRANT privilege_list ON WORKLOAD GROUP workload_group_name TO user_identity [ROLE role_name]
 
@@ -105,67 +105,67 @@ role_list is the list of roles to be assigned, separated by commas,the specified
 
    ```sql
    GRANT SELECT_PRIV ON *.*.* TO 'jack'@'%';
-   ````
+   ```
 
 2. Grant permissions to the specified database table to the user
 
    ```sql
    GRANT SELECT_PRIV,ALTER_PRIV,LOAD_PRIV ON ctl1.db1.tbl1 TO 'jack'@'192.8.%';
-   ````
+   ```
 
 3. Grant permissions to the specified database table to the role
 
    ```sql
    GRANT LOAD_PRIV ON ctl1.db1.* TO ROLE 'my_role';
-   ````
+   ```
 
 4. Grant access to all resources to users
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE * TO 'jack'@'%';
-   ````
+   ```
 
 5. Grant the user permission to use the specified resource
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE 'spark_resource' TO 'jack'@'%';
-   ````
+   ```
 
 6. Grant access to specified resources to roles
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE 'spark_resource' TO ROLE 'my_role';
-   ````
+   ```
 
 7. Grant the specified role to a user
 
     ```sql
     GRANT 'role1','role2' TO 'jack'@'%';
-    ````
+    ```
 
 8. Grant the specified workload group 'g1' to user jack
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO 'jack'@'%'.
-    ````
+    ```
 
 9. match all workload groups granted to user jack
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP '%' TO 'jack'@'%'.
-    ````
+    ```
 
 10. grant the workload group 'g1' to the role my_role
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO ROLE 'my_role'.
-    ````
+    ```
 
 11. Allow jack to view the creation statement of view1 under db1
 
     ```sql
     GRANT SHOW_VIEW_PRIV ON db1.view1 TO 'jack'@'%';
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Account-Management-Statements/LDAP.md
+++ b/docs/sql-manual/sql-statements/Account-Management-Statements/LDAP.md
@@ -36,7 +36,7 @@ SET LDAP_ADMIN_PASSWORD
 
 ```sql
   SET LDAP_ADMIN_PASSWORD = PASSWORD('plain password')
-````
+```
 
   The SET LDAP_ADMIN_PASSWORD command is used to set the LDAP administrator password. When using LDAP authentication, doris needs to use the administrator account and password to query the LDAP service for login user information.
 
@@ -46,7 +46,7 @@ SET LDAP_ADMIN_PASSWORD
 
 ```sql
 SET LDAP_ADMIN_PASSWORD = PASSWORD('123456')
-````
+```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Account-Management-Statements/REVOKE.md
+++ b/docs/sql-manual/sql-statements/Account-Management-Statements/REVOKE.md
@@ -47,7 +47,7 @@ REVOKE privilege_list ON db_name[.tbl_name] FROM user_identity [ROLE role_name]
 REVOKE privilege_list ON RESOURCE resource_name FROM user_identity [ROLE role_name]
 
 REVOKE role_list FROM user_identity
-````
+```
 
 user_identity:
 
@@ -63,13 +63,13 @@ role_list is the list of roles to be revoked, separated by commas. The specified
 
     ```sql
     REVOKE SELECT_PRIV ON db1.* FROM 'jack'@'192.%';
-    ````
+    ```
 
 2. Revoke user jack resource spark_resource permission
 
     ```sql
     REVOKE USAGE_PRIV ON RESOURCE 'spark_resource' FROM 'jack'@'192.%';
-    ````
+    ```
 3. Revoke the roles role1 and role2 previously granted to jack
 
     ```sql

--- a/docs/sql-manual/sql-statements/Account-Management-Statements/SET-PASSWORD.md
+++ b/docs/sql-manual/sql-statements/Account-Management-Statements/SET-PASSWORD.md
@@ -37,7 +37,7 @@ The SET PASSWORD command can be used to modify a user's login password. If the [
 ```sql
 SET PASSWORD [FOR user_identity] =
     [PASSWORD('plain password')]|['hashed password']
-````
+```
 
 Note that the user_identity here must exactly match the user_identity specified when creating a user with CREATE USER, otherwise an error will be reported that the user does not exist. If user_identity is not specified, the current user is 'username'@'ip', which may not match any user_identity. Current users can be viewed through SHOW GRANTS.
 
@@ -51,14 +51,14 @@ To modify the passwords of other users, administrator privileges are required.
    ```sql
    SET PASSWORD = PASSWORD('123456')
    SET PASSWORD = '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9'
-   ````
+   ```
 
 2. Modify the specified user password
 
    ```sql
    SET PASSWORD FOR 'jack'@'192.%' = PASSWORD('123456')
    SET PASSWORD FOR 'jack'@['domain'] = '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9'
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Account-Management-Statements/SET-PROPERTY.md
+++ b/docs/sql-manual/sql-statements/Account-Management-Statements/SET-PROPERTY.md
@@ -72,7 +72,7 @@ Super user privileges:
 
    ```sql
    SET PROPERTY FOR 'jack' 'max_query_instances' = '3000';
-   ````
+   ```
 
 3. Modify the sql block rule of user jack
 
@@ -84,7 +84,7 @@ Super user privileges:
 
     ```sql
     SET PROPERTY FOR 'jack' 'cpu_resource_limit' = '2';
-    ````
+    ```
 
 5. Modify the user's resource tag permissions
 

--- a/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
+++ b/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 -- Add nodes (add this method if you do not use the multi-tenancy function)
    ALTER SYSTEM ADD BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
  illustrate:
 
@@ -53,7 +53,7 @@ grammar:
 
     ```sql
     ALTER SYSTEM ADD BACKEND "host:port";
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BROKER.md
+++ b/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BROKER.md
@@ -39,7 +39,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host2:broker_ipc_port2",...;
-````
+```
 
 ### Example
 
@@ -47,7 +47,7 @@ ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host
 
     ```sql
      ALTER SYSTEM ADD BROKER "host1:port", "host2:port";
-    ````
+    ```
 2. When fe enable fqdn([fqdn](../../../admin-manual/cluster-management/fqdn.md)),add one Broker
 
    ```sql

--- a/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-FOLLOWER.md
+++ b/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-FOLLOWER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD FOLLOWER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM ADD FOLLOWER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-OBSERVER.md
+++ b/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-OBSERVER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD OBSERVER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM ADD OBSERVER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DECOMMISSION-BACKEND.md
+++ b/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DECOMMISSION-BACKEND.md
@@ -40,13 +40,13 @@ grammar:
 
 ```sql
 ALTER SYSTEM DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM DECOMMISSION BACKEND "id1","id2"...;
-````
+```
 
   illustrate:
 
@@ -61,11 +61,11 @@ ALTER SYSTEM DECOMMISSION BACKEND "id1","id2"...;
 
     ```sql
     ALTER SYSTEM DECOMMISSION BACKEND "host1:port", "host2:port";
-    ````
+    ```
 
     ```sql
     ALTER SYSTEM DECOMMISSION BACKEND "id1", "id2";
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BACKEND.md
+++ b/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BACKEND.md
@@ -40,12 +40,12 @@ grammar:
 
 ```sql
 ALTER SYSTEM DROP BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...]
-````
+```
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM DROP BACKEND "id1","id2"...;
-````
+```
 
 illustrate:
 
@@ -59,11 +59,11 @@ illustrate:
 
     ```sql
     ALTER SYSTEM DROP BACKEND "host1:port", "host2:port";
-    ````
+    ```
 
     ```sql
     ALTER SYSTEM DROP BACKEND "ids1", "ids2";
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BROKER.md
+++ b/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BROKER.md
@@ -42,7 +42,7 @@ grammar:
 ALTER SYSTEM DROP ALL BROKER broker_name
 -- Delete a Broker node
 ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
-````
+```
 
 ### Example
 
@@ -50,13 +50,13 @@ ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
 
     ```sql
     ALTER SYSTEM DROP ALL BROKER broker_name
-    ````
+    ```
 
 2. Delete a Broker node
 
     ```sql
     ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-OBSERVER.md
+++ b/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-OBSERVER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM DROP OBSERVER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM DROP OBSERVER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
+++ b/docs/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
@@ -41,13 +41,13 @@ grammar:
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
-````
+```
 
   illustrate:
 
@@ -69,32 +69,32 @@ Note:
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("tag.location" = "group_a");
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a");
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-    ````
+    ```
 
 2. Modify the query disable property of BE
 
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("disable_query" = "true");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_query" = "true");
-    ````
+    ```
 
 3. Modify the import disable property of BE
 
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("disable_load" = "true");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_load" = "true");
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Cluster-Management-Statements/CANCEL-ALTER-SYSTEM.md
+++ b/docs/sql-manual/sql-statements/Cluster-Management-Statements/CANCEL-ALTER-SYSTEM.md
@@ -40,13 +40,13 @@ grammar:
 
 ```sql
 CANCEL DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 CANCEL DECOMMISSION BACKEND "id1","id2","id3...";
-````
+```
 
 ### Example
 
@@ -54,7 +54,7 @@ CANCEL DECOMMISSION BACKEND "id1","id2","id3...";
 
       ```sql
       CANCEL DECOMMISSION BACKEND "host1:port", "host2:port";
-      ````
+      ```
 
  2. Cancel the offline operation of the node with backend_id 1:
     

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-SQL-BLOCK-RULE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-SQL-BLOCK-RULE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 ALTER SQL_BLOCK_RULE rule_name
 [PROPERTIES ("key"="value", ...)];
-````
+```
 
 illustrate:
 
@@ -52,18 +52,18 @@ illustrate:
 
 ```sql
 ALTER SQL_BLOCK_RULE test_rule PROPERTIES("sql"="select \\* from test_table","enable"="true")
-````
+```
 
 2. If a rule sets partition_num, then sql or sqlHash cannot be modified
 
 ```sql
 ALTER SQL_BLOCK_RULE test_rule2 PROPERTIES("partition_num" = "10","tablet_num"="300","enable"="true")
-````
+```
 
 ### Keywords
 
-````text
+```text
 ALTER,SQL_BLOCK_RULE
-````
+```
 
 ### Best Practice

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
@@ -172,7 +172,7 @@ ALTER TABLE example_db.mysql_table SET ("replication_num" = "2");
 ALTER TABLE example_db.mysql_table SET ("default.replication_num" = "2");
 ALTER TABLE example_db.mysql_table SET ("replication_allocation" = "tag.location.default: 1");
 ALTER TABLE example_db.mysql_table SET ("default.replication_allocation" = "tag.location.default: 1");
-````
+```
 
 Note:
 1. The property with the default prefix indicates the default replica distribution for the modified table. This modification does not modify the current actual replica distribution of the table, but only affects the replica distribution of newly created partitions on the partitioned table.

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-DATABASE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-DATABASE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 CREATE DATABASE [IF NOT EXISTS] db_name
     [PROPERTIES ("key"="value", ...)];
-````
+```
 
 `PROPERTIES` Additional information about the database, which can be defaulted.
 
@@ -57,7 +57,7 @@ CREATE DATABASE [IF NOT EXISTS] db_name
 
    ```sql
    CREATE DATABASE db_test;
-   ````
+   ```
 
 2. Create a new database with default replica distribution:
 
@@ -66,7 +66,7 @@ CREATE DATABASE [IF NOT EXISTS] db_name
    PROPERTIES (
        "replication_allocation" = "tag.location.group_1:3"
    );
-   ````
+   ```
 
 :::caution
 If the create table statement has attributes replication_allocation or replication_num, then the default replica distribution policy of the database will not take effect.
@@ -74,9 +74,9 @@ If the create table statement has attributes replication_allocation or replicati
 
 ### Keywords
 
-````text
+```text
 CREATE, DATABASE
-````
+```
 
 ### Best Practice
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-ENCRYPT-KEY.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-ENCRYPT-KEY.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 CREATE ENCRYPTKEY key_name AS "key_string"
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ If `key_name` contains the database name, then the custom key will be created in
 
    ```sql
    CREATE ENCRYPTKEY my_key AS "ABCD123456789";
-   ````
+   ```
 
 2. Use a custom key
 
@@ -76,7 +76,7 @@ If `key_name` contains the database name, then the custom key will be created in
    | Doris is Great |
    +------------------------------------------------- -------------------+
    1 row in set (0.01 sec)
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FILE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FILE.md
@@ -46,7 +46,7 @@ grammar:
 ```sql
 CREATE FILE "file_name" [IN database]
 PROPERTIES("key"="value", ...)
-````
+```
 
 illustrate:
 
@@ -68,7 +68,7 @@ illustrate:
        "url" = "https://test.bj.bcebos.com/kafka-key/ca.pem",
        "catalog" = "kafka"
    );
-   ````
+   ```
 
 2. Create a file client.key, classified as my_catalog
 
@@ -81,13 +81,13 @@ illustrate:
        "catalog" = "my_catalog",
        "md5" = "b5bb901bf10f99205b39a46ac3557dd9"
    );
-   ````
+   ```
 
 ### Keywords
 
-````text
+```text
 CREATE, FILE
-````
+```
 
 ### Best Practice
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
@@ -45,7 +45,7 @@ CREATE [GLOBAL] [AGGREGATE] [ALIAS] FUNCTION function_name
     [INTERMEDIATE inter_type]
     [WITH PARAMETER(param [,...]) AS origin_function]
     [PROPERTIES ("key" = "value" [, ...]) ]
-````
+```
 
 Parameter Description:
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-INDEX.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-INDEX.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 CREATE INDEX [IF NOT EXISTS] index_name ON table_name (column [, ...],) [USING INVERTED] [COMMENT 'balabala'];
-````
+```
 Notice:
 - INVERTED indexes are only created on a single column
 
@@ -47,14 +47,14 @@ Notice:
 
     ```sql
     CREATE INDEX [IF NOT EXISTS] index_name ON table1 (siteid) USING INVERTED COMMENT 'balabala';
-    ````
+    ```
 
 
 ### Keywords
 
-````text
+```text
 CREATE, INDEX
-````
+```
 
 ### Best Practice
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-MATERIALIZED-VIEW.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-MATERIALIZED-VIEW.md
@@ -41,7 +41,7 @@ grammar:
 ```sql
 CREATE MATERIALIZED VIEW < MV name > as < query >
 [PROPERTIES ("key" = "value")]
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ illustrate:
   FROM [Base view name]
   GROUP BY column_name[, column_name ...]
   ORDER BY column_name[, column_name ...]
-  ````
+  ```
 
   The syntax is the same as the query syntax.
 
@@ -73,16 +73,16 @@ illustrate:
 
   Declare some configuration of the materialized view, optional.
 
-  ````text
+  ```text
   PROPERTIES ("key" = "value", "key" = "value" ...)
-  ````
+  ```
 
   The following configurations can be declared here:
 
-  ````text
+  ```text
    short_key: The number of sorting columns.
    timeout: The timeout for materialized view construction.
-  ````
+  ```
 
 ### Example
 
@@ -98,7 +98,7 @@ mysql> desc duplicate_table;
 | k3 | BIGINT | Yes | true | N/A | |
 | k4 | BIGINT | Yes | true | N/A | |
 +-------+--------+------+------+---------+-------+
-````
+```
 ```sql
 create table duplicate_table(
 	k1 int null,
@@ -117,49 +117,49 @@ attention：If the materialized view contains partitioned and distributed column
    ```sql
    create materialized view k2_k1 as
    select k2, k1 from duplicate_table;
-   ````
+   ```
 
    The schema of the materialized view is as follows, the materialized view contains only two columns k1, k2 without any aggregation
 
-   ````text
+   ```text
    +-------+-------+--------+------+------+ ---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------+ ---------+-------+
    | k2_k1 | k2 | INT | Yes | true | N/A | |
    | | k1 | INT | Yes | true | N/A | |
    +-------+-------+--------+------+------+ ---------+-------+
-   ````
+   ```
 
 2. Create a materialized view with k2 as the sort column
 
    ```sql
    create materialized view k2_order as
    select k2, k1 from duplicate_table order by k2;
-   ````
+   ```
 
    The schema of the materialized view is shown in the figure below. The materialized view contains only two columns k2, k1, where k2 is the sorting column without any aggregation.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
    | k2_order | k2 | INT | Yes | true | N/A | |
    | | k1 | INT | Yes | false | N/A | NONE |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 3. Create a materialized view with k1, k2 grouping and k3 column aggregated by SUM
 
    ```sql
    create materialized view k1_k2_sumk3 as
    select k1, k2, sum(k3) from duplicate_table group by k1, k2;
-   ````
+   ```
 
    The schema of the materialized view is shown in the figure below. The materialized view contains two columns k1, k2, sum(k3) where k1, k2 are the grouping columns, and sum(k3) is the sum value of the k3 column grouped by k1, k2.
 
    Since the materialized view does not declare a sorting column, and the materialized view has aggregated data, the system defaults to supplement the grouping columns k1 and k2 as sorting columns.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
@@ -167,18 +167,18 @@ attention：If the materialized view contains partitioned and distributed column
    | | k2 | INT | Yes | true | N/A | |
    | | k3 | BIGINT | Yes | false | N/A | SUM |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 4. Create a materialized view that removes duplicate rows
 
    ```sql
    create materialized view deduplicate as
    select k1, k2, k3, k4 from duplicate_table group by k1, k2, k3, k4;
-   ````
+   ```
 
    The materialized view schema is as shown below. The materialized view contains columns k1, k2, k3, and k4, and there are no duplicate rows.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
@@ -187,13 +187,13 @@ attention：If the materialized view contains partitioned and distributed column
    | | k3 | BIGINT | Yes | true | N/A | |
    | | k4 | BIGINT | Yes | true | N/A | |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 5. Create a non-aggregate materialized view that does not declare a sort column
 
    The schema of all_type_table is as follows
 
-   ````
+   ```
    +-------+--------------+------+-------+---------+- ------+
    | Field | Type | Null | Key | Default | Extra |
    +-------+--------------+------+-------+---------+- ------+
@@ -205,14 +205,14 @@ attention：If the materialized view contains partitioned and distributed column
    | k6 | DOUBLE | Yes | false | N/A | NONE |
    | k7 | VARCHAR(20) | Yes | false | N/A | NONE |
    +-------+--------------+------+-------+---------+- ------+
-   ````
+   ```
 
    The materialized view contains k3, k4, k5, k6, k7 columns, and does not declare a sort column, the creation statement is as follows:
 
    ```sql
    create materialized view mv_1 as
    select k3, k4, k5, k6, k7 from all_type_table;
-   ````
+   ```
 
    The default added sorting column of the system is k3, k4, k5 three columns. The sum of the bytes of these three column types is 4(INT) + 8(BIGINT) + 16(DECIMAL) = 28 < 36. So the addition is that these three columns are used as sorting columns. The schema of the materialized view is as follows, you can see that the key field of the k3, k4, k5 columns is true, that is, the sorting column. The key field of the k6, k7 columns is false, which is a non-sorted column.
 
@@ -226,7 +226,7 @@ attention：If the materialized view contains partitioned and distributed column
    | | k6 | DOUBLE | Yes | false | N/A | NONE |
    | | k7 | VARCHAR(20) | Yes | false | N/A | NONE |
    +----------------+-------+--------------+------+-- -----+---------+-------+
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-RESOURCE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-RESOURCE.md
@@ -40,7 +40,7 @@ grammar:
 ```sql
 CREATE [EXTERNAL] RESOURCE "resource_name"
 PROPERTIES ("key"="value", ...);
-````
+```
 
 illustrate:
 
@@ -69,7 +69,7 @@ illustrate:
      "broker.username" = "user0",
      "broker.password" = "password0"
    );
-   ````
+   ```
 
    Spark related parameters are as follows:
    - spark.master: Required, currently supports yarn, spark://host:port.
@@ -100,7 +100,7 @@ illustrate:
    "odbc_type" = "oracle",
    "driver" = "Oracle 19 ODBC driver"
    );
-   ````
+   ```
 
    The relevant parameters of ODBC are as follows:
    - hosts: IP address of the external database

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-SQL-BLOCK-RULE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-SQL-BLOCK-RULE.md
@@ -45,7 +45,7 @@ grammar:
 ```sql
 CREATE SQL_BLOCK_RULE rule_name
 [PROPERTIES ("key"="value", ...)];
-````
+```
 
 Parameter Description:
 
@@ -68,7 +68,7 @@ Parameter Description:
     "global"="false",
     "enable"="true"
     );
-    ````
+    ```
 
     >Notes:
     >
@@ -79,7 +79,7 @@ Parameter Description:
     ```sql
     select * from order_analysis;
     ERROR 1064 (HY000): errCode = 2, detailMessage = sql match regex sql block rule: order_analysis_rule
-    ````
+    ```
 
 
 2. Create test_rule2, limit the maximum number of scanned partitions to 30, and limit the maximum scan base to 10 billion rows. The example is as follows:
@@ -92,7 +92,7 @@ Parameter Description:
     "global" = "false",
     "enable" = "true"
     );
-   ````
+   ```
 3. Create SQL BLOCK RULE with special chars
 
     ```sql
@@ -150,9 +150,9 @@ Here are some commonly used regular expressions:
 
 ### Keywords
 
-````text
+```text
 CREATE, SQL_BLCOK_RULE
-````
+```
 
 ### Best Practice
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE-LIKE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE-LIKE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 CREATE [EXTERNAL] TABLE [IF NOT EXISTS] [database.]table_name LIKE [database.]table_name [WITH ROLLUP (r1,r2,r3,...)]
-````
+```
 
 illustrate: 
 
@@ -53,43 +53,43 @@ illustrate:
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1
-    ````
+    ```
 
 2. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1
-    ````
+    ```
 
 3. Create an empty table with the same table structure as table1 under the test1 library, the table name is table2, and copy the two rollups of r1 and r2 of table1 at the same time
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1 WITH ROLLUP (r1,r2)
-    ````
+    ```
 
 4. Create an empty table with the same table structure as table1 under the test1 library, the table name is table2, and copy all the rollups of table1 at the same time
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1 WITH ROLLUP
-    ````
+    ```
 
 5. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2, and copy the two rollups of r1 and r2 of table1 at the same time
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1 WITH ROLLUP (r1,r2)
-    ````
+    ```
 
 6. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2, and copy all the rollups of table1 at the same time
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1 WITH ROLLUP
-    ````
+    ```
 
 7. Create an empty table under the test1 library with the same table structure as the MySQL outer table1, the table name is table2
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-VIEW.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-VIEW.md
@@ -40,7 +40,7 @@ CREATE VIEW [IF NOT EXISTS]
  [db_name.]view_name
  (column1[ COMMENT "col comment"][, column2, ...])
 AS query_stmt
-````
+```
 
 
 illustrate:
@@ -57,7 +57,7 @@ illustrate:
     AS
     SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table
     WHERE k1 = 20160112 GROUP BY k1,k2,k3;
-    ````
+    ```
     
 2. Create a view with a comment
 
@@ -73,7 +73,7 @@ illustrate:
     AS
     SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table
     WHERE k1 = 20160112 GROUP BY k1,k2,k3;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-DATABASE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-DATABASE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP DATABASE [IF EXISTS] db_name [FORCE];
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
    
      ```sql
      DROP DATABASE db_test;
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-ENCRYPT-KEY.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-ENCRYPT-KEY.md
@@ -36,7 +36,7 @@ grammar:
 
 ```sql
 DROP ENCRYPTKEY key_name
-````
+```
 
 Parameter Description:
 
@@ -52,7 +52,7 @@ Executing this command requires the user to have `ADMIN` privileges.
 
     ```sql
     DROP ENCRYPTKEY my_key;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FILE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FILE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 DROP FILE "file_name" [FROM database]
 [properties]
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ illustrate:
 
      ```sql
      DROP FILE "ca.pem" properties("catalog" = "kafka");
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 DROP [GLOBAL] FUNCTION function_name
      (arg_type [, ...])
-````
+```
 
 Parameter Description:
 
@@ -52,12 +52,12 @@ Parameter Description:
 
     ```sql
     DROP FUNCTION my_add(INT, INT)
-    ````
+    ```
 2. Delete a global function
 
     ```sql
     DROP GLOBAL FUNCTION my_add(INT, INT)
-    ````   
+    ```   
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-INDEX.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-INDEX.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP INDEX [IF EXISTS] index_name ON [db_name.]table_name;
-````
+```
 
 ### Example
 
@@ -45,7 +45,7 @@ DROP INDEX [IF EXISTS] index_name ON [db_name.]table_name;
 
     ```sql
     DROP INDEX [IF NOT EXISTS] index_name ON table1 ;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-MATERIALIZED-VIEW.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-MATERIALIZED-VIEW.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DROP MATERIALIZED VIEW [IF EXISTS] mv_name ON table_name;
-````
+```
 
 
 1. IF EXISTS:
@@ -70,17 +70,17 @@ mysql> desc all_type_table all;
 | k1_sumk2 | k1 | TINYINT | Yes | true | N/A | |
 | | k2 | SMALLINT | Yes | false | N/A | SUM |
 +----------------+-------+----------+------+------ -+---------+-------+
-````
+```
 
 1. Drop the materialized view named k1_sumk2 of the table all_type_table
 
    ```sql
    drop materialized view k1_sumk2 on all_type_table;
-   ````
+   ```
 
    The table structure after the materialized view is deleted
 
-   ````text
+   ```text
    +----------------+-------+----------+------+------ -+---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +----------------+-------+----------+------+------ -+---------+-------+
@@ -92,14 +92,14 @@ mysql> desc all_type_table all;
    | | k6 | FLOAT | Yes | false | N/A | NONE |
    | | k7 | DOUBLE | Yes | false | N/A | NONE |
    +----------------+-------+----------+------+------ -+---------+-------+
-   ````
+   ```
 
 2. Drop a non-existent materialized view in the table all_type_table
 
    ```sql
    drop materialized view k1_k2 on all_type_table;
    ERROR 1064 (HY000): errCode = 2, detailMessage = Materialized view [k1_k2] does not exist in table [all_type_table]
-   ````
+   ```
 
    The delete request reports an error directly
 
@@ -108,7 +108,7 @@ mysql> desc all_type_table all;
    ```sql
    drop materialized view if exists k1_k2 on all_type_table;
    Query OK, 0 rows affected (0.00 sec)
-   ````
+   ```
 
     If it exists, delete it, if it does not exist, no error is reported.
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-RESOURCE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-RESOURCE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP RESOURCE 'resource_name'
-````
+```
 
 Note: ODBC/S3 resources in use cannot be deleted.
 
@@ -47,7 +47,7 @@ Note: ODBC/S3 resources in use cannot be deleted.
    
      ```sql
      DROP RESOURCE 'spark0';
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-SQL-BLOCK-RULE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-SQL-BLOCK-RULE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DROP SQL_BLOCK_RULE test_rule1,...
-````
+```
 
 ### Example
 
@@ -47,12 +47,12 @@ DROP SQL_BLOCK_RULE test_rule1,...
     ```sql
     mysql> DROP SQL_BLOCK_RULE test_rule1,test_rule2;
     Query OK, 0 rows affected (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 
-````text
+```text
 DROP, SQL_BLOCK_RULE
-````
+```
 
 ### Best Practice

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-TABLE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-TABLE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP TABLE [IF EXISTS] [db_name.]table_name [FORCE];
-````
+```
 
 
 illustrate:
@@ -51,13 +51,13 @@ illustrate:
    
      ```sql
      DROP TABLE my_table;
-     ````
+     ```
     
 2. If it exists, delete the table of the specified database
    
      ```sql
      DROP TABLE IF EXISTS example_db.my_table;
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/TRUNCATE-TABLE.md
+++ b/docs/sql-manual/sql-statements/Data-Definition-Statements/Drop/TRUNCATE-TABLE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 TRUNCATE TABLE [db.]tbl[ PARTITION(p1, p2, ...)];
-````
+```
 
 illustrate:
 
@@ -54,13 +54,13 @@ illustrate:
 
      ```sql
      TRUNCATE TABLE example_db.tbl;
-     ````
+     ```
 
 2. Empty p1 and p2 partitions of table tbl
 
      ```sql
      TRUNCATE TABLE tbl PARTITION(p1, p2);
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/ALTER-ROUTINE-LOAD.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/ALTER-ROUTINE-LOAD.md
@@ -43,7 +43,7 @@ ALTER ROUTINE LOAD FOR [db.]job_name
 [job_properties]
 FROM data_source
 [data_source_properties]
-````
+```
 
 1. `[db.]job_name`
 
@@ -103,7 +103,7 @@ FROM data_source
    (
        "desired_concurrent_number" = "1"
    );
-   ````
+   ```
 
 2. Modify `desired_concurrent_number` to 10, modify the offset of the partition, and modify the group id.
 
@@ -119,7 +119,7 @@ FROM data_source
        "kafka_offsets" = "100, 200, 100",
        "property.group.id" = "new_group"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/BROKER-LOAD.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/BROKER-LOAD.md
@@ -76,7 +76,7 @@ WITH BROKER broker_name
   [DELETE ON expr]
   [ORDER BY source_sequence]
   [PROPERTIES ("key1"="value1", ...)]
-  ````
+  ```
 
   - `[MERGE|APPEND|DELETE]`
 
@@ -159,13 +159,13 @@ WITH BROKER broker_name
 
   Specifies the information required by the broker. This information is usually used by the broker to be able to access remote storage systems. Such as BOS or HDFS. See the [Broker](../../../../advanced/broker.md) documentation for specific information.
 
-  ````text
+  ```text
   (
       "key1" = "val1",
       "key2" = "val2",
       ...
   )
-  ````
+  ```
 
 - `load_properties`
 
@@ -232,7 +232,7 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    Import the file `file.txt`, separated by commas, into the table `my_table`.
 
@@ -260,7 +260,7 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    Import two batches of files `file-10*` and `file-20*` using wildcard matching. Imported into two tables `my_table1` and `my_table2` respectively. Where `my_table1` specifies to import into partition `p1`, and will import the values of the second and third columns in the source file +1.
 
@@ -283,7 +283,7 @@ WITH BROKER broker_name
        "dfs.namenode.rpc-address.my_ha.my_namenode2" = "nn2_host:rpc_port",
        "dfs.client.failover.proxy.provider.my_ha" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
    );
-   ````
+   ```
 
    Specify the delimiter as Hive's default delimiter `\\x01`, and use the wildcard * to specify all files in all directories under the `data` directory. Use simple authentication while configuring namenode HA.
 
@@ -302,7 +302,7 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
 5. Import the data and extract the partition field in the file path
 
@@ -320,18 +320,18 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    The columns in the `my_table` table are `k1, k2, k3, city, utc_date`.
 
    The `hdfs://hdfs_host:hdfs_port/user/doris/data/input/dir/city=beijing` directory includes the following files:
 
-   ````text
+   ```text
    hdfs://hdfs_host:hdfs_port/input/city=beijing/utc_date=2020-10-01/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=beijing/utc_date=2020-10-02/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=tianji/utc_date=2020-10-03/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=tianji/utc_date=2020-10-04/0000.csv
-   ````
+   ```
 
    The file only contains three columns of `k1, k2, k3`, and the two columns of `city, utc_date` will be extracted from the file path.
 
@@ -354,7 +354,7 @@ WITH BROKER broker_name
        "username"="user",
        "password"="pass"
    );
-   ````
+   ```
 
    Only in the original data, k1 = 1, and after transformation, rows with k1 > k2 will be imported.
 
@@ -377,22 +377,22 @@ WITH BROKER broker_name
        "username"="user",
        "password"="pass"
    );
-   ````
+   ```
 
    There are the following files in the path:
 
-   ````text
+   ```text
    /user/data/data_time=2020-02-17 00%3A00%3A00/test.txt
    /user/data/data_time=2020-02-18 00%3A00%3A00/test.txt
-   ````
+   ```
 
    The table structure is:
 
-   ````text
+   ```text
    data_time DATETIME,
    k2 INT,
    k3 INT
-   ````
+   ```
 
 8. Import a batch of data from HDFS, specify the timeout and filter ratio. Broker with clear text my_hdfs_broker. Simple authentication. And delete the columns in the original data that match the columns with v2 greater than 100 in the imported data, and other columns are imported normally
 
@@ -414,7 +414,7 @@ WITH BROKER broker_name
         "timeout" = "3600",
         "max_filter_ratio" = "0.1"
     );
-    ````
+    ```
 
    Import using the MERGE method. `my_table` must be a table with Unique Key. When the value of the v2 column in the imported data is greater than 100, the row is considered a delete row.
 
@@ -436,7 +436,7 @@ WITH BROKER broker_name
         "hadoop.username"="user",
         "password"="pass"
     )
-    ````
+    ```
 
    `my_table` must be an Unique Key model table with Sequence Col specified. The data will be ordered according to the value of the `source_sequence` column in the source data.
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CANCEL-LOAD.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CANCEL-LOAD.md
@@ -50,7 +50,7 @@ Notice: Cancel by State is supported since 1.2.0.
     CANCEL LOAD
     FROM example_db
     WHERE LABEL = "example_db_test_load_label";
-    ````
+    ```
 
 2. Cancel all import jobs containing example* on the database example*db.
 
@@ -58,7 +58,7 @@ Notice: Cancel by State is supported since 1.2.0.
     CANCEL LOAD
     FROM example_db
     WHERE LABEL like "example_";
-    ````
+    ```
 
 3. Cancel all import jobs which state are "LOADING"
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md
@@ -74,7 +74,7 @@ FROM data_source [data_source_properties]
 
   Used to describe imported data. The composition is as follows:
 
-  ````SQL
+  ```SQL
   [column_separator],
   [columns_mapping],
   [preceding_filter],
@@ -82,7 +82,7 @@ FROM data_source [data_source_properties]
   [partitions],
   [DELETE ON],
   [ORDER BY]
-  ````
+  ```
 
   - `column_separator`
 
@@ -138,12 +138,12 @@ FROM data_source [data_source_properties]
 
   Common parameters for specifying routine import jobs.
 
-  ````text
+  ```text
   PROPERTIES (
       "key1" = "val1",
       "key2" = "val2"
   )
-  ````
+  ```
 
   Currently we support the following parameters:
 
@@ -165,11 +165,11 @@ FROM data_source [data_source_properties]
 
      These three parameters are used to control the execution time and processing volume of a subtask. When either one reaches the threshold, the task ends.
 
-     ````text
+     ```text
      "max_batch_interval" = "20",
      "max_batch_rows" = "300000",
      "max_batch_size" = "209715200"
-     ````
+     ```
 
   3. `max_error_number`
 
@@ -270,13 +270,13 @@ FROM data_source [data_source_properties]
 
   The type of data source. Currently supports:
 
-  ````text
+  ```text
   FROM KAFKA
   (
       "key1" = "val1",
       "key2" = "val2"
   )
-  ````
+  ```
 
   `data_source_properties` supports the following data source properties:
 
@@ -304,15 +304,15 @@ FROM data_source [data_source_properties]
 
      If not specified, all partitions under topic will be subscribed from `OFFSET_END` by default.
 
-     ````text
+     ```text
      "kafka_partitions" = "0,1,2,3",
      "kafka_offsets" = "101,0,OFFSET_BEGINNING,OFFSET_END"
-     ````
+     ```
 
-     ````text
+     ```text
      "kafka_partitions" = "0,1,2,3",
      "kafka_offsets" = "2021-05-22 11:00:00,2021-05-22 11:00:00,2021-05-22 11:00:00"
-     ````
+     ```
 
      Note that the time format cannot be mixed with the OFFSET format.
 
@@ -326,20 +326,20 @@ FROM data_source [data_source_properties]
 
      For more supported custom parameters, please refer to the configuration items on the client side in the official CONFIGURATION document of librdkafka. Such as:
 
-     ````text
+     ```text
      "property.client.id" = "12345",
      "property.ssl.ca.location" = "FILE:ca.pem"
-     ````
+     ```
 
      1. When connecting to Kafka using SSL, you need to specify the following parameters:
 
-        ````text
+        ```text
         "property.security.protocol" = "ssl",
         "property.ssl.ca.location" = "FILE:ca.pem",
         "property.ssl.certificate.location" = "FILE:client.pem",
         "property.ssl.key.location" = "FILE:client.key",
         "property.ssl.key.password" = "abcdefg"
-        ````
+        ```
 
         in:
 
@@ -347,11 +347,11 @@ FROM data_source [data_source_properties]
 
         If client authentication is enabled on the Kafka server side, thenAlso set:
 
-        ````text
+        ```text
         "property.ssl.certificate.location"
         "property.ssl.key.location"
         "property.ssl.key.password"
-        ````
+        ```
 
         They are used to specify the client's public key, private key, and password for the private key, respectively.
 
@@ -363,9 +363,9 @@ FROM data_source [data_source_properties]
 
         Example:
 
-        ````text
+        ```text
         "property.kafka_default_offsets" = "OFFSET_BEGINNING"
-        ````
+        ```
 - comment
   Comment for the routine load job.
 ### Example
@@ -394,7 +394,7 @@ FROM data_source [data_source_properties]
        "property.client.id" = "xxx",
        "property.kafka_default_offsets" = "OFFSET_BEGINNING"
    );
-   ````
+   ```
 
 2. Create a Kafka routine dynamic multiple tables import task named "test1" for the "example_db". Specify the column delimiter, group.id, and client.id, and automatically consume all partitions, subscribing from the position with data (OFFSET_BEGINNING).
 
@@ -444,7 +444,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 4. Import data from the Kafka cluster through SSL authentication. Also set the client.id parameter. The import task is in non-strict mode and the time zone is Africa/Abidjan
 
@@ -474,7 +474,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "property.ssl.key.password" = "abcdefg",
        "property.client.id" = "my_client_id"
    );
-   ````
+   ```
 
 5. Import data in Json format. By default, the field name in Json is used as the column name mapping. Specify to import three partitions 0, 1, and 2, and the starting offsets are all 0
 
@@ -499,7 +499,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2",
        "kafka_offsets" = "0,0,0"
    );
-   ````
+   ```
 
 6. Import Json data, extract fields through Jsonpaths, and specify the root node of the Json document
 
@@ -527,7 +527,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2",
        "kafka_offsets" = "0,0,0"
    );
-   ````
+   ```
 
 7. Create a Kafka routine import task named test1 for example_tbl of example_db. And use conditional filtering.
 
@@ -554,7 +554,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 8. Import data to Unique with sequence column Key model table
 
@@ -578,7 +578,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 9. Consume from a specified point in time
 
@@ -598,7 +598,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_topic" = "my_topic",
        "kafka_default_offsets" = "2021-05-21 10:00:00"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-SYNC-JOB.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-SYNC-JOB.md
@@ -48,7 +48,7 @@ CREATE SYNC [db.]job_name
  ...
  )
 binlog_desc
-````
+```
 
 1. `job_name`
 
@@ -63,7 +63,7 @@ binlog_desc
    ```sql
    FROM mysql_db.src_tbl INTO des_tbl
    [columns_mapping]
-   ````
+   ```
    
    1. `mysql_db.src_tbl`
    
@@ -81,7 +81,7 @@ binlog_desc
    
       Example:
    
-      ````
+      ```
       Suppose the target table column is (k1, k2, v1),
       
       Change the order of columns k1 and k2
@@ -89,7 +89,7 @@ binlog_desc
       
       Ignore the fourth column of the source data
       (k2, k1, v1, dummy_column)
-      ````
+      ```
    
 3. `binlog_desc`
 
@@ -103,7 +103,7 @@ binlog_desc
        "key1" = "value1",
        "key2" = "value2"
    )
-   ````
+   ```
 
    1. The properties corresponding to the Canal data source, prefixed with `canal.`
 
@@ -119,7 +119,7 @@ binlog_desc
 
 1. Simply create a data synchronization job named `job1` for `test_tbl` of `test_db`, connect to the local Canal server, corresponding to the Mysql source table `mysql_db1.tbl1`.
 
-   ````SQL
+   ```SQL
    CREATE SYNC `test_db`.`job1`
    (
    FROM `mysql_db1`.`tbl1` INTO `test_tbl`
@@ -133,11 +133,11 @@ binlog_desc
    "canal.username" = "",
    "canal.password" = ""
    );
-   ````
+   ```
 
 2. Create a data synchronization job named `job1` for multiple tables of `test_db`, corresponding to multiple Mysql source tables one-to-one, and explicitly specify the column mapping.
 
-   ````SQL
+   ```SQL
    CREATE SYNC `test_db`.`job1`
    (
    FROM `mysql_db`.`t1` INTO `test1` (k1, k2, v1) ,
@@ -152,7 +152,7 @@ binlog_desc
    "canal.username" = "username",
    "canal.password" = "password"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/MULTI-LOAD.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/MULTI-LOAD.md
@@ -34,7 +34,7 @@ MULTI LOAD
 
 Users submit multiple import jobs through the HTTP protocol. Multi Load can ensure the atomic effect of multiple import jobs
 
-````
+```
 Syntax:
     curl --location-trusted -u user:passwd -XPOST http://host:port/api/{db}/_multi_start?label=xxx
     curl --location-trusted -u user:passwd -T data.file http://host:port/api/{db}/{table1}/_load?label=xxx\&sub_label=yyy
@@ -91,11 +91,11 @@ NOTE:
 
     3. Supports the use of curl to import data into Doris in a way similar to streaming, but only after the streaming ends Doris
     The real import behavior will occur, and the amount of data in this way cannot be too large.
-````
+```
 
 ### Example
 
-````
+```
 1. Import the data in the local file 'testData1' into the table 'testTbl1' in the database 'testDb', and
 Import the data of 'testData2' into table 'testTbl2' in 'testDb' (user is in defalut_cluster)
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_start?label=123
@@ -112,7 +112,7 @@ Import the data of 'testData2' into table 'testTbl2' in 'testDb' (user is in def
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_start?label=123
     curl --location-trusted -u root -T testData1 http://host:port/api/testDb/testTbl1/_load?label=123\&sub_label=1
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_desc?label=123
-````
+```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-ROUTINE-LOAD.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ Used to pause a Routine Load job. A suspended job can be rerun with the RESUME c
 
 ```sql
 PAUSE [ALL] ROUTINE LOAD FOR job_name
-````
+```
 
 ### Example
 
@@ -44,13 +44,13 @@ PAUSE [ALL] ROUTINE LOAD FOR job_name
 
     ```sql
     PAUSE ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 2. Pause all routine import jobs.
 
     ```sql
     PAUSE ALL ROUTINE LOAD;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-SYNC-JOB.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 PAUSE SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ PAUSE SYNC JOB [db.]job_name
 
     ```sql
     PAUSE SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-ROUTINE-LOAD.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ Used to restart a suspended Routine Load job. The restarted job will continue to
 
 ```sql
 RESUME [ALL] ROUTINE LOAD FOR job_name
-````
+```
 
 ### Example
 
@@ -44,13 +44,13 @@ RESUME [ALL] ROUTINE LOAD FOR job_name
 
     ```sql
     RESUME ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 2. Restart all routine import jobs.
 
     ```sql
     RESUME ALL ROUTINE LOAD;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-SYNC-JOB.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 RESUME SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ RESUME SYNC JOB [db.]job_name
 
     ```sql
     RESUME SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-ROUTINE-LOAD.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ User stops a Routine Load job. A stopped job cannot be rerun.
 
 ```sql
 STOP ROUTINE LOAD FOR job_name;
-````
+```
 
 ### Example
 
@@ -44,7 +44,7 @@ STOP ROUTINE LOAD FOR job_name;
 
     ```sql
     STOP ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-SYNC-JOB.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 STOP SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ STOP SYNC JOB [db.]job_name
 
     ```sql
     STOP SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STREAM-LOAD.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STREAM-LOAD.md
@@ -34,9 +34,9 @@ STREAM LOAD
 
 stream-load: load data to table in streaming
 
-````
+```
 curl --location-trusted -u user:passwd [-H ""...] -T data.file -XPUT http://fe_host:http_port/api/{db}/{table}/_stream_load
-````
+```
 
 This statement is used to import data into the specified table. The difference from ordinary Load is that this import method is synchronous import.
 
@@ -105,20 +105,20 @@ Parameter introduction:
 
     Simple mode: The simple mode is not set the jsonpaths parameter. In this mode, the json data is required to be an object type, for example:
 
-       ````
+       ```
     {"k1":1, "k2":2, "k3":"hello"}, where k1, k2, k3 are column names.
-       ````
+       ```
 
     Matching mode: It is relatively complex for json data and needs to match the corresponding value through the jsonpaths parameter.
 
 14. strip_outer_array: Boolean type, true indicates that the json data starts with an array object and flattens the array object, the default value is false. E.g:
 
-     ````
+     ```
       [
        {"k1" : 1, "v1" : 2},
        {"k1" : 3, "v1" : 4}
       ]
-    ````
+    ```
     When strip_outer_array is true, the final import into doris will generate two rows of data.
 
 
@@ -164,56 +164,56 @@ separated by commas.
 
 1. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', and use Label for deduplication. Specify a timeout of 100 seconds
 
-   ````
+   ```
        curl --location-trusted -u root -H "label:123" -H "timeout:100" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 2. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', use Label for deduplication, and only import data whose k1 is equal to 20180601
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "where: k1=20180601" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 3. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', allowing a 20% error rate (the user is in the defalut_cluster)
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 4. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', allow a 20% error rate, and specify the column name of the file (the user is in the defalut_cluster)
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -H "columns: k2, k1, v1" -T testData http://host:port/api/testDb/testTbl /_stream_load
-   ````
+   ```
 
 5. Import the data in the local file 'testData' into the p1, p2 partitions of the table 'testTbl' in the database 'testDb', allowing a 20% error rate.
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -H "partitions: p1, p2" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 6. Import using streaming (user is in defalut_cluster)
 
-    ````
+    ```
     seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/ _stream_load
-    ````
+    ```
 
 7. Import a table containing HLL columns, which can be columns in the table or columns in the data to generate HLL columns, or use hll_empty to supplement columns that are not in the data
 
-   ````
+   ```
    curl --location-trusted -u root -H "columns: k1, k2, v1=hll_hash(k1), v2=hll_empty()" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 8. Import data for strict mode filtering and set the time zone to Africa/Abidjan
 
-   ````
+   ```
    curl --location-trusted -u root -H "strict_mode: true" -H "timezone: Africa/Abidjan" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 9. Import a table with a BITMAP column, which can be a column in the table or a column in the data to generate a BITMAP column, or use bitmap_empty to fill an empty Bitmap
-   ````
+   ```
     curl --location-trusted -u root -H "columns: k1, k2, v1=to_bitmap(k1), v2=bitmap_empty()" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 10. Simple mode, import json data
     Table Structure:
@@ -224,39 +224,39 @@ separated by commas.
     `price` double NULL COMMENT ""
     ```
     json data format:
-    ````
+    ```
     {"category":"C++","author":"avc","title":"C++ primer","price":895}
-    ````
+    ```
     
     Import command:
     
-    ````
+    ```
     curl --location-trusted -u root -H "label:123" -H "format: json" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
     In order to improve throughput, it supports importing multiple pieces of json data at one time, each line is a json object, and \n is used as a newline by default. You need to set read_json_by_line to true. The json data format is as follows:
 
-    ````
+    ```
     {"category":"C++","author":"avc","title":"C++ primer","price":89.5}
     {"category":"Java","author":"avc","title":"Effective Java","price":95}
     {"category":"Linux","author":"avc","title":"Linux kernel","price":195}
-    ````
+    ```
     
 11. Match pattern, import json data
     json data format:
 
-    ````
+    ```
     [
     {"category":"xuxb111","author":"1avc","title":"SayingsoftheCentury","price":895},{"category":"xuxb222","author":"2avc"," title":"SayingsoftheCentury","price":895},
     {"category":"xuxb333","author":"3avc","title":"SayingsoftheCentury","price":895}
     ]
-    ````
+    ```
 
     Precise import by specifying jsonpath, such as importing only three attributes of category, author, and price
 
-    ````
+    ```
     curl --location-trusted -u root -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\" $.price\",\"$.author\"]" -H "strip_outer_array: true" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
 
     illustrate:
         1) If the json data starts with an array, and each object in the array is a record, you need to set strip_outer_array to true, which means flatten the array.
@@ -265,7 +265,7 @@ separated by commas.
 12. User specified json root node
     json data format:
 
-    ````
+    ```
     {
      "RECORDS":[
     {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
@@ -273,31 +273,31 @@ separated by commas.
     {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
     ]
     }
-    ````
+    ```
 
     Precise import by specifying jsonpath, such as importing only three attributes of category, author, and price
     
-    ````
+    ```
     curl --location-trusted -u root -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\" $.price\",\"$.author\"]" -H "strip_outer_array: true" -H "json_root: $.RECORDS" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
 13. Delete the data with the same import key as this batch
 
-    ````
+    ```
     curl --location-trusted -u root -H "merge_type: DELETE" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
 
 14. Delete the columns in this batch of data that match the data whose flag is listed as true, and append other rows normally
     
-    ````
+    ```
     curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv, flag" -H "merge_type: MERGE" -H "delete: flag=1" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
 15. Import data into UNIQUE_KEYS table with sequence column
     
-    ````
+    ```
     curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/ _stream_load
-    ````
+    ```
 
 16. csv file line header filter import
 
@@ -345,7 +345,7 @@ separated by commas.
 
    Stream Load is a synchronous import process. The successful execution of the statement means that the data is imported successfully. The imported execution result will be returned synchronously through the HTTP return value. And display it in Json format. An example is as follows:
 
-   ````json
+   ```json
    {
        "TxnId": 17,
        "Label": "707717c0-271a-44c5-be0b-4e71bfeacaa5",
@@ -363,7 +363,7 @@ separated by commas.
        "WriteDataTimeMs": 3,
        "CommitAndPublishTimeMs": 18
    }
-   ````
+   ```
 
    The following main explanations are given for the Stream load import result parameters:
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/CANCEL-EXPORT.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/CANCEL-EXPORT.md
@@ -48,7 +48,7 @@ WHERE [LABEL = "export_label" | LABEL like "label_pattern" | STATE = "PENDING/IN
     CANCEL EXPORT
     FROM example_db
     WHERE LABEL = "example_db_test_export_label" and STATE = "EXPORTING";
-    ````
+    ```
 
 2. Cancel all export jobs containing example* on the database example*db.
 
@@ -56,7 +56,7 @@ WHERE [LABEL = "export_label" | LABEL like "label_pattern" | STATE = "PENDING/IN
     CANCEL EXPORT
     FROM example_db
     WHERE LABEL like "%example%";
-    ````
+    ```
 
 3. Cancel all export jobs which state are "PENDING"
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/DELETE.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/DELETE.md
@@ -86,21 +86,21 @@ DELETE FROM table_name
    ```sql
    DELETE FROM my_table PARTITION p1
        WHERE k1 = 3;
-   ````
+   ```
 
 2. Delete the data rows where the value of column k1 is greater than or equal to 3 and the value of column k2 is "abc" in my_table partition p1
 
    ```sql
    DELETE FROM my_table PARTITION p1
    WHERE k1 >= 3 AND k2 = "abc";
-   ````
+   ```
 
 3. Delete the data rows where the value of column k1 is greater than or equal to 3 and the value of column k2 is "abc" in my_table partition p1, p2
 
    ```sql
    DELETE FROM my_table PARTITIONS (p1, p2)
    WHERE k1 >= 3 AND k2 = "abc";
-   ````
+   ```
 
 4. use the result of `t2` join `t3` to romve rows from `t1`,delete table only support unique key model
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/EXPORT.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/EXPORT.md
@@ -72,7 +72,7 @@ The bottom layer of the `Export` statement actually executes the `select...outfi
 
   ```sql
   [PROPERTIES ("key"="value", ...)]
-  ````
+  ```
 
   The following parameters can be specified:
 
@@ -116,7 +116,7 @@ The bottom layer of the `Export` statement actually executes the `select...outfi
         hadoop.security.authentication: specify the authentication method as kerberos
         kerberos_principal: specifies the principal of kerberos
         kerberos_keytab: specifies the path to the keytab file of kerberos. The file must be the absolute path to the file on the server where the broker process is located. and can be accessed by the Broker process
-  ````
+  ```
 
 - `WITH HDFS`
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/INSERT.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/INSERT.md
@@ -41,7 +41,7 @@ INSERT INTO table_name
     [ (column [, ...]) ]
     [ [ hint [, ...] ] ]
     { VALUES ( { expression | DEFAULT } [, ...] ) [, ...] | query }
-````
+```
 
  Parameters
 
@@ -83,7 +83,7 @@ INSERT INTO test VALUES (1, 2);
 INSERT INTO test (c1, c2) VALUES (1, 2);
 INSERT INTO test (c1, c2) VALUES (1, DEFAULT);
 INSERT INTO test (c1) VALUES (1);
-````
+```
 
 The first and second statements have the same effect. When no target column is specified, the column order in the table is used as the default target column.
 The third and fourth statements express the same meaning, use the default value of the `c2` column to complete the data import.
@@ -95,7 +95,7 @@ INSERT INTO test VALUES (1, 2), (3, 2 + 2);
 INSERT INTO test (c1, c2) VALUES (1, 2), (3, 2 * 2);
 INSERT INTO test (c1) VALUES (1), (3);
 INSERT INTO test (c1, c2) VALUES (1, DEFAULT), (3, DEFAULT);
-````
+```
 
 The first and second statements have the same effect, import two pieces of data into the `test` table at one time
 The effect of the third and fourth statements is known, and the default value of the `c2` column is used to import two pieces of data into the `test` table
@@ -105,14 +105,14 @@ The effect of the third and fourth statements is known, and the default value of
 ```sql
 INSERT INTO test SELECT * FROM test2;
 INSERT INTO test (c1, c2) SELECT * from test2;
-````
+```
 
 4. Import a query result into the `test` table, specifying the partition and label
 
 ```sql
 INSERT INTO test PARTITION(p1, p2) WITH LABEL `label1` SELECT * FROM test2;
 INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
-````
+```
 
 
 ### Keywords
@@ -158,17 +158,17 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
          mysql> insert into tbl1 select * from tbl2;
          Query OK, 2 rows affected, 2 warnings (0.31 sec)
          {'label':'insert_f0747f0e-7a35-46e2-affa-13a235f4020d', 'status':'committed', 'txnId':'4005'}
-         ````
+         ```
 
          `Query OK` indicates successful execution. `4 rows affected` means that a total of 4 rows of data were imported. `2 warnings` indicates the number of lines to be filtered.
 
          Also returns a json string:
 
-         ````json
+         ```json
          {'label':'my_label1', 'status':'visible', 'txnId':'4005'}
          {'label':'insert_f0747f0e-7a35-46e2-affa-13a235f4020d', 'status':'committed', 'txnId':'4005'}
          {'label':'my_label1', 'status':'visible', 'txnId':'4005', 'err':'some other error'}
-         ````
+         ```
 
          `label` is a user-specified label or an automatically generated label. Label is the ID of this Insert Into import job. Each import job has a unique Label within a single database.
 
@@ -182,7 +182,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
          ```sql
          show load where label="xxx";
-         ````
+         ```
 
          The URL in the returned result can be used to query the wrong data. For details, see the summary of **Viewing Error Lines** later.
 
@@ -192,7 +192,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
          ```sql
          show transaction where id=4005;
-         ````
+         ```
 
          If the `TransactionStatus` column in the returned result is `visible`, the representation data is visible.
 
@@ -209,7 +209,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
       ```sql
       show load warnings on "url";
-      ````
+      ```
 
       You can view the specific error line.
 

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/SELECT.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/SELECT.md
@@ -323,7 +323,7 @@ Recursive CTE is currently not supported.
      
      SELECT college, region, seed FROM tournament
        ORDER BY 2, 3;
-     ````
+     ```
 
    - If ORDER BY appears in a subquery and also applies to the outer query, the outermost ORDER BY takes precedence.
 
@@ -331,7 +331,7 @@ Recursive CTE is currently not supported.
 
      ```sql
      SELECT a, COUNT(b) FROM test_table GROUP BY a ORDER BY NULL;
-     ````
+     ```
 
      
 
@@ -345,7 +345,7 @@ Recursive CTE is currently not supported.
 
      ```sql
      SELECT COUNT(col1) AS col2 FROM t GROUP BY col2 HAVING col2 = 2;
-     ````
+     ```
 
    - Remember not to use HAVING where WHERE should be used. HAVING is paired with GROUP BY.
 
@@ -354,7 +354,7 @@ Recursive CTE is currently not supported.
      ```sql
      SELECT user, MAX(salary) FROM users
        GROUP BY user HAVING MAX(salary) > 10;
-     ````
+     ```
 
    - The LIMIT clause can be used to constrain the number of rows returned by a SELECT statement. LIMIT can have one or two arguments, both of which must be non-negative integers.
 
@@ -364,7 +364,7 @@ Recursive CTE is currently not supported.
      /*Then if you want to retrieve all rows after a certain offset is set, you can set a very large constant for the second parameter. The following query fetches all data from row 96 onwards */
      SELECT * FROM tbl LIMIT 95,18446744073709551615;
      /*If LIMIT has only one parameter, the parameter specifies the number of rows that should be retrieved, and the offset defaults to 0, that is, starting from the first row*/
-     ````
+     ```
 
    - SELECT...INTO allows query results to be written to a file
 
@@ -405,7 +405,7 @@ Recursive CTE is currently not supported.
        | 21 |
        +-------------+
        4 rows in set (0.01 sec)
-       ````
+       ```
    
 6. JOIN
    

--- a/docs/sql-manual/sql-statements/Data-Manipulation-Statements/OUTFILE.md
+++ b/docs/sql-manual/sql-statements/Data-Manipulation-Statements/OUTFILE.md
@@ -199,7 +199,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "line_delimiter" = "\n",
        "max_file_size" = "100MB"
    );
-   ````
+   ```
 
    If the final generated file is not larger than 100MB, it will be: `result_0.csv`.
    If larger than 100MB, it may be `result_0.csv, result_1.csv, ...`.
@@ -217,7 +217,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.kerberos_principal" = "doris@YOUR.COM",
        "broker.kerberos_keytab" = "/home/doris/my.keytab"
    );
-   ````
+   ```
 
 3. Export the query result of the CTE statement to the file `hdfs://path/to/result.txt`. The default export format is CSV. Use `my_broker` and set hdfs high availability information. Use the default row and column separators.
 
@@ -240,7 +240,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.dfs.namenode.rpc-address.my_ha.my_namenode2" = "nn2_host:rpc_port",
        "broker.dfs.client.failover.proxy.provider.my_ha" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
    );
-   ````
+   ```
 
    If the final generated file is not larger than 1GB, it will be: `result_0.csv`.
    If larger than 1GB, it may be `result_0.csv, result_1.csv, ...`.
@@ -259,7 +259,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.bos_accesskey" = "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
        "broker.bos_secret_accesskey" = "yyyyyyyyyyyyyyyyyyyyyyyyy"
    );
-   ````
+   ```
 
 5. Export the query result of the select statement to the file `s3a://${bucket_name}/path/result.txt`. Specify the export format as csv.
    After the export is complete, an identity file is generated.
@@ -279,7 +279,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "max_file_size" = "1024MB",
        "success_file_name" = "SUCCESS"
    )
-   ````
+   ```
 
    If the final generated file is not larger than 1GB, it will be: `my_file_0.csv`.
    If larger than 1GB, it may be `my_file_0.csv, result_1.csv, ...`.
@@ -302,7 +302,7 @@ Parquet and ORC file formats have their own data types. The export function of D
         "s3.secret_key" = "xxx",
         "s3.region" = "bd"
    )
-   ````
+   ```
 
    The resulting file is prefixed with `my_file_{fragment_instance_id}_`.
 
@@ -321,7 +321,7 @@ Parquet and ORC file formats have their own data types. The export function of D
         "s3.secret_key" = "xxx",
         "s3.region" = "bd"
    )
-   ````
+   ```
 
 8. Use hdfs export to export simple query results to the file `hdfs://${host}:${fileSystem_port}/path/to/result.txt`. Specify the export format as CSV and the user name as work. Specify the column separator as `,` and the row separator as `\n`.
 
@@ -378,7 +378,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "max_file_size" = "1024MB",
        "success_file_name" = "SUCCESS"
    )
-   ````
+   ```
 
 ### keywords
 

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CANCEL-REPAIR.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CANCEL-REPAIR.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN CANCEL REPAIR TABLE table_name[ PARTITION (p1,...)];
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
 
      ```sql
       ADMIN CANCEL REPAIR TABLE tbl PARTITION(p1);
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CLEAN-TRASH.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CLEAN-TRASH.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 ADMIN CLEAN TRASH [ON ("BackendHost1:BackendHeartBeatPort1", "BackendHost2:BackendHeartBeatPort2", ...)];
-````
+```
 
 illustrate:
 

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-REPAIR-TABLE.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-REPAIR-TABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN REPAIR TABLE table_name[ PARTITION (p1,...)]
-````
+```
 
 illustrate:
 

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-SET-REPLICA-STATUS.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-SET-REPLICA-STATUS.md
@@ -41,7 +41,7 @@ grammar:
 ```sql
 ADMIN SET REPLICA STATUS
         PROPERTIES ("key" = "value", ...);
-````
+```
 
  The following properties are currently supported:
 
@@ -63,20 +63,20 @@ If the specified replica does not exist, or the status is already bad, it will b
 
        ```sql
     ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "bad");
-       ````
+       ```
 
  2. Set the replica status of tablet 10003 on BE 10001 to drop.
 
        ```sql
     ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "drop");
-       ````
+       ```
 
 
  3. Set the replica status of tablet 10003 on BE 10001 to ok.
 
    ```sql
    ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "ok");
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/INSTALL-PLUGIN.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/INSTALL-PLUGIN.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 INSTALL PLUGIN FROM [source] [PROPERTIES ("key"="value", ...)]
-````
+```
 
 source supports three types:
 
@@ -52,19 +52,19 @@ source supports three types:
 
     ```sql
     INSTALL PLUGIN FROM "/home/users/doris/auditdemo.zip";
-    ````
+    ```
 
 2. Install the plugin in a local directory:
 
     ```sql
     INSTALL PLUGIN FROM "/home/users/doris/auditdemo/";
-    ````
+    ```
 
 3. Download and install a plugin:
 
     ```sql
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip";
-    ````
+    ```
 
     Note than an md5 file with the same name as the `.zip` file needs to be placed, such as `http://mywebsite.com/plugin.zip.md5` . 
     The content is the MD5 value of the .zip file.
@@ -73,7 +73,7 @@ source supports three types:
 
     ```sql
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip" PROPERTIES("md5sum" = "73877f6029216f4314d712086a146570");
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/KILL.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/KILL.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 KILL [CONNECTION] processlist_id
-````
+```
 
 In addition, you can also use processlist_id or query_id terminates the executing query command
 
@@ -48,7 +48,7 @@ grammar:
 
 ```sql
 KILL QUERY processlist_id | query_id
-````
+```
 
 
 ### Example

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/SET-VARIABLE.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/SET-VARIABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SET variable_assignment [, variable_assignment] ...
-````
+```
 
 illustrate:
 
@@ -55,15 +55,15 @@ illustrate:
 
 1. Set the time zone to Dongba District
 
-   ````
+   ```
    SET time_zone = "Asia/Shanghai";
-   ````
+   ```
 
 2. Set the global execution memory size
 
-   ````
+   ```
    SET GLOBAL exec_mem_limit = 137438953472
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/SHOW-CONFIG.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/SHOW-CONFIG.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW FRONTEND CONFIG [LIKE "pattern"];
-````
+```
 
 The columns in the results have the following meanings:
 
@@ -59,7 +59,7 @@ The columns in the results have the following meanings:
 
 2. Use the like predicate to search the configuration of the current Fe node
 
-   ````
+   ```
    mysql> SHOW FRONTEND CONFIG LIKE '%check_java_version%';
    +--------------------+-------+---------+---------- -+------------+---------+
    | Key | Value | Type | IsMutable | MasterOnly | Comment |
@@ -67,7 +67,7 @@ The columns in the results have the following meanings:
    | check_java_version | true | boolean | false | false | |
    +--------------------+-------+---------+---------- -+------------+---------+
    1 row in set (0.01 sec)
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-DISTRIBUTION.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-DISTRIBUTION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW REPLICA DISTRIBUTION FROM [db_name.]tbl_name [PARTITION (p1, ...)];
-````
+```
 
 illustrate:
 
@@ -50,13 +50,13 @@ illustrate:
 
     ```sql
     SHOW REPLICA DISTRIBUTION FROM tbl1;
-    ````
+    ```
 
   2. View the replica distribution of the partitions of the table
 
       ```sql
      SHOW REPLICA DISTRIBUTION FROM db1.tbl1 PARTITION(p1, p2);
-      ````
+      ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-STATUS.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-STATUS.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW REPLICA STATUS FROM [db_name.]tbl_name [PARTITION (p1, ...)]
 [where_clause];
-````
+```
 
 illustrate
 
@@ -59,21 +59,21 @@ illustrate
 
    ```sql
    SHOW REPLICA STATUS FROM db1.tbl1;
-   ````
+   ```
 
 2. View a copy of a table with a partition status of VERSION_ERROR
 
    ```sql
    SHOW REPLICA STATUS FROM tbl1 PARTITION (p1, p2)
    WHERE STATUS = "VERSION_ERROR";
-   ````
+   ```
 
 3. View all unhealthy replicas of the table
 
    ```sql
    SHOW REPLICA STATUS FROM tbl1
    WHERE STATUS != "OK";
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/UNINSTALL-PLUGIN.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/UNINSTALL-PLUGIN.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 UNINSTALL PLUGIN plugin_name;
-````
+```
 
   plugin_name can be viewed with the `SHOW PLUGINS;` command.
 
@@ -50,7 +50,7 @@ Only non-builtin plugins can be uninstalled.
 
     ```sql
     UNINSTALL PLUGIN auditdemo;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Database-Administration-Statements/UNSET-VARIABLE.md
+++ b/docs/sql-manual/sql-statements/Database-Administration-Statements/UNSET-VARIABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 UNSET [SESSION|GLOBAL] VARIABLE (variable_name | ALL)
-````
+```
 
 illustrate:
 
@@ -53,15 +53,15 @@ illustrate:
 
 1. Restore value of the time zone
 
-   ````
+   ```
    UNSET VARIABLE time_zone;
-   ````
+   ```
 
 2. Restore the global execution memory size
 
-   ````
+   ```
    UNSET GLOBAL VARIABLE exec_mem_limit;
-   ````
+   ```
 3. Restore all variables globally
 
    ```

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-ALTER-TABLE-MATERIALIZED-VIEW.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-ALTER-TABLE-MATERIALIZED-VIEW.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database: View jobs under the specified database. If not specified, the current database is used.
 - WHERE: You can filter the result column, currently only the following columns are supported:
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`: Job unique ID.
 
@@ -110,7 +110,7 @@ RollupIndexName: r1
 
    ```sql
    SHOW ALTER TABLE MATERIALIZED VIEW FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-ALTER.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-ALTER.md
@@ -36,7 +36,7 @@ This statement is used to display the execution of various modification tasks cu
 
 ```sql
 SHOW ALTER [CLUSTER | TABLE [COLUMN | ROLLUP] [FROM db_name]];
-````
+```
 
 TABLE COLUMN: show ALTER tasks that modify columns
                       Support syntax [WHERE TableName|CreateTime|FinishTime|State] [ORDER BY] [LIMIT]
@@ -50,25 +50,25 @@ TABLE COLUMN: show ALTER tasks that modify columns
 
    ```sql
     SHOW ALTER TABLE COLUMN;
-   ````
+   ```
 
 2. Display the task execution status of the last modified column of a table
 
    ```sql
    SHOW ALTER TABLE COLUMN WHERE TableName = "table1" ORDER BY CreateTime DESC LIMIT 1;
-   ````
+   ```
 
 3. Display the task execution of creating or deleting ROLLUP index for the specified db
 
    ```sql
    SHOW ALTER TABLE ROLLUP FROM example_db;
-   ````
+   ```
 
 4. Show tasks related to cluster operations (only for administrators! To be implemented...)
 
-   ````
+   ```
    SHOW ALTER CLUSTER;
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-BACKENDS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-BACKENDS.md
@@ -36,7 +36,7 @@ This statement is used to view the BE nodes in the cluster
 
 ```sql
  SHOW BACKENDS;
-````
+```
 
 illustrate:
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-BACKUP.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-BACKUP.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
  SHOW BACKUP [FROM db_name]
     [WHERE SnapshotName ( LIKE | = ) 'snapshot name']
-````
+```
 
 illustrate:
 
@@ -72,7 +72,7 @@ illustrate:
 
    ```sql
     SHOW BACKUP FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-BROKER.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-BROKER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW BROKER;
-````
+```
 
 illustrate:
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-COLUMNS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-COLUMNS.md
@@ -46,7 +46,7 @@ SHOW [FULL] COLUMNS FROM tbl;
 
     ```sql
      SHOW FULL COLUMNS FROM tbl;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
@@ -46,7 +46,7 @@ SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS [FROM db]
 
     ```sql
      SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS FROM test;
-    ````
+    ```
 
 2. View the converting process globally
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-DATABASE.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-DATABASE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE DATABASE db_name;
-````
+```
 
 illustrate:
 
@@ -57,7 +57,7 @@ illustrate:
     | test | CREATE DATABASE `test` |
     +----------+----------------------------+
     1 row in set (0.00 sec)
-    ````
+    ```
 
 2. view a database named `hdfs_text` from a hms catalog
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-FUNCTION.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-FUNCTION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE [GLOBAL] FUNCTION function_name(arg_type [, ...]) [FROM db_name]];
-````
+```
 
 illustrate:
 1. `global`: The show function is global 
@@ -54,12 +54,12 @@ illustrate:
 
     ```sql
     SHOW CREATE FUNCTION my_add(INT, INT)
-    ````
+    ```
 2. Show the creation statement of the specified global function
 
     ```sql
     SHOW CREATE GLOBAL FUNCTION my_add(INT, INT)
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-LOAD.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-LOAD.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE LOAD for load_name;
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
 
     ```sql
     SHOW CREATE LOAD for test_load
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-REPOSITORY.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-REPOSITORY.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE REPOSITORY for repository_name;
-````
+```
 
 illustrate:
 -  `repository_name`: repository name
@@ -49,7 +49,7 @@ illustrate:
 
     ```sql
     SHOW CREATE REPOSITORY for test_repository
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-ROUTINE-LOAD.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-ROUTINE-LOAD.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW [ALL] CREATE ROUTINE LOAD for load_name;
-````
+```
 
 illustrate:
 
@@ -53,7 +53,7 @@ illustrate:
 
     ```sql
     SHOW CREATE ROUTINE LOAD for test_load
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-TABLE.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-TABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [BRIEF] CREATE TABLE [DBNAME.]TABLE_NAME
-````
+```
 
 illustrate:
 
@@ -53,7 +53,7 @@ illustrate:
 
     ```sql
     SHOW CREATE TABLE demo.tb1
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-DATA.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-DATA.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATA [FROM [db_name.]table_name] [ORDER BY ...];
-````
+```
 
 illustrate:
 
@@ -82,9 +82,9 @@ illustrate:
    ```sql
    USE db1;
    SHOW DATA;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-------------+--------------+
    | TableName | Size        | ReplicaCount |
    +-----------+-------------+--------------+
@@ -94,15 +94,15 @@ illustrate:
    | Quota     | 1024.000 GB | 1073741824   |
    | Left      | 1021.921 GB | 1073741815   |
    +-----------+-------------+--------------+
-   ````
+   ```
 
 3. Display the subdivided data volume, the number of replicas and the number of statistical rows of the specified table under the specified db
 
    ```sql
    SHOW DATA FROM example_db.test;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-----------+-----------+--------------+----------+
    | TableName | IndexName | Size      | ReplicaCount | RowCount |
    +-----------+-----------+-----------+--------------+----------+
@@ -111,15 +111,15 @@ illustrate:
    |           | test2     | 50.000MB  | 30           | 50000    |
    |           | Total     | 80.000    | 90           |          |
    +-----------+-----------+-----------+--------------+----------+
-   ````
+   ```
 
 4. It can be combined and sorted according to the amount of data, the number of copies, the number of statistical rows, etc.
 
    ```sql
    SHOW DATA ORDER BY ReplicaCount desc,Size asc;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-------------+--------------+
    | TableName | Size        | ReplicaCount |
    +-----------+-------------+--------------+
@@ -131,7 +131,7 @@ illustrate:
    | Quota     | 1024.000 GB | 1073741824   |
    | Left      | 1024.000 GB | 1073741734   |
    +-----------+-------------+--------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-DATABASE-ID.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-DATABASE-ID.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATABASE [database_id]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DATABASE [database_id]
 
     ```sql
     SHOW DATABASE 1001;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATABASES [FROM catalog] [filter expr];
-````
+```
 
 illustrate:
 1. `SHOW DATABASES` will get all database names from current catalog.
@@ -51,45 +51,45 @@ illustrate:
 
    ```sql
    SHOW DATABASES;
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | test               |
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 2. Display all database names from the catalog named 'hms_catalog'.
 
    ```sql
    SHOW DATABASES from hms_catalog;
-   ````
+   ```
 
-   ````
+   ```
   +---------------+
   | Database      |
   +---------------+
   | default       |
   | tpch          |
   +---------------+
-   ````
+   ```
 
 3. Display the filtered database names from current catalog with the expr 'like'.
 
    ```sql
    SHOW DATABASES like 'infor%';
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-DELETE.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-DELETE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DELETE [FROM db_name]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DELETE [FROM db_name]
 
       ```sql
       SHOW DELETE FROM database;
-      ````
+      ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-DYNAMIC-PARTITION.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-DYNAMIC-PARTITION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DYNAMIC PARTITION TABLES [FROM db_name];
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DYNAMIC PARTITION TABLES [FROM db_name];
 
      ```sql
      SHOW DYNAMIC PARTITION TABLES FROM database;
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-ENCRYPT-KEY.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-ENCRYPT-KEY.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW ENCRYPTKEYS [IN|FROM db] [LIKE 'key_pattern']
-````
+```
 
 parameter
 
@@ -65,7 +65,7 @@ parameter
     | example_db.my_key | ABCD123456789     |
     +-------------------+-------------------+
     1 row in set (0.00 sec)
- ````
+ ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-EXPORT.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-EXPORT.md
@@ -47,7 +47,7 @@ SHOW EXPORT
    ]
 [ORDER BY...]
 [LIMIT limit];
-````
+```
 
 illustrate:
       1. If db_name is not specified, the current default db is used
@@ -61,31 +61,31 @@ illustrate:
 
    ```sql
    SHOW EXPORT;
-   ````
+   ```
 
 2. Display the export tasks of the specified db, sorted by StartTime in descending order
 
    ```sql
     SHOW EXPORT FROM example_db ORDER BY StartTime DESC;
-   ````
+   ```
 
 3. Display the export tasks of the specified db, the state is "exporting", and sort by StartTime in descending order
 
    ```sql
    SHOW EXPORT FROM example_db WHERE STATE = "exporting" ORDER BY StartTime DESC;
-   ````
+   ```
 
 4. Display the export task of the specified db and specified job_id
 
    ```sql
      SHOW EXPORT FROM example_db WHERE ID = job_id;
-   ````
+   ```
 
 5. Display the specified db and specify the export task of the label
 
    ```sql
     SHOW EXPORT FROM example_db WHERE LABEL = "mylabel";
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-FILE.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-FILE.md
@@ -38,18 +38,18 @@ grammar:
 
 ```sql
 SHOW FILE [FROM database];
-````
+```
 
 illustrate:
 
-````text
+```text
 FileId: file ID, globally unique
 DbName: the name of the database to which it belongs
 Catalog: Custom Category
 FileName: file name
 FileSize: file size, in bytes
 MD5: MD5 of the file
-````
+```
 
 ### Example
 
@@ -57,7 +57,7 @@ MD5: MD5 of the file
 
      ```sql
      SHOW FILE FROM my_database;
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS-DISKS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS-DISKS.md
@@ -38,7 +38,7 @@ This statement is used to view FE nodes's important paths' disk information, suc
 
 ```sql
 SHOW FRONTENDS DISKS;
-````
+```
 
 illustrate:
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS.md
@@ -38,7 +38,7 @@ This statement is used to view FE nodes
 
 ```sql
 SHOW FRONTENDS;
-````
+```
 
 illustrate:
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-FUNCTIONS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-FUNCTIONS.md
@@ -40,7 +40,7 @@ grammar
 
 ```sql
 SHOW [FULL] [BUILTIN] FUNCTIONS [IN|FROM db] [LIKE 'function_pattern']
-````
+```
 
 Parameters
 
@@ -53,7 +53,7 @@ grammar
 
 ```sql
 SHOW GLOBAL [FULL] FUNCTIONS [LIKE 'function_pattern']
-````
+```
 
 Parameters
 
@@ -65,7 +65,7 @@ Parameters
 
 ### Example
 
-````sql
+```sql
 mysql> show full functions in testDb\G
 **************************** 1. row ******************** ******
         Signature: my_add(INT,INT)
@@ -122,7 +122,7 @@ mysql> show global functions ;
 +---------------+
 2 rows in set (0.00 sec)    
     
-````
+```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-GRANTS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-GRANTS.md
@@ -52,19 +52,19 @@ illustrate:
 
     ```sql
     SHOW ALL GRANTS;
-    ````
+    ```
 
 2. View the permissions of the specified user
 
     ```sql
     SHOW GRANTS FOR jack@'%';
-    ````
+    ```
 
 3. View the permissions of the current user
 
     ```sql
     SHOW GRANTS;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-INDEX.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-INDEX.md
@@ -36,19 +36,19 @@ SHOW INDEX
 
 grammar:
 
-````SQL
+```SQL
 SHOW INDEX[ES] FROM [db_name.]table_name [FROM database];
 or
 SHOW KEY[S] FROM [db_name.]table_name [FROM database];
-````
+```
 
 ### Example
 
   1. Display the lower index of the specified table_name
 
-     ````SQL
+     ```SQL
       SHOW INDEX FROM example_db.table_name;
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-LAST-INSERT.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-LAST-INSERT.md
@@ -39,11 +39,11 @@ grammar:
 
 ```sql
 SHOW LAST INSERT
-````
+```
 
 Example of returned result:
 
-````
+```
      TransactionId: 64067
              Label: insert_ba8f33aea9544866-8ed77e2844d0cc9b
           Database: default_cluster:db1
@@ -51,7 +51,7 @@ Example of returned result:
 TransactionStatus: VISIBLE
         LoadedRows: 2
       FilteredRows: 0
-````
+```
 
 illustrate:
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-PROFILE.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-PROFILE.md
@@ -40,13 +40,13 @@ This statement is used to view the Profile information of the import operation. 
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Versions 0.15 and later perform the following settings:
 
 ```sql
 SET [GLOBAL] enable_profile=true;
-````
+```
 
 grammar:
 
@@ -60,7 +60,7 @@ show load profile "/[queryId]/[TaskId]"
 show load profile "/[queryId]/[TaskId]/[FragmentId]/"
 
 show load profile "/[queryId]/[TaskId]/[FragmentId]/[InstanceId]"
-````
+```
 
 This command will list all currently saved import profiles. Each line corresponds to one import. where the QueryId column is the ID of the import job. This ID can also be viewed through the SHOW LOAD statement. We can select the QueryId corresponding to the Profile we want to see to see the specific situation
 
@@ -106,7 +106,7 @@ WaitAndFetchResultTime: NULL
        FetchResultTime: 0ns
        WriteResultTime: 0ns
 WaitAndFetchResultTime: N/A
-   ````
+   ```
 
 2. View an overview of the subtasks with imported jobs:
 
@@ -117,7 +117,7 @@ WaitAndFetchResultTime: N/A
    +-----------------------------------+------------+
    | 980014623046410a-af5d36f23381017f | 3m14s      |
    +-----------------------------------+------------+
-   ````
+   ```
    
 3. View the plan tree of the specified subtask
 
@@ -177,7 +177,7 @@ WaitAndFetchResultTime: N/A
    | 980014623046410a-88e260f0c43031f4 | 10.81.85.89:9067 | 3m10s      |
    | 980014623046410a-88e260f0c43031f5 | 10.81.85.89:9067 | 3m14s      |
    +-----------------------------------+------------------+------------+
-   ````
+   ```
 
 4. Continue to view the detailed Profile of each operator on a specific Instance
 
@@ -225,7 +225,7 @@ WaitAndFetchResultTime: N/A
    │      - TotalReadThroughput: 30.39858627319336 MB/sec│
    │      - WaitScannerTime: 56s528ms                    │
    └-----------------------------------------------------┘
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-WARNINGS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-WARNINGS.md
@@ -44,7 +44,7 @@ SHOW LOAD WARNINGS
     [LABEL[="your_label"]]
     [LOAD_JOB_ID = ["job id"]]
 ]
-````
+```
 
 1) If db_name is not specified, the current default db is used
 1) If LABEL = is used, it matches the specified label exactly
@@ -56,7 +56,7 @@ SHOW LOAD WARNINGS
 
     ```sql
     SHOW LOAD WARNINGS FROM demo WHERE LABEL = "load_demo_20210112"
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-LOAD.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-LOAD.md
@@ -46,7 +46,7 @@ SHOW LOAD
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -68,7 +68,7 @@ illustrate:
 
    ```sql
    SHOW LOAD WARNINGS ON 'url'
-   ````
+   ```
 
 ### Example
 
@@ -76,38 +76,38 @@ illustrate:
 
    ```sql
    SHOW LOAD;
-   ````
+   ```
 
 2. Display the import tasks of the specified db, the label contains the string "2014_01_02", and display the oldest 10
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 3. Display the import tasks of the specified db, specify the label as "load_example_db_20140102" and sort by LoadStartTime in descending order
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL = "load_example_db_20140102" ORDER BY LoadStartTime DESC;
-   ````
+   ```
 
 4. Display the import task of the specified db, specify the label as "load_example_db_20140102", the state as "loading", and sort by LoadStartTime in descending order
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL = "load_example_db_20140102" AND STATE = "loading" ORDER BY LoadStartTime DESC;
-   ````
+   ```
 
 5. Display the import tasks of the specified db and sort them in descending order by LoadStartTime, and display 10 query results starting from offset 5
 
    ```sql
    SHOW LOAD FROM example_db ORDER BY LoadStartTime DESC limit 5,10;
    SHOW LOAD FROM example_db ORDER BY LoadStartTime DESC limit 10 offset 5;
-   ````
+   ```
 
 6. Small batch import is a command to check the import status
 
-   ````
+   ```
    curl --location-trusted -u {user}:{passwd} http://{hostname}:{port}/api/{database}/_load_info?label={labelname}
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-PARTITION-ID.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-PARTITION-ID.md
@@ -45,7 +45,7 @@ SHOW PARTITION [partition_id]
 
     ```sql
     SHOW PARTITION 10002;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-PARTITIONS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-PARTITIONS.md
@@ -36,9 +36,9 @@ SHOW PARTITIONS
 
 grammar:
 
-````SQL
+```SQL
   SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT];
-````
+```
 
 illustrate:
 
@@ -54,27 +54,27 @@ Will return all partitions' name. Support multilevel partition table
 
 1. Display all non-temporary partition information of the specified table under the specified db
 
-````SQL
+```SQL
   SHOW PARTITIONS FROM example_db.table_name;
-````
+```
 
 2. Display all temporary partition information of the specified table under the specified db
 
-    ````SQL
+    ```SQL
     SHOW TEMPORARY PARTITIONS FROM example_db.table_name;
-    ````
+    ```
 
 3. Display the information of the specified non-temporary partition of the specified table under the specified db
 
-    ````SQL
+    ```SQL
      SHOW PARTITIONS FROM example_db.table_name WHERE PartitionName = "p1";
-    ````
+    ```
 
 4. Display the latest non-temporary partition information of the specified table under the specified db
 
-    ````SQL
+    ```SQL
     SHOW PARTITIONS FROM example_db.table_name ORDER BY PartitionId DESC LIMIT 1;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-PLUGINS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-PLUGINS.md
@@ -36,9 +36,9 @@ This statement is used to display installed plugins
 
 grammar:
 
-````SQL
+```SQL
 SHOW PLUGINS
-````
+```
 
 This command will display all user-installed and system built-in plugins
 
@@ -46,9 +46,9 @@ This command will display all user-installed and system built-in plugins
 
 1. Show installed plugins:
 
-    ````SQL
+    ```SQL
     SHOW PLUGINS;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-PROC.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-PROC.md
@@ -49,7 +49,7 @@ After connecting to Doris through the MySQL client, you can execute the SHOW PRO
 
 The results of the show proc statement are presented in a two-dimensional table. And usually the first column of the result table is the next subdirectory of proc.
 
-````none
+```none
 mysql> show proc "/";
 +---------------------------+
 | name                      |
@@ -80,7 +80,7 @@ mysql> show proc "/";
 | trash                     |
 +---------------------------+
 23 rows in set (0.00 sec)
-````
+```
 
 illustrate:
 
@@ -124,7 +124,7 @@ illustrate:
    | 10124   | test_parquet_import  | 1        | NULL                | 1            | NORMAL | OLAP | NULL                     | 1            |
    +---------+----------------------+----------+---------------------+--------------+--------+------+--------------------------+--------------+
    4 rows in set (0.00 sec)
-   ````
+   ```
 
 2. Display information about the number of all database tables in the cluster.
 
@@ -137,11 +137,11 @@ illustrate:
    | Total | 1                    | 4        | 12           | 12       | 21        | 21         |
    +-------+----------------------+----------+--------------+----------+-----------+------------+
    2 rows in set (0.00 sec)
-   ````
+   ```
 
 3. The following command can view the existing Group information in the cluster.
 
-   ````
+   ```
    SHOW PROC '/colocation_group';
    
    +-------------+--------------+--------------+------------+----------------+----------+----------+
@@ -149,7 +149,7 @@ illustrate:
    +-------------+--------------+--------------+------------+----------------+----------+----------+
    | 10005.10008 | 10005_group1 | 10007, 10040 | 10         | 3              | int(11)  | true     |
    +-------------+--------------+--------------+------------+----------------+----------+----------+
-   ````
+   ```
 
    - GroupId: The cluster-wide unique identifier of a group, the first half is the db id, and the second half is the group id.
    - GroupName: The full name of the Group.
@@ -176,7 +176,7 @@ illustrate:
    | 6           | 10003, 10004, 10001 |
    | 7           | 10003, 10004, 10002 |
    +-------------+---------------------+
-   ````
+   ```
 
    - BucketIndex: The index of the bucket sequence.
    - BackendIds: The list of BE node IDs where the data shards in the bucket are located.
@@ -216,7 +216,7 @@ illustrate:
    | Total                   | 0         | 0        |
    +-------------------------+-----------+----------+
    26 rows in set (0.01 sec)
-   ````
+   ```
 
 5. Display the replica status of the entire cluster.
    ```sql

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-PROCESSLIST.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-PROCESSLIST.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW [FULL] PROCESSLIST
-````
+```
 
 illustrate:
 
@@ -70,9 +70,9 @@ Other types can refer to [MySQL official website for explanation](https://dev.my
 
 1. View the threads running by the current user
 
-   ````SQL
+   ```SQL
    SHOW PROCESSLIST
-   ````
+   ```
    return
    ```
    MySQL [test]> show full processlist;

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-REPOSITORIES.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-REPOSITORIES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW REPOSITORIES;
-````
+```
 
 illustrate:
 
@@ -57,7 +57,7 @@ illustrate:
 
 ```sql
   SHOW REPOSITORIES;
-````
+```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-RESOURCES.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-RESOURCES.md
@@ -45,7 +45,7 @@ SHOW RESOURCES
 ] | [LIKE "pattern"]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-RESTORE.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-RESTORE.md
@@ -36,9 +36,9 @@ This statement is used to view RESTORE tasks
 
 grammar:
 
-````SQL
+```SQL
 SHOW [BRIEF] RESTORE [FROM DB_NAME]
-````
+```
 
 illustrate:
         1. Only the most recent RESTORE task is saved in Doris.
@@ -76,7 +76,7 @@ illustrate:
 
    ```sql
    SHOW RESTORE FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-ROLES.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-ROLES.md
@@ -36,17 +36,17 @@ This statement is used to display all created role information, including role n
 
 grammar:
 
-````SQL
+```SQL
 SHOW ROLES
-````
+```
 
 ### Example
 
 1. View created roles
 
-    ````SQL
+    ```SQL
     SHOW ROLES
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
@@ -39,11 +39,11 @@ View the currently running subtasks of a specified Routine Load job.
 ```sql
 SHOW ROUTINE LOAD TASK
 WHERE JobName = "job_name";
-````
+```
 
 The returned results are as follows:
 
-````text
+```text
               TaskId: d67ce537f1be4b86-abf47530b79ab8e6
                TxnId: 4
            TxnStatus: UNKNOWN
@@ -53,7 +53,7 @@ The returned results are as follows:
              Timeout: 20
                 BeId: 10002
 DataSourceProperties: {"0":19}
-````
+```
 
 - `TaskId`: The unique ID of the subtask.
 - `TxnId`: The import transaction ID corresponding to the subtask.
@@ -71,7 +71,7 @@ DataSourceProperties: {"0":19}
 
    ```sql
    SHOW ROUTINE LOAD TASK WHERE JobName = "test1";
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD.md
@@ -38,11 +38,11 @@ grammar:
 
 ```sql
 SHOW [ALL] ROUTINE LOAD [FOR jobName];
-````
+```
 
 Result description:
 
-````
+```
                   Id: job ID
                 Name: job name
           CreateTime: job creation time
@@ -63,7 +63,7 @@ DataSourceProperties: Data source configuration details
 ReasonOfStateChanged: The reason for the job state change
         ErrorLogUrls: The viewing address of the filtered unqualified data
             OtherMsg: other error messages
-````
+```
 
 * State
 
@@ -88,39 +88,39 @@ ReasonOfStateChanged: The reason for the job state change
 
    ```sql
    SHOW ALL ROUTINE LOAD FOR test1;
-   ````
+   ```
 
 2. Show the currently running routine import job named test1
 
    ```sql
    SHOW ROUTINE LOAD FOR test1;
-   ````
+   ```
 
 3. Display all routine import jobs (including stopped or canceled jobs) under example_db. The result is one or more lines.
 
    ```sql
    use example_db;
    SHOW ALL ROUTINE LOAD;
-   ````
+   ```
 
 4. Display all running routine import jobs under example_db
 
    ```sql
    use example_db;
    SHOW ROUTINE LOAD;
-   ````
+   ```
 
 5. Display the currently running routine import job named test1 under example_db
 
    ```sql
    SHOW ROUTINE LOAD FOR example_db.test1;
-   ````
+   ```
 
 6. Displays all routine import jobs named test1 under example_db (including stopped or canceled jobs). The result is one or more lines.
 
    ```sql
    SHOW ALL ROUTINE LOAD FOR example_db.test1;
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-SMALL-FILES.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-SMALL-FILES.md
@@ -36,7 +36,7 @@ This statement is used to display files created by the CREATE FILE command withi
 
 ```sql
 SHOW FILE [FROM database];
-````
+```
 
 Return result description:
 
@@ -53,7 +53,7 @@ Return result description:
 
     ```sql
     SHOW FILE FROM my_database;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-SNAPSHOT.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-SNAPSHOT.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW SNAPSHOT ON `repo_name`
 [WHERE SNAPSHOT = "snapshot" [AND TIMESTAMP = "backup_timestamp"]];
-````
+```
 
 illustrate:
 
@@ -57,20 +57,20 @@ illustrate:
 
    ```sql
    SHOW SNAPSHOT ON example_repo;
-   ````
+   ```
 
 2. View only the backup named backup1 in the repository example_repo:
 
    ```sql
    SHOW SNAPSHOT ON example_repo WHERE SNAPSHOT = "backup1";
-   ````
+   ```
 
 3. View the details of the backup named backup1 in the warehouse example_repo with the time version "2018-05-05-15-34-26":
 
    ```sql
    SHOW SNAPSHOT ON example_repo
    WHERE SNAPSHOT = "backup1" AND TIMESTAMP = "2018-05-05-15-34-26";
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-SQL-BLOCK-RULE.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-SQL-BLOCK-RULE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
-````
+```
 
 ### Example
 
@@ -53,7 +53,7 @@ SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
     | test_rule2 | NULL | NULL | 30 | 0 | 10000000000 | false | true |
     +------------+----------------------------+---------+- -------------+------------+-------------+--------+- -------+
     2 rows in set (0.01 sec)
-    ````
+    ```
     
 2. Make a rule name query
 
@@ -66,7 +66,7 @@ SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
     +------------+------+---------+---------------+---- -------+-------------+--------+--------+
     1 row in set (0.00 sec)
     
-    ````
+    ```
     
 
 ### Keywords

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database: View jobs under the specified database. If not specified, the current database is used.
 - WHERE: You can filter the result column, currently only the following columns are supported:
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`: Job unique ID.
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-STREAM-LOAD.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-STREAM-LOAD.md
@@ -46,7 +46,7 @@ SHOW STREAM LOAD
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -65,32 +65,32 @@ illustrate:
 
    ```sql
      SHOW STREAM LOAD;
-   ````
+   ```
 
 2. Display the Stream Load task of the specified db, the label contains the string "2014_01_02", and display the oldest 10
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE LABEL LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 3. Display the Stream Load task of the specified db and specify the label as "load_example_db_20140102"
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE LABEL = "load_example_db_20140102";
-   ````
+   ```
 
 4. Display the Stream Load task of the specified db, specify the status as "success", and sort by StartTime in descending order
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE STATUS = "success" ORDER BY StartTime DESC;
-   ````
+   ```
 
 5. Display the import tasks of the specified db and sort them in descending order of StartTime, and display 10 query results starting from offset 5
 
    ```sql
    SHOW STREAM LOAD FROM example_db ORDER BY StartTime DESC limit 5,10;
    SHOW STREAM LOAD FROM example_db ORDER BY StartTime DESC limit 10 offset 5;
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-SYNC-JOB.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-SYNC-JOB.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW SYNC JOB [FROM db_name]
-````
+```
 
 ### Example
 
@@ -48,13 +48,13 @@ SHOW SYNC JOB [FROM db_name]
 
     ```sql
     SHOW SYNC JOB;
-    ````
+    ```
 
 2. Display the status of all data synchronization jobs under the database `test_db`.
 
     ```sql
     SHOW SYNC JOB FROM `test_db`;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-ID.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-ID.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TABLE [table_id]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW TABLE [table_id]
 
      ```sql
      SHOW TABLE 10001;
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-STATUS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-STATUS.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW TABLE STATUS
 [FROM db] [LIKE "pattern"]
-````
+```
 
 illustrate:
 
@@ -51,13 +51,13 @@ illustrate:
 
      ```sql
      SHOW TABLE STATUS;
-     ````
+     ```
 
   2. View the information of the table whose name contains example under the specified database
 
      ```sql
      SHOW TABLE STATUS FROM db LIKE "%example%";
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-TABLES.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-TABLES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [FULL] TABLES [LIKE]
-````
+```
 
 illustrate:
 
@@ -60,7 +60,7 @@ illustrate:
      | left_table                      |
      +---------------------------------+
      5 rows in set (0.00 sec)
-     ````
+     ```
 
 2. Fuzzy query by table name
 
@@ -73,7 +73,7 @@ illustrate:
     | cmy2           |
     +----------------+
     2 rows in set (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-TABLET.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-TABLET.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TABLET tablet_id
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW TABLET tablet_id
 
     ```sql
     SHOW TABLET 10000;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
@@ -42,7 +42,7 @@ SHOW TABLETS FROM [database.]table [PARTITIONS(p1,p2)]
 [WHERE where_condition]
 [ORDER BY col_name]
 [LIMIT [offset,] row_count]
-````
+```
 
 1. **Syntax Description:**
 
@@ -61,19 +61,19 @@ or compound them with operator `AND`.
 
     ```sql
     SHOW TABLETS FROM example_db.table_name;
-    ````
+    ```
 
 2. list all tablets of the specified partitions
 
     ```sql
     SHOW TABLETS FROM example_db.table_name PARTITIONS(p1, p2);
-    ````
+    ```
 
 3. list all DECOMMISSION tablets on the specified backend
 
     ```sql
     SHOW TABLETS FROM example_db.table_name WHERE state="DECOMMISSION" AND BackendId=11003;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-TRANSACTION.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-TRANSACTION.md
@@ -42,11 +42,11 @@ SHOW TRANSACTION
 WHERE
 [id=transaction_id]
 [label = label_name];
-````
+```
 
 Example of returned result:
 
-````
+```
      TransactionId: 4005
              Label: insert_8d807d5d-bcdd-46eb-be6d-3fa87aa4952d
        Coordinator: FE: 10.74.167.16
@@ -59,7 +59,7 @@ Example of returned result:
 ErrorReplicasCount: 0
         ListenerId: -1
          TimeoutMs: 300000
-````
+```
 
 * TransactionId: transaction id
 * Label: the label corresponding to the import task
@@ -84,19 +84,19 @@ ErrorReplicasCount: 0
 
    ```sql
    SHOW TRANSACTION WHERE ID=4005;
-   ````
+   ```
 
 2. In the specified db, view the transaction with id 4005:
 
    ```sql
    SHOW TRANSACTION FROM db WHERE ID=4005;
-   ````
+   ```
 
 3. View the transaction whose label is label_name:
 
    ```sql
    SHOW TRANSACTION WHERE LABEL = 'label_name';
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-TRASH.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-TRASH.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TRASH [ON BackendHost:BackendHeartBeatPort];
-````
+```
 
 illustrate:
 
@@ -51,13 +51,13 @@ illustrate:
 
    ```sql
     SHOW TRASH;
-   ````
+   ```
 
 2. View the space occupied by garbage data of '192.168.0.1:9050' (specific disk information will be displayed).
 
    ```sql
    SHOW TRASH ON "192.168.0.1:9050";
-   ````
+   ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
@@ -40,7 +40,7 @@ grammar
 
 ```sql
 SHOW TYPE_CAST [IN|FROM db]
-````
+```
 
  Parameters
 
@@ -48,7 +48,7 @@ SHOW TYPE_CAST [IN|FROM db]
 
 ### Example
 
-````sql
+```sql
 mysql> show type_cast in testDb\G
 **************************** 1. row ******************** ******
 Origin Type: TIMEV2
@@ -61,7 +61,7 @@ Origin Type: TIMEV2
   Cast Type: TIMEV2
 
 3 rows in set (0.00 sec)
-````
+```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-VARIABLES.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-VARIABLES.md
@@ -36,10 +36,10 @@ This statement is used to display Doris system variables, which can be queried b
 
 grammar:
 
-````sql
+```sql
 SHOW [GLOBAL | SESSION] VARIABLES
      [LIKE 'pattern' | WHERE expr]
-````
+```
 
 illustrate:
 
@@ -54,19 +54,19 @@ illustrate:
 
     ```sql
     show variables like 'max_connections';
-    ````
+    ```
 
 2. Matching through the percent sign (%) wildcard can match multiple items
 
     ```sql
     show variables like '%connec%';
-    ````
+    ```
 
 3. Use the Where clause for matching queries
 
     ```sql
     show variables where variable_name = 'version';
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Show-Statements/SHOW-VIEW.md
+++ b/docs/sql-manual/sql-statements/Show-Statements/SHOW-VIEW.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
   SHOW VIEW { FROM | IN } table [ FROM db ]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ grammar:
 
     ```sql
     SHOW VIEW FROM testTbl;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Utility-Statements/DESCRIBE.md
+++ b/docs/sql-manual/sql-statements/Utility-Statements/DESCRIBE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DESC[RIBE] [db_name.]table_name [ALL];
-````
+```
 
 illustrate:
 
@@ -50,13 +50,13 @@ illustrate:
 
     ```sql
     DESC table_name;
-    ````
+    ```
 
 2. Display the schema of all indexes of the table
 
     ```sql
     DESC db1.table_name ALL;
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/sql-manual/sql-statements/Utility-Statements/HELP.md
+++ b/docs/sql-manual/sql-statements/Utility-Statements/HELP.md
@@ -36,9 +36,9 @@ The directory of help can be queried by changing the command
 
 grammar:
 
-```` sql
+``` sql
 HELP <item>
-````
+```
 
 All Doris commands can be listed with `help`
 
@@ -72,7 +72,7 @@ nowarning (\w) Don't show warnings after every statement.
 resetconnection(\x) Clean session context.
 
 For server side help, type 'help contents'
-````
+```
 
 Get the Doris SQL help contents via `help contents`
 
@@ -83,7 +83,7 @@ where <item> is one of the following
 categories:
    sql-functions
    sql-statements
-````
+```
 
 ### Example
 
@@ -91,19 +91,19 @@ categories:
 
    ```sql
    help contents
-   ````
+   ```
 
 2. The command to list all function directories of the Doris cluster
 
    ```sql
    help sql-functions
-   ````
+   ```
 
 3. List all functions under the date function
 
    ```sql
    help date-time-functions
-   ````
+   ```
 
 
 ### Keywords

--- a/docs/sql-manual/sql-statements/Utility-Statements/USE.md
+++ b/docs/sql-manual/sql-statements/Utility-Statements/USE.md
@@ -36,9 +36,9 @@ The USE command allows us to use the database
 
 grammar:
 
-````SQL
+```SQL
 USE <[CATALOG_NAME].DATABASE_NAME>
-````
+```
 
 illustrate:
 1. `USE CATALOG_NAME.DATABASE_NAME` will switch the current catalog into `CATALOG_NAME` and then change the current database into `DATABASE_NAME`
@@ -50,13 +50,13 @@ illustrate:
     ```sql
     mysql> use demo;
     Database changed
-    ````
+    ```
 2. If the demo database exists in catalog hms_catalog, try switching the catalog and accessing it:
 
     ```sql
     mysql> use hms_catalog.demo;
     Database changed
-    ````
+    ```
 
 ### Keywords
 

--- a/docs/table-design/index/ngram-bloomfilter-index.md
+++ b/docs/table-design/index/ngram-bloomfilter-index.md
@@ -133,7 +133,7 @@ https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/amazon_
 
 **Import the data using stream load:**
 
-```bash
+```shell
 curl --location-trusted -u root: -T amazon_reviews_2010.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load
 curl --location-trusted -u root: -T amazon_reviews_2011.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load
 curl --location-trusted -u root: -T amazon_reviews_2012.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load

--- a/ecosystem/beats.md
+++ b/ecosystem/beats.md
@@ -47,7 +47,7 @@ To use the Beats Doris output plugin, there are three main steps:
 
 Execute the following commands in the `extension/beats/` directory:
 
-````
+```
 cd doris/extension/beats
 
 go build -o filebeat-doris filebeat/filebeat.go
@@ -56,7 +56,7 @@ go build -o winlogbeat-doris winlogbeat/winlogbeat.go
 go build -o packetbeat-doris packetbeat/packetbeat.go
 go build -o auditbeat-doris auditbeat/auditbeat.go
 go build -o heartbeat-doris heartbeat/heartbeat.go
-````
+```
 
 ## Configuration
 
@@ -252,7 +252,7 @@ This example demonstrates JSON log collection using data from the GitHub events 
 
 The GitHub events archive contains archived data of GitHub user actions, formatted as JSON. It can be downloaded from [here](https://data.gharchive.org/), for example, the data for January 1, 2024, at 3 PM.
 
-```bash
+```shell
 wget https://data.gharchive.org/2024-01-01-15.json.gz
 ```
 

--- a/ecosystem/doris-streamloader.md
+++ b/ecosystem/doris-streamloader.md
@@ -53,7 +53,7 @@ The obtained result is the executable binary.
 
 ## How to use
 
-```bash
+```shell
 
 doris-streamloader --source_file={FILE_LIST} --url={FE_OR_BE_SERVER_URL}:{PORT} --header={STREAMLOAD_HEADER} --db={TARGET_DATABASE} --table={TARGET_TABLE}
 
@@ -110,7 +110,7 @@ doris-streamloader --source_file={FILE_LIST} --url={FE_OR_BE_SERVER_URL}:{PORT} 
 
 Example:
 
-```bash
+```shell
 doris-streamloader --source_file="data.csv" --url="http://localhost:8330" --header="column_separator:|?columns:col1,col2" --db="testdb" --table="testtbl"
 ```
 

--- a/ecosystem/logstash.md
+++ b/ecosystem/logstash.md
@@ -51,11 +51,11 @@ You can download the plugin from the official website or compile it from the sou
 
 - Compile from source code
 
-````
+```
 cd extension/logstash/
 
 gem build logstash-output-doris.gemspec
-````
+```
 
 ### Installing the Plugin
 
@@ -63,13 +63,13 @@ gem build logstash-output-doris.gemspec
 
 `${LOGSTASH_HOME}` is the installation directory of Logstash. Run the `bin/logstash-plugin` command under it to install the plugin.
 
-````
+```
 ${LOGSTASH_HOME}/bin/logstash-plugin install logstash-output-doris-1.0.0.gem
 
 Validating logstash-output-doris-1.0.0.gem
 Installing logstash-output-doris
 Installation successful
-````
+```
 
 The standard installation mode will automatically install the ruby modules that the plugin depends on. In cases where the network is not available, it will get stuck and cannot complete. In such cases, you can download the zip installation package with dependencies for a completely offline installation, noting that you need to use `file://` to specify the local file system.
 
@@ -278,7 +278,7 @@ This example demonstrates JSON log collection using data from the GitHub events 
 
 The GitHub events archive contains archived data of GitHub user actions, formatted as JSON. It can be downloaded from [here](https://data.gharchive.org/), for example, the data for January 1, 2024, at 3 PM.
 
-```bash
+```shell
 wget https://data.gharchive.org/2024-01-01-15.json.gz
 ```
 

--- a/faq/data-faq.md
+++ b/faq/data-faq.md
@@ -96,9 +96,9 @@ So this problem can be solved in two ways:
 
 When performing operations such as import, query, etc., you may encounter the following errors:
 
-````text
+```text
 failed to initialize storage reader. tablet=63416.1050661139.aa4d304e7a7aff9c-f0fa7579928c85a0, res=-214, backend=192.168.100.10
-````
+```
 
 A -214 error means that the data version for the corresponding tablet is missing. For example, the above error indicates that the data version of the copy of tablet 63416 on the BE of 192.168.100.10 is missing. (There may be other similar error codes, which can be checked and repaired in the following ways).
 
@@ -145,10 +145,10 @@ The reason for this problem may be that when importing data from external storag
 
 Modify the `fe.conf` configuration file to add the following parameters:
 
-````
+```
 broker_timeout_ms = 10000
 ##The default here is 10 seconds, you need to increase this parameter appropriately
-````
+```
 
 Adding parameters here requires restarting the FE service.
 

--- a/faq/install-faq.md
+++ b/faq/install-faq.md
@@ -100,9 +100,9 @@ In many cases, we need to troubleshoot problems through logs. The format and vie
 
    A typical FE log is as follows:
 
-   ````text
+   ```text
    2021-09-16 23:13:22,502 INFO (tablet scheduler|43) [BeLoadRebalancer.selectAlternativeTabletsForCluster():85] cluster is balance: default_cluster with medium: HDD.skip
-   ````
+   ```
 
    - `2021-09-16 23:13:22,502`: log time.
    - `INFO: log level, default is INFO`.
@@ -122,9 +122,9 @@ In many cases, we need to troubleshoot problems through logs. The format and vie
 
    A typical BE log is as follows:
 
-   ````text
+   ```text
    I0916 23:21:22.038795 28087 task_worker_pool.cpp:1594] finish report TASK. master host: 10.10.10.10, port: 9222
-   ````
+   ```
 
    - `I0916 23:21:22.038795`: log level and datetime. The capital letter I means INFO, W means WARN, and F means FATAL.
    - `28087`: thread id. Through the thread id, you can view the context information of this thread and check what happened in this thread.
@@ -175,18 +175,18 @@ In other words, ".HDD" and ".SSD" are only used to identify the "relative" "low 
 
 Doris can deploy multiple FEs. When accessing the Web UI, if Nginx is used for load balancing, there will be a constant prompt to log in again because of the session problem. This problem is actually a problem of session sharing. Nginx provides centralized session sharing. The solution, here we use the ip_hash technology in nginx, ip_hash can direct the request of an ip to the same backend, so that a client and a backend under this ip can establish a stable session, ip_hash is defined in the upstream configuration:
 
-````text
+```text
 upstream doris.com {
    server 172.22.197.238:8030 weight=3;
    server 172.22.197.239:8030 weight=4;
    server 172.22.197.240:8030 weight=4;
    ip_hash;
 }
-````
+```
 
 The complete Nginx example configuration is as follows:
 
-````text
+```text
 user nginx;
 worker_processes auto;
 error_log /var/log/nginx/error.log;
@@ -244,7 +244,7 @@ http {
         }
     }
  }
-````
+```
 
 ### Q9. FE fails to start, "wait catalog to be ready. FE type UNKNOWN" keeps scrolling in fe.log
 

--- a/faq/sql-faq.md
+++ b/faq/sql-faq.md
@@ -58,10 +58,10 @@ This may be because, in the same batch of imported data, there are data with the
 
 For example, the table is defined as k1, v1. A batch of imported data is as follows:
 
-````text
+```text
 1, "abc"
 1, "def"
-````
+```
 
 Then maybe the result of copy 1 is `1, "abc"`, and the result of copy 2 is `1, "def"`. As a result, the query results are inconsistent.
 

--- a/gettingStarted/quick-start.md
+++ b/gettingStarted/quick-start.md
@@ -38,7 +38,7 @@ This guide is about how to download the latest stable version of Apache Doris, i
 
 Download the Apache Doris installation package from doris.apache.org and proceed with the following steps.
 
-```Bash
+```shell
 # Download the binary installation package of Apache Doris
 server1:~ doris$ wget https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-2.0.3-bin-x64.tar.gz
 
@@ -70,7 +70,7 @@ JAVA_HOME=/home/doris/jdk8
 
 Run the following command under apache-doris/fe to start FE.
 
-```Bash
+```shell
 # Start FE in the background to ensure that the process continues running even after exiting the terminal.
 server1:apache-doris/fe doris$ ./bin/start_fe.sh --daemon
 ```
@@ -94,7 +94,7 @@ JAVA_HOME=/home/doris/jdk8
 
 Run the following command under apache-doris/be to start BE.
 
-```Bash
+```shell
 # Start BE in the background to ensure that the process continues running even after exiting the terminal.
 server1:apache-doris/be doris$ ./bin/start_be.sh --daemon
 ```
@@ -105,7 +105,7 @@ Download the [portable MySQL client](https://dev.mysql.com/downloads/mysql/) to 
 
 Unpack the client, find the `mysql` command-line tool in the `bin/` directory. Then execute the following command to connect to Apache Doris.
 
-```Bash
+```shell
 mysql -uroot -P9030 -h127.0.0.1
 ```
 
@@ -153,7 +153,7 @@ The root and admin users are two default accounts that are automatically created
 
 Use admin account to connect to Apache Doris FE.
 
-```Bash
+```shell
 mysql -uadmin -P9030 -h127.0.0.1
 ```
 
@@ -192,7 +192,7 @@ Save the following example data to the local "data.csv" file:
 
 Load the data from "data.csv" into the newly created table using the Stream Load method.
 
-```Bash
+```shell
 curl  --location-trusted -u admin:admin_password -T data.csv -H "column_separator:," http://127.0.0.1:8030/api/demo/mytable/_stream_load
 ```
 
@@ -202,7 +202,7 @@ curl  --location-trusted -u admin:admin_password -T data.csv -H "column_separato
 
 Once it is executed successfully, a message like the following will be returned: 
 
-```Bash
+```shell
 {                                                     
     "TxnId": 30,                                  
     "Label": "a56d2861-303a-4b50-9907-238fea904363",        
@@ -251,7 +251,7 @@ mysql> select * from mytable;
 
 Execute the following command under apache-doris/fe to stop FE.
 
-```Bash
+```shell
 server1:apache-doris/fe doris$ ./bin/stop_fe.sh
 ```
 
@@ -259,7 +259,7 @@ server1:apache-doris/fe doris$ ./bin/stop_fe.sh
 
 Execute the following command under apache-doris/be to stop BE.
 
-```Bash
+```shell
 server1:apache-doris/be doris$ ./bin/stop_be.sh
 ```
 

--- a/gettingStarted/tutorials/log-storage-analysis.md
+++ b/gettingStarted/tutorials/log-storage-analysis.md
@@ -398,7 +398,7 @@ output {
 
 3. Run Logstash according to the command below, collect logs, and output to Apache Doris.
 
-```Bash  
+```shell  
 ./bin/logstash -f logstash_demo.conf
 ```
 
@@ -465,7 +465,7 @@ headers:
 
 3. Run Filebeat according to the command below, collect logs, and output to Apache Doris.
 
-    ```Bash  
+    ```shell  
     chmod +x filebeat-doris-1.0.0  
     ./filebeat-doris-1.0.0 -c filebeat_demo.yml
     ```
@@ -509,7 +509,7 @@ For more information about Kafka, see [Routine Load](../../data-operate/import/r
 
 In addition to integrating common log collectors, you can also customize programs to import log data into Apache Doris using the Stream Load HTTP API. Refer to the following code:
 
-```Bash  
+```shell
 curl   
 --location-trusted   
 -u username:password   

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/developer-guide/docker-dev.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/developer-guide/docker-dev.md
@@ -84,7 +84,7 @@ RUN wget https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -
 
 运行构建命令
 
-```bash
+```shell
 docker build -t doris .
 ```
 
@@ -98,7 +98,7 @@ docker build -t doris .
 
 `--cap-add SYS_PTRACE`参数可以允许docker使用ptrace，便于我们使用ptrace和gdb远程调试功能。
 
-```bash
+```shell
 docker run -it --cap-add SYS_PTRACE doris:latest /bin/bash
 ```
 
@@ -111,7 +111,7 @@ plugins=(git zsh-autosuggestions zsh-syntax-highlighting)
 
 创建目录并下载 doris
 
-```bash
+```shell
 su <your user>
 mkdir code && cd code
 git clone https://github.com/apache/doris.git
@@ -125,7 +125,7 @@ git submodule update --init --recursive
 
 第一次编译的时候要使用如下命令
 
-```bash
+```shell
 sh build.sh --clean --be --fe --ui
 ```
 
@@ -133,7 +133,7 @@ sh build.sh --clean --be --fe --ui
 
 编译 Doris
 
-```bash
+```shell
 sh build.sh
 ```
 
@@ -141,26 +141,26 @@ sh build.sh
 
 手动创建 `meta_dir` 元数据存放位置, 默认值为 `${DORIS_HOME}/doris-meta`
 
-```bash
+```shell
 mkdir meta_dir
 ```
 
 启动FE
 
-```bash
+```shell
 cd output/fe
 sh bin/start_fe.sh --daemon
 ```
 
 启动BE
 
-```bash
+```shell
 cd output/be
 sh bin/start_be.sh --daemon
 ```
 
 mysql-client 连接
 
-```bash
+```shell
 mysql -h 127.0.0.1 -P 9030 -u root
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/developer-guide/fe-vscode-dev.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/developer-guide/fe-vscode-dev.md
@@ -77,7 +77,7 @@ example:
 
 为了进行调试，需要在 fe 启动时，加上调试的参数，比如 
 
-```bash
+```shell
 -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/how-to-contribute/docs-format-specification.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/how-to-contribute/docs-format-specification.md
@@ -195,6 +195,8 @@ SQL 函数文档排版请参考文档贡献指南-**[如何编写命令帮助手
 
 - 在 Visual Studio Code 等编辑器中统一设置一个 Tab 等于四个半角空格
 
+- 缩进可能会影响文档渲染结果，**以 vscode 等富文本编辑器能够正确渲染为准（例如，在多级缩进结构内的代码块有时仍需要 0 级缩进才可正确渲染）**。
+
 ### 03 空格使用
 
 - 英文、数字与中文需要前后半角空格
@@ -239,7 +241,7 @@ SQL 函数文档排版请参考文档贡献指南-**[如何编写命令帮助手
 
 插入代码块建议遵循以下规范：
 
-- 行内代码，使用反引号 ``` 创建，多行代码使用三个反引号 创建。
+- 行内代码，使用反引号 (\```) 创建，多行代码使用三个反引号 创建。
 
 - 行内代码块前后加上空格、多行代码与正文空一行
 
@@ -249,33 +251,33 @@ SQL 函数文档排版请参考文档贡献指南-**[如何编写命令帮助手
 
    | 代码类型                                | 代码围栏指定方式         |
     | :-------------------------------------- | :----------------------- |
-    | Shell 脚本                              | ```shell``` 或 ```bash```  |
-    | Python 代码                             | ````python```              |
-    | JSON 代码                               | ````json```                |
-    | XML 文档                                | ````xml```                 |
-    | SQL 查询（请使用小写 sql 否则渲染失败） | ````sql```                |
-    | YAML 文件                               | ````yaml``` 或```yml```      |
-    | Markdown 文本                           | ```markdown``` 或```md```  |
-    | JavaScript 代码                         | ```js```或```javascript``` |
-    | Java 代码                               | ```java```              |
-    | C++ 代码                                | ```cpp```                 |
-    | C 代码                                  | ```c```                   |
-    | Ruby 代码                               | ```ruby```                |
-    | HTML 代码                               | ```html```                |
-    | CSS 代码                                | ```css```                 |
-    | PHP 代码                                | ```php```                |
+    | Shell 脚本                              | \```shell```  |
+    | Python 代码                             | \```python```              |
+    | JSON 代码                               | \```json```                |
+    | XML 文档                                | \```xml```                 |
+    | SQL 查询（请使用小写 sql 否则渲染失败）     | \```sql```                |
+    | YAML 文件                               | \```yaml\``` 或 \```yml```      |
+    | Markdown 文本                           | \```markdown\``` 或 \```md```  |
+    | JavaScript 代码                         | \```js\```或\```javascript``` |
+    | Java 代码                               | \```java```              |
+    | C++ 代码                                | \```cpp```                 |
+    | C 代码                                  | \```c```                   |
+    | Ruby 代码                               | \```ruby```                |
+    | HTML 代码                               | \```html```                |
+    | CSS 代码                                | \```css```                 |
+    | PHP 代码                                | \```php```                |
 
-- 当使用 ```bash``` 代码时，写入命令与输出结果需分开编写。下面以 Kubernetes 集群访问文档为例：
+- 当使用 ```shell``` 代码时，写入命令与输出结果需分开编写。下面以 Kubernetes 集群访问文档为例：
 
   - 使用以下命令查看相应 Service：
 
-    ```Bash
+    ```shell
     kubectl get pod --namespace doris
     ```
 
   - 返回结果如下
   
-    ```Bash
+    ```shell
     NAME                     READY   STATUS    RESTARTS   AGE
     doriscluster-helm-fe-0   1/1     Running   0          1m39s
     doriscluster-helm-fe-1   1/1     Running   0          1m39s

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/release-and-verify/release-doris-sdk.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/release-and-verify/release-doris-sdk.md
@@ -46,7 +46,7 @@ under the License.
 
 执行以下命令开始生成 release tag：
 
-```bash
+```shell
 mvn release:clean
 mvn release:prepare -DpushChanges=false
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/release-and-verify/release-doris-shade.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/release-and-verify/release-doris-shade.md
@@ -46,7 +46,7 @@ under the License.
 
 执行以下命令开始生成 release tag：
 
-```bash
+```shell
 mvn release:clean
 mvn release:prepare -DpushChanges=false
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/auth/certificate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/auth/certificate.md
@@ -41,7 +41,7 @@ Doris 开启 SSL 功能需要配置 CA 密钥证书和 Server 端密钥证书，
 
 1. 生成 CA、Server 端和 Client 端的密钥和证书
 
-```BASH
+```shell
 # 生成CA certificate
 openssl genrsa 2048 > ca-key.pem
 openssl req -new -x509 -nodes -days 3600 \
@@ -66,13 +66,13 @@ openssl x509 -req -in client-req.pem -days 3600 \
 
 2. 验证创建的证书。
 
-```bash
+```shell
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
 3. 将您的 CA 密钥和证书和 Sever 端密钥和证书分别合并到 PKCS#12 (P12) 包中。您也可以指定某个证书格式，默认 PKCS12，可以通过修改 conf/fe.conf 配置文件，添加参数 ssl_trust_store_type 指定证书格式
 
-```bash
+```shell
 # 打包CA密钥和证书
 openssl pkcs12 -inkey ca-key.pem -in ca.pem -export -out ca_certificate.p12
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/auth/ldap.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/auth/ldap.md
@@ -128,13 +128,13 @@ set ldap_admin_password = password('ldap_admin_password');
 
   例如在 linux 或者 mac 环境中可以使用：
 
-  ```bash
+  ```shell
   echo "export LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN=1" >> ～/.bash_profile && source ～/.bash_profile
   ```
 
 - 每次登录 Doris 时添加参数 `--enable-cleartext-plugin`
 
-  ```bash
+  ```shell
   mysql -hDORIS_HOST -PDORIS_PORT -u user -p --enable-cleartext-plugin
   
   输入 ldap 密码
@@ -196,13 +196,13 @@ LDAP 密码验证和组授权是 Doris 密码验证和授权的补充，开启 L
 
     使用以下命令登录 Doris 可以登录 `jack@'172.10.1.10'` 账户：
 
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
     ```
 
     使用以下命令将登录失败：
     
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
     ```
 
@@ -212,7 +212,7 @@ LDAP 密码验证和组授权是 Doris 密码验证和授权的补充，开启 L
 
     使用以下命令创建临时用户并登录 jack@'%'，临时用户具有基本权限 DatabasePrivs：Select_priv，用户退出登录后 Doris 将删除该临时用户：
     
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
     ```
 
@@ -222,7 +222,7 @@ LDAP 密码验证和组授权是 Doris 密码验证和授权的补充，开启 L
 
     使用 Doris 密码登录账户，成功：
     
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/check-tablet-segment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/check-tablet-segment.md
@@ -69,7 +69,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/check_tablet_segment_lost?repair=false
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/compaction-run.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/compaction-run.md
@@ -135,6 +135,6 @@ under the License.
 
 ### Examples
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/compaction/run?tablet_id=10015&compact_type=cumulative"
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/compaction-status.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/compaction-status.md
@@ -114,6 +114,6 @@ under the License.
 
 ## Examples
 
-```bash
+```shell
 curl http://192.168.10.24:8040/api/compaction/show?tablet_id=10015
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/config.md
@@ -91,15 +91,15 @@ under the License.
 ## Examples
 
 
-```bash
+```shell
 curl "http://127.0.0.1:8040/api/show_config"
 ```
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/update_config?agent_task_trace_threshold_sec=2&persist=true"
 
 ```
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/update_config?agent_task_trace_threshold_sec=2&enable_merge_on_write_correctness_check=true&persist=true"
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/download.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/download.md
@@ -53,7 +53,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/_load_error_log?file=a&token=1"
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/health.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/health.md
@@ -49,7 +49,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/health
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/meta.md
@@ -66,7 +66,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/metrics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/metrics.md
@@ -63,7 +63,7 @@ prometheus 监控采集接口
 ## Examples
 
 
-    ```bash
+    ```shell
         curl "http://127.0.0.1:8040/metrics?type=json&with_tablet=true"
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/pad-rowset.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/pad-rowset.md
@@ -61,7 +61,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl -X POST "http://127.0.0.1:8040/api/pad_rowset?tablet_id=123456&start_version=1111111&end_version=1111112"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/reset-rpc-channel.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/reset-rpc-channel.md
@@ -60,11 +60,11 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/reset_rpc_channel/all
     ```
     
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/reset_rpc_channel/1.1.1.1:8080,2.2.2.2:8080
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/snapshot.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/snapshot.md
@@ -55,7 +55,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/snapshot?tablet_id=123456&schema_hash=1111111"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/tablet-distribution.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/tablet-distribution.md
@@ -85,7 +85,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/tablets_distribution?group_by=partition&partition_id=123"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/tablet-info.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/tablet-info.md
@@ -71,7 +71,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/tablets_json?limit=123
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/tablet-migration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/tablet-migration.md
@@ -104,7 +104,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/tablet_migration?goal=run&tablet_id=123&schema_hash=333&disk=/disk1"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/tablet-reload.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/be/tablet-reload.md
@@ -51,13 +51,13 @@ under the License.
 
 ## Response
 
-    ```bash
+    ```shell
     load header succeed
     ```
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/reload_tablet?tablet_id=123456&schema_hash=1111111&path=/abc"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/cluster-management/load-balancing.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/cluster-management/load-balancing.md
@@ -51,7 +51,7 @@ Doris 的 FE 进程负责接收用户连接和查询请求，其本身是可以�
 
 ### 安装 ProxySQL（yum 方式）
 
-```bash
+```shell
 配置yum源
 # vim /etc/yum.repos.d/proxysql.repo
 
@@ -91,7 +91,7 @@ ProxySQL 有配置文件 `/etc/proxysql.cnf` 和配置数据库文件`/var/lib/p
 
 这里主要是几个参数，在下面已经注释出来了，可以根据自己的需要进行修改
 
-```bash
+```shell
 # egrep -v "^#|^$" /etc/proxysql.cnf
 datadir="/var/lib/proxysql"         #数据目录
 admin_variables=
@@ -508,7 +508,7 @@ IP: 172.31.7.119
 
 ### 安装依赖
 
-```bash
+```shell
 sudo apt-get install build-essential
 sudo apt-get install libpcre3 libpcre3-dev 
 sudo apt-get install zlib1g-dev
@@ -517,7 +517,7 @@ sudo apt-get install openssl libssl-dev
 
 ### 安装 Nginx
 
-```bash
+```shell
 sudo wget http://nginx.org/download/nginx-1.18.0.tar.gz
 sudo tar zxvf nginx-1.18.0.tar.gz
 cd nginx-1.18.0
@@ -529,13 +529,13 @@ sudo make && make install
 
 这里是新建了一个配置文件
 
-```bash
+```shell
 vim /usr/local/nginx/conf/default.conf
 ```
 
 然后在里面加上下面的内容
 
-```bash
+```shell
 events {
 worker_connections 1024;
 }

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/data-admin/ccr.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/data-admin/ccr.md
@@ -75,7 +75,7 @@ enable_feature_binlog=true
 
 1. 构建 CCR syncer
 
-    ```Bash
+    ```shell
     git clone https://github.com/selectdb/ccr-syncer
 
     cd ccr-syncer
@@ -87,7 +87,7 @@ enable_feature_binlog=true
 
 2. 启动和停止 syncer
 
-    ```Bash
+    ```shell
     # 启动
     cd bin && sh start_syncer.sh --daemon
 
@@ -97,7 +97,7 @@ enable_feature_binlog=true
 
 **5. 打开源集群中同步库/表的 Binlog**
 
-```Bash
+```shell
 -- 如果是整库同步，可以执行如下脚本，使得该库下面所有的表都要打开 binlog.enable
 vim shell/enable_db_binlog.sh
 修改源集群的 host、port、user、password、db
@@ -109,7 +109,7 @@ ALTER TABLE enable_binlog SET ("binlog.enable" = "true");
 
 **6. 向 syncer 发起同步任务**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -135,7 +135,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 同步任务的参数说明：
 
-```Bash
+```shell
 name: CCR同步任务的名称，唯一即可
 host、port：对应集群 Master FE的host和mysql(jdbc) 的端口
 user、password：syncer以何种身份去开启事务、拉取数据等
@@ -280,7 +280,7 @@ bash bin/start_syncer.sh --pid_dir /path/to/pids
 
 在编译完成后的输出路径下，文件结构大致如下所示：
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -316,7 +316,7 @@ output_dir
 
 指定 pid 文件所在目录，上述三种关闭方法都依赖于 pid 文件的所在目录执行
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --pid_dir /path/to/pids
 ```
 
@@ -328,7 +328,7 @@ bash bin/stop_syncer.sh --pid_dir /path/to/pids
 
 关闭 pid_dir 路径下 host:port 对应的 Syncer
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --host 127.0.0.1 --port 9190
 ```
 
@@ -342,7 +342,7 @@ host 与 port 都不为空时**方法 1**才能生效
 
 关闭 pid_dir 路径下指定 pid 文件名对应的 Syncer
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 ```
 
@@ -352,7 +352,7 @@ bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 
 **请求的通用模板**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d {json_body} http://ccr_syncer_host:ccr_syncer_port/operator
 ```
 
@@ -376,7 +376,7 @@ or
 
 ​    创建 CCR 任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "ccr_test",
         "src": {
@@ -418,7 +418,7 @@ or
 
 ​    查看同步进度
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/get_lag
@@ -430,7 +430,7 @@ or
 
 ​    暂停同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/pause 
@@ -440,7 +440,7 @@ or
 
 ​    恢复同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/resume
@@ -450,7 +450,7 @@ or
 
 ​    删除同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/delete
@@ -460,7 +460,7 @@ or
 
     获取版本信息
 
-    ```Bash
+    ```shell
     curl http://ccr_syncer_host:ccr_syncer_port/version
 
     # > return
@@ -471,7 +471,7 @@ or
 
     查看 job 的状态
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/job_status
@@ -490,7 +490,7 @@ or
 
     不做 sync，此时用户可以将源和目的集群互换
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/desync
@@ -500,7 +500,7 @@ or
 
     展示已经创建的所有任务
 
-    ```Bash
+    ```shell
     curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
     {"success":true,"jobs":["ccr_db_table_alias"]}
@@ -512,7 +512,7 @@ or
 
 在编译完成后的输出路径下，文件结构大致如下所示：
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -530,7 +530,7 @@ output_dir
 
 **使用说明**
 
-```Bash
+```shell
 bash bin/enable_db_binlog.sh -h host -p port -u user -P password -d db
 ```
 
@@ -586,7 +586,7 @@ Syncer 高可用依赖 mysql，如果使用 mysql 作为后端存储，Syncer �
 
 BE 端配置参数
 
-```Bash
+```shell
 download_binlog_rate_limit_kbs=1024 # 这就是限制到1MB，这个是单个be对所有关于binlog 包括local snapshot的配置
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/log-management/fe-log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/log-management/fe-log.md
@@ -130,7 +130,7 @@ FE 的 Debug 级别日志可以通过修改配置文件开启，也可以通过�
 
    通过以下 API 也可以在运行时修改日志级别。无需重启 FE 节点。
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?add_verbose=org.apache.doris.catalog.Catalog
    ```
 
@@ -153,7 +153,7 @@ FE 的 Debug 级别日志可以通过修改配置文件开启，也可以通过�
 
    也可以通过以下 API 关闭 Debug 日志：
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?del_verbose=org.apache.doris.catalog.Catalog
    ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/maint-monitor/automatic-service-start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/maint-monitor/automatic-service-start.md
@@ -162,20 +162,20 @@ doris   ALL=(ALL)       NOPASSWD:DORISCTL
 
     添加或修改配置文件后，需要重新加载
 
-    ```bash
+    ```shell
     systemctl daemon-reload
     ```
 
     设置自启动，实质就是在 /etc/systemd/system/multi-user.target.wants/ 添加服务文件的链接
 
-    ```bash
+    ```shell
     systemctl enable doris-fe
     systemctl enable doris-be
     ```
 
 8. 服务启动
 
-    ```bash
+    ```shell
     systemctl start doris-fe
     systemctl start doris-be
     ```
@@ -190,14 +190,14 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 1. yum 安装 supervisor
     
-    ```bash
+    ```shell
     yum install epel-release
     yum install -y supervisor
     ```
 
 2. 启动服务并查看状态
 
-    ```bash
+    ```shell
     systemctl enable supervisord # 开机自启动
     systemctl start supervisord # 启动 supervisord 服务
     systemctl status supervisord # 查看 supervisord 服务状态
@@ -206,7 +206,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 3. 配置 BE 进程管理
 
-    ```bash
+    ```shell
     修改 start_be.sh 脚本，去掉最后的 & 符号
 
     vim /path/doris/be/bin/start_be.sh
@@ -216,7 +216,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 BE 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-be.ini
 
     [program:doris_be]      
@@ -239,7 +239,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 4. 配置 FE 进程管理
 
-    ```bash
+    ```shell
     修改 start_fe.sh 脚本，去掉最后的 & 符号
 
     vim /path/doris/fe/bin/start_fe.sh 
@@ -249,7 +249,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 FE 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-fe.ini
 
     [program:PaloFe]
@@ -273,7 +273,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 5. 配置 Broker 进程管理
 
-    ```bash
+    ```shell
     修改 start_broker.sh 脚本，去掉最后的 & 符号
 
     vim /path/apache_hdfs_broker/bin/start_broker.sh
@@ -283,7 +283,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 Broker 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-broker.ini
 
     [program:BrokerBootstrap]
@@ -307,7 +307,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 6. 首先确定 Doris 服务是停止状态，然后使用 supervisor 将 Doris 自动拉起，然后确定进程是否正常启动
     
-    ```bash
+    ```shell
     supervisorctl reload # 重新加载 Supervisor 中的所有配置文件
     supervisorctl status # 查看 supervisor 状态，验证 Doris 服务进程是否正常启动
 
@@ -321,7 +321,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 - 如果使用 yum 安装的 supervisor 启动报错 :  pkg_resources.DistributionNotFound: The 'supervisor==3.4.0' distribution was not found
 
-    ```bash
+    ```shell
     这个是 python 版本不兼容问题，通过 yum 命令直接安装的 supervisor 只支持 python2 版本，所以需要将 /usr/bin/supervisord 和 /usr/bin/supervisorctl 中文件内容开头 #!/usr/bin/python 改为 #!/usr/bin/python2，前提是要装 python2 版本
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/maint-monitor/tablet-local-debug.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/maint-monitor/tablet-local-debug.md
@@ -100,7 +100,7 @@ PROPERTIES (
 
 该目下会有一个 tablet id 命名的目录，将这个目录整体打包后备用。（注意，该目录最多保留 60 分钟，之后会自动删除）。
 
-```bash
+```shell
 cd /path/to/be/storage/snapshot/20220830101353.2.3600
 tar czf 10020.tar.gz 10020/
 ```
@@ -178,13 +178,13 @@ tar czf 10020.tar.gz 10020/
 
     同时，我们还需要到调试环境 BE 节点的数据目录下，确认新的 tablet 所在的 shard id：
     
-    ```bash
+    ```shell
     cd /path/to/storage/data/*/10017 && pwd
     ```
     
     这个命令会进入 10017 这个 tablet 所在目录并展示路径。这里我们会看到类似如下的路径：
     
-    ```bash
+    ```shell
     /path/to/storage/data/0/10017
     ```
     
@@ -208,7 +208,7 @@ tar czf 10020.tar.gz 10020/
     
     通过 `meta_tool` 工具删除原来的 tablet meta。该工具位于 `be/lib` 目录下。
     
-    ```bash
+    ```shell
     ./lib/meta_tool --root_path=/path/to/storage --operation=delete_meta --tablet_id=10017 --schema_hash=44622287
     ```
     
@@ -216,7 +216,7 @@ tar czf 10020.tar.gz 10020/
     
     通过 `meta_tool` 工具加载新的 tablet meta。
     
-    ```bash
+    ```shell
     ./lib/meta_tool --root_path=/path/to/storage --operation=load_meta --json_meta_path=/path/to/10017.hdr.json
     ```
     

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/maint-monitor/tablet-meta-tool.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/maint-monitor/tablet-meta-tool.md
@@ -89,7 +89,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./lib/meta_tool --operation=load_meta --root_path=/path/to/root_path --json_meta_path=path
 ```
 
@@ -99,13 +99,13 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 删除单个 tablet 元数据：
 
-```bash
+```shell
 ./lib/meta_tool --operation=delete_meta --root_path=/path/to/root_path --tablet_id=xxx --schema_hash=xxx
 ```
 
 删除一组 tablet 元数据：
 
-```bash
+```shell
 ./lib/meta_tool --operation=batch_delete_meta --tablet_file=/path/to/tablet_file.txt
 ```
 
@@ -117,7 +117,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 `tablet_file` 文件示例：
 
-```bash
+```shell
 /output/be/data/,14217,352781111
 /output/be/data/,14219,352781111
 /output/be/data/,14223,352781111
@@ -134,7 +134,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./lib/meta_tool --operation=show_meta --root_path=/path/to/root_path --pb_header_path=path
 ```
 
@@ -144,7 +144,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./meta_tool --operation=show_segment_footer --file=/path/to/segment/file
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/plugin-development-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/plugin-development-manual.md
@@ -74,7 +74,7 @@ auditodemo/:
 
 `plugin.properties` 内容示例：
 
-```bash
+```shell
 ### required:
 #
 # the plugin name
@@ -113,13 +113,13 @@ soName = example.so
 
 我们可以通过以下命令在 `fe_plugins` 目录创建一个子模块用户实现创建和创建工程。其中 `doris-fe-test` 为插件名称。
 
-```bash
+```shell
 mvn archetype: generate -DarchetypeCatalog = internal -DgroupId = org.apache -DartifactId = doris-fe-test -DinteractiveMode = false
 ```
 
 这个命令会创建一个新的 maven 工程，并且自动向 `fe_plugins/pom.xml` 中添加一个子模块：
 
-```bash
+```shell
     .....
     <groupId>org.apache</groupId>
     <artifactId>doris-fe-plugins</artifactId>
@@ -135,7 +135,7 @@ mvn archetype: generate -DarchetypeCatalog = internal -DgroupId = org.apache -Da
 
 新的工程目录结构如下：
 
-```bash
+```shell
 -doris-fe-test/
 -pom.xml
 -src/

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/before-deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/before-deployment.md
@@ -205,7 +205,7 @@ Welcome to the fdbcli. For help, type `help'.
 
 以下是一个基于 8 核 CPU、32GB 内存和一块 500GB SSD 数据盘的机器的`foundationdb.conf`示例（请确保正确设置 `data` 和 `log` 的存放路径；目前，数据盘一般挂载在 `mnt` 上）：
 
-```Bash
+```shell
 # foundationdb.conf
 ##
 ## Configuration file for FoundationDB server processes
@@ -291,7 +291,7 @@ chmod -R 777 /etc/foundationdb
 
 然后重启 FoundationDB 服务：
 
-```Bash
+```shell
 # for service
 user@host$ sudo service foundationdb restart
 
@@ -342,7 +342,7 @@ chmod -R 777 /etc/foundationdb
 
 随后在本机重启 FoundationDB 服务。
 
-```Bash
+```shell
 # for service
 user@host$ sudo service foundationdb restart
 
@@ -431,7 +431,7 @@ OpenJDK 17 需安装到所有的节点上，可通过以下链接获取安装：
 
 然后，将下载好的 OpenJDK 安装包直接解压到安装路径即可：
 
-```Bash
+```shell
 tar xf openjdk-17.0.1_linux-x64_bin.tar.gz  -C /opt/
 
 # 启动 Meta Service 或者 Recycler 之前

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/compilation-and-deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/compilation-and-deployment.md
@@ -32,13 +32,13 @@ under the License.
 存算分离和存算一体模式下的编译方式相似，均使用代码库自带的 `build.sh` 脚本编译，新增的 MS 模块使用参数`--cloud` 即可编出（二进制名为 `doris_cloud`）。
 **已经编译好的二进制（包含所有 Doris 模块）可以直接从 [Doris 下载页面](https://doris.apache.org/download/)下载（选择大于等于3.0.0的版本）**。
 
-```Bash
+```shell
 sh build.sh --fe --be --cloud 
 ```
 
 相比 3.0.0 之前的版本，编译完成的二进制包中（产出）多了 `ms` 目录。
 
-```Bash
+```shell
 output
 ├── be
 ├── fe
@@ -63,7 +63,7 @@ cp -r ms re
 - `bin/start.sh --version`
 - `lib/doris_cloud --version`
 
-```Bash
+```shell
 $ lib/doris_cloud --version
 version:{doris_cloud-0.0.0-debug} code_version:{commit=b9c1d057f07dd874ad32501ff43701247179adcb time=2024-03-24 20:44:50 +0800} build_info:{initiator=gavinchou@VM-10-7-centos build_at=2024-03-24 20:44:50 +0800 build_on=NAME="TencentOS Server" VERSION="3.1 (Final)" }
 ```
@@ -87,7 +87,7 @@ fdb_cluster = xxx:yyy@127.0.0.1:4500
 
 **示例**
 
-```Bash
+```shell
 cat /etc/foundationdb/fdb.cluster
 
 DO NOT EDIT!
@@ -110,7 +110,7 @@ fdb_cluster = xxx:yyy@127.0.0.1:4500
 
 **示例**
 
-```Bash
+```shell
 cat /etc/foundationdb/fdb.cluster
 
 DO NOT EDIT!

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/creating-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/creating-cluster.md
@@ -84,7 +84,7 @@ Doris 存算分离模式采用服务发现的机制进行工作，创建存算�
 
 **示例**
 
-```Bash
+```shell
 curl -s "127.0.0.1:5000/MetaService/http/create_instance?token=greedisgood9999" -d \
 '{
   "instance_id": "sample_instance_id",
@@ -357,7 +357,7 @@ GRANT
 
 **示例**
 
-```Bash
+```shell
 grant usage_priv on storage vault my_storage_vault to user1
 ```
 
@@ -376,7 +376,7 @@ REVOKE
 
 **示例**
 
-```Bash
+```shell
 revoke usage_priv on storage vault my_storage_vault from user1
 ```
 
@@ -405,7 +405,7 @@ revoke usage_priv on storage vault my_storage_vault from user1
 
 以下为添加一个 FE 的示例：
 
-```Bash
+```shell
 # 添加 FE
 curl '127.0.0.1:5000/MetaService/http/add_cluster?token=greedisgood9999' -d '{
     "instance_id":"sample_instance_id",
@@ -467,7 +467,7 @@ curl '127.0.0.1:5000/MetaService/http/get_cluster?token=greedisgood9999' -d '{
 
 如下是创建包含 1 个 BE 的 计算集群：
 
-```Bash
+```shell
 # 172.19.0.11
 # 添加 BE
 curl '127.0.0.1:5000/MetaService/http/add_cluster?token=greedisgood9999' -d '{

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/file-cache.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/file-cache.md
@@ -66,7 +66,7 @@ Doris 支持 LRU 和 TTL 两种缓存管理策略。
 
 - `file_cache_ttl_seconds` : 新导入的数据期望在缓存中保留的时间，单位为秒。
 
-```Bash
+```shell
 CREATE TABLE IF NOT EXISTS customer (
   C_CUSTKEY     INTEGER NOT NULL,
   C_NAME        VARCHAR(25) NOT NULL,
@@ -208,7 +208,7 @@ mysql> show warm up job where id = 13418;
 
 在 LRU 缓存策略下，大表数据如果被查询访问，可能会替换掉需要常驻缓存的小表数据，造成性能波动。为了解决这个问题，用户采取 TTL 缓存策略，将两张表的 TTL 时间分别设置为 1 年和 1 天。
 
-```Bash
+```shell
 ALTER TABLE dimension_table set ("file_cache_ttl_seconds"="31536000");
 
 ALTER TABLE fact_table set ("file_cache_ttl_seconds"="86400");

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/managing-compute-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/managing-compute-cluster.md
@@ -330,7 +330,7 @@ Query OK, 0 rows affected (0.01 sec)
 USE { [catalog_name.]database_name[@cluster_name] | @cluster_name }
 ```
 
-若数据库或计算集群名称包含是保留关键字，需用反引号将相应的名称 ```` 包围。
+若数据库或计算集群名称包含是保留关键字，需用反引号将相应的名称 ``` 包围。
 
 **示例**
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/meta-service-api.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/meta-service-api.md
@@ -60,7 +60,7 @@ PUT /MetaService/http/v1/create_instance?token=<token> HTTP/1.1
 
 - 创建基于 HDFS 为存储后端的请求语法
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token> HTTP/1.1
 Content-Length: <ContentLength>
 Content-Type: text/plain
@@ -140,7 +140,7 @@ Content-Type: text/plain
 
 - 创建基于对象存储为存储后端的请求语法
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token HTTP/1.1
 Content-Length: <ContentLength>
 Content-Type: text/plain
@@ -183,7 +183,7 @@ Content-Type: text/plain
 
 - 创建基于对象存储为存储后端的请求示例
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=greedisgood9999 HTTP/1.1
 Content-Length: 441
 Content-Type: text/plain
@@ -248,7 +248,7 @@ Content-Type: text/plain
 
 - 请求语法
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token HTTP/1.1
 Content-Length: <ContentLength
 Content-Type: text/plain

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/delete/batch-delete-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/delete/batch-delete-manual.md
@@ -161,19 +161,19 @@ mysql DESC test;
 
 **1. 正常导入数据：**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: APPEND"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
 其中的 APPEND 条件可以省略，与下面的语句效果相同：
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
 **2. 将与导入数据 Key 相同的数据全部删除**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
@@ -208,7 +208,7 @@ curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, ci
 
 **3. 将导入数据中与`site_id=1` 的行的 Key 列相同的行**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: MERGE" -H "delete: siteid=1"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
@@ -247,7 +247,7 @@ curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, ci
 
 **4. 当存在 sequence 列时，将与导入数据 Key 相同的数据全部删除**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: name, gender, age" -H "function_column.sequence_col: age" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/error-data-handling.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/error-data-handling.md
@@ -112,7 +112,7 @@ mysql> desc user_profile;
 18,9999999,2023-07-03 12:00:03
 ```
 
-```bash
+```shell
 curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:false" -H "column_separator:," -H "columns:id,balance,last_access_time" -T /tmp/test.csv http://host:port/api/db1/user_profile/_stream_load
 ```
 
@@ -120,7 +120,7 @@ curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:false
 
 当用户使用严格模式的 Stream Load 部分列更新向表中插入上述数据时，由于开启了严格模式且第二、三行的数据的 key(`(3)`, `(18)`) 不在原表中，所以本次导入会失败。
 
-``` bash
+```shell
 curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:true" -H "column_separator:," -H "columns:id,balance,last_access_time" -T /tmp/test.csv http://host:port/api/db1/user_profile/_stream_load
 ```
 
@@ -129,7 +129,7 @@ curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:true"
 
 [STREAM LOAD](./import-way/stream-load-manual.md)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "strict_mode: true" \
    -T 1.txt \
@@ -217,7 +217,7 @@ curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:true"
 
 [Stream Load](./import-way/stream-load-manual.md)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "max_filter_ratio: 0.1" \
    -T 1.txt \

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/import-way/stream-load-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/import-way/stream-load-manual.md
@@ -120,7 +120,7 @@ Stream Load 需要对目标表的 INSERT 权限。如果没有 INSERT 权限，�
 
     通过 `curl` 命令可以提交 Stream Load 导入作业。
 
-    ```Bash
+    ```shell
     curl --location-trusted -u <doris_user>:<doris_password> \
         -H "Expect:100-continue" \
         -H "column_separator:," \
@@ -203,7 +203,7 @@ Stream Load 需要对目标表的 INSERT 权限。如果没有 INSERT 权限，�
 
     通过 `curl` 命令可以提交 Stream Load 导入作业。
 
-    ```Bash
+    ```shell
     curl --location-trusted -u <doris_user>:<doris_password> \
         -H "label:124" \
         -H "Expect:100-continue" \
@@ -264,7 +264,7 @@ mysql> show stream load from testdb;
 
 Stream Load 导入语法如下：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
   -H "Expect:100-continue" [-H ""...] \
   -T <file_path> \
@@ -408,7 +408,7 @@ Stream Load 是一种同步的导入方式，导入结果会通过创建导入�
 :::
 
 使用 `curl` 来使用 Stream Load 的 http stream 模式：
-```Bash
+```shell
 curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -XPUT http://fe_host:http_port/api/_http_stream
 ```
 
@@ -416,7 +416,7 @@ curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -
 
 load_sql 举例：
 
-```Bash
+```shell
 insert into db.table (col, ...) select stream_col, ... from http_stream("property1"="value1");
 ```
 
@@ -462,7 +462,7 @@ Doris 的导入任务可以容忍一部分格式错误的数据。容忍率通�
 
 通过以下命令可以指定 max_filter_ratio 容忍度为 0.4 创建 stream load 导入任务：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "max_filter_ratio:0.4" \
@@ -492,7 +492,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 将本地文件中的数据导入到表中的 p1, p2 分区，允许 20% 的错误率。
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:123" \
     -H "Expect:100-continue" \
@@ -520,7 +520,7 @@ Stream Load 是基于 HTTP 的协议进行导入，所以是支持使用程序�
 
 下面通过 `bash` 的命令管道来举例这种使用方式，这种导入的数据就是程序流式生成的，而不是本地文件。
 
-```Bash
+```shell
 seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -544,7 +544,7 @@ curl --location-trusted -u root -T test.csv  -H "label:1" -H "format:csv_with_na
 
 在 Stream Load 中有三种导入类型：APPEND、DELETE 与 MERGE。可以通过指定参数 merge_type 进行调整。如想指定将与导入数据 Key 相同的数据全部删除，可以使用以下命令：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: DELETE" \
@@ -587,7 +587,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 指定 merge_type 为 MERGE，可以将导入的数据 MERGE 到表中。MERGE 语义需要结合 DELETE 条件联合使用，表示满足 DELETE 条件的数据按照 DELETE 语义处理，其余按照 APPEND 语义添加到表中，如下面操作表示删除 siteid 为 1 的行，其余数据添加到表中：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: MERGE" \
@@ -779,7 +779,7 @@ JSON 数据格式：
 
 导入命令：
 
-```Bash
+```shell
 curl --location-trusted -u root -T test.json -H "label:1" -H "format:json" -H 'columns: id, order_code, create_time=CURRENT_TIMESTAMP()' http://host:port/api/testDb/testTbl/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/load-data-convert.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/load-data-convert.md
@@ -60,7 +60,7 @@ WITH BROKER bos
 
 ### STREAM LOAD
 
-```Bash
+```shell
 curl
 --location-trusted
 -u user:passwd
@@ -96,7 +96,7 @@ Stream load 不支持前置过滤。
 
 示例：
 
-```Bash
+```shell
 curl
 --location-trusted
 -u user:passwd

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/load-data-format.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/load-data-format.md
@@ -338,7 +338,7 @@ k2 int, k1 int
 
 导入语句 1（以 Stream Load 为例）：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -356,7 +356,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", 
 
 导入语句 2：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, k1" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -372,7 +372,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", 
 
 当然，如其他导入一样，可以在 Columns 中进行列的转换操作。示例如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, tmp_k1, k1 = tmp_k1 * 100" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -396,7 +396,7 @@ k2 int, k1 int, k1_copy int
 ```
 如果你想将 json 中的某一字段多次赋予给表中几列，那么可以在 jsonPaths 中多次指定该列，并且依次指定映射顺序。示例如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\", \"$.k1\"]" -H "columns: k2,k1,k1_copy" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -426,7 +426,7 @@ k2 int, k1 int, k1_nested1 int, k1_nested2 int
 ```
 如果你想将 json 中嵌套的多级同名字段赋予给表中不同的列，那么可以在 jsonPaths 中指定该列，并且依次指定映射顺序。示例如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\",\"$.k3.k1\",\"$.k3.k1_nested.k1\" -H "columns: k2,k1,k1_nested1,k1_nested2" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -489,7 +489,7 @@ JSON 数据为：
 
 导入语句如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -523,7 +523,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: tru
 
 这是因为通过导入语句中的信息，Doris 并不知道“缺失的列是表中的 k2 列”。如果要对以上数据按照期望结果导入，则导入语句如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -H "jsonpaths: [\"$.k1\", \"$.k2\"]" -H "columns: k1, tmp_k2, k2 = ifnull(tmp_k2, 'x')" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -549,7 +549,7 @@ code    INT     NULL
 
  - 不指定 JSON Path
 
- ```bash
+ ```shell
  curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
  ```
 
@@ -561,7 +561,7 @@ code    INT     NULL
 
  - 指定 JSON Path
 
- ```bash
+ ```shell
  curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
  ```
 
@@ -579,7 +579,7 @@ code    INT     NULL
 
  - 指定 JSON Path
 
- ```bash
+ ```shell
  curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
  ```
 
@@ -610,7 +610,7 @@ code    INT     NULL
 
 - 指定 JSON Path
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -636,7 +636,7 @@ curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\
 
 StreamLoad 导入：
 
- ```bash
+ ```shell
  curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
  ```
 
@@ -653,7 +653,7 @@ StreamLoad 导入：
 
 数据依然是示例 3 中的多行数据，现需要对导入数据中的 `code` 列加 1 后导入。
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -679,7 +679,7 @@ curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\
 {"k1": 40, "k2": ["10000000000000000000.1111111222222222"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H ":0.01" -H "format:json" -H "timeout:300" -T test_decimal.json http://localhost:8035/api/example_db/array_test_decimal/_stream_load
 ```
 
@@ -699,7 +699,7 @@ MySQL > select * from array_test_decimal;
 {"k1": 999, "k2": ["76959836937749932879763573681792701709", "26017042825937891692910431521038521227"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_largeint.json http://localhost:8035/api/example_db/array_test_largeint/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/transaction.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/transaction.md
@@ -408,7 +408,7 @@ mysql> SELECT * FROM dt3;
 
 **1. 在 HTTP Header 中设置 `two_phase_commit:true` 启用两阶段提交。**
 
-```Bash
+```shell
 curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt http://fe_host:http_port/api/{db}/{table}/_stream_load
 {
     "TxnId": 18036,
@@ -434,7 +434,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 可以使用事务 id 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18036" -H "txn_operation:commit" http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -444,7 +444,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 也可以使用 label 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:commit"  http://fe_host:http_port/api/{db}/{table}/_stream_load_2pc
   {
       "status": "Success",
@@ -456,7 +456,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 可以使用事务 id 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "txn_id:18037" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -466,7 +466,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 也可以使用 label 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/update/unique-update-transaction.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/update/unique-update-transaction.md
@@ -108,7 +108,7 @@ sequence_type 用来指定 sequence 列的类型，可以为整型和时间类�
 
 stream load 的写法是在 header 中的`function_column.sequence_col`字段添加隐藏列对应的 source_sequence 的映射，示例
 
-```Bash
+```shell
 curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -227,7 +227,7 @@ MySQL  desc test_table;
 
 此处以 stream load 为例
 
-```Bash
+```shell
 curl --location-trusted -u root: -T testData http://host:port/api/test/test_table/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/db-connect/database-connect.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/db-connect/database-connect.md
@@ -33,14 +33,14 @@ Apache Doris 采用 MySQL 网络连接协议，兼容 MySQL 生态的命令行�
 
 解压下载的 MySQL 客户端，在 `bin/` 目录下可以找到 `mysql` 命令行工具。然后执行下面的命令连接 Doris。
 
-```Bash
+```shell
 # FE_IP 为 FE 的监听地址， FE_QUERY_PORT 为 FE 的 MYSQL 协议服务的端口，在 fe.conf 中对应 query_port, 默认为 9030.
 mysql -h FE_IP -P FE_QUERY_PORT -u USER_NAME 
 ```
 
 登录后，显示如下。
 
-```Bash
+```shell
 Welcome to the MySQL monitor.  Commands end with ; or \g.                                                                                                                                                                                  
 Your MySQL connection id is 236                                                                                                                                                                                                            
 Server version: 5.7.99 Doris version doris-2.0.3-rc06-37d31a5                                                                                                                                                                              

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-access-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-access-cluster.md
@@ -36,13 +36,13 @@ Doris 在 Kubernetes 上默认提供 ClusterIP 访问模式。无需进行修改
 
 在部署集群后，通过以下命令可以查看 Doris Operator 暴露的 service：
 
-```bash
+```shell
 kubectl -n doris get svc
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                               AGE
 doriscluster-sample-be-internal   ClusterIP   None          <none>        9050/TCP                              9m
 doriscluster-sample-be-service    ClusterIP   10.1.68.128   <none>        9060/TCP,8040/TCP,9050/TCP,8060/TCP   9m
@@ -59,13 +59,13 @@ doriscluster-sample-fe-service    ClusterIP   10.1.118.16   <none>        8030/T
 
 使用以下命令，可以在当前的 Kubernetes 集群中创建一个包含 mysql client 的 pod：
 
-```bash
+```shell
 kubectl run mysql-client --image=mysql:5.7 -it --rm --restart=Never --namespace=doris -- /bin/bash
 ```
 
 在集群内的容器中，可以使用对外暴露的后缀为 `service` 的服务名访问 Doris 集群：
 
-```bash
+```shell
 ## 使用 service 类型 pod name 访问 Doris 集群
 mysql -uroot -P9030 -hdoriscluster-sample-fe-service
 ```
@@ -145,13 +145,13 @@ spec:
 
 在部署集群后，通过以下命令可以查看 Doris Operator 暴露的 service：
 
-```bash
+```shell
 kubectl get service
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                                       AGE
 kubernetes                        ClusterIP   10.152.183.1     <none>        443/TCP                                                       169d
 doriscluster-sample-fe-internal   ClusterIP   None             <none>        9030/TCP                                                      2d
@@ -162,13 +162,13 @@ doriscluster-sample-be-service    NodePort    10.152.183.244   <none>        906
 
 Doris 的 Query Port 端口默认为 9030，在本地中被映射到本地端口 31545。在访问 Doris 集群时，同时需要获取到对应的 IP 地址，可以通过以下命令查看：
 
-```bash
+```shell
 kubectl get nodes -owide
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME   STATUS   ROLES           AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION          CONTAINER-RUNTIME
 r60    Ready    control-plane   14d   v1.28.2   192.168.88.60   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
 r61    Ready    <none>          14d   v1.28.2   192.168.88.61   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
@@ -178,7 +178,7 @@ r63    Ready    <none>          14d   v1.28.2   192.168.88.63   <none>        Ce
 
 在 NodePort 模式下，可以根据任何 node 节点的宿主机 IP 与端口映射访问 Kubernetes 集群内的服务。在本例中可以使用任一的 node 节点 IP，192.168.88.61、192.168.88.62、192.168.88.63 访问 Doris 服务。如在下例中使用了 node 节点 192.168.88.62 与映射出的 query port 端口 31545 访问集群：
 
-```bash
+```shell
 mysql -h 192.168.88.62 -P 31545 -uroot
 ```
 
@@ -194,7 +194,7 @@ mysql -h 192.168.88.62 -P 31545 -uroot
 
 在上例返回结果中，可以直接在同一个 Kubernetes 集群内的 Pod 中通过 curl 命令获取返回结果：
 
-```bash
+```shell
 curl http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local:8040/api/_load_error_log?file=__shard_1/error_log_insert_stmt_af474190276a2e9c-49bb9d175b8e968e_af474190276a2e9c_49bb9d175b8e968e
 ```
 
@@ -245,7 +245,7 @@ spec:
 
 按照上例中的 service 将 CR 中的 ${podName} 替换成 doriscluster-sample-be-2，将 ${ServiceType} 替换为 NodePort。通过 kubectl apply 命令，在于 doris 集群相同的 namespace 中创建 service 服务。
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -253,13 +253,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 使用以下命令查看上述部署 Service 分配的 NodePort 端口：
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
 doriscluster-detail-error         NodePort    10.152.183.35    <none>        8040:31201/TCP     32s
 ```
@@ -268,13 +268,13 @@ doriscluster-detail-error         NodePort    10.152.183.35    <none>        804
 
 获取 K8s 管控的宿主机地址：
 
-```bash
+```shell
 kubectl get node -owide
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME             STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION       CONTAINER-RUNTIME
 vm-10-8-centos   Ready    <none>   226d   v1.28.7   10.16.10.8    <none>        TencentOS Server 3.1 (Final)   5.4.119-19-0009.3    containerd://1.6.28
 vm-10-7-centos   Ready    <none>   19d    v1.28.7   10.16.10.7    <none>        TencentOS Server 3.1 (Final)   5.4.119-19.0009.25   containerd://1.6.28
@@ -301,7 +301,7 @@ http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluste
 
 上述地址的域名地址为 `doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local` 在 `Kubernetes` 上 `Doris Operator` 部署的 pod 使用的域名中，三级域名为  pod 的名称。将上述模板中 {podName} 替换为真实的 `pod` 名称，将 {serviceType} 替换为 `LoadBalancer` ，更改后保存到新建的 `stream_load_get_error.yaml` 文件中。使用如下命令部署 service：
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -309,13 +309,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 使用如下命令查看上述部署 Service 分配的  LoadBalaner 地址 EXTERNAL-IP ,以下为在 aws eks 测试实例：
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                         TYPE          CLUSTER-IP       EXTERNAL-IP                                                              PORT(S)           AGE
 doriscluster-detail-error    LoadBalancer  172.20.183.136   ac4828493dgrftb884g67wg4tb68gyut-1137856348.us-east-1.elb.amazonaws.com  8040:32003/TCP    14s
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-config-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-config-cluster.md
@@ -98,13 +98,13 @@ feSpec:
 
 其中，需要在 ${storageClassName} 指定 [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) 的名称。可以通过 以下命令查看当前 Kubernetes 集群内支持的 StorageClass：
 
-```bash
+```shell
 kubectl get sc
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                          PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
 openebs-hostpath              openebs.io/local               Delete          WaitForFirstConsumer   false                  212d
 openebs-device                openebs.io/local               Delete          WaitForFirstConsumer   false                  212d

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-doris-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-doris-cluster.md
@@ -36,13 +36,13 @@ under the License.
 
 1. 创建 namespace：
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 2. 部署 Doris 集群
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -61,7 +61,7 @@ selectdb/doris.be-ubuntu:2.0.2
 
 将镜像下载到本地后打包成 tar 文件
 
-```bash
+```shell
 ## download docker image
 docker pull selectdb/doris.fe-ubuntu:2.0.2
 docker pull selectdb/doris.be-ubuntu:2.0.2
@@ -73,7 +73,7 @@ docker save -o doris.be-ubuntu-v2.0.2.tar docker pull selectdb/doris.be-ubuntu:2
 
 将 image tar 包上传到服务器上，执行 docker load 命令：
 
-```bash
+```shell
 ## load docker image
 docker load -i doris.fe-ubuntu-v2.0.2.tar
 docker load -i doris.be-ubuntu-v2.0.2.tar
@@ -81,13 +81,13 @@ docker load -i doris.be-ubuntu-v2.0.2.tar
 
 2. 创建 namespace：
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 3. 部署 Doris 集群
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -101,13 +101,13 @@ kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 
 安装 [doriscluster](https://artifacthub.io/packages/helm/doris/doris)，使用默认配置此部署仅部署 3 个 FE 和 3 个 BE 组件，使用默认 `storageClass` 实现 PV 动态供给。
 
-```bash
+```shell
 helm install doriscluster doris-repo/doris
 ```
 
 如果需要自定义资源和集群形态，请根据 [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) 的各个资源配置的注解自定义资源配置，并执行如下命令:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-repo/doris
 ```
 
@@ -115,13 +115,13 @@ helm install -f values.yaml doriscluster doris-repo/doris
 
 通过 `kubectl get pods` 命令可以查看 pod 部署状态。当 `doriscluster` 的 Pod 处于 `Running` 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -137,7 +137,7 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 下载 `doris-{chart_version}.tgz` 安装 Doris Cluster chart。如需要下载 2.0.6 版本的 Doris 集群可以使用以下命令：
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-2.0.6.tgz
 ```
 
@@ -145,13 +145,13 @@ wget https://charts.selectdb.com/doris-2.0.6.tgz
 
 通过 `helm install` 命令可以安装 Doris 集群。
 
-```bash
+```shell
 helm install doriscluster doris-1.4.0.tgz
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-1.4.0.tgz
 ```
 
@@ -159,13 +159,13 @@ helm install -f values.yaml doriscluster doris-1.4.0.tgz
 
 通过 `kubectl get pods` 命令可以查看 pod 部署状态。当 `doriscluster` 的 Pod 处于 `Running` 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -181,13 +181,13 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 集群部署资源下发后，可以通过以下命令检查集群状态。
 
-```bash
+```shell
 kubectl get pods -n ${namespace}
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                       READY   STATUS    RESTARTS   AGE
 doriscluster-sample-fe-0   1/1     Running   0          20m
 doriscluster-sample-be-0   1/1     Running   0          19m
@@ -199,13 +199,13 @@ doriscluster-sample-be-0   1/1     Running   0          19m
 
 Doris Operator 会收集集群服务的状态显示到下发的资源中。Doris Operator 定义了 `DorisCluster` 类型资源名称的简写 `dcr`，在使用资源类型查看集群状态时可用简写替代。
 
-```bash
+```shell
 kubectl get dcr
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                  FESTATUS    BESTATUS    CNSTATUS   BROKERSTATUS
 doriscluster-sample   available   available
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-operator.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-operator.md
@@ -30,32 +30,32 @@ Doris Operator 使用自定义资源定义（Custom Resource Definition, CRD）�
 
 通过以下命令可以在 Kubernetes 环境中部署 Doris Cluster CRD：
 
-```bash
+```shell
 kubectl create -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 ```
 
 如果没有外网，先将 CRD 文件下载到本地：
 
-```bash
+```shell
 wget https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 kubectl create -f ./doris.selectdb.com_dorisclusters.yaml
 ```
 
 以下是期望输出结果：
 
-```bash
+```shell
 customresourcedefinition.apiextensions.k8s.io/dorisclusters.doris.selectdb.com created
 ```
 
 在创建了 Doris Cluster CRD 后，可以通过以下命令查看创建的 CRD。
 
-```bash
+```shell
 kubectl get crd | grep doris
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 ```
 
@@ -67,13 +67,13 @@ dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 
 使用以下命令可以在 Kubernetes 集群中部署 Doris Operator：
 
-```bash
+```shell
 kubectl apply -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/operator/operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -93,13 +93,13 @@ deployment.apps/doris-operator created
 
 在修改 operator.yaml 文件后，可以使用以下命令部署 Doris Operator 服务：
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -115,13 +115,13 @@ deployment.apps/doris-operator created
 
 如果服务器没有连通外网，需要先下载对应的 operator 镜像文件。Doris Operator 用到以下的镜像：
 
-```bash
+```shell
 selectdb/doris.k8s-operator:latest
 ```
 
 在可以连通外网的服务器中运行以下的命令，可以将镜像下载下来：
 
-```bash
+```shell
 ## download doris operator image
 docker pull selectdb/doris.k8s-operator:latest
 ## save the doris operator image as a tar package
@@ -130,7 +130,7 @@ docker save -o doris.k8s-operator-latest.tar selectdb/doris.k8s-operator:latest
 
 将已打包的 tar 文件放置到所有的 Kubernetes node 节点中，运行以下命令上传镜像：
 
-```bash
+```shell
 docker load -i doris.k8s-operator-latest.tar
 ```
 
@@ -140,7 +140,7 @@ docker load -i doris.k8s-operator-latest.tar
 
 Doris Operator 在 Kubernetes 集群中是一个无状态的 Deployment，可以根据需求修改如 `limits`、`replica`、`label`、`namespace` 等项目。如需要指定某一版本的 doirs operator 镜像，可以在上传镜像后对 operator.yaml 文件做如下修改：
 
-```bash
+```shell
 ...
 containers:
   - command:
@@ -161,13 +161,13 @@ containers:
 
 在修改 Doris Operator 模板后，可以使用 apply 命令部署 Operator：
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -187,13 +187,13 @@ Helm Chart 是一系列描述 Kubernetes 相关资源的 YAML 文件的封装。
 
 通过 `repo add` 命令添加远程仓库
 
-```bash
+```shell
 helm repo add doris-repo https://charts.selectdb.com
 ```
 
 通过 `repo update` 命令更新最新版本的 chart
 
-```bash
+```shell
 helm repo update doris-repo
 ```
 
@@ -201,25 +201,25 @@ helm repo update doris-repo
 
 通过 `helm install` 命令可以使用默认配置在 doris 的 namespace 中安装 Doris Operator
 
-```bash
+```shell
 helm install operator doris-repo/doris-operator
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-repo/doris-operator
 ```
 
 通过 `kubectl get pods` 命令查看 Pod 的部署状态。当 Doris Operator 的 Pod 处于 Running 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -232,7 +232,7 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 下载 `doris-operator-{chart_version}.tgz` 安装 Doris Operator chart。如需要下载 1.4.0 版本的 Doris Operator 可以使用以下命令：
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 ```
 
@@ -240,25 +240,25 @@ wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 
 通过 `helm install` 命令可以安装 Doris Operator。
 
-```bash
+```shell
 helm install operator doris-operator-1.4.0.tgz
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-operator-1.4.0.tgz
 ```
 
 通过 `kubectl get pods` 命令查看 Pod 的部署状态。当 Doris Operator 的 Pod 处于 Running 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -267,13 +267,13 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 当部署 Operator 服务后，可以通过以下命令查看服务状态。
 
-```bash
+```shell
 kubectl get pod -n doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-6f47594455-p5tp7   1/1     Running   0          11s
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/k8s-deploy/install-env.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/k8s-deploy/install-env.md
@@ -39,7 +39,7 @@ under the License.
 
 在 Kubernetes 上部署 Doris 集群，建议关闭防火墙配置：
 
-```bash
+```shell
 systemctl stop firewalld
 systemctl disable firewalld
 ```
@@ -56,7 +56,7 @@ systemctl disable firewalld
 
 通过以下命令可以永久关闭 swap 分区。
 
-```bash
+```shell
 echo "vm.swappiness = 0">> /etc/sysctl.conf
 swapoff -a && swapon -a
 sysctl -p
@@ -64,7 +64,7 @@ sysctl -p
 
 ### 设置系统最大打开文件句柄数
 
-```bash
+```shell
 vi /etc/security/limits.conf 
 * soft nofile 65536
 * hard nofile 65536
@@ -74,7 +74,7 @@ vi /etc/security/limits.conf
 
 修改虚拟内存区域至少 2000000
 
-```bash
+```shell
 sysctl -w vm.max_map_count=2000000
 ```
 
@@ -82,7 +82,7 @@ sysctl -w vm.max_map_count=2000000
 
 在部署 Doris 时，建议关闭透明大页。
 
-```bash
+```shell
 echo never > /sys/kernel/mm/transparent_hugepage/enabled
 echo never > /sys/kernel/mm/transparent_hugepage/defrag
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/run-docker-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/run-docker-cluster.md
@@ -89,7 +89,7 @@ Docker Version：20.10 及以后版本
 
 3. 编写 Dockerfile
 
-```Bash
+```shell
 # 选择基础镜像
 FROM openjdk:8u342-jdk
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/standard-deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/cluster-deployment/standard-deployment.md
@@ -308,7 +308,7 @@ FE 的配置文件在 FE 部署路径下的 conf 目录中，启动 FE 节点前
 
 通过以下命令可以启动 FE 进程
 
-```Bash
+```shell
 bin/start_fe.sh --daemon
 ```
 
@@ -377,7 +377,7 @@ ALTER SYSTEM ADD OBSERVER "<fe_ip_address>:<fe_edit_log_port>"
 
 通过以下命令，可以启动 FE Follower 节点，并自动同步元数据。
 
-```Bash
+```shell
 bin/start_fe.sh --helper <helper_fe_ip>:<fe_edit_log_port> --daemon
 ```
 
@@ -605,7 +605,7 @@ Doris 作为一个分布式数据库，一般拥有众多 BE 节点，Doris 采�
 
 可以通过下面的命令来检查 Doris 是否启动成功
 
-```Bash
+```shell
 # 重试执行下面命令，如果返回"msg":"success"，则说明已经启动成功
 server1:apache-doris/fe doris$ curl http://127.0.0.1:8030/api/bootstrap
 {"msg":"success","code":0,"data":{"replayedJournalId":0,"queryPort":0,"rpcPort":0,"version":""},"count":0}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/source-install/compilation-arm.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/source-install/compilation-arm.md
@@ -62,7 +62,7 @@ import TabItem from '@theme/TabItem';
 
 **1.  创建软件下载安装包根目录和软件安装根目录**
 
-```Bash
+```shell
 # 创建软件下载安装包根目录
 mkdir /opt/tools
 
@@ -72,7 +72,7 @@ mkdir /opt/software
 
 **2.  安装依赖项**
 
-```Bash
+```shell
 ### Git ###
 # 省去编译麻烦，直接使用 yum 安装
 yum install -y git
@@ -119,7 +119,7 @@ wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz && \
 
 **3.  配置环境变量**
 
-```Bash
+```shell
 # 配置环境变量
 vim /etc/profile.d/doris.sh
 export JAVA_HOME=/opt/software/jdk8
@@ -146,13 +146,13 @@ gcc --version
 
 **1.  更新 apt-get 软件库**
 
-```Bash
+```shell
 apt-get update
 ```
 
 **2.  重新配置 shell**
 
-```Bash
+```shell
 # Ubuntu 的 shell 默认安装的是 dash，而不是 bash，要切换成 bash 才能执行，运行以下命令查看 sh 的详细信息，确认 shell 对应的程序是哪个：
 ls -al /bin/sh
 
@@ -163,7 +163,7 @@ sudo dpkg-reconfigure dash
 
 **3.  创建软件下载安装包根目录和软件安装根目录**
 
-```Bash
+```shell
 # 创建软件下载安装包根目录
 mkdir /opt/tools
 
@@ -173,7 +173,7 @@ mkdir /opt/software
 
 **4.  安装依赖项**
 
-```Bash
+```shell
 ### Git ###
 # 省去编译麻烦，直接使用 apt-get 安装
 apt-get -y install git
@@ -229,7 +229,7 @@ wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz && \
 
 **5.  配置环境变量**
 
-```Bash
+```shell
 # 配置环境变量
 vim /etc/profile.d/doris.sh
 export JAVA_HOME=/opt/software/jdk8
@@ -258,7 +258,7 @@ gcc --version
 
 在 ARM 平台编译 Doris 时，请关闭 AVX2 和 LIBUNWIND 三方库：
 
-```Bash
+```shell
 export USE_AVX2=OFF
 export USE_UNWIND=OFF
 ```
@@ -275,7 +275,7 @@ export USE_UNWIND=OFF
 
 解决方案：使用第三方库下载仓库    
 
-```Bash
+```shell
 export REPOSITORY_URL=https://doris-thirdparty-repo.bj.bcebos.com/thirdparty
 sh /opt/doris/thirdparty/build-thirdparty.sh
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/source-install/compilation-mac.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/source-install/compilation-mac.md
@@ -91,7 +91,7 @@ cd output/fe/bin
 
 可以在 [Apache Doris Third Party Prebuilt](https://github.com/apache/doris-thirdparty/releases/tag/automation) 页面直接下载预编译好的第三方库，省去编译第三方库的过程，参考下面的命令。
 
-```Bash
+```shell
 cd thirdparty
 rm -rf installed
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/source-install/compilation-with-docker.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/source-install/compilation-with-docker.md
@@ -34,7 +34,7 @@ under the License.
 
 比如在 CentOS 下，执行命令安装 Docker
 
-```Bash
+```shell
 yum install docker
 ```
 
@@ -53,7 +53,7 @@ yum install docker
 
 下面就以编译 Doris 2.0 版本作为介绍，下载并检查 Docker 镜像
 
-```Bash
+```shell
 # 可以选择 docker.io/apache/doris:build-env-for-2.0
 $ docker pull apache/doris:build-env-for-2.0
 
@@ -75,7 +75,7 @@ apache/doris    build-env-for-2.0    f29cf1979dba    3 days ago    3.3GB
 
 -   最新版本的 `apache/doris:build-env-ldb-toolchain-latest` 镜像中同时包含 JDK 8 和 JDK 17。2.1（含）之前的版本，请使用 JDK 8。3.0（含）之后的版本或 master 分支，请使用 JDK 17。
 
-```Bash
+```shell
 # 切换到 JDK 8
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0
 export PATH=$JAVA_HOME/bin/:$PATH

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/source-install/compilation-with-ldb-toolchain.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/source-install/compilation-with-ldb-toolchain.md
@@ -118,7 +118,7 @@ Doris 源码编译时首先会下载三方库进行编译，可以参考下文�
 
 **1.  进入 Doris 源码目录，执行如下命令查看编译机器是否支持 AVX2 指令集**
 
-```Bash
+```shell
 $ cat /proc/cpuinfo | grep avx2
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/database/es.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/database/es.md
@@ -124,7 +124,7 @@ Elasticsearch 没有明确的数组类型，但是它的某个字段可以含有
 
 该结构的数组字段可以通过使用以下命令将字段属性定义添加到目标索引映射的`_meta.doris`属性来定义。
 
-```bash
+```shell
 # ES 7.x and above
 curl -X PUT "localhost:9200/doc/_mapping?pretty" -H 'Content-Type:application/json' -d '
 {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
@@ -36,7 +36,7 @@ DROP ROLE
 
 ```sql
   DROP ROLE [IF EXISTS] role1;
-````
+```
 
 删除角色不会影响以前属于角色的用户的权限。 它仅相当于解耦来自用户的角色。 用户从角色获得的权限不会改变
 
@@ -46,7 +46,7 @@ DROP ROLE
 
 ```sql
 DROP ROLE role1;
-````
+```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
@@ -141,31 +141,31 @@ role_list 是需要赋予的角色列表，以逗号分隔，指定的角色必�
 
     ```sql
     GRANT 'role1','role2' TO 'jack'@'%';
-    ````
+    ```
 
 8. 将指定 workload group‘g1’授予用户 jack
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO 'jack'@'%';
-    ````
+    ```
 
 9. 匹配所有 workload group 授予用户 jack
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP '%' TO 'jack'@'%';
-    ````
+    ```
 
 10. 将指定 workload group‘g1’授予角色 my_role
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO ROLE 'my_role';
-    ````
+    ```
 
 11. 允许 jack 查看 db1 下 view1 的创建语句
 
     ```sql
     GRANT SHOW_VIEW_PRIV ON db1.view1 TO 'jack'@'%';
-    ````
+    ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
@@ -47,7 +47,7 @@ ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
-````
+```
 
  说明：
 
@@ -74,7 +74,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
    ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a");
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-   ````
+   ```
 
 2. 修改 BE 的查询禁用属性
    
@@ -84,7 +84,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
 
     ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_query" = "true");
-    ````   
+    ```   
 
 3. 修改 BE 的导入禁用属性
    
@@ -94,7 +94,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
 
     ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_load" = "true");
-    ````   
+    ```   
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
@@ -123,7 +123,7 @@ CREATE [GLOBAL] [AGGREGATE] [ALIAS] FUNCTION function_name
 
    ```sql
    CREATE GLOBAL ALIAS FUNCTION id_masking(INT) WITH PARAMETER(id) AS CONCAT(LEFT(id, 3), '****', RIGHT(id, 4));
-   ```` 
+   ``` 
    
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
@@ -57,7 +57,7 @@ DROP [GLOBAL] FUNCTION function_name
 
     ```sql
     DROP GLOBAL FUNCTION my_add(INT, INT)
-    ````      
+    ```      
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
@@ -46,7 +46,7 @@ SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS [FROM db]
 
     ```sql
      SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS FROM test;
-    ````
+    ```
 
 2. 查看全局的转换情况
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
@@ -38,7 +38,7 @@ SHOW DATABASES
 
 ```sql
 SHOW DATABASES [FROM catalog] [filter expr];
-````
+```
 
 说明:
 1. `SHOW DATABASES` 会展示当前所有的数据库名称.
@@ -51,45 +51,45 @@ SHOW DATABASES [FROM catalog] [filter expr];
 
    ```sql
    SHOW DATABASES;
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | test               |
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 2. 会展示`hms_catalog`中所有的数据库名称.
 
    ```sql
    SHOW DATABASES from hms_catalog;
-   ````
+   ```
 
-   ````
+   ```
   +---------------+
   | Database      |
   +---------------+
   | default       |
   | tpch          |
   +---------------+
-   ````
+   ```
 
 3. 展示当前所有经过表示式`like 'infor%'`过滤后的数据库名称.
 
    ```sql
    SHOW DATABASES like 'infor%';
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database ：查看指定数据库下的作业。 如果未指定，则使用当前数据库。
 - WHERE：您可以过滤结果列，目前仅支持以下列：
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`：作业唯一 ID。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
@@ -59,19 +59,19 @@ IndexName = rollup_name
 
     ```sql
     SHOW TABLETS FROM example_db.table_name;
-    ````
+    ```
 
 2. 列出指定partitions的所有tablets
 
     ```sql
     SHOW TABLETS FROM example_db.table_name PARTITIONS(p1, p2);
-    ````
+    ```
 
 3. 列出某个backend上状态为DECOMMISSION的tablets
 
     ```sql
     SHOW TABLETS FROM example_db.table_name WHERE state="DECOMMISSION" AND BackendId=11003;
-    ````
+    ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
@@ -40,7 +40,7 @@ SHOW TYPECAST
 
 ```sql
 SHOW TYPE_CAST [IN|FROM db]
-````
+```
 
  Parameters
 
@@ -48,7 +48,7 @@ SHOW TYPE_CAST [IN|FROM db]
 
 ### Example
 
-````sql
+```sql
 mysql> show type_cast in testDb\G
 **************************** 1. row ******************** ******
 Origin Type: TIMEV2
@@ -61,7 +61,7 @@ Origin Type: TIMEV2
   Cast Type: TIMEV2
 
 3 rows in set (0.00 sec)
-````
+```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Utility-Statements/USE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/Utility-Statements/USE.md
@@ -57,7 +57,7 @@ USE <[CATALOG_NAME].DATABASE_NAME>
     ```sql
     mysql> use hms_catalog.demo;
     Database changed
-    ````
+    ```
 ### Keywords
 
     USE

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/data-partition.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/data-partition.md
@@ -201,7 +201,7 @@ PARTITION BY RANGE(col1[, col2, ...])
 
 示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(`date`)
 (
     PARTITION `p201701` VALUES [("2017-01-01"),  ("2017-02-01")),
@@ -249,7 +249,7 @@ PARTITION BY RANGE(date_col)
 
 示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(age)
 (
     FROM (1) TO (100) INTERVAL 10
@@ -263,7 +263,7 @@ PARTITION BY RANGE(`date`)
 
 4.MULTI RANGE：批量创建 RANGE 分区，定义分区的左闭右开区间。示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(col)                                                                                                                                                                                                                
 (                                                                                                                                                                                                                                      
    FROM ("2000-11-14") TO ("2021-11-14") INTERVAL 1 YEAR,                                                                                                                                                                              
@@ -282,7 +282,7 @@ Partition 支持通过 `VALUES IN (...)` 来指定每个分区包含的枚举值
 
 举例如下：
 
-```Bash
+```shell
 PARTITION BY LIST(city)
 (
     PARTITION `p_cn` VALUES IN ("Beijing", "Shanghai", "Hong Kong"),

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/admin-manual/certificate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/admin-manual/certificate.md
@@ -61,13 +61,13 @@ openssl x509 -req -in client-req.pem -days 3600 \
 
 2.验证创建的证书。
 
-```bash
+```shell
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
 3.将您的CA密钥和证书和Sever端密钥和证书分别合并到 PKCS#12 (P12) 包中。
 
-```bash
+```shell
 # 打包CA密钥和证书
 openssl pkcs12 -inkey ca-key.pem -in ca.pem -export -out ca_certificate.p12
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/admin-manual/cluster-management/load-balancing.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/admin-manual/cluster-management/load-balancing.md
@@ -51,7 +51,7 @@ Doris 的 FE 进程负责接收用户连接和查询请求，其本身是可以�
 
 ### 安装ProxySQL （yum方式）
 
-```bash
+```shell
 配置yum源
 # vim /etc/yum.repos.d/proxysql.repo
 [proxysql_repo]
@@ -487,7 +487,7 @@ IP: 172.31.7.119
 
 ### 安装依赖
 
-```bash
+```shell
 sudo apt-get install build-essential
 sudo apt-get install libpcre3 libpcre3-dev 
 sudo apt-get install zlib1g-dev
@@ -496,7 +496,7 @@ sudo apt-get install openssl libssl-dev
 
 ### 安装Nginx
 
-```bash
+```shell
 sudo wget http://nginx.org/download/nginx-1.18.0.tar.gz
 sudo tar zxvf nginx-1.18.0.tar.gz
 cd nginx-1.18.0
@@ -508,13 +508,13 @@ sudo make && make install
 
 这里是新建了一个配置文件
 
-```bash
+```shell
 vim /usr/local/nginx/conf/default.conf
 ```
 
 然后在里面加上下面的内容
 
-```bash
+```shell
 events {
 worker_connections 1024;
 }

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/admin-manual/privilege-ldap/ldap.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/admin-manual/privilege-ldap/ldap.md
@@ -89,13 +89,13 @@ set ldap_admin_password = password('ldap_admin_password');
 
   例如在linux或者mac环境中可以使用：
 
-  ```bash
+  ```shell
   echo "export LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN=1" >> ～/.bash_profile && source ～/.bash_profile
   ```
 
 - 每次登录Doris时添加参数“--enable-cleartext-plugin”：
 
-  ```bash
+  ```shell
   mysql -hDORIS_HOST -PDORIS_PORT -u user -p --enable-cleartext-plugin
   
   输入ldap密码
@@ -129,13 +129,13 @@ LDAP密码验证和组授权是Doris密码验证和授权的补充，开启LDAP�
 LDAP用户节点存在属性：uid: jack 用户密码：abcdef
 使用以下命令登录Doris可以登录jack@'172.10.1.10'账户：
 
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
 使用以下命令将登录失败：
 
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 
@@ -144,7 +144,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 LDAP用户节点存在属性：uid: jack 用户密码：abcdef
 使用以下命令创建临时用户并登录jack@'%'，临时用户具有基本权限 DatabasePrivs：Select_priv， 用户退出登录后Doris将删除该临时用户：
 
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
@@ -153,7 +153,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 存在Doris账户：jack@'172.10.1.10'，密码：123456
 使用Doris密码登录账户，成功：
 
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/advanced/best-practice/debug-log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/advanced/best-practice/debug-log.md
@@ -71,7 +71,7 @@ FE 的 Debug 级别日志可以通过修改配置文件开启，也可以通过�
 
    通过以下 API 也可以在运行时修改日志级别。无需重启 FE 节点。
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?add_verbose=org.apache.doris.catalog.Catalog
    ```
 
@@ -94,7 +94,7 @@ FE 的 Debug 级别日志可以通过修改配置文件开启，也可以通过�
 
    也可以通过以下 API 关闭 Debug 日志：
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?del_verbose=org.apache.doris.catalog.Catalog
    ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-operate/import/import-scenes/load-data-convert.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-operate/import/import-scenes/load-data-convert.md
@@ -50,7 +50,7 @@ under the License.
 
 - [STREAM LOAD](../../../sql-manual/sql-reference/Data-Manipulation-Statements/Load/STREAM-LOAD.md)
 
-  ```bash
+  ```shell
   curl
   --location-trusted
   -u user:passwd

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-operate/import/import-scenes/load-strict-mode.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-operate/import/import-scenes/load-strict-mode.md
@@ -60,7 +60,7 @@ under the License.
 
 2. [STREAM LOAD](../../../sql-manual/sql-reference/Data-Manipulation-Statements/Load/STREAM-LOAD.md)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "strict_mode: true" \
    -T 1.txt \

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-operate/import/import-way/load-json-format.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-operate/import/import-way/load-json-format.md
@@ -236,7 +236,7 @@ k2 int, k1 int
 
 导入语句 1（以 Stream Load 为例）：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -254,7 +254,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", 
 
 导入语句 2：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, k1" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -270,7 +270,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", 
 
 当然，如其他导入一样，可以在 Columns 中进行列的转换操作。示例如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, tmp_k1, k1 = tmp_k1 * 100" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -332,7 +332,7 @@ Doris 支持通过 JSON root 抽取 JSON 中指定的数据。
 
 导入语句如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -366,7 +366,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: tru
 
 这是因为通过导入语句中的信息，Doris 并不知道“缺失的列是表中的 k2 列”。如果要对以上数据按照期望结果导入，则导入语句如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -H "jsonpaths: [\"$.k1\", \"$.k2\"]" -H "columns: k1, tmp_k2, k2 = ifnull(tmp_k2, 'x')" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -392,7 +392,7 @@ code    INT     NULL
 
    - 不指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -404,7 +404,7 @@ code    INT     NULL
 
    - 指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -422,7 +422,7 @@ code    INT     NULL
 
    - 指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -453,7 +453,7 @@ code    INT     NULL
 
    - 指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -479,7 +479,7 @@ code    INT     NULL
 
 StreamLoad 导入：
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -496,7 +496,7 @@ curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: 
 
 数据依然是示例 3 中的多行数据，现需要对导入数据中的 `code` 列加 1 后导入。
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -522,7 +522,7 @@ curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\
 {"k1": 40, "k2": ["10000000000000000000.1111111222222222"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_decimal.json http://localhost:8035/api/example_db/array_test_decimal/_stream_load
 ```
 
@@ -542,7 +542,7 @@ MySQL > select * from array_test_decimal;
 {"k1": 999, "k2": ["76959836937749932879763573681792701709", "26017042825937891692910431521038521227"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_largeint.json http://localhost:8035/api/example_db/array_test_largeint/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-operate/update-delete/batch-delete-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-operate/update-delete/batch-delete-manual.md
@@ -159,19 +159,19 @@ mysql> DESC test;
 
 1. 正常导入数据：
 
-```bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: APPEND"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
 其中的APPEND 条件可以省略，与下面的语句效果相同：
 
-```bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
 2. 将与导入数据key 相同的数据全部删除
 
-```bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
@@ -206,7 +206,7 @@ curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, ci
 
 3. 将导入数据中与`site_id=1` 的行的key列相同的行
 
-```bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: MERGE" -H "delete: siteid=1"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
@@ -245,7 +245,7 @@ curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, ci
 
 4. 当存在sequence列时，将与导入数据key 相同的数据全部删除
 
-```bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: name, gender, age" -H "function_column.sequence_col: age" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-operate/update-delete/sequence-column-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-operate/update-delete/sequence-column-manual.md
@@ -95,7 +95,7 @@ sequence_type用来指定sequence列的类型，可以为整型和时间类型�
 
 stream load 的写法是在header中的`function_column.sequence_col`字段添加隐藏列对应的source_sequence的映射， 示例
 
-```bash
+```shell
 curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -210,7 +210,7 @@ MySQL > desc test_table;
 
 此处以stream load为例
 
-```bash
+```shell
 curl --location-trusted -u root: -T testData http://host:port/api/test/test_table/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-table/basic-usage.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/data-table/basic-usage.md
@@ -46,7 +46,7 @@ Doris 内置 root，密码默认为空。
 
 启动完 Doris 程序之后，可以通过 root 或 admin 用户连接到 Doris 集群。 使用下面命令即可登录 Doris，登录后进入到Doris对应的Mysql命令行操作界面：
 
-```bash
+```shell
 [root@doris ~]# mysql  -h FE_HOST -P9030 -uroot
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 41
@@ -78,14 +78,14 @@ Query OK, 0 rows affected (0.00 sec)
 
 我们可以通过下面的命令创建一个普通用户`test`：
 
-```bash
+```shell
 mysql> CREATE USER 'test' IDENTIFIED BY 'test_passwd';
 Query OK, 0 rows affected (0.00 sec)
 ```
 
 后续登录时就可以通过下面链接命令登录：
 
-```bash
+```shell
 [root@doris ~]# mysql -h FE_HOST -P9030 -utest -ptest_passwd
 ```
 
@@ -292,7 +292,7 @@ Doris 支持多种数据导入方式。具体可以参阅 [数据导入](../data
 
 示例1：以 "table1_20170707" 为 Label，使用本地文件 table1_data 导入 table1 表。
 
-```bash
+```shell
 curl --location-trusted -u test:test_passwd -H "label:table1_20170707" -H "column_separator:," -T table1_data http://FE_HOST:8030/api/example_db/table1/_stream_load
 ```
 
@@ -311,7 +311,7 @@ curl --location-trusted -u test:test_passwd -H "label:table1_20170707" -H "colum
 
 示例2: 以 "table2_20170707" 为 Label，使用本地文件 table2_data 导入 table2 表。
 
-```bash
+```shell
 curl --location-trusted -u test:test -H "label:table2_20170707" -H "column_separator:|" -T table2_data http://127.0.0.1:8030/api/example_db/table2/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/install/standard-deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/install/standard-deployment.md
@@ -309,7 +309,7 @@ Broker 以插件的形式，独立于 Doris 部署。如果需要从第三方存
 
    BE 进程启动后，如果之前有数据，则可能有数分钟不等的数据索引加载时间。
 
-   如果是 BE 的第一次启动，或者该 BE 尚未加入任何集群，则 BE 日志会定期滚动 ```waiting to receive first heartbeat from frontend``` 字样。表示 BE 还未通过 FE 的心跳收到 Master 的地址，正在被动等待。这种错误日志，在 FE 中 ADD BACKEND 并发送心跳后，就会消失。如果在接到心跳后，又重复出现 ``````master client, get client from cache failed.host: , port: 0, code: 7`````` 字样，说明 FE 成功连接了 BE，但 BE 无法主动连接 FE。可能需要检查 BE 到 FE 的 rpc_port 的连通性。
+   如果是 BE 的第一次启动，或者该 BE 尚未加入任何集群，则 BE 日志会定期滚动 ```waiting to receive first heartbeat from frontend``` 字样。表示 BE 还未通过 FE 的心跳收到 Master 的地址，正在被动等待。这种错误日志，在 FE 中 ADD BACKEND 并发送心跳后，就会消失。如果在接到心跳后，又重复出现 ```master client, get client from cache failed.host: , port: 0, code: 7``` 字样，说明 FE 成功连接了 BE，但 BE 无法主动连接 FE。可能需要检查 BE 到 FE 的 rpc_port 的连通性。
 
    如果 BE 已经被加入集群，日志中应该每隔 5 秒滚动来自 FE 的心跳日志：```get heartbeat, host: xx.xx.xx.xx, port: 9020, cluster id: xxxxxx```，表示心跳正常。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/lakehouse/multi-catalog/es.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/lakehouse/multi-catalog/es.md
@@ -116,7 +116,7 @@ Elasticsearch 没有明确的数组类型，但是它的某个字段可以含有
 
 该结构的数组字段可以通过使用以下命令将字段属性定义添加到目标索引映射的`_meta.doris`属性来定义。
 
-```bash
+```shell
 # ES 7.x and above
 curl -X PUT "localhost:9200/doc/_mapping?pretty" -H 'Content-Type:application/json' -d '
 {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/DROP-ROLE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/DROP-ROLE.md
@@ -36,7 +36,7 @@ DROP ROLE
 
 ```sql
   DROP ROLE [IF EXISTS] role1;
-````
+```
 
 删除角色不会影响以前属于角色的用户的权限。 它仅相当于解耦来自用户的角色。 用户从角色获得的权限不会改变
 
@@ -46,7 +46,7 @@ DROP ROLE
 
 ```sql
 DROP ROLE role1;
-````
+```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FUNCTION.md
@@ -156,13 +156,13 @@ CREATE [GLOBAL] [AGGREGATE] [ALIAS] FUNCTION function_name
    "symbol" = "_ZN9doris_udf6AddUdfEPNS_15FunctionContextERKNS_6IntValES4_",
    "object_file" = "http://host:port/libmyadd.so"
    );
-   ````
+   ```
 
 7. 创建一个全局自定义别名函数
 
    ```sql
    CREATE GLOBAL ALIAS FUNCTION id_masking(INT) WITH PARAMETER(id) AS CONCAT(LEFT(id, 3), '****', RIGHT(id, 4));
-   ```` 
+   ``` 
    
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FUNCTION.md
@@ -57,7 +57,7 @@ DROP [GLOBAL] FUNCTION function_name
 
     ```sql
     DROP GLOBAL FUNCTION my_add(INT, INT)
-    ````      
+    ```      
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DATABASES.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DATABASES.md
@@ -38,7 +38,7 @@ SHOW DATABASES
 
 ```sql
 SHOW DATABASES [FROM catalog] [filter expr];
-````
+```
 
 说明:
 1. `SHOW DATABASES` 会展示当前所有的数据库名称.
@@ -51,45 +51,45 @@ SHOW DATABASES [FROM catalog] [filter expr];
 
    ```sql
    SHOW DATABASES;
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | test               |
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 2. 会展示`hms_catalog`中所有的数据库名称.
 
    ```sql
    SHOW DATABASES from hms_catalog;
-   ````
+   ```
 
-   ````
+   ```
   +---------------+
   | Database      |
   +---------------+
   | default       |
   | tpch          |
   +---------------+
-   ````
+   ```
 
 3. 展示当前所有经过表示式`like 'infor%'`过滤后的数据库名称.
 
    ```sql
    SHOW DATABASES like 'infor%';
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-STATUS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-STATUS.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database ：查看指定数据库下的作业。 如果未指定，则使用当前数据库。
 - WHERE：您可以过滤结果列，目前仅支持以下列：
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`：作业唯一 ID。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLETS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLETS.md
@@ -59,19 +59,19 @@ IndexName = rollup_name
 
     ```sql
     SHOW TABLETS FROM example_db.table_name;
-    ````
+    ```
 
 2. 列出指定partitions的所有tablets
 
     ```sql
     SHOW TABLETS FROM example_db.table_name PARTITIONS(p1, p2);
-    ````
+    ```
 
 3. 列出某个backend上状态为DECOMMISSION的tablets
 
     ```sql
     SHOW TABLETS FROM example_db.table_name WHERE state="DECOMMISSION" AND BackendId=11003;
-    ````
+    ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TYPECAST.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TYPECAST.md
@@ -40,7 +40,7 @@ SHOW TYPECAST
 
 ```sql
 SHOW TYPE_CAST [IN|FROM db]
-````
+```
 
  Parameters
 
@@ -48,7 +48,7 @@ SHOW TYPE_CAST [IN|FROM db]
 
 ### Example
 
-````sql
+```sql
 mysql> show type_cast in testDb\G
 **************************** 1. row ******************** ******
 Origin Type: TIMEV2
@@ -61,7 +61,7 @@ Origin Type: TIMEV2
   Cast Type: TIMEV2
 
 3 rows in set (0.00 sec)
-````
+```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Utility-Statements/USE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-reference/Utility-Statements/USE.md
@@ -57,7 +57,7 @@ USE <[CATALOG_NAME].DATABASE_NAME>
     ```sql
     mysql> use hms_catalog.demo;
     Database changed
-    ````
+    ```
 ### Keywords
 
     USE

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/check-tablet-segment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/check-tablet-segment.md
@@ -69,7 +69,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/check_tablet_segment_lost?repair=false
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/compaction-run.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/compaction-run.md
@@ -135,6 +135,6 @@ under the License.
 
 ### Examples
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/compaction/run?tablet_id=10015&compact_type=cumulative"
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/compaction-status.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/compaction-status.md
@@ -114,6 +114,6 @@ under the License.
 
 ## Examples
 
-```bash
+```shell
 curl http://192.168.10.24:8040/api/compaction/show?tablet_id=10015
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/config.md
@@ -91,15 +91,15 @@ under the License.
 ## Examples
 
 
-```bash
+```shell
 curl "http://127.0.0.1:8040/api/show_config"
 ```
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/update_config?agent_task_trace_threshold_sec=2&persist=true"
 
 ```
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/update_config?agent_task_trace_threshold_sec=2&enable_merge_on_write_correctness_check=true&persist=true"
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/download.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/download.md
@@ -53,7 +53,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/_load_error_log?file=a&token=1"
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/health.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/health.md
@@ -49,7 +49,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/health
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/meta.md
@@ -66,7 +66,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/metrics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/metrics.md
@@ -63,7 +63,7 @@ prometheus 监控采集接口
 ## Examples
 
 
-    ```bash
+    ```shell
         curl "http://127.0.0.1:8040/metrics?type=json&with_tablet=true"
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/pad-rowset.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/pad-rowset.md
@@ -61,7 +61,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl -X POST "http://127.0.0.1:8040/api/pad_rowset?tablet_id=123456&start_version=1111111&end_version=1111112"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/reset-rpc-channel.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/reset-rpc-channel.md
@@ -60,11 +60,11 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/reset_rpc_channel/all
     ```
     
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/reset_rpc_channel/1.1.1.1:8080,2.2.2.2:8080
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/snapshot.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/snapshot.md
@@ -55,7 +55,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/snapshot?tablet_id=123456&schema_hash=1111111"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/tablet-distribution.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/tablet-distribution.md
@@ -85,7 +85,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/tablets_distribution?group_by=partition&partition_id=123"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/tablet-info.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/tablet-info.md
@@ -71,7 +71,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/tablets_json?limit=123
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/tablet-migration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/tablet-migration.md
@@ -104,7 +104,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/tablet_migration?goal=run&tablet_id=123&schema_hash=333&disk=/disk1"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/tablet-reload.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/tablet-reload.md
@@ -51,13 +51,13 @@ under the License.
 
 ## Response
 
-    ```bash
+    ```shell
     load header succeed
     ```
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/reload_tablet?tablet_id=123456&schema_hash=1111111&path=/abc"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/cluster-management/load-balancing.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/cluster-management/load-balancing.md
@@ -51,7 +51,7 @@ Doris 的 FE 进程负责接收用户连接和查询请求，其本身是可以�
 
 ### 安装 ProxySQL（yum 方式）
 
-```bash
+```shell
 配置yum源
 # vim /etc/yum.repos.d/proxysql.repo
 
@@ -91,7 +91,7 @@ ProxySQL 有配置文件 `/etc/proxysql.cnf` 和配置数据库文件`/var/lib/p
 
 这里主要是几个参数，在下面已经注释出来了，可以根据自己的需要进行修改
 
-```bash
+```shell
 # egrep -v "^#|^$" /etc/proxysql.cnf
 datadir="/var/lib/proxysql"         #数据目录
 admin_variables=
@@ -512,7 +512,7 @@ IP: 172.31.7.119
 
 ### 安装依赖
 
-```bash
+```shell
 sudo apt-get install build-essential
 sudo apt-get install libpcre3 libpcre3-dev 
 sudo apt-get install zlib1g-dev
@@ -521,7 +521,7 @@ sudo apt-get install openssl libssl-dev
 
 ### 安装 Nginx
 
-```bash
+```shell
 sudo wget http://nginx.org/download/nginx-1.18.0.tar.gz
 sudo tar zxvf nginx-1.18.0.tar.gz
 cd nginx-1.18.0
@@ -533,13 +533,13 @@ sudo make && make install
 
 这里是新建了一个配置文件
 
-```bash
+```shell
 vim /usr/local/nginx/conf/default.conf
 ```
 
 然后在里面加上下面的内容
 
-```bash
+```shell
 events {
 worker_connections 1024;
 }

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/data-admin/ccr.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/data-admin/ccr.md
@@ -75,7 +75,7 @@ enable_feature_binlog=true
 
 1. 构建 CCR syncer
 
-    ```Bash
+    ```shell
     git clone https://github.com/selectdb/ccr-syncer
 
     cd ccr-syncer
@@ -87,7 +87,7 @@ enable_feature_binlog=true
 
 2. 启动和停止 syncer
 
-    ```Bash
+    ```shell
     # 启动
     cd bin && sh start_syncer.sh --daemon
 
@@ -97,7 +97,7 @@ enable_feature_binlog=true
 
 **5. 打开源集群中同步库/表的 Binlog**
 
-```Bash
+```shell
 -- 如果是整库同步，可以执行如下脚本，使得该库下面所有的表都要打开 binlog.enable
 vim shell/enable_db_binlog.sh
 修改源集群的 host、port、user、password、db
@@ -109,7 +109,7 @@ ALTER TABLE enable_binlog SET ("binlog.enable" = "true");
 
 **6. 向 syncer 发起同步任务**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -135,7 +135,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 同步任务的参数说明：
 
-```Bash
+```shell
 name: CCR同步任务的名称，唯一即可
 host、port：对应集群 Master FE的host和mysql(jdbc) 的端口
 user、password：syncer以何种身份去开启事务、拉取数据等
@@ -280,7 +280,7 @@ bash bin/start_syncer.sh --pid_dir /path/to/pids
 
 在编译完成后的输出路径下，文件结构大致如下所示：
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -316,7 +316,7 @@ output_dir
 
 指定 pid 文件所在目录，上述三种关闭方法都依赖于 pid 文件的所在目录执行
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --pid_dir /path/to/pids
 ```
 
@@ -328,7 +328,7 @@ bash bin/stop_syncer.sh --pid_dir /path/to/pids
 
 关闭 pid_dir 路径下 host:port 对应的 Syncer
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --host 127.0.0.1 --port 9190
 ```
 
@@ -342,7 +342,7 @@ host 与 port 都不为空时**方法 1**才能生效
 
 关闭 pid_dir 路径下指定 pid 文件名对应的 Syncer
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 ```
 
@@ -352,7 +352,7 @@ bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 
 **请求的通用模板**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d {json_body} http://ccr_syncer_host:ccr_syncer_port/operator
 ```
 
@@ -376,7 +376,7 @@ or
 
 ​    创建 CCR 任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "ccr_test",
         "src": {
@@ -418,7 +418,7 @@ or
 
 ​    查看同步进度
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/get_lag
@@ -430,7 +430,7 @@ or
 
 ​    暂停同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/pause 
@@ -440,7 +440,7 @@ or
 
 ​    恢复同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/resume
@@ -450,7 +450,7 @@ or
 
 ​    删除同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/delete
@@ -460,7 +460,7 @@ or
 
     获取版本信息
 
-    ```Bash
+    ```shell
     curl http://ccr_syncer_host:ccr_syncer_port/version
 
     # > return
@@ -471,7 +471,7 @@ or
 
     查看 job 的状态
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/job_status
@@ -490,7 +490,7 @@ or
 
     不做 sync，此时用户可以将源和目的集群互换
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/desync
@@ -500,7 +500,7 @@ or
 
     展示已经创建的所有任务
 
-    ```Bash
+    ```shell
     curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
     {"success":true,"jobs":["ccr_db_table_alias"]}
@@ -512,7 +512,7 @@ or
 
 在编译完成后的输出路径下，文件结构大致如下所示：
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -530,7 +530,7 @@ output_dir
 
 **使用说明**
 
-```Bash
+```shell
 bash bin/enable_db_binlog.sh -h host -p port -u user -P password -d db
 ```
 
@@ -586,7 +586,7 @@ Syncer 高可用依赖 mysql，如果使用 mysql 作为后端存储，Syncer �
 
 BE 端配置参数
 
-```Bash
+```shell
 download_binlog_rate_limit_kbs=1024 # 这就是限制到1MB，这个是单个be对所有关于binlog 包括local snapshot的配置
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/automatic-service-start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/automatic-service-start.md
@@ -162,20 +162,20 @@ doris   ALL=(ALL)       NOPASSWD:DORISCTL
 
     添加或修改配置文件后，需要重新加载
 
-    ```bash
+    ```shell
     systemctl daemon-reload
     ```
 
     设置自启动，实质就是在 /etc/systemd/system/multi-user.target.wants/ 添加服务文件的链接
 
-    ```bash
+    ```shell
     systemctl enable doris-fe
     systemctl enable doris-be
     ```
 
 8. 服务启动
 
-    ```bash
+    ```shell
     systemctl start doris-fe
     systemctl start doris-be
     ```
@@ -190,14 +190,14 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 1. yum 安装 supervisor
     
-    ```bash
+    ```shell
     yum install epel-release
     yum install -y supervisor
     ```
 
 2. 启动服务并查看状态
 
-    ```bash
+    ```shell
     systemctl enable supervisord # 开机自启动
     systemctl start supervisord # 启动 supervisord 服务
     systemctl status supervisord # 查看 supervisord 服务状态
@@ -206,7 +206,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 3. 配置 BE 进程管理
 
-    ```bash
+    ```shell
     修改 start_be.sh 脚本，去掉最后的 & 符号
 
     vim /path/doris/be/bin/start_be.sh
@@ -216,7 +216,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 BE 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-be.ini
 
     [program:doris_be]      
@@ -239,7 +239,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 4. 配置 FE 进程管理
 
-    ```bash
+    ```shell
     修改 start_fe.sh 脚本，去掉最后的 & 符号
 
     vim /path/doris/fe/bin/start_fe.sh 
@@ -249,7 +249,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 FE 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-fe.ini
 
     [program:PaloFe]
@@ -273,7 +273,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 5. 配置 Broker 进程管理
 
-    ```bash
+    ```shell
     修改 start_broker.sh 脚本，去掉最后的 & 符号
 
     vim /path/apache_hdfs_broker/bin/start_broker.sh
@@ -283,7 +283,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 Broker 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-broker.ini
 
     [program:BrokerBootstrap]
@@ -307,7 +307,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 6. 首先确定 Doris 服务是停止状态，然后使用 supervisor 将 Doris 自动拉起，然后确定进程是否正常启动
     
-    ```bash
+    ```shell
     supervisorctl reload # 重新加载 Supervisor 中的所有配置文件
     supervisorctl status # 查看 supervisor 状态，验证 Doris 服务进程是否正常启动
 
@@ -321,7 +321,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 - 如果使用 yum 安装的 supervisor 启动报错 :  pkg_resources.DistributionNotFound: The 'supervisor==3.4.0' distribution was not found
 
-    ```bash
+    ```shell
     这个是 python 版本不兼容问题，通过 yum 命令直接安装的 supervisor 只支持 python2 版本，所以需要将 /usr/bin/supervisord 和 /usr/bin/supervisorctl 中文件内容开头 #!/usr/bin/python 改为 #!/usr/bin/python2，前提是要装 python2 版本
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/debug-log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/debug-log.md
@@ -75,7 +75,7 @@ FE 的 Debug 级别日志可以通过修改配置文件开启，也可以通过�
 
    通过以下 API 也可以在运行时修改日志级别。无需重启 FE 节点。
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?add_verbose=org.apache.doris.catalog.Catalog
    ```
 
@@ -98,7 +98,7 @@ FE 的 Debug 级别日志可以通过修改配置文件开启，也可以通过�
 
    也可以通过以下 API 关闭 Debug 日志：
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?del_verbose=org.apache.doris.catalog.Catalog
    ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/metadata-operation.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/metadata-operation.md
@@ -321,7 +321,7 @@ FE 目前有以下几个端口
 
 2. 执行以下命令，从 Master FE 内存中 dump 出元数据：(下面称为 image_mem)
 
-    ```bash
+    ```shell
     curl -u $root_user:$password http://$master_hostname:8030/dump
     ```
 
@@ -330,7 +330,7 @@ FE 目前有以下几个端口
 
     自 1.2.0 版本起，推荐使用以下功能验证 `image_mem` 文件：
 
-    ```bash
+    ```shell
     sh start_fe.sh --image path_to_image_mem
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/monitor-alert.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/monitor-alert.md
@@ -68,7 +68,7 @@ Doris 的监控数据通过 Frontend 和 Backend 的 http 接口向外暴露。�
 
 用户将看到如下监控项结果（示例为 FE 部分监控项）：
 
-```bash
+```shell
 # HELP  jvm_heap_size_bytes jvm heap stat
 # TYPE  jvm_heap_size_bytes gauge
 jvm_heap_size_bytes{type="max"} 8476557312
@@ -111,7 +111,7 @@ jvm_thread{type="terminated_count"} 0
 
 这是一个以 [Prometheus 格式](https://prometheus.io/docs/practices/naming/) 呈现的监控数据。我们以其中一个监控项为例进行说明：
 
-```bash
+```shell
 # HELP  jvm_heap_size_bytes jvm heap stat
 # TYPE  jvm_heap_size_bytes gauge
 jvm_heap_size_bytes{type="max"} 8476557312
@@ -152,7 +152,7 @@ jvm_heap_size_bytes{type="used"} 156375280
 
     这里我们使用最简单的静态文件的方式进行监控配置。Prometheus 支持多种 [服务发现](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) 方式，可以动态的感知节点的加入和删除。
  
-    ```bash
+    ```shell
     # my global config
     global:
       scrape_interval:     15s # 全局的采集间隔，默认是 1m，这里设置为 15s
@@ -219,7 +219,7 @@ jvm_heap_size_bytes{type="used"} 156375280
 
 3. 打开配置文件 conf/defaults.ini。这里我们仅列举需要改动的配置项，其余配置可使用默认。
 
-    ```bash
+    ```shell
     # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
     data = data
     

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/monitor-metrics/metrics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/monitor-metrics/metrics.md
@@ -34,14 +34,14 @@ Doris 的 FE 进程和 BE 进程都提供了完备的监控指标。监控指标
 
 可以通过访问 FE 或 BE 节点的 http 端口获取当前监控。如：
 
-```bash
+```shell
 curl http://fe_host:http_port/metrics
 curl http://be_host:webserver_port/metrics
 ```
 
 默认返回 Prometheus 兼容格式的监控指标，如：
 
-```bash
+```shell
 doris_fe_cache_added{type="partition"} 0
 doris_fe_cache_added{type="sql"} 0
 doris_fe_cache_hit{type="partition"} 0
@@ -51,7 +51,7 @@ doris_fe_connection_total 2
 
 如需获取 JSON 格式的监控指标，请访问：
 
-```bash
+```shell
 curl http://fe_host:http_port/metrics?type=json
 curl http://be_host:webserver_port/metrics?type=json
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/tablet-local-debug.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/tablet-local-debug.md
@@ -100,7 +100,7 @@ PROPERTIES (
 
 该目下会有一个 tablet id 命名的目录，将这个目录整体打包后备用。（注意，该目录最多保留 60 分钟，之后会自动删除）。
 
-```bash
+```shell
 cd /path/to/be/storage/snapshot/20220830101353.2.3600
 tar czf 10020.tar.gz 10020/
 ```
@@ -178,13 +178,13 @@ tar czf 10020.tar.gz 10020/
 
     同时，我们还需要到调试环境 BE 节点的数据目录下，确认新的 tablet 所在的 shard id：
     
-    ```bash
+    ```shell
     cd /path/to/storage/data/*/10017 && pwd
     ```
     
     这个命令会进入 10017 这个 tablet 所在目录并展示路径。这里我们会看到类似如下的路径：
     
-    ```bash
+    ```shell
     /path/to/storage/data/0/10017
     ```
     
@@ -208,7 +208,7 @@ tar czf 10020.tar.gz 10020/
     
     通过 `meta_tool` 工具删除原来的 tablet meta。该工具位于 `be/lib` 目录下。
     
-    ```bash
+    ```shell
     ./lib/meta_tool --root_path=/path/to/storage --operation=delete_meta --tablet_id=10017 --schema_hash=44622287
     ```
     
@@ -216,7 +216,7 @@ tar czf 10020.tar.gz 10020/
     
     通过 `meta_tool` 工具加载新的 tablet meta。
     
-    ```bash
+    ```shell
     ./lib/meta_tool --root_path=/path/to/storage --operation=load_meta --json_meta_path=/path/to/10017.hdr.json
     ```
     

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/tablet-meta-tool.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/tablet-meta-tool.md
@@ -89,7 +89,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./lib/meta_tool --operation=load_meta --root_path=/path/to/root_path --json_meta_path=path
 ```
 
@@ -99,13 +99,13 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 删除单个 tablet 元数据：
 
-```bash
+```shell
 ./lib/meta_tool --operation=delete_meta --root_path=/path/to/root_path --tablet_id=xxx --schema_hash=xxx
 ```
 
 删除一组 tablet 元数据：
 
-```bash
+```shell
 ./lib/meta_tool --operation=batch_delete_meta --tablet_file=/path/to/tablet_file.txt
 ```
 
@@ -117,7 +117,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 `tablet_file` 文件示例：
 
-```bash
+```shell
 /output/be/data/,14217,352781111
 /output/be/data/,14219,352781111
 /output/be/data/,14223,352781111
@@ -134,7 +134,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./lib/meta_tool --operation=show_meta --root_path=/path/to/root_path --pb_header_path=path
 ```
 
@@ -144,7 +144,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./meta_tool --operation=show_segment_footer --file=/path/to/segment/file
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/tablet-repair-and-balance.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/tablet-repair-and-balance.md
@@ -48,7 +48,7 @@ Colocation 属性的表的副本修复和均衡可以参阅[这里](../../query/
 
 7. Storage Medium：存储介质。Doris 支持对分区粒度指定不同的存储介质，包括 SSD 和 HDD。副本调度策略也是针对不同的存储介质分别调度的。
 
-```bash
+```shell
 
               +--------+              +-----------+
               |  Meta  |              |  Backends |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/tablet-restore-tool.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/maint-monitor/tablet-restore-tool.md
@@ -30,7 +30,7 @@ under the License.
 
 用户在使用 Doris 的过程中，可能会发生因为一些误操作或者线上 bug，导致一些有效的 tablet 被删除（包括元数据和数据）。为了防止在这些异常情况出现数据丢失，Doris 提供了回收站机制，来保护用户数据。用户删除的 tablet 数据不会被直接删除，会被放在回收站中存储一段时间，在一段时间之后会有定时清理机制将过期的数据删除。回收站中的数据包括：tablet 的 data 文件 (.dat)，tablet 的索引文件 (.idx) 和 tablet 的元数据文件 (.hdr)。数据将会存放在如下格式的路径：
 
-```bash
+```shell
 /root_path/trash/time_label/tablet_id/schema_hash/
 ```
 
@@ -56,7 +56,7 @@ BE 提供 http 接口和 `restore_tablet_tool.sh` 脚本实现这个功能，支
 
     BE 中提供单个 tablet 数据恢复的 http 接口，接口如下：
     
-    ```bash
+    ```shell
     curl -X POST "http://be_host:be_webserver_port/api/restore_tablet?tablet_id=11111\&schema_hash=12345"
     ```
     
@@ -112,7 +112,7 @@ sh restore_tablet_tool.sh --backend "http://127.0.0.1:8040" --file tablets.txt
 
     如果出现数据丢失的情况，则日志中会有类似如下日志：
     
-    ```bash
+    ```shell
     backend [10001] invalid situation. tablet[20000] has few replica[1], replica num setting is [3]
     ```
 
@@ -122,7 +122,7 @@ sh restore_tablet_tool.sh --backend "http://127.0.0.1:8040" --file tablets.txt
 
     当确认数据已经无法恢复后，可以通过执行以下命令，生成空白副本。
     
-    ```bash
+    ```shell
     ADMIN SET FRONTEND CONFIG ("recover_with_empty_tablet" = "true");
     ```
 
@@ -130,7 +130,7 @@ sh restore_tablet_tool.sh --backend "http://127.0.0.1:8040" --file tablets.txt
 
 3. 设置完成几分钟后，应该会在 Master FE 日志 `fe.log` 中看到如下日志：
 
-    ```bash
+    ```shell
     tablet 20000 has only one replica 20001 on backend 10001 and it is lost. create an empty replica to recover it.
     ```
 
@@ -140,6 +140,6 @@ sh restore_tablet_tool.sh --backend "http://127.0.0.1:8040" --file tablets.txt
 
 5. 全部修复成功后，通过以下命令关闭 `recover_with_empty_tablet` 参数：
 
-    ```bash
+    ```shell
     ADMIN SET FRONTEND CONFIG ("recover_with_empty_tablet" = "false");
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/memory-management/memory-limit-exceeded-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/memory-management/memory-limit-exceeded-analysis.md
@@ -30,7 +30,7 @@ under the License.
 
 当查询或导入报错`Memory limit exceeded`时，可能的原因：进程内存超限、系统剩余可用内存不足、超过单次查询执行的内存上限。
 
-```bash
+```shell
 ERROR 1105 (HY000): errCode = 2, detailMessage = Memory limit exceeded:<consuming tracker:<xxx>, xxx. backend 172.1.1.1 process memory used xxx GB, limit xxx GB. If query tracker exceed, `set exec_mem_limit=8G` to change limit, details mem usage see be.INFO.
 ```
 
@@ -74,7 +74,7 @@ ERROR 1105 (HY000): errCode = 2, detailMessage = Memory limit exceeded:<consumin
 2. 当进程内存超限后，BE 会触发内存 GC。
 :::
 
-```bash
+```shell
 W1127 17:23:16.372572 19896 mem_tracker_limiter.cpp:214] System Mem Exceed Limit Check Failed, Try Alloc: 1062688
 Process Memory Summary:
     process memory used 2.68 GB limit 2.47 GB, sys mem available 50.95 GB min reserve 3.20 GB, tc/jemalloc allocator cache 51.97 MB
@@ -138,7 +138,7 @@ https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34
 
 当返回如下报错时，说明超过单次执行内存限制。
 
-```bash
+```shell
 ERROR 1105 (HY000): errCode = 2, detailMessage = Memory limit exceeded:<consuming tracker:<Query#Id=f78208b15e064527-a84c5c0b04c04fcf>, failed alloc size 1.03 MB, exceeded tracker:<Query#Id=f78208b15e064527-a84c5c0b04c04fcf>, limit 100.00 MB, peak used 99.29 MB, current used 99.25 MB>, executing msg:<execute:<ExecNode:VHASH_JOIN_NODE (id=4)>>. backend 172.24.47.117 process memory used 1.13 GB, limit 98.92 GB. If query tracker exceed, `set exec_mem_limit=8G` to change limit, details mem usage see log/be.INFO.
 ```
 
@@ -163,7 +163,7 @@ ERROR 1105 (HY000): errCode = 2, detailMessage = Memory limit exceeded:<consumin
 3. `Memory Tracker Summary`：当前查询的 memory tracker 统计，可以看到查询每个算子当前使用的内存和峰值，具体可参考 [Memory Tracker](../memory-management/memory-tracker)。
 注意：一个查询在内存超限后只会打印一次日志，此时查询的多个线程都会感知，并尝试等待内存释放，或者 cancel 当前查询，如果日志中 Try Alloc 的值很小，则无须关注`Alloc Stacktrace`，直接分析`Memory Tracker Summary`即可。
 
-```bash
+```shell
 W1128 01:34:11.016165 357796 mem_tracker_limiter.cpp:191] Memory limit exceeded:<consuming tracker:<Query#Id=78208b15e064527-a84c5c0b04c04fcf>, failed alloc size 4.00 MB, exceeded tracker:<Query#Id=78208b15e064527-a84c5c0b04c04fcf>, limit 100.00 MB, peak used 98.59 MB,
 current used 96.88 MB>, executing msg:<execute:<ExecNode:VHASH_JOIN_NODE (id=2)>>. backend 172.24.47.117 process memory used 1.13 GB, limit 98.92 GB. If query tracker exceed, `set exec_mem_limit=8G` to change limit, details mem usage see be.INFO.
 Process Memory Summary:    

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/plugin-development-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/plugin-development-manual.md
@@ -74,7 +74,7 @@ auditodemo/:
 
 `plugin.properties` 内容示例：
 
-```bash
+```shell
 ### required:
 #
 # the plugin name
@@ -113,13 +113,13 @@ soName = example.so
 
 我们可以通过以下命令在 `fe_plugins` 目录创建一个子模块用户实现创建和创建工程。其中 `doris-fe-test` 为插件名称。
 
-```bash
+```shell
 mvn archetype: generate -DarchetypeCatalog = internal -DgroupId = org.apache -DartifactId = doris-fe-test -DinteractiveMode = false
 ```
 
 这个命令会创建一个新的 maven 工程，并且自动向 `fe_plugins/pom.xml` 中添加一个子模块：
 
-```bash
+```shell
     .....
     <groupId>org.apache</groupId>
     <artifactId>doris-fe-plugins</artifactId>
@@ -135,7 +135,7 @@ mvn archetype: generate -DarchetypeCatalog = internal -DgroupId = org.apache -Da
 
 新的工程目录结构如下：
 
-```bash
+```shell
 -doris-fe-test/
 -pom.xml
 -src/

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/privilege-ldap/certificate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/privilege-ldap/certificate.md
@@ -41,7 +41,7 @@ Doris 开启 SSL 功能需要配置 CA 密钥证书和 Server 端密钥证书，
 
 1. 生成 CA、Server 端和 Client 端的密钥和证书
 
-```BASH
+```shell
 # 生成CA certificate
 openssl genrsa 2048 > ca-key.pem
 openssl req -new -x509 -nodes -days 3600 \
@@ -66,13 +66,13 @@ openssl x509 -req -in client-req.pem -days 3600 \
 
 2. 验证创建的证书。
 
-```bash
+```shell
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
 3. 将您的 CA 密钥和证书和 Sever 端密钥和证书分别合并到 PKCS#12 (P12) 包中。您也可以指定某个证书格式，默认 PKCS12，可以通过修改 conf/fe.conf 配置文件，添加参数 ssl_trust_store_type 指定证书格式
 
-```bash
+```shell
 # 打包CA密钥和证书
 openssl pkcs12 -inkey ca-key.pem -in ca.pem -export -out ca_certificate.p12
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/privilege-ldap/ldap.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/privilege-ldap/ldap.md
@@ -140,13 +140,13 @@ set ldap_admin_password = password('ldap_admin_password');
 
   例如在 linux 或者 mac 环境中可以使用：
 
-  ```bash
+  ```shell
   echo "export LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN=1" >> ～/.bash_profile && source ～/.bash_profile
   ```
 
 - 每次登录 Doris 时添加参数“--enable-cleartext-plugin”：
 
-  ```bash
+  ```shell
   mysql -hDORIS_HOST -PDORIS_PORT -u user -p --enable-cleartext-plugin
   
   输入 ldap 密码
@@ -211,13 +211,13 @@ LDAP 密码验证和组授权是 Doris 密码验证和授权的补充，开启 L
 LDAP 用户节点存在属性：uid: jack 用户密码：abcdef
 使用以下命令登录 Doris 可以登录 jack@'172.10.1.10'账户：
 
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
 使用以下命令将登录失败：
 
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 
@@ -226,7 +226,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 LDAP 用户节点存在属性：uid: jack 用户密码：abcdef
 使用以下命令创建临时用户并登录 jack@'%'，临时用户具有基本权限 DatabasePrivs：Select_priv，用户退出登录后 Doris 将删除该临时用户：
 
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
@@ -235,7 +235,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 存在 Doris 账户：jack@'172.10.1.10'，密码：123456
 使用 Doris 密码登录账户，成功：
 
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/resource-admin/workload-group.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/resource-admin/workload-group.md
@@ -52,7 +52,7 @@ properties (
 
 2. 开启 experimental_enable_workload_group 配置项，在 fe.conf 中设置：
 
-```bash
+```shell
 experimental_enable_workload_group=true
 ```
 
@@ -71,7 +71,7 @@ properties (
 
 4. 开启 Pipeline 执行引擎，Workload Group CPU 隔离基于 Pipeline 执行引擎实现，因此需开启 Session 变量：
 
-```bash
+```shell
 set experimental_enable_pipeline_engine = true;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/delete/batch-delete-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/delete/batch-delete-manual.md
@@ -171,19 +171,19 @@ mysql DESC test;
 
 **1. 正常导入数据：**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: APPEND"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
 其中的 APPEND 条件可以省略，与下面的语句效果相同：
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
 **2. 将与导入数据 Key 相同的数据全部删除**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
@@ -218,7 +218,7 @@ curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, ci
 
 **3. 将导入数据中与`site_id=1` 的行的 Key 列相同的行**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: MERGE" -H "delete: siteid=1"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
@@ -257,7 +257,7 @@ curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, ci
 
 **4. 当存在 sequence 列时，将与导入数据 Key 相同的数据全部删除**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: name, gender, age" -H "function_column.sequence_col: age" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/import/load-atomicity.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/import/load-atomicity.md
@@ -188,7 +188,7 @@ Empty set (0.019 sec)
 
 **1. 在 HTTP Header 中设置 `two_phase_commit:true` 启用两阶段提交。**
 
-```Bash
+```shell
 curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt http://fe_host:http_port/api/{db}/{table}/_stream_load
 {
     "TxnId": 18036,
@@ -214,7 +214,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 可以使用事务 id 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18036" -H "txn_operation:commit" http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -224,7 +224,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 也可以使用 label 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:commit"  http://fe_host:http_port/api/{db}/{table}/_stream_load_2pc
   {
       "status": "Success",
@@ -236,7 +236,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 可以使用事务 id 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "txn_id:18037" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -246,7 +246,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 也可以使用 label 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/import/load-data-convert.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/import/load-data-convert.md
@@ -60,7 +60,7 @@ WITH BROKER bos
 
 ### STREAM LOAD
 
-```Bash
+```shell
 curl
 --location-trusted
 -u user:passwd
@@ -96,7 +96,7 @@ Stream load 不支持前置过滤。
 
 示例：
 
-```Bash
+```shell
 curl
 --location-trusted
 -u user:passwd

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/import/load-json-format.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/import/load-json-format.md
@@ -240,7 +240,7 @@ k2 int, k1 int
 
 导入语句 1（以 Stream Load 为例）：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -258,7 +258,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", 
 
 导入语句 2：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, k1" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -274,7 +274,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", 
 
 当然，如其他导入一样，可以在 Columns 中进行列的转换操作。示例如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, tmp_k1, k1 = tmp_k1 * 100" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -338,7 +338,7 @@ Doris 支持通过 JSON root 抽取 JSON 中指定的数据。
 
 导入语句如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -372,7 +372,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: tru
 
 这是因为通过导入语句中的信息，Doris 并不知道“缺失的列是表中的 k2 列”。如果要对以上数据按照期望结果导入，则导入语句如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -H "jsonpaths: [\"$.k1\", \"$.k2\"]" -H "columns: k1, tmp_k2, k2 = ifnull(tmp_k2, 'x')" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -398,7 +398,7 @@ code    INT     NULL
 
 - 不指定 JSON Path
 
-  ```bash
+  ```shell
   curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
   ```
 
@@ -410,7 +410,7 @@ code    INT     NULL
 
 - 指定 JSON Path
 
-  ```bash
+  ```shell
   curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
   ```
 
@@ -428,7 +428,7 @@ code    INT     NULL
 
   - 指定 JSON Path
 
-  ```bash
+  ```shell
   curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
   ```
 
@@ -459,7 +459,7 @@ code    INT     NULL
 
 - 指定 JSON Path
 
-  ```bash
+  ```shell
   curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
   ```
 
@@ -485,7 +485,7 @@ code    INT     NULL
 
 - StreamLoad 导入：
 
-  ```bash
+  ```shell
   curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
   ```
 
@@ -502,7 +502,7 @@ code    INT     NULL
 
 数据依然是示例 3 中的多行数据，现需要对导入数据中的 `code` 列加 1 后导入。
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -528,7 +528,7 @@ curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\
 {"k1": 40, "k2": ["10000000000000000000.1111111222222222"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_decimal.json http://localhost:8035/api/example_db/array_test_decimal/_stream_load
 ```
 
@@ -548,7 +548,7 @@ MySQL > select * from array_test_decimal;
 {"k1": 999, "k2": ["76959836937749932879763573681792701709", "26017042825937891692910431521038521227"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_largeint.json http://localhost:8035/api/example_db/array_test_largeint/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/import/load-strict-mode.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/import/load-strict-mode.md
@@ -58,7 +58,7 @@ under the License.
 
 2. [STREAM LOAD](../../sql-manual/sql-reference/Data-Manipulation-Statements/Load/STREAM-LOAD)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "strict_mode: true" \
    -T 1.txt \
@@ -171,7 +171,7 @@ mysql> desc user_profile;
 18,9999999,2023-07-03 12:00:03
 ```
 
-```bash
+```shell
 curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:false" -H "column_separator:," -H "columns:id,balance,last_access_time" -T /tmp/test.csv http://host:port/api/db1/user_profile/_stream_load
 ```
 
@@ -179,7 +179,7 @@ curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:false
 
 而当用户使用严格模式的 Stream Load 部分列更新向表中插入上述数据时
 
-``` bash
+```shell
 curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:true" -H "column_separator:," -H "columns:id,balance,last_access_time" -T /tmp/test.csv http://host:port/api/db1/user_profile/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/import/stream-load-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/import/stream-load-manual.md
@@ -120,7 +120,7 @@ Stream Load 需要对目标表的 INSERT 权限。如果没有 INSERT 权限，�
 
     通过 `curl` 命令可以提交 Stream Load 导入作业。
 
-    ```Bash
+    ```shell
     curl --location-trusted -u <doris_user>:<doris_password> \
         -H "Expect:100-continue" \
         -H "column_separator:," \
@@ -203,7 +203,7 @@ Stream Load 需要对目标表的 INSERT 权限。如果没有 INSERT 权限，�
 
     通过 `curl` 命令可以提交 Stream Load 导入作业。
 
-    ```Bash
+    ```shell
     curl --location-trusted -u <doris_user>:<doris_password> \
         -H "label:124" \
         -H "Expect:100-continue" \
@@ -264,7 +264,7 @@ mysql> show stream load from testdb;
 
 Stream Load 导入语法如下：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
   -H "Expect:100-continue" [-H ""...] \
   -T <file_path> \
@@ -407,7 +407,7 @@ Stream Load 是一种同步的导入方式，导入结果会通过创建导入�
 :::
 
 使用 `curl` 来使用 Stream Load 的 http stream 模式：
-```Bash
+```shell
 curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -XPUT http://fe_host:http_port/api/_http_stream
 ```
 
@@ -415,7 +415,7 @@ curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -
 
 load_sql 举例：
 
-```Bash
+```shell
 insert into db.table (col, ...) select stream_col, ... from http_stream("property1"="value1");
 ```
 
@@ -461,7 +461,7 @@ Doris 的导入任务可以容忍一部分格式错误的数据。容忍率通�
 
 通过以下命令可以指定 max_filter_ratio 容忍度为 0.4 创建 stream load 导入任务：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "max_filter_ratio:0.4" \
@@ -491,7 +491,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 将本地文件中的数据导入到表中的 p1, p2 分区，允许 20% 的错误率。
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:123" \
     -H "Expect:100-continue" \
@@ -519,7 +519,7 @@ Stream Load 是基于 HTTP 的协议进行导入，所以是支持使用程序�
 
 下面通过 `bash` 的命令管道来举例这种使用方式，这种导入的数据就是程序流式生成的，而不是本地文件。
 
-```Bash
+```shell
 seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -543,7 +543,7 @@ curl --location-trusted -u root -T test.csv  -H "label:1" -H "format:csv_with_na
 
 在 Stream Load 中有三种导入类型：APPEND、DELETE 与 MERGE。可以通过指定参数 merge_type 进行调整。如想指定将与导入数据 Key 相同的数据全部删除，可以使用以下命令：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: DELETE" \
@@ -586,7 +586,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 指定 merge_type 为 MERGE，可以将导入的数据 MERGE 到表中。MERGE 语义需要结合 DELETE 条件联合使用，表示满足 DELETE 条件的数据按照 DELETE 语义处理，其余按照 APPEND 语义添加到表中，如下面操作表示删除 siteid 为 1 的行，其余数据添加到表中：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: MERGE" \
@@ -778,7 +778,7 @@ JSON 数据格式：
 
 导入命令：
 
-```Bash
+```shell
 curl --location-trusted -u root -T test.json -H "label:1" -H "format:json" -H 'columns: id, order_code, create_time=CURRENT_TIMESTAMP()' http://host:port/api/testDb/testTbl/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/update/unique-update-transaction.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/data-operate/update/unique-update-transaction.md
@@ -108,7 +108,7 @@ sequence_type 用来指定 sequence 列的类型，可以为整型和时间类�
 
 stream load 的写法是在 header 中的`function_column.sequence_col`字段添加隐藏列对应的 source_sequence 的映射，示例
 
-```Bash
+```shell
 curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -227,7 +227,7 @@ MySQL  desc test_table;
 
 此处以 stream load 为例
 
-```Bash
+```shell
 curl --location-trusted -u root: -T testData http://host:port/api/test/test_table/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/db-connect/database-connect.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/db-connect/database-connect.md
@@ -33,14 +33,14 @@ Apache Doris 采用 MySQL 网络连接协议，兼容 MySQL 生态的命令行�
 
 解压下载的 MySQL 客户端，在 `bin/` 目录下可以找到 `mysql` 命令行工具。然后执行下面的命令连接 Doris。
 
-```Bash
+```shell
 # FE_IP 为 FE 的监听地址， FE_QUERY_PORT 为 FE 的 MYSQL 协议服务的端口，在 fe.conf 中对应 query_port, 默认为 9030.
 mysql -h FE_IP -P FE_QUERY_PORT -u USER_NAME 
 ```
 
 登录后，显示如下。
 
-```Bash
+```shell
 Welcome to the MySQL monitor.  Commands end with ; or \g.                                                                                                                                                                                  
 Your MySQL connection id is 236                                                                                                                                                                                                            
 Server version: 5.7.99 Doris version doris-2.0.3-rc06-37d31a5                                                                                                                                                                              

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/k8s-deploy/install-access-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/k8s-deploy/install-access-cluster.md
@@ -36,13 +36,13 @@ Doris 在 Kubernetes 上默认提供 ClusterIP 访问模式。无需进行修改
 
 在部署集群后，通过以下命令可以查看 Doris Operator 暴露的 service：
 
-```bash
+```shell
 kubectl -n doris get svc
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                               AGE
 doriscluster-sample-be-internal   ClusterIP   None          <none>        9050/TCP                              9m
 doriscluster-sample-be-service    ClusterIP   10.1.68.128   <none>        9060/TCP,8040/TCP,9050/TCP,8060/TCP   9m
@@ -59,13 +59,13 @@ doriscluster-sample-fe-service    ClusterIP   10.1.118.16   <none>        8030/T
 
 使用以下命令，可以在当前的 Kubernetes 集群中创建一个包含 mysql client 的 pod：
 
-```bash
+```shell
 kubectl run mysql-client --image=mysql:5.7 -it --rm --restart=Never --namespace=doris -- /bin/bash
 ```
 
 在集群内的容器中，可以使用对外暴露的后缀为 `service` 的服务名访问 Doris 集群：
 
-```bash
+```shell
 ## 使用 service 类型 pod name 访问 Doris 集群
 mysql -uroot -P9030 -hdoriscluster-sample-fe-service
 ```
@@ -145,13 +145,13 @@ spec:
 
 在部署集群后，通过以下命令可以查看 Doris Operator 暴露的 service：
 
-```bash
+```shell
 kubectl get service
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                                       AGE
 kubernetes                        ClusterIP   10.152.183.1     <none>        443/TCP                                                       169d
 doriscluster-sample-fe-internal   ClusterIP   None             <none>        9030/TCP                                                      2d
@@ -162,13 +162,13 @@ doriscluster-sample-be-service    NodePort    10.152.183.244   <none>        906
 
 Doris 的 Query Port 端口默认为 9030，在本地中被映射到本地端口 31545。在访问 Doris 集群时，同时需要获取到对应的 IP 地址，可以通过以下命令查看：
 
-```bash
+```shell
 kubectl get nodes -owide
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME   STATUS   ROLES           AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION          CONTAINER-RUNTIME
 r60    Ready    control-plane   14d   v1.28.2   192.168.88.60   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
 r61    Ready    <none>          14d   v1.28.2   192.168.88.61   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
@@ -178,7 +178,7 @@ r63    Ready    <none>          14d   v1.28.2   192.168.88.63   <none>        Ce
 
 在 NodePort 模式下，可以根据任何 node 节点的宿主机 IP 与端口映射访问 Kubernetes 集群内的服务。在本例中可以使用任一的 node 节点 IP，192.168.88.61、192.168.88.62、192.168.88.63 访问 Doris 服务。如在下例中使用了 node 节点 192.168.88.62 与映射出的 query port 端口 31545 访问集群：
 
-```bash
+```shell
 mysql -h 192.168.88.62 -P 31545 -uroot
 ```
 
@@ -194,7 +194,7 @@ mysql -h 192.168.88.62 -P 31545 -uroot
 
 在上例返回结果中，可以直接在同一个 Kubernetes 集群内的 Pod 中通过 curl 命令获取返回结果：
 
-```bash
+```shell
 curl http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local:8040/api/_load_error_log?file=__shard_1/error_log_insert_stmt_af474190276a2e9c-49bb9d175b8e968e_af474190276a2e9c_49bb9d175b8e968e
 ```
 
@@ -245,7 +245,7 @@ spec:
 
 按照上例中的 service 将 CR 中的 ${podName} 替换成 doriscluster-sample-be-2，将 ${ServiceType} 替换为 NodePort。通过 kubectl apply 命令，在于 doris 集群相同的 namespace 中创建 service 服务。
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -253,13 +253,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 使用以下命令查看上述部署 Service 分配的 NodePort 端口：
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
 doriscluster-detail-error         NodePort    10.152.183.35    <none>        8040:31201/TCP     32s
 ```
@@ -268,13 +268,13 @@ doriscluster-detail-error         NodePort    10.152.183.35    <none>        804
 
 获取 K8s 管控的宿主机地址：
 
-```bash
+```shell
 kubectl get node -owide
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME             STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION       CONTAINER-RUNTIME
 vm-10-8-centos   Ready    <none>   226d   v1.28.7   10.16.10.8    <none>        TencentOS Server 3.1 (Final)   5.4.119-19-0009.3    containerd://1.6.28
 vm-10-7-centos   Ready    <none>   19d    v1.28.7   10.16.10.7    <none>        TencentOS Server 3.1 (Final)   5.4.119-19.0009.25   containerd://1.6.28
@@ -301,7 +301,7 @@ http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluste
 
 上述地址的域名地址为 `doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local` 在 `Kubernetes` 上 `Doris Operator` 部署的 pod 使用的域名中，三级域名为  pod 的名称。将上述模板中 {podName} 替换为真实的 `pod` 名称，将 {serviceType} 替换为 `LoadBalancer` ，更改后保存到新建的 `stream_load_get_error.yaml` 文件中。使用如下命令部署 service：
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -309,13 +309,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 使用如下命令查看上述部署 Service 分配的  LoadBalaner 地址 EXTERNAL-IP ,以下为在 aws eks 测试实例：
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                         TYPE          CLUSTER-IP       EXTERNAL-IP                                                              PORT(S)           AGE
 doriscluster-detail-error    LoadBalancer  172.20.183.136   ac4828493dgrftb884g67wg4tb68gyut-1137856348.us-east-1.elb.amazonaws.com  8040:32003/TCP    14s
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/k8s-deploy/install-config-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/k8s-deploy/install-config-cluster.md
@@ -98,13 +98,13 @@ feSpec:
 
 其中，需要在 ${storageClassName} 指定 [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) 的名称。可以通过 以下命令查看当前 Kubernetes 集群内支持的 StorageClass：
 
-```bash
+```shell
 kubectl get sc
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                          PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
 openebs-hostpath              openebs.io/local               Delete          WaitForFirstConsumer   false                  212d
 openebs-device                openebs.io/local               Delete          WaitForFirstConsumer   false                  212d

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/k8s-deploy/install-doris-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/k8s-deploy/install-doris-cluster.md
@@ -36,13 +36,13 @@ under the License.
 
 1. 创建 namespace：
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 2. 部署 Doris 集群
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -61,7 +61,7 @@ selectdb/doris.be-ubuntu:2.0.2
 
 将镜像下载到本地后打包成 tar 文件
 
-```bash
+```shell
 ## download docker image
 docker pull selectdb/doris.fe-ubuntu:2.0.2
 docker pull selectdb/doris.be-ubuntu:2.0.2
@@ -73,7 +73,7 @@ docker save -o doris.be-ubuntu-v2.0.2.tar docker pull selectdb/doris.be-ubuntu:2
 
 将 image tar 包上传到服务器上，执行 docker load 命令：
 
-```bash
+```shell
 ## load docker image
 docker load -i doris.fe-ubuntu-v2.0.2.tar
 docker load -i doris.be-ubuntu-v2.0.2.tar
@@ -81,13 +81,13 @@ docker load -i doris.be-ubuntu-v2.0.2.tar
 
 2. 创建 namespace：
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 3. 部署 Doris 集群
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -101,13 +101,13 @@ kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 
 安装 [doriscluster](https://artifacthub.io/packages/helm/doris/doris)，使用默认配置此部署仅部署 3 个 FE 和 3 个 BE 组件，使用默认 `storageClass` 实现 PV 动态供给。
 
-```bash
+```shell
 helm install doriscluster doris-repo/doris
 ```
 
 如果需要自定义资源和集群形态，请根据 [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) 的各个资源配置的注解自定义资源配置，并执行如下命令:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-repo/doris
 ```
 
@@ -115,13 +115,13 @@ helm install -f values.yaml doriscluster doris-repo/doris
 
 通过 `kubectl get pods` 命令可以查看 pod 部署状态。当 `doriscluster` 的 Pod 处于 `Running` 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -137,7 +137,7 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 下载 `doris-{chart_version}.tgz` 安装 Doris Cluster chart。如需要下载 2.0.6 版本的 Doris 集群可以使用以下命令：
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-2.0.6.tgz
 ```
 
@@ -145,13 +145,13 @@ wget https://charts.selectdb.com/doris-2.0.6.tgz
 
 通过 `helm install` 命令可以安装 Doris 集群。
 
-```bash
+```shell
 helm install doriscluster doris-1.4.0.tgz
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-1.4.0.tgz
 ```
 
@@ -159,13 +159,13 @@ helm install -f values.yaml doriscluster doris-1.4.0.tgz
 
 通过 `kubectl get pods` 命令可以查看 pod 部署状态。当 `doriscluster` 的 Pod 处于 `Running` 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -181,13 +181,13 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 集群部署资源下发后，可以通过以下命令检查集群状态。
 
-```bash
+```shell
 kubectl get pods -n ${namespace}
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                       READY   STATUS    RESTARTS   AGE
 doriscluster-sample-fe-0   1/1     Running   0          20m
 doriscluster-sample-be-0   1/1     Running   0          19m
@@ -199,13 +199,13 @@ doriscluster-sample-be-0   1/1     Running   0          19m
 
 Doris Operator 会收集集群服务的状态显示到下发的资源中。Doris Operator 定义了 `DorisCluster` 类型资源名称的简写 `dcr`，在使用资源类型查看集群状态时可用简写替代。
 
-```bash
+```shell
 kubectl get dcr
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                  FESTATUS    BESTATUS    CNSTATUS   BROKERSTATUS
 doriscluster-sample   available   available
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/k8s-deploy/install-env.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/k8s-deploy/install-env.md
@@ -39,7 +39,7 @@ under the License.
 
 在 Kubernetes 上部署 Doris 集群，建议关闭防火墙配置：
 
-```bash
+```shell
 systemctl stop firewalld
 systemctl disable firewalld
 ```
@@ -56,7 +56,7 @@ systemctl disable firewalld
 
 通过以下命令可以永久关闭 swap 分区。
 
-```bash
+```shell
 echo "vm.swappiness = 0">> /etc/sysctl.conf
 swapoff -a && swapon -a
 sysctl -p
@@ -64,7 +64,7 @@ sysctl -p
 
 ### 设置系统最大打开文件句柄数
 
-```bash
+```shell
 vi /etc/security/limits.conf 
 * soft nofile 65536
 * hard nofile 65536
@@ -74,7 +74,7 @@ vi /etc/security/limits.conf
 
 修改虚拟内存区域至少 2000000
 
-```bash
+```shell
 sysctl -w vm.max_map_count=2000000
 ```
 
@@ -82,7 +82,7 @@ sysctl -w vm.max_map_count=2000000
 
 在部署 Doris 时，建议关闭透明大页。
 
-```bash
+```shell
 echo never > /sys/kernel/mm/transparent_hugepage/enabled
 echo never > /sys/kernel/mm/transparent_hugepage/defrag
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/k8s-deploy/install-operator.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/k8s-deploy/install-operator.md
@@ -30,32 +30,32 @@ Doris Operator 使用自定义资源定义（Custom Resource Definition, CRD）�
 
 通过以下命令可以在 Kubernetes 环境中部署 Doris Cluster CRD：
 
-```bash
+```shell
 kubectl create -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 ```
 
 如果没有外网，先将 CRD 文件下载到本地：
 
-```bash
+```shell
 wget https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 kubectl create -f ./doris.selectdb.com_dorisclusters.yaml
 ```
 
 以下是期望输出结果：
 
-```bash
+```shell
 customresourcedefinition.apiextensions.k8s.io/dorisclusters.doris.selectdb.com created
 ```
 
 在创建了 Doris Cluster CRD 后，可以通过以下命令查看创建的 CRD。
 
-```bash
+```shell
 kubectl get crd | grep doris
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 ```
 
@@ -67,13 +67,13 @@ dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 
 使用以下命令可以在 Kubernetes 集群中部署 Doris Operator：
 
-```bash
+```shell
 kubectl apply -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/operator/operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -93,13 +93,13 @@ deployment.apps/doris-operator created
 
 在修改 operator.yaml 文件后，可以使用以下命令部署 Doris Operator 服务：
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -115,13 +115,13 @@ deployment.apps/doris-operator created
 
 如果服务器没有连通外网，需要先下载对应的 operator 镜像文件。Doris Operator 用到以下的镜像：
 
-```bash
+```shell
 selectdb/doris.k8s-operator:latest
 ```
 
 在可以连通外网的服务器中运行以下的命令，可以将镜像下载下来：
 
-```bash
+```shell
 ## download doris operator image
 docker pull selectdb/doris.k8s-operator:latest
 ## save the doris operator image as a tar package
@@ -130,7 +130,7 @@ docker save -o doris.k8s-operator-latest.tar selectdb/doris.k8s-operator:latest
 
 将已打包的 tar 文件放置到所有的 Kubernetes node 节点中，运行以下命令上传镜像：
 
-```bash
+```shell
 docker load -i doris.k8s-operator-latest.tar
 ```
 
@@ -140,7 +140,7 @@ docker load -i doris.k8s-operator-latest.tar
 
 Doris Operator 在 Kubernetes 集群中是一个无状态的 Deployment，可以根据需求修改如 `limits`、`replica`、`label`、`namespace` 等项目。如需要指定某一版本的 doirs operator 镜像，可以在上传镜像后对 operator.yaml 文件做如下修改：
 
-```bash
+```shell
 ...
 containers:
   - command:
@@ -161,13 +161,13 @@ containers:
 
 在修改 Doris Operator 模板后，可以使用 apply 命令部署 Operator：
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -187,13 +187,13 @@ Helm Chart 是一系列描述 Kubernetes 相关资源的 YAML 文件的封装。
 
 通过 `repo add` 命令添加远程仓库
 
-```bash
+```shell
 helm repo add doris-repo https://charts.selectdb.com
 ```
 
 通过 `repo update` 命令更新最新版本的 chart
 
-```bash
+```shell
 helm repo update doris-repo
 ```
 
@@ -201,25 +201,25 @@ helm repo update doris-repo
 
 通过 `helm install` 命令可以使用默认配置在 doris 的 namespace 中安装 Doris Operator
 
-```bash
+```shell
 helm install operator doris-repo/doris-operator
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-repo/doris-operator
 ```
 
 通过 `kubectl get pods` 命令查看 Pod 的部署状态。当 Doris Operator 的 Pod 处于 Running 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -232,7 +232,7 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 下载 `doris-operator-{chart_version}.tgz` 安装 Doris Operator chart。如需要下载 1.4.0 版本的 Doris Operator 可以使用以下命令：
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 ```
 
@@ -240,25 +240,25 @@ wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 
 通过 `helm install` 命令可以安装 Doris Operator。
 
-```bash
+```shell
 helm install operator doris-operator-1.4.0.tgz
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-operator-1.4.0.tgz
 ```
 
 通过 `kubectl get pods` 命令查看 Pod 的部署状态。当 Doris Operator 的 Pod 处于 Running 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -267,13 +267,13 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 当部署 Operator 服务后，可以通过以下命令查看服务状态。
 
-```bash
+```shell
 kubectl get pod -n doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-6f47594455-p5tp7   1/1     Running   0          11s
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/run-docker-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/run-docker-cluster.md
@@ -85,7 +85,7 @@ Docker Version：20.10 及以后版本
 
 3. 编写 Dockerfile
 
-```Bash
+```shell
 # 选择基础镜像
 FROM openjdk:8u342-jdk
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/standard-deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/cluster-deployment/standard-deployment.md
@@ -304,7 +304,7 @@ FE 的配置文件在 FE 部署路径下的 conf 目录中，启动 FE 节点前
 
 通过以下命令可以启动 FE 进程
 
-```Bash
+```shell
 bin/start_fe.sh --daemon
 ```
 
@@ -373,7 +373,7 @@ ALTER SYSTEM ADD OBSERVER "<fe_ip_address>:<fe_edit_log_port>"
 
 通过以下命令，可以启动 FE Follower 节点，并自动同步元数据。
 
-```Bash
+```shell
 bin/start_fe.sh --helper <helper_fe_ip>:<fe_edit_log_port> --daemon
 ```
 
@@ -601,7 +601,7 @@ Doris 作为一个分布式数据库，一般拥有众多 BE 节点，Doris 采�
 
 可以通过下面的命令来检查 Doris 是否启动成功
 
-```Bash
+```shell
 # 重试执行下面命令，如果返回"msg":"success"，则说明已经启动成功
 server1:apache-doris/fe doris$ curl http://127.0.0.1:8030/api/bootstrap
 {"msg":"success","code":0,"data":{"replayedJournalId":0,"queryPort":0,"rpcPort":0,"version":""},"count":0}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/source-install/compilation-arm.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/source-install/compilation-arm.md
@@ -58,7 +58,7 @@ import TabItem from '@theme/TabItem';
 
 **1.  创建软件下载安装包根目录和软件安装根目录**
 
-```Bash
+```shell
 # 创建软件下载安装包根目录
 mkdir /opt/tools
 
@@ -68,7 +68,7 @@ mkdir /opt/software
 
 **2.  安装依赖项**
 
-```Bash
+```shell
 ### Git ###
 # 省去编译麻烦，直接使用 yum 安装
 yum install -y git
@@ -115,7 +115,7 @@ wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz && \
 
 **3.  配置环境变量**
 
-```Bash
+```shell
 # 配置环境变量
 vim /etc/profile.d/doris.sh
 export JAVA_HOME=/opt/software/jdk8
@@ -142,13 +142,13 @@ gcc --version
 
 **1.  更新 apt-get 软件库**
 
-```Bash
+```shell
 apt-get update
 ```
 
 **2.  重新配置 shell**
 
-```Bash
+```shell
 # Ubuntu 的 shell 默认安装的是 dash，而不是 bash，要切换成 bash 才能执行，运行以下命令查看 sh 的详细信息，确认 shell 对应的程序是哪个：
 ls -al /bin/sh
 
@@ -159,7 +159,7 @@ sudo dpkg-reconfigure dash
 
 **3.  创建软件下载安装包根目录和软件安装根目录**
 
-```Bash
+```shell
 # 创建软件下载安装包根目录
 mkdir /opt/tools
 
@@ -169,7 +169,7 @@ mkdir /opt/software
 
 **4.  安装依赖项**
 
-```Bash
+```shell
 ### Git ###
 # 省去编译麻烦，直接使用 apt-get 安装
 apt-get -y install git
@@ -225,7 +225,7 @@ wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz && \
 
 **5.  配置环境变量**
 
-```Bash
+```shell
 # 配置环境变量
 vim /etc/profile.d/doris.sh
 export JAVA_HOME=/opt/software/jdk8
@@ -254,7 +254,7 @@ gcc --version
 
 在 ARM 平台编译 Doris 时，请关闭 AVX2 和 LIBUNWIND 三方库：
 
-```Bash
+```shell
 export USE_AVX2=OFF
 export USE_UNWIND=OFF
 ```
@@ -271,7 +271,7 @@ export USE_UNWIND=OFF
 
 解决方案：使用第三方库下载仓库    
 
-```Bash
+```shell
 export REPOSITORY_URL=https://doris-thirdparty-repo.bj.bcebos.com/thirdparty
 sh /opt/doris/thirdparty/build-thirdparty.sh
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/source-install/compilation-mac.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/source-install/compilation-mac.md
@@ -87,7 +87,7 @@ cd output/fe/bin
 
 可以在 [Apache Doris Third Party Prebuilt](https://github.com/apache/doris-thirdparty/releases/tag/automation) 页面直接下载预编译好的第三方库，省去编译第三方库的过程，参考下面的命令。
 
-```Bash
+```shell
 cd thirdparty
 rm -rf installed
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/source-install/compilation-with-docker.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/source-install/compilation-with-docker.md
@@ -30,7 +30,7 @@ under the License.
 
 比如在 CentOS 下，执行命令安装 Docker
 
-```Bash
+```shell
 yum install docker
 ```
 
@@ -49,7 +49,7 @@ yum install docker
 
 下面就以编译 Doris 2.0 版本作为介绍，下载并检查 Docker 镜像
 
-```Bash
+```shell
 # 可以选择 docker.io/apache/doris:build-env-for-2.0
 $ docker pull apache/doris:build-env-for-2.0
 
@@ -69,7 +69,7 @@ apache/doris    build-env-for-2.0    f29cf1979dba    3 days ago    3.3GB
 
 -   编译镜像变更信息可参考 [ChangeLog](https://github.com/apache/doris/blob/master/thirdparty/CHANGELOG.md)。
 
-```Bash
+```shell
 # 切换到 JDK 8
 alternatives --set java java-1.8.0-openjdk.x86_64
 alternatives --set javac java-1.8.0-openjdk.x86_64

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/source-install/compilation-with-ldb-toolchain.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/install/source-install/compilation-with-ldb-toolchain.md
@@ -118,7 +118,7 @@ Doris 源码编译时首先会下载三方库进行编译，可以参考下文�
 
 **1.  进入 Doris 源码目录，执行如下命令查看编译机器是否支持 AVX2 指令集**
 
-```Bash
+```shell
 $ cat /proc/cpuinfo | grep avx2
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/lakehouse/database/es.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/lakehouse/database/es.md
@@ -124,7 +124,7 @@ Elasticsearch 没有明确的数组类型，但是它的某个字段可以含有
 
 该结构的数组字段可以通过使用以下命令将字段属性定义添加到目标索引映射的`_meta.doris`属性来定义。
 
-```bash
+```shell
 # ES 7.x and above
 curl -X PUT "localhost:9200/doc/_mapping?pretty" -H 'Content-Type:application/json' -d '
 {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/DROP-ROLE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/DROP-ROLE.md
@@ -36,7 +36,7 @@ DROP ROLE
 
 ```sql
   DROP ROLE [IF EXISTS] role1;
-````
+```
 
 删除角色不会影响以前属于角色的用户的权限。 它仅相当于解耦来自用户的角色。 用户从角色获得的权限不会改变
 
@@ -46,7 +46,7 @@ DROP ROLE
 
 ```sql
 DROP ROLE role1;
-````
+```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/GRANT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/GRANT.md
@@ -144,7 +144,7 @@ role_list 是需要赋予的角色列表，以逗号分隔，指定的角色必�
 
     ```sql
     GRANT 'role1','role2' TO 'jack'@'%';
-    ````
+    ```
 
 
  
@@ -153,25 +153,25 @@ role_list 是需要赋予的角色列表，以逗号分隔，指定的角色必�
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO 'jack'@'%';
-    ````
+    ```
 
 9. 匹配所有 workload group 授予用户 jack
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP '%' TO 'jack'@'%';
-    ````
+    ```
 
 10. 将指定 workload group‘g1’授予角色 my_role
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO ROLE 'my_role';
-    ````
+    ```
 
 11. 允许 jack 查看 db1 下 view1 的创建语句
 
     ```sql
     GRANT SHOW_VIEW_PRIV ON db1.view1 TO 'jack'@'%';
-    ````
+    ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
@@ -47,7 +47,7 @@ ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
-````
+```
 
  说明：
 
@@ -74,7 +74,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
    ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a");
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-   ````
+   ```
 
 2. 修改 BE 的查询禁用属性
    
@@ -84,7 +84,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
 
     ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_query" = "true");
-    ````   
+    ```   
 
 3. 修改 BE 的导入禁用属性
    
@@ -94,7 +94,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
 
     ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_load" = "true");
-    ````   
+    ```   
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-EXTERNAL-TABLE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-EXTERNAL-TABLE.md
@@ -119,7 +119,7 @@ CREATE EXTERNAL TABLE
    "hudi.table" = "hudi_table_in_hive_metastore",
    "hudi.hive.metastore.uris" = "thrift://127.0.0.1:9083"
    )
-   ````
+   ```
 
    其中 hudi.database 是 hive 表对应的库名字，hudi.table 是 hive 表的名字，hive.metastore.uris 是 hive metastore 服务地址。
 
@@ -248,7 +248,7 @@ CREATE EXTERNAL TABLE
    "hudi.table" = "hudi_table_in_hive_metastore",
    "hudi.hive.metastore.uris" = "thrift://127.0.0.1:9083"
    );
-   ````
+   ```
 
    创建时指定schema
    ```sql
@@ -262,7 +262,7 @@ CREATE EXTERNAL TABLE
    "hudi.table" = "hudi_table_in_hive_metastore",
    "hudi.hive.metastore.uris" = "thrift://127.0.0.1:9083"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FUNCTION.md
@@ -123,7 +123,7 @@ CREATE [GLOBAL] [AGGREGATE] [ALIAS] FUNCTION function_name
 
    ```sql
    CREATE GLOBAL ALIAS FUNCTION id_masking(INT) WITH PARAMETER(id) AS CONCAT(LEFT(id, 3), '****', RIGHT(id, 4));
-   ```` 
+   ``` 
    
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FUNCTION.md
@@ -57,7 +57,7 @@ DROP [GLOBAL] FUNCTION function_name
 
     ```sql
     DROP GLOBAL FUNCTION my_add(INT, INT)
-    ````      
+    ```      
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
@@ -46,7 +46,7 @@ SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS [FROM db]
 
     ```sql
      SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS FROM test;
-    ````
+    ```
 
 2. 查看全局的转换情况
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DATABASES.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DATABASES.md
@@ -38,7 +38,7 @@ SHOW DATABASES
 
 ```sql
 SHOW DATABASES [FROM catalog] [filter expr];
-````
+```
 
 说明:
 1. `SHOW DATABASES` 会展示当前所有的数据库名称.
@@ -51,45 +51,45 @@ SHOW DATABASES [FROM catalog] [filter expr];
 
    ```sql
    SHOW DATABASES;
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | test               |
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 2. 会展示`hms_catalog`中所有的数据库名称.
 
    ```sql
    SHOW DATABASES from hms_catalog;
-   ````
+   ```
 
-   ````
+   ```
   +---------------+
   | Database      |
   +---------------+
   | default       |
   | tpch          |
   +---------------+
-   ````
+   ```
 
 3. 展示当前所有经过表示式`like 'infor%'`过滤后的数据库名称.
 
    ```sql
    SHOW DATABASES like 'infor%';
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-STATUS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-STATUS.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database ：查看指定数据库下的作业。 如果未指定，则使用当前数据库。
 - WHERE：您可以过滤结果列，目前仅支持以下列：
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`：作业唯一 ID。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLETS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLETS.md
@@ -59,19 +59,19 @@ IndexName = rollup_name
 
     ```sql
     SHOW TABLETS FROM example_db.table_name;
-    ````
+    ```
 
 2. 列出指定partitions的所有tablets
 
     ```sql
     SHOW TABLETS FROM example_db.table_name PARTITIONS(p1, p2);
-    ````
+    ```
 
 3. 列出某个backend上状态为DECOMMISSION的tablets
 
     ```sql
     SHOW TABLETS FROM example_db.table_name WHERE state="DECOMMISSION" AND BackendId=11003;
-    ````
+    ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TYPECAST.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TYPECAST.md
@@ -40,7 +40,7 @@ SHOW TYPECAST
 
 ```sql
 SHOW TYPE_CAST [IN|FROM db]
-````
+```
 
  Parameters
 
@@ -48,7 +48,7 @@ SHOW TYPE_CAST [IN|FROM db]
 
 ### Example
 
-````sql
+```sql
 mysql> show type_cast in testDb\G
 **************************** 1. row ******************** ******
 Origin Type: TIMEV2
@@ -61,7 +61,7 @@ Origin Type: TIMEV2
   Cast Type: TIMEV2
 
 3 rows in set (0.00 sec)
-````
+```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Utility-Statements/USE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Utility-Statements/USE.md
@@ -57,7 +57,7 @@ USE <[CATALOG_NAME].DATABASE_NAME>
     ```sql
     mysql> use hms_catalog.demo;
     Database changed
-    ````
+    ```
 ### Keywords
 
     USE

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/table-design/data-partition.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/table-design/data-partition.md
@@ -205,7 +205,7 @@ PARTITION BY RANGE(col1[, col2, ...])
 
 示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(`date`)
 (
     PARTITION `p201701` VALUES [("2017-01-01"),  ("2017-02-01")),
@@ -253,7 +253,7 @@ PARTITION BY RANGE(date_col)
 
 示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(age)
 (
     FROM (1) TO (100) INTERVAL 10
@@ -267,7 +267,7 @@ PARTITION BY RANGE(`date`)
 
 4.MULTI RANGE：批量创建 RANGE 分区，定义分区的左闭右开区间。示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(col)                                                                                                                                                                                                                
 (                                                                                                                                                                                                                                      
    FROM ("2000-11-14") TO ("2021-11-14") INTERVAL 1 YEAR,                                                                                                                                                                              
@@ -286,7 +286,7 @@ Partition 支持通过 `VALUES IN (...)` 来指定每个分区包含的枚举值
 
 举例如下：
 
-```Bash
+```shell
 PARTITION BY LIST(city)
 (
     PARTITION `p_cn` VALUES IN ("Beijing", "Shanghai", "Hong Kong"),

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/auth/certificate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/auth/certificate.md
@@ -41,7 +41,7 @@ Doris 开启 SSL 功能需要配置 CA 密钥证书和 Server 端密钥证书，
 
 1. 生成 CA、Server 端和 Client 端的密钥和证书
 
-```BASH
+```shell
 # 生成CA certificate
 openssl genrsa 2048 > ca-key.pem
 openssl req -new -x509 -nodes -days 3600 \
@@ -66,13 +66,13 @@ openssl x509 -req -in client-req.pem -days 3600 \
 
 2. 验证创建的证书。
 
-```bash
+```shell
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
 3. 将您的 CA 密钥和证书和 Sever 端密钥和证书分别合并到 PKCS#12 (P12) 包中。您也可以指定某个证书格式，默认 PKCS12，可以通过修改 conf/fe.conf 配置文件，添加参数 ssl_trust_store_type 指定证书格式
 
-```bash
+```shell
 # 打包CA密钥和证书
 openssl pkcs12 -inkey ca-key.pem -in ca.pem -export -out ca_certificate.p12
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/auth/ldap.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/auth/ldap.md
@@ -127,13 +127,13 @@ set ldap_admin_password = password('ldap_admin_password');
 
   例如在 linux 或者 mac 环境中可以使用：
 
-  ```bash
+  ```shell
   echo "export LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN=1" >> ～/.bash_profile && source ～/.bash_profile
   ```
 
 - 每次登录 Doris 时添加参数 `--enable-cleartext-plugin`
 
-  ```bash
+  ```shell
   mysql -hDORIS_HOST -PDORIS_PORT -u user -p --enable-cleartext-plugin
   
   输入 ldap 密码
@@ -195,13 +195,13 @@ LDAP 密码验证和组授权是 Doris 密码验证和授权的补充，开启 L
 
     使用以下命令登录 Doris 可以登录 `jack@'172.10.1.10'` 账户：
 
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
     ```
 
     使用以下命令将登录失败：
     
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
     ```
 
@@ -211,7 +211,7 @@ LDAP 密码验证和组授权是 Doris 密码验证和授权的补充，开启 L
 
     使用以下命令创建临时用户并登录 jack@'%'，临时用户具有基本权限 DatabasePrivs：Select_priv，用户退出登录后 Doris 将删除该临时用户：
     
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
     ```
 
@@ -221,7 +221,7 @@ LDAP 密码验证和组授权是 Doris 密码验证和授权的补充，开启 L
 
     使用 Doris 密码登录账户，成功：
     
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/check-tablet-segment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/check-tablet-segment.md
@@ -69,7 +69,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/check_tablet_segment_lost?repair=false
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/compaction-run.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/compaction-run.md
@@ -135,6 +135,6 @@ under the License.
 
 ### Examples
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/compaction/run?tablet_id=10015&compact_type=cumulative"
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/compaction-status.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/compaction-status.md
@@ -114,6 +114,6 @@ under the License.
 
 ## Examples
 
-```bash
+```shell
 curl http://192.168.10.24:8040/api/compaction/show?tablet_id=10015
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/config.md
@@ -91,15 +91,15 @@ under the License.
 ## Examples
 
 
-```bash
+```shell
 curl "http://127.0.0.1:8040/api/show_config"
 ```
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/update_config?agent_task_trace_threshold_sec=2&persist=true"
 
 ```
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/update_config?agent_task_trace_threshold_sec=2&enable_merge_on_write_correctness_check=true&persist=true"
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/download.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/download.md
@@ -53,7 +53,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/_load_error_log?file=a&token=1"
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/health.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/health.md
@@ -49,7 +49,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/health
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/meta.md
@@ -66,7 +66,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/metrics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/metrics.md
@@ -63,7 +63,7 @@ prometheus 监控采集接口
 ## Examples
 
 
-    ```bash
+    ```shell
         curl "http://127.0.0.1:8040/metrics?type=json&with_tablet=true"
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/pad-rowset.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/pad-rowset.md
@@ -61,7 +61,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl -X POST "http://127.0.0.1:8040/api/pad_rowset?tablet_id=123456&start_version=1111111&end_version=1111112"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/reset-rpc-channel.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/reset-rpc-channel.md
@@ -60,11 +60,11 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/reset_rpc_channel/all
     ```
     
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/reset_rpc_channel/1.1.1.1:8080,2.2.2.2:8080
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/snapshot.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/snapshot.md
@@ -55,7 +55,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/snapshot?tablet_id=123456&schema_hash=1111111"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/tablet-distribution.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/tablet-distribution.md
@@ -85,7 +85,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/tablets_distribution?group_by=partition&partition_id=123"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/tablet-info.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/tablet-info.md
@@ -71,7 +71,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/tablets_json?limit=123
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/tablet-migration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/tablet-migration.md
@@ -104,7 +104,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/tablet_migration?goal=run&tablet_id=123&schema_hash=333&disk=/disk1"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/tablet-reload.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/be/tablet-reload.md
@@ -51,13 +51,13 @@ under the License.
 
 ## Response
 
-    ```bash
+    ```shell
     load header succeed
     ```
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/reload_tablet?tablet_id=123456&schema_hash=1111111&path=/abc"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/cluster-management/load-balancing.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/cluster-management/load-balancing.md
@@ -51,7 +51,7 @@ Doris 的 FE 进程负责接收用户连接和查询请求，其本身是可以�
 
 ### 安装 ProxySQL（yum 方式）
 
-```bash
+```shell
 配置yum源
 # vim /etc/yum.repos.d/proxysql.repo
 
@@ -91,7 +91,7 @@ ProxySQL 有配置文件 `/etc/proxysql.cnf` 和配置数据库文件`/var/lib/p
 
 这里主要是几个参数，在下面已经注释出来了，可以根据自己的需要进行修改
 
-```bash
+```shell
 # egrep -v "^#|^$" /etc/proxysql.cnf
 datadir="/var/lib/proxysql"         #数据目录
 admin_variables=
@@ -508,7 +508,7 @@ IP: 172.31.7.119
 
 ### 安装依赖
 
-```bash
+```shell
 sudo apt-get install build-essential
 sudo apt-get install libpcre3 libpcre3-dev 
 sudo apt-get install zlib1g-dev
@@ -517,7 +517,7 @@ sudo apt-get install openssl libssl-dev
 
 ### 安装 Nginx
 
-```bash
+```shell
 sudo wget http://nginx.org/download/nginx-1.18.0.tar.gz
 sudo tar zxvf nginx-1.18.0.tar.gz
 cd nginx-1.18.0
@@ -529,13 +529,13 @@ sudo make && make install
 
 这里是新建了一个配置文件
 
-```bash
+```shell
 vim /usr/local/nginx/conf/default.conf
 ```
 
 然后在里面加上下面的内容
 
-```bash
+```shell
 events {
 worker_connections 1024;
 }

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr.md
@@ -75,7 +75,7 @@ enable_feature_binlog=true
 
 1. 构建 CCR syncer
 
-    ```Bash
+    ```shell
     git clone https://github.com/selectdb/ccr-syncer
 
     cd ccr-syncer
@@ -87,7 +87,7 @@ enable_feature_binlog=true
 
 2. 启动和停止 syncer
 
-    ```Bash
+    ```shell
     # 启动
     cd bin && sh start_syncer.sh --daemon
 
@@ -97,7 +97,7 @@ enable_feature_binlog=true
 
 **5. 打开源集群中同步库/表的 Binlog**
 
-```Bash
+```shell
 -- 如果是整库同步，可以执行如下脚本，使得该库下面所有的表都要打开 binlog.enable
 vim shell/enable_db_binlog.sh
 修改源集群的 host、port、user、password、db
@@ -109,7 +109,7 @@ ALTER TABLE enable_binlog SET ("binlog.enable" = "true");
 
 **6. 向 syncer 发起同步任务**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -135,7 +135,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 同步任务的参数说明：
 
-```Bash
+```shell
 name: CCR同步任务的名称，唯一即可
 host、port：对应集群 Master FE的host和mysql(jdbc) 的端口
 user、password：syncer以何种身份去开启事务、拉取数据等
@@ -280,7 +280,7 @@ bash bin/start_syncer.sh --pid_dir /path/to/pids
 
 在编译完成后的输出路径下，文件结构大致如下所示：
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -316,7 +316,7 @@ output_dir
 
 指定 pid 文件所在目录，上述三种关闭方法都依赖于 pid 文件的所在目录执行
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --pid_dir /path/to/pids
 ```
 
@@ -328,7 +328,7 @@ bash bin/stop_syncer.sh --pid_dir /path/to/pids
 
 关闭 pid_dir 路径下 host:port 对应的 Syncer
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --host 127.0.0.1 --port 9190
 ```
 
@@ -342,7 +342,7 @@ host 与 port 都不为空时**方法 1**才能生效
 
 关闭 pid_dir 路径下指定 pid 文件名对应的 Syncer
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 ```
 
@@ -352,7 +352,7 @@ bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 
 **请求的通用模板**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d {json_body} http://ccr_syncer_host:ccr_syncer_port/operator
 ```
 
@@ -376,7 +376,7 @@ or
 
 ​    创建 CCR 任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "ccr_test",
         "src": {
@@ -418,7 +418,7 @@ or
 
 ​    查看同步进度
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/get_lag
@@ -430,7 +430,7 @@ or
 
 ​    暂停同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/pause 
@@ -440,7 +440,7 @@ or
 
 ​    恢复同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/resume
@@ -450,7 +450,7 @@ or
 
 ​    删除同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/delete
@@ -460,7 +460,7 @@ or
 
     获取版本信息
 
-    ```Bash
+    ```shell
     curl http://ccr_syncer_host:ccr_syncer_port/version
 
     # > return
@@ -471,7 +471,7 @@ or
 
     查看 job 的状态
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/job_status
@@ -490,7 +490,7 @@ or
 
     不做 sync，此时用户可以将源和目的集群互换
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/desync
@@ -500,7 +500,7 @@ or
 
     展示已经创建的所有任务
 
-    ```Bash
+    ```shell
     curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
     {"success":true,"jobs":["ccr_db_table_alias"]}
@@ -512,7 +512,7 @@ or
 
 在编译完成后的输出路径下，文件结构大致如下所示：
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -530,7 +530,7 @@ output_dir
 
 **使用说明**
 
-```Bash
+```shell
 bash bin/enable_db_binlog.sh -h host -p port -u user -P password -d db
 ```
 
@@ -586,7 +586,7 @@ Syncer 高可用依赖 mysql，如果使用 mysql 作为后端存储，Syncer �
 
 BE 端配置参数
 
-```Bash
+```shell
 download_binlog_rate_limit_kbs=1024 # 这就是限制到1MB，这个是单个be对所有关于binlog 包括local snapshot的配置
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/log-management/fe-log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/log-management/fe-log.md
@@ -130,7 +130,7 @@ FE 的 Debug 级别日志可以通过修改配置文件开启，也可以通过�
 
    通过以下 API 也可以在运行时修改日志级别。无需重启 FE 节点。
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?add_verbose=org.apache.doris.catalog.Catalog
    ```
 
@@ -153,7 +153,7 @@ FE 的 Debug 级别日志可以通过修改配置文件开启，也可以通过�
 
    也可以通过以下 API 关闭 Debug 日志：
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?del_verbose=org.apache.doris.catalog.Catalog
    ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/maint-monitor/automatic-service-start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/maint-monitor/automatic-service-start.md
@@ -162,20 +162,20 @@ doris   ALL=(ALL)       NOPASSWD:DORISCTL
 
     添加或修改配置文件后，需要重新加载
 
-    ```bash
+    ```shell
     systemctl daemon-reload
     ```
 
     设置自启动，实质就是在 /etc/systemd/system/multi-user.target.wants/ 添加服务文件的链接
 
-    ```bash
+    ```shell
     systemctl enable doris-fe
     systemctl enable doris-be
     ```
 
 8. 服务启动
 
-    ```bash
+    ```shell
     systemctl start doris-fe
     systemctl start doris-be
     ```
@@ -190,14 +190,14 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 1. yum 安装 supervisor
     
-    ```bash
+    ```shell
     yum install epel-release
     yum install -y supervisor
     ```
 
 2. 启动服务并查看状态
 
-    ```bash
+    ```shell
     systemctl enable supervisord # 开机自启动
     systemctl start supervisord # 启动 supervisord 服务
     systemctl status supervisord # 查看 supervisord 服务状态
@@ -206,7 +206,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 3. 配置 BE 进程管理
 
-    ```bash
+    ```shell
     修改 start_be.sh 脚本，去掉最后的 & 符号
 
     vim /path/doris/be/bin/start_be.sh
@@ -216,7 +216,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 BE 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-be.ini
 
     [program:doris_be]      
@@ -239,7 +239,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 4. 配置 FE 进程管理
 
-    ```bash
+    ```shell
     修改 start_fe.sh 脚本，去掉最后的 & 符号
 
     vim /path/doris/fe/bin/start_fe.sh 
@@ -249,7 +249,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 FE 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-fe.ini
 
     [program:PaloFe]
@@ -273,7 +273,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 5. 配置 Broker 进程管理
 
-    ```bash
+    ```shell
     修改 start_broker.sh 脚本，去掉最后的 & 符号
 
     vim /path/apache_hdfs_broker/bin/start_broker.sh
@@ -283,7 +283,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 Broker 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-broker.ini
 
     [program:BrokerBootstrap]
@@ -307,7 +307,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 6. 首先确定 Doris 服务是停止状态，然后使用 supervisor 将 Doris 自动拉起，然后确定进程是否正常启动
     
-    ```bash
+    ```shell
     supervisorctl reload # 重新加载 Supervisor 中的所有配置文件
     supervisorctl status # 查看 supervisor 状态，验证 Doris 服务进程是否正常启动
 
@@ -321,7 +321,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 - 如果使用 yum 安装的 supervisor 启动报错 :  pkg_resources.DistributionNotFound: The 'supervisor==3.4.0' distribution was not found
 
-    ```bash
+    ```shell
     这个是 python 版本不兼容问题，通过 yum 命令直接安装的 supervisor 只支持 python2 版本，所以需要将 /usr/bin/supervisord 和 /usr/bin/supervisorctl 中文件内容开头 #!/usr/bin/python 改为 #!/usr/bin/python2，前提是要装 python2 版本
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/maint-monitor/tablet-local-debug.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/maint-monitor/tablet-local-debug.md
@@ -100,7 +100,7 @@ PROPERTIES (
 
 该目下会有一个 tablet id 命名的目录，将这个目录整体打包后备用。（注意，该目录最多保留 60 分钟，之后会自动删除）。
 
-```bash
+```shell
 cd /path/to/be/storage/snapshot/20220830101353.2.3600
 tar czf 10020.tar.gz 10020/
 ```
@@ -178,13 +178,13 @@ tar czf 10020.tar.gz 10020/
 
     同时，我们还需要到调试环境 BE 节点的数据目录下，确认新的 tablet 所在的 shard id：
     
-    ```bash
+    ```shell
     cd /path/to/storage/data/*/10017 && pwd
     ```
     
     这个命令会进入 10017 这个 tablet 所在目录并展示路径。这里我们会看到类似如下的路径：
     
-    ```bash
+    ```shell
     /path/to/storage/data/0/10017
     ```
     
@@ -208,7 +208,7 @@ tar czf 10020.tar.gz 10020/
     
     通过 `meta_tool` 工具删除原来的 tablet meta。该工具位于 `be/lib` 目录下。
     
-    ```bash
+    ```shell
     ./lib/meta_tool --root_path=/path/to/storage --operation=delete_meta --tablet_id=10017 --schema_hash=44622287
     ```
     
@@ -216,7 +216,7 @@ tar czf 10020.tar.gz 10020/
     
     通过 `meta_tool` 工具加载新的 tablet meta。
     
-    ```bash
+    ```shell
     ./lib/meta_tool --root_path=/path/to/storage --operation=load_meta --json_meta_path=/path/to/10017.hdr.json
     ```
     

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/maint-monitor/tablet-meta-tool.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/maint-monitor/tablet-meta-tool.md
@@ -89,7 +89,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./lib/meta_tool --operation=load_meta --root_path=/path/to/root_path --json_meta_path=path
 ```
 
@@ -99,13 +99,13 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 删除单个 tablet 元数据：
 
-```bash
+```shell
 ./lib/meta_tool --operation=delete_meta --root_path=/path/to/root_path --tablet_id=xxx --schema_hash=xxx
 ```
 
 删除一组 tablet 元数据：
 
-```bash
+```shell
 ./lib/meta_tool --operation=batch_delete_meta --tablet_file=/path/to/tablet_file.txt
 ```
 
@@ -117,7 +117,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 `tablet_file` 文件示例：
 
-```bash
+```shell
 /output/be/data/,14217,352781111
 /output/be/data/,14219,352781111
 /output/be/data/,14223,352781111
@@ -134,7 +134,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./lib/meta_tool --operation=show_meta --root_path=/path/to/root_path --pb_header_path=path
 ```
 
@@ -144,7 +144,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./meta_tool --operation=show_segment_footer --file=/path/to/segment/file
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/plugin-development-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/plugin-development-manual.md
@@ -74,7 +74,7 @@ auditodemo/:
 
 `plugin.properties` 内容示例：
 
-```bash
+```shell
 ### required:
 #
 # the plugin name
@@ -113,13 +113,13 @@ soName = example.so
 
 我们可以通过以下命令在 `fe_plugins` 目录创建一个子模块用户实现创建和创建工程。其中 `doris-fe-test` 为插件名称。
 
-```bash
+```shell
 mvn archetype: generate -DarchetypeCatalog = internal -DgroupId = org.apache -DartifactId = doris-fe-test -DinteractiveMode = false
 ```
 
 这个命令会创建一个新的 maven 工程，并且自动向 `fe_plugins/pom.xml` 中添加一个子模块：
 
-```bash
+```shell
     .....
     <groupId>org.apache</groupId>
     <artifactId>doris-fe-plugins</artifactId>
@@ -135,7 +135,7 @@ mvn archetype: generate -DarchetypeCatalog = internal -DgroupId = org.apache -Da
 
 新的工程目录结构如下：
 
-```bash
+```shell
 -doris-fe-test/
 -pom.xml
 -src/

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/delete/batch-delete-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/delete/batch-delete-manual.md
@@ -161,19 +161,19 @@ mysql DESC test;
 
 **1. 正常导入数据：**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: APPEND"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
 其中的 APPEND 条件可以省略，与下面的语句效果相同：
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
 **2. 将与导入数据 Key 相同的数据全部删除**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
@@ -208,7 +208,7 @@ curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, ci
 
 **3. 将导入数据中与`site_id=1` 的行的 Key 列相同的行**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: MERGE" -H "delete: siteid=1"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
@@ -247,7 +247,7 @@ curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, ci
 
 **4. 当存在 sequence 列时，将与导入数据 Key 相同的数据全部删除**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: name, gender, age" -H "function_column.sequence_col: age" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/load-atomicity.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/load-atomicity.md
@@ -188,7 +188,7 @@ Empty set (0.019 sec)
 
 **1. 在 HTTP Header 中设置 `two_phase_commit:true` 启用两阶段提交。**
 
-```Bash
+```shell
 curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt http://fe_host:http_port/api/{db}/{table}/_stream_load
 {
     "TxnId": 18036,
@@ -214,7 +214,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 可以使用事务 id 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18036" -H "txn_operation:commit" http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -224,7 +224,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 也可以使用 label 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:commit"  http://fe_host:http_port/api/{db}/{table}/_stream_load_2pc
   {
       "status": "Success",
@@ -236,7 +236,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 可以使用事务 id 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "txn_id:18037" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -246,7 +246,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 也可以使用 label 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/load-data-convert.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/load-data-convert.md
@@ -60,7 +60,7 @@ WITH BROKER bos
 
 ### STREAM LOAD
 
-```Bash
+```shell
 curl
 --location-trusted
 -u user:passwd
@@ -96,7 +96,7 @@ Stream load 不支持前置过滤。
 
 示例：
 
-```Bash
+```shell
 curl
 --location-trusted
 -u user:passwd

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/load-json-format.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/load-json-format.md
@@ -238,7 +238,7 @@ k2 int, k1 int
 
 导入语句 1（以 Stream Load 为例）：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -256,7 +256,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", 
 
 导入语句 2：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, k1" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -272,7 +272,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", 
 
 当然，如其他导入一样，可以在 Columns 中进行列的转换操作。示例如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, tmp_k1, k1 = tmp_k1 * 100" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -296,7 +296,7 @@ k2 int, k1 int, k1_copy int
 ```
 如果你想将 json 中的某一字段多次赋予给表中几列，那么可以在 jsonPaths 中多次指定该列，并且依次指定映射顺序。示例如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\", \"$.k1\"]" -H "columns: k2,k1,k1_copy" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -326,7 +326,7 @@ k2 int, k1 int, k1_nested1 int, k1_nested2 int
 ```
 如果你想将 json 中嵌套的多级同名字段赋予给表中不同的列，那么可以在 jsonPaths 中指定该列，并且依次指定映射顺序。示例如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\",\"$.k3.k1\",\"$.k3.k1_nested.k1\" -H "columns: k2,k1,k1_nested1,k1_nested2" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -389,7 +389,7 @@ Doris 支持通过 JSON root 抽取 JSON 中指定的数据。
 
 导入语句如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -423,7 +423,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: tru
 
 这是因为通过导入语句中的信息，Doris 并不知道“缺失的列是表中的 k2 列”。如果要对以上数据按照期望结果导入，则导入语句如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -H "jsonpaths: [\"$.k1\", \"$.k2\"]" -H "columns: k1, tmp_k2, k2 = ifnull(tmp_k2, 'x')" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -449,7 +449,7 @@ code    INT     NULL
 
    - 不指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -461,7 +461,7 @@ code    INT     NULL
 
    - 指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -479,7 +479,7 @@ code    INT     NULL
 
    - 指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -510,7 +510,7 @@ code    INT     NULL
 
    - 指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -536,7 +536,7 @@ code    INT     NULL
 
 StreamLoad 导入：
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -553,7 +553,7 @@ curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: 
 
 数据依然是示例 3 中的多行数据，现需要对导入数据中的 `code` 列加 1 后导入。
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -579,7 +579,7 @@ curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\
 {"k1": 40, "k2": ["10000000000000000000.1111111222222222"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H ":0.01" -H "format:json" -H "timeout:300" -T test_decimal.json http://localhost:8035/api/example_db/array_test_decimal/_stream_load
 ```
 
@@ -599,7 +599,7 @@ MySQL > select * from array_test_decimal;
 {"k1": 999, "k2": ["76959836937749932879763573681792701709", "26017042825937891692910431521038521227"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_largeint.json http://localhost:8035/api/example_db/array_test_largeint/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/load-strict-mode.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/load-strict-mode.md
@@ -58,7 +58,7 @@ under the License.
 
 2. [STREAM LOAD](../../sql-manual/sql-statements/Data-Manipulation-Statements/Load/STREAM-LOAD)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "strict_mode: true" \
    -T 1.txt \
@@ -172,7 +172,7 @@ mysql> desc user_profile;
 18,9999999,2023-07-03 12:00:03
 ```
 
-```bash
+```shell
 curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:false" -H "column_separator:," -H "columns:id,balance,last_access_time" -T /tmp/test.csv http://host:port/api/db1/user_profile/_stream_load
 ```
 
@@ -180,7 +180,7 @@ curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:false
 
 而当用户使用严格模式的 Stream Load 部分列更新向表中插入上述数据时
 
-``` bash
+```shell
 curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:true" -H "column_separator:," -H "columns:id,balance,last_access_time" -T /tmp/test.csv http://host:port/api/db1/user_profile/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/stream-load-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/stream-load-manual.md
@@ -120,7 +120,7 @@ Stream Load 需要对目标表的 INSERT 权限。如果没有 INSERT 权限，�
 
     通过 `curl` 命令可以提交 Stream Load 导入作业。
 
-    ```Bash
+    ```shell
     curl --location-trusted -u <doris_user>:<doris_password> \
         -H "Expect:100-continue" \
         -H "column_separator:," \
@@ -203,7 +203,7 @@ Stream Load 需要对目标表的 INSERT 权限。如果没有 INSERT 权限，�
 
     通过 `curl` 命令可以提交 Stream Load 导入作业。
 
-    ```Bash
+    ```shell
     curl --location-trusted -u <doris_user>:<doris_password> \
         -H "label:124" \
         -H "Expect:100-continue" \
@@ -264,7 +264,7 @@ mysql> show stream load from testdb;
 
 Stream Load 导入语法如下：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
   -H "Expect:100-continue" [-H ""...] \
   -T <file_path> \
@@ -408,7 +408,7 @@ Stream Load 是一种同步的导入方式，导入结果会通过创建导入�
 :::
 
 使用 `curl` 来使用 Stream Load 的 http stream 模式：
-```Bash
+```shell
 curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -XPUT http://fe_host:http_port/api/_http_stream
 ```
 
@@ -416,7 +416,7 @@ curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -
 
 load_sql 举例：
 
-```Bash
+```shell
 insert into db.table (col, ...) select stream_col, ... from http_stream("property1"="value1");
 ```
 
@@ -462,7 +462,7 @@ Doris 的导入任务可以容忍一部分格式错误的数据。容忍率通�
 
 通过以下命令可以指定 max_filter_ratio 容忍度为 0.4 创建 stream load 导入任务：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "max_filter_ratio:0.4" \
@@ -492,7 +492,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 将本地文件中的数据导入到表中的 p1, p2 分区，允许 20% 的错误率。
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:123" \
     -H "Expect:100-continue" \
@@ -520,7 +520,7 @@ Stream Load 是基于 HTTP 的协议进行导入，所以是支持使用程序�
 
 下面通过 `bash` 的命令管道来举例这种使用方式，这种导入的数据就是程序流式生成的，而不是本地文件。
 
-```Bash
+```shell
 seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -544,7 +544,7 @@ curl --location-trusted -u root -T test.csv  -H "label:1" -H "format:csv_with_na
 
 在 Stream Load 中有三种导入类型：APPEND、DELETE 与 MERGE。可以通过指定参数 merge_type 进行调整。如想指定将与导入数据 Key 相同的数据全部删除，可以使用以下命令：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: DELETE" \
@@ -587,7 +587,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 指定 merge_type 为 MERGE，可以将导入的数据 MERGE 到表中。MERGE 语义需要结合 DELETE 条件联合使用，表示满足 DELETE 条件的数据按照 DELETE 语义处理，其余按照 APPEND 语义添加到表中，如下面操作表示删除 siteid 为 1 的行，其余数据添加到表中：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: MERGE" \
@@ -779,7 +779,7 @@ JSON 数据格式：
 
 导入命令：
 
-```Bash
+```shell
 curl --location-trusted -u root -T test.json -H "label:1" -H "format:json" -H 'columns: id, order_code, create_time=CURRENT_TIMESTAMP()' http://host:port/api/testDb/testTbl/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/update/unique-update-transaction.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/update/unique-update-transaction.md
@@ -108,7 +108,7 @@ sequence_type 用来指定 sequence 列的类型，可以为整型和时间类�
 
 stream load 的写法是在 header 中的`function_column.sequence_col`字段添加隐藏列对应的 source_sequence 的映射，示例
 
-```Bash
+```shell
 curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -227,7 +227,7 @@ MySQL  desc test_table;
 
 此处以 stream load 为例
 
-```Bash
+```shell
 curl --location-trusted -u root: -T testData http://host:port/api/test/test_table/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/db-connect/database-connect.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/db-connect/database-connect.md
@@ -33,14 +33,14 @@ Apache Doris 采用 MySQL 网络连接协议，兼容 MySQL 生态的命令行�
 
 解压下载的 MySQL 客户端，在 `bin/` 目录下可以找到 `mysql` 命令行工具。然后执行下面的命令连接 Doris。
 
-```Bash
+```shell
 # FE_IP 为 FE 的监听地址， FE_QUERY_PORT 为 FE 的 MYSQL 协议服务的端口，在 fe.conf 中对应 query_port, 默认为 9030.
 mysql -h FE_IP -P FE_QUERY_PORT -u USER_NAME 
 ```
 
 登录后，显示如下。
 
-```Bash
+```shell
 Welcome to the MySQL monitor.  Commands end with ; or \g.                                                                                                                                                                                  
 Your MySQL connection id is 236                                                                                                                                                                                                            
 Server version: 5.7.99 Doris version doris-2.0.3-rc06-37d31a5                                                                                                                                                                              

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/k8s-deploy/install-access-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/k8s-deploy/install-access-cluster.md
@@ -36,13 +36,13 @@ Doris 在 Kubernetes 上默认提供 ClusterIP 访问模式。无需进行修改
 
 在部署集群后，通过以下命令可以查看 Doris Operator 暴露的 service：
 
-```bash
+```shell
 kubectl -n doris get svc
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                               AGE
 doriscluster-sample-be-internal   ClusterIP   None          <none>        9050/TCP                              9m
 doriscluster-sample-be-service    ClusterIP   10.1.68.128   <none>        9060/TCP,8040/TCP,9050/TCP,8060/TCP   9m
@@ -59,13 +59,13 @@ doriscluster-sample-fe-service    ClusterIP   10.1.118.16   <none>        8030/T
 
 使用以下命令，可以在当前的 Kubernetes 集群中创建一个包含 mysql client 的 pod：
 
-```bash
+```shell
 kubectl run mysql-client --image=mysql:5.7 -it --rm --restart=Never --namespace=doris -- /bin/bash
 ```
 
 在集群内的容器中，可以使用对外暴露的后缀为 `service` 的服务名访问 Doris 集群：
 
-```bash
+```shell
 ## 使用 service 类型 pod name 访问 Doris 集群
 mysql -uroot -P9030 -hdoriscluster-sample-fe-service
 ```
@@ -145,13 +145,13 @@ spec:
 
 在部署集群后，通过以下命令可以查看 Doris Operator 暴露的 service：
 
-```bash
+```shell
 kubectl get service
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                                       AGE
 kubernetes                        ClusterIP   10.152.183.1     <none>        443/TCP                                                       169d
 doriscluster-sample-fe-internal   ClusterIP   None             <none>        9030/TCP                                                      2d
@@ -162,13 +162,13 @@ doriscluster-sample-be-service    NodePort    10.152.183.244   <none>        906
 
 Doris 的 Query Port 端口默认为 9030，在本地中被映射到本地端口 31545。在访问 Doris 集群时，同时需要获取到对应的 IP 地址，可以通过以下命令查看：
 
-```bash
+```shell
 kubectl get nodes -owide
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME   STATUS   ROLES           AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION          CONTAINER-RUNTIME
 r60    Ready    control-plane   14d   v1.28.2   192.168.88.60   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
 r61    Ready    <none>          14d   v1.28.2   192.168.88.61   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
@@ -178,7 +178,7 @@ r63    Ready    <none>          14d   v1.28.2   192.168.88.63   <none>        Ce
 
 在 NodePort 模式下，可以根据任何 node 节点的宿主机 IP 与端口映射访问 Kubernetes 集群内的服务。在本例中可以使用任一的 node 节点 IP，192.168.88.61、192.168.88.62、192.168.88.63 访问 Doris 服务。如在下例中使用了 node 节点 192.168.88.62 与映射出的 query port 端口 31545 访问集群：
 
-```bash
+```shell
 mysql -h 192.168.88.62 -P 31545 -uroot
 ```
 
@@ -194,7 +194,7 @@ mysql -h 192.168.88.62 -P 31545 -uroot
 
 在上例返回结果中，可以直接在同一个 Kubernetes 集群内的 Pod 中通过 curl 命令获取返回结果：
 
-```bash
+```shell
 curl http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local:8040/api/_load_error_log?file=__shard_1/error_log_insert_stmt_af474190276a2e9c-49bb9d175b8e968e_af474190276a2e9c_49bb9d175b8e968e
 ```
 
@@ -245,7 +245,7 @@ spec:
 
 按照上例中的 service 将 CR 中的 ${podName} 替换成 doriscluster-sample-be-2，将 ${ServiceType} 替换为 NodePort。通过 kubectl apply 命令，在于 doris 集群相同的 namespace 中创建 service 服务。
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -253,13 +253,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 使用以下命令查看上述部署 Service 分配的 NodePort 端口：
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
 doriscluster-detail-error         NodePort    10.152.183.35    <none>        8040:31201/TCP     32s
 ```
@@ -268,13 +268,13 @@ doriscluster-detail-error         NodePort    10.152.183.35    <none>        804
 
 获取 K8s 管控的宿主机地址：
 
-```bash
+```shell
 kubectl get node -owide
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME             STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION       CONTAINER-RUNTIME
 vm-10-8-centos   Ready    <none>   226d   v1.28.7   10.16.10.8    <none>        TencentOS Server 3.1 (Final)   5.4.119-19-0009.3    containerd://1.6.28
 vm-10-7-centos   Ready    <none>   19d    v1.28.7   10.16.10.7    <none>        TencentOS Server 3.1 (Final)   5.4.119-19.0009.25   containerd://1.6.28
@@ -301,7 +301,7 @@ http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluste
 
 上述地址的域名地址为 `doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local` 在 `Kubernetes` 上 `Doris Operator` 部署的 pod 使用的域名中，三级域名为  pod 的名称。将上述模板中 {podName} 替换为真实的 `pod` 名称，将 {serviceType} 替换为 `LoadBalancer` ，更改后保存到新建的 `stream_load_get_error.yaml` 文件中。使用如下命令部署 service：
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -309,13 +309,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 使用如下命令查看上述部署 Service 分配的  LoadBalaner 地址 EXTERNAL-IP ,以下为在 aws eks 测试实例：
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                         TYPE          CLUSTER-IP       EXTERNAL-IP                                                              PORT(S)           AGE
 doriscluster-detail-error    LoadBalancer  172.20.183.136   ac4828493dgrftb884g67wg4tb68gyut-1137856348.us-east-1.elb.amazonaws.com  8040:32003/TCP    14s
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/k8s-deploy/install-config-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/k8s-deploy/install-config-cluster.md
@@ -98,13 +98,13 @@ feSpec:
 
 其中，需要在 ${storageClassName} 指定 [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) 的名称。可以通过 以下命令查看当前 Kubernetes 集群内支持的 StorageClass：
 
-```bash
+```shell
 kubectl get sc
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                          PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
 openebs-hostpath              openebs.io/local               Delete          WaitForFirstConsumer   false                  212d
 openebs-device                openebs.io/local               Delete          WaitForFirstConsumer   false                  212d

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/k8s-deploy/install-doris-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/k8s-deploy/install-doris-cluster.md
@@ -36,13 +36,13 @@ under the License.
 
 1. 创建 namespace：
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 2. 部署 Doris 集群
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -61,7 +61,7 @@ selectdb/doris.be-ubuntu:2.0.2
 
 将镜像下载到本地后打包成 tar 文件
 
-```bash
+```shell
 ## download docker image
 docker pull selectdb/doris.fe-ubuntu:2.0.2
 docker pull selectdb/doris.be-ubuntu:2.0.2
@@ -73,7 +73,7 @@ docker save -o doris.be-ubuntu-v2.0.2.tar docker pull selectdb/doris.be-ubuntu:2
 
 将 image tar 包上传到服务器上，执行 docker load 命令：
 
-```bash
+```shell
 ## load docker image
 docker load -i doris.fe-ubuntu-v2.0.2.tar
 docker load -i doris.be-ubuntu-v2.0.2.tar
@@ -81,13 +81,13 @@ docker load -i doris.be-ubuntu-v2.0.2.tar
 
 2. 创建 namespace：
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 3. 部署 Doris 集群
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -101,13 +101,13 @@ kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 
 安装 [doriscluster](https://artifacthub.io/packages/helm/doris/doris)，使用默认配置此部署仅部署 3 个 FE 和 3 个 BE 组件，使用默认 `storageClass` 实现 PV 动态供给。
 
-```bash
+```shell
 helm install doriscluster doris-repo/doris
 ```
 
 如果需要自定义资源和集群形态，请根据 [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) 的各个资源配置的注解自定义资源配置，并执行如下命令:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-repo/doris
 ```
 
@@ -115,13 +115,13 @@ helm install -f values.yaml doriscluster doris-repo/doris
 
 通过 `kubectl get pods` 命令可以查看 pod 部署状态。当 `doriscluster` 的 Pod 处于 `Running` 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -137,7 +137,7 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 下载 `doris-{chart_version}.tgz` 安装 Doris Cluster chart。如需要下载 2.0.6 版本的 Doris 集群可以使用以下命令：
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-2.0.6.tgz
 ```
 
@@ -145,13 +145,13 @@ wget https://charts.selectdb.com/doris-2.0.6.tgz
 
 通过 `helm install` 命令可以安装 Doris 集群。
 
-```bash
+```shell
 helm install doriscluster doris-1.4.0.tgz
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-1.4.0.tgz
 ```
 
@@ -159,13 +159,13 @@ helm install -f values.yaml doriscluster doris-1.4.0.tgz
 
 通过 `kubectl get pods` 命令可以查看 pod 部署状态。当 `doriscluster` 的 Pod 处于 `Running` 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -181,13 +181,13 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 集群部署资源下发后，可以通过以下命令检查集群状态。
 
-```bash
+```shell
 kubectl get pods -n ${namespace}
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                       READY   STATUS    RESTARTS   AGE
 doriscluster-sample-fe-0   1/1     Running   0          20m
 doriscluster-sample-be-0   1/1     Running   0          19m
@@ -199,13 +199,13 @@ doriscluster-sample-be-0   1/1     Running   0          19m
 
 Doris Operator 会收集集群服务的状态显示到下发的资源中。Doris Operator 定义了 `DorisCluster` 类型资源名称的简写 `dcr`，在使用资源类型查看集群状态时可用简写替代。
 
-```bash
+```shell
 kubectl get dcr
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                  FESTATUS    BESTATUS    CNSTATUS   BROKERSTATUS
 doriscluster-sample   available   available
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/k8s-deploy/install-env.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/k8s-deploy/install-env.md
@@ -39,7 +39,7 @@ under the License.
 
 在 Kubernetes 上部署 Doris 集群，建议关闭防火墙配置：
 
-```bash
+```shell
 systemctl stop firewalld
 systemctl disable firewalld
 ```
@@ -56,7 +56,7 @@ systemctl disable firewalld
 
 通过以下命令可以永久关闭 swap 分区。
 
-```bash
+```shell
 echo "vm.swappiness = 0">> /etc/sysctl.conf
 swapoff -a && swapon -a
 sysctl -p
@@ -64,7 +64,7 @@ sysctl -p
 
 ### 设置系统最大打开文件句柄数
 
-```bash
+```shell
 vi /etc/security/limits.conf 
 * soft nofile 65536
 * hard nofile 65536
@@ -74,7 +74,7 @@ vi /etc/security/limits.conf
 
 修改虚拟内存区域至少 2000000
 
-```bash
+```shell
 sysctl -w vm.max_map_count=2000000
 ```
 
@@ -82,7 +82,7 @@ sysctl -w vm.max_map_count=2000000
 
 在部署 Doris 时，建议关闭透明大页。
 
-```bash
+```shell
 echo never > /sys/kernel/mm/transparent_hugepage/enabled
 echo never > /sys/kernel/mm/transparent_hugepage/defrag
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/k8s-deploy/install-operator.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/k8s-deploy/install-operator.md
@@ -30,32 +30,32 @@ Doris Operator 使用自定义资源定义（Custom Resource Definition, CRD）�
 
 通过以下命令可以在 Kubernetes 环境中部署 Doris Cluster CRD：
 
-```bash
+```shell
 kubectl create -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 ```
 
 如果没有外网，先将 CRD 文件下载到本地：
 
-```bash
+```shell
 wget https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 kubectl create -f ./doris.selectdb.com_dorisclusters.yaml
 ```
 
 以下是期望输出结果：
 
-```bash
+```shell
 customresourcedefinition.apiextensions.k8s.io/dorisclusters.doris.selectdb.com created
 ```
 
 在创建了 Doris Cluster CRD 后，可以通过以下命令查看创建的 CRD。
 
-```bash
+```shell
 kubectl get crd | grep doris
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 ```
 
@@ -67,13 +67,13 @@ dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 
 使用以下命令可以在 Kubernetes 集群中部署 Doris Operator：
 
-```bash
+```shell
 kubectl apply -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/operator/operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -93,13 +93,13 @@ deployment.apps/doris-operator created
 
 在修改 operator.yaml 文件后，可以使用以下命令部署 Doris Operator 服务：
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -115,13 +115,13 @@ deployment.apps/doris-operator created
 
 如果服务器没有连通外网，需要先下载对应的 operator 镜像文件。Doris Operator 用到以下的镜像：
 
-```bash
+```shell
 selectdb/doris.k8s-operator:latest
 ```
 
 在可以连通外网的服务器中运行以下的命令，可以将镜像下载下来：
 
-```bash
+```shell
 ## download doris operator image
 docker pull selectdb/doris.k8s-operator:latest
 ## save the doris operator image as a tar package
@@ -130,7 +130,7 @@ docker save -o doris.k8s-operator-latest.tar selectdb/doris.k8s-operator:latest
 
 将已打包的 tar 文件放置到所有的 Kubernetes node 节点中，运行以下命令上传镜像：
 
-```bash
+```shell
 docker load -i doris.k8s-operator-latest.tar
 ```
 
@@ -140,7 +140,7 @@ docker load -i doris.k8s-operator-latest.tar
 
 Doris Operator 在 Kubernetes 集群中是一个无状态的 Deployment，可以根据需求修改如 `limits`、`replica`、`label`、`namespace` 等项目。如需要指定某一版本的 doirs operator 镜像，可以在上传镜像后对 operator.yaml 文件做如下修改：
 
-```bash
+```shell
 ...
 containers:
   - command:
@@ -161,13 +161,13 @@ containers:
 
 在修改 Doris Operator 模板后，可以使用 apply 命令部署 Operator：
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -187,13 +187,13 @@ Helm Chart 是一系列描述 Kubernetes 相关资源的 YAML 文件的封装。
 
 通过 `repo add` 命令添加远程仓库
 
-```bash
+```shell
 helm repo add doris-repo https://charts.selectdb.com
 ```
 
 通过 `repo update` 命令更新最新版本的 chart
 
-```bash
+```shell
 helm repo update doris-repo
 ```
 
@@ -201,25 +201,25 @@ helm repo update doris-repo
 
 通过 `helm install` 命令可以使用默认配置在 doris 的 namespace 中安装 Doris Operator
 
-```bash
+```shell
 helm install operator doris-repo/doris-operator
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-repo/doris-operator
 ```
 
 通过 `kubectl get pods` 命令查看 Pod 的部署状态。当 Doris Operator 的 Pod 处于 Running 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -232,7 +232,7 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 下载 `doris-operator-{chart_version}.tgz` 安装 Doris Operator chart。如需要下载 1.4.0 版本的 Doris Operator 可以使用以下命令：
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 ```
 
@@ -240,25 +240,25 @@ wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 
 通过 `helm install` 命令可以安装 Doris Operator。
 
-```bash
+```shell
 helm install operator doris-operator-1.4.0.tgz
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-operator-1.4.0.tgz
 ```
 
 通过 `kubectl get pods` 命令查看 Pod 的部署状态。当 Doris Operator 的 Pod 处于 Running 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -267,13 +267,13 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 当部署 Operator 服务后，可以通过以下命令查看服务状态。
 
-```bash
+```shell
 kubectl get pod -n doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-6f47594455-p5tp7   1/1     Running   0          11s
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/run-docker-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/run-docker-cluster.md
@@ -85,7 +85,7 @@ Docker Version：20.10 及以后版本
 
 3. 编写 Dockerfile
 
-```Bash
+```shell
 # 选择基础镜像
 FROM openjdk:8u342-jdk
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/standard-deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/cluster-deployment/standard-deployment.md
@@ -304,7 +304,7 @@ FE 的配置文件在 FE 部署路径下的 conf 目录中，启动 FE 节点前
 
 通过以下命令可以启动 FE 进程
 
-```Bash
+```shell
 bin/start_fe.sh --daemon
 ```
 
@@ -373,7 +373,7 @@ ALTER SYSTEM ADD OBSERVER "<fe_ip_address>:<fe_edit_log_port>"
 
 通过以下命令，可以启动 FE Follower 节点，并自动同步元数据。
 
-```Bash
+```shell
 bin/start_fe.sh --helper <helper_fe_ip>:<fe_edit_log_port> --daemon
 ```
 
@@ -601,7 +601,7 @@ Doris 作为一个分布式数据库，一般拥有众多 BE 节点，Doris 采�
 
 可以通过下面的命令来检查 Doris 是否启动成功
 
-```Bash
+```shell
 # 重试执行下面命令，如果返回"msg":"success"，则说明已经启动成功
 server1:apache-doris/fe doris$ curl http://127.0.0.1:8030/api/bootstrap
 {"msg":"success","code":0,"data":{"replayedJournalId":0,"queryPort":0,"rpcPort":0,"version":""},"count":0}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/source-install/compilation-arm.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/source-install/compilation-arm.md
@@ -58,7 +58,7 @@ import TabItem from '@theme/TabItem';
 
 **1.  创建软件下载安装包根目录和软件安装根目录**
 
-```Bash
+```shell
 # 创建软件下载安装包根目录
 mkdir /opt/tools
 
@@ -68,7 +68,7 @@ mkdir /opt/software
 
 **2.  安装依赖项**
 
-```Bash
+```shell
 ### Git ###
 # 省去编译麻烦，直接使用 yum 安装
 yum install -y git
@@ -115,7 +115,7 @@ wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz && \
 
 **3.  配置环境变量**
 
-```Bash
+```shell
 # 配置环境变量
 vim /etc/profile.d/doris.sh
 export JAVA_HOME=/opt/software/jdk8
@@ -142,13 +142,13 @@ gcc --version
 
 **1.  更新 apt-get 软件库**
 
-```Bash
+```shell
 apt-get update
 ```
 
 **2.  重新配置 shell**
 
-```Bash
+```shell
 # Ubuntu 的 shell 默认安装的是 dash，而不是 bash，要切换成 bash 才能执行，运行以下命令查看 sh 的详细信息，确认 shell 对应的程序是哪个：
 ls -al /bin/sh
 
@@ -159,7 +159,7 @@ sudo dpkg-reconfigure dash
 
 **3.  创建软件下载安装包根目录和软件安装根目录**
 
-```Bash
+```shell
 # 创建软件下载安装包根目录
 mkdir /opt/tools
 
@@ -169,7 +169,7 @@ mkdir /opt/software
 
 **4.  安装依赖项**
 
-```Bash
+```shell
 ### Git ###
 # 省去编译麻烦，直接使用 apt-get 安装
 apt-get -y install git
@@ -225,7 +225,7 @@ wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz && \
 
 **5.  配置环境变量**
 
-```Bash
+```shell
 # 配置环境变量
 vim /etc/profile.d/doris.sh
 export JAVA_HOME=/opt/software/jdk8
@@ -254,7 +254,7 @@ gcc --version
 
 在 ARM 平台编译 Doris 时，请关闭 AVX2 和 LIBUNWIND 三方库：
 
-```Bash
+```shell
 export USE_AVX2=OFF
 export USE_UNWIND=OFF
 ```
@@ -271,7 +271,7 @@ export USE_UNWIND=OFF
 
 解决方案：使用第三方库下载仓库    
 
-```Bash
+```shell
 export REPOSITORY_URL=https://doris-thirdparty-repo.bj.bcebos.com/thirdparty
 sh /opt/doris/thirdparty/build-thirdparty.sh
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/source-install/compilation-mac.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/source-install/compilation-mac.md
@@ -87,7 +87,7 @@ cd output/fe/bin
 
 可以在 [Apache Doris Third Party Prebuilt](https://github.com/apache/doris-thirdparty/releases/tag/automation) 页面直接下载预编译好的第三方库，省去编译第三方库的过程，参考下面的命令。
 
-```Bash
+```shell
 cd thirdparty
 rm -rf installed
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/source-install/compilation-with-docker.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/source-install/compilation-with-docker.md
@@ -30,7 +30,7 @@ under the License.
 
 比如在 CentOS 下，执行命令安装 Docker
 
-```Bash
+```shell
 yum install docker
 ```
 
@@ -49,7 +49,7 @@ yum install docker
 
 下面就以编译 Doris 2.0 版本作为介绍，下载并检查 Docker 镜像
 
-```Bash
+```shell
 # 可以选择 docker.io/apache/doris:build-env-for-2.0
 $ docker pull apache/doris:build-env-for-2.0
 
@@ -71,7 +71,7 @@ apache/doris    build-env-for-2.0    f29cf1979dba    3 days ago    3.3GB
 
 -   最新版本的 `apache/doris:build-env-ldb-toolchain-latest` 镜像中同时包含 JDK 8 和 JDK 17。2.1（含）之前的版本，请使用 JDK 8。3.0（含）之后的版本或 master 分支，请使用 JDK 17。
 
-```Bash
+```shell
 # 切换到 JDK 8
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0
 export PATH=$JAVA_HOME/bin/:$PATH

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/source-install/compilation-with-ldb-toolchain.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/source-install/compilation-with-ldb-toolchain.md
@@ -118,7 +118,7 @@ Doris 源码编译时首先会下载三方库进行编译，可以参考下文�
 
 **1.  进入 Doris 源码目录，执行如下命令查看编译机器是否支持 AVX2 指令集**
 
-```Bash
+```shell
 $ cat /proc/cpuinfo | grep avx2
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/lakehouse/database/es.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/lakehouse/database/es.md
@@ -124,7 +124,7 @@ Elasticsearch 没有明确的数组类型，但是它的某个字段可以含有
 
 该结构的数组字段可以通过使用以下命令将字段属性定义添加到目标索引映射的`_meta.doris`属性来定义。
 
-```bash
+```shell
 # ES 7.x and above
 curl -X PUT "localhost:9200/doc/_mapping?pretty" -H 'Content-Type:application/json' -d '
 {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
@@ -36,7 +36,7 @@ DROP ROLE
 
 ```sql
   DROP ROLE [IF EXISTS] role1;
-````
+```
 
 删除角色不会影响以前属于角色的用户的权限。 它仅相当于解耦来自用户的角色。 用户从角色获得的权限不会改变
 
@@ -46,7 +46,7 @@ DROP ROLE
 
 ```sql
 DROP ROLE role1;
-````
+```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
@@ -142,7 +142,7 @@ role_list 是需要赋予的角色列表，以逗号分隔，指定的角色必�
 
     ```sql
     GRANT 'role1','role2' TO 'jack'@'%';
-    ````
+    ```
 :::tip 提示
 该功能自 Apache Doris 2.0 版本起支持
 :::
@@ -153,25 +153,25 @@ role_list 是需要赋予的角色列表，以逗号分隔，指定的角色必�
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO 'jack'@'%';
-    ````
+    ```
 
 9. 匹配所有 workload group 授予用户 jack
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP '%' TO 'jack'@'%';
-    ````
+    ```
 
 10. 将指定 workload group‘g1’授予角色 my_role
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO ROLE 'my_role';
-    ````
+    ```
 
 11. 允许 jack 查看 db1 下 view1 的创建语句
 
     ```sql
     GRANT SHOW_VIEW_PRIV ON db1.view1 TO 'jack'@'%';
-    ````
+    ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
@@ -47,7 +47,7 @@ ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
-````
+```
 
  说明：
 
@@ -74,7 +74,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
    ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a");
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-   ````
+   ```
 
 2. 修改 BE 的查询禁用属性
    
@@ -84,7 +84,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
 
     ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_query" = "true");
-    ````   
+    ```   
 
 3. 修改 BE 的导入禁用属性
    
@@ -94,7 +94,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
 
     ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_load" = "true");
-    ````   
+    ```   
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
@@ -123,7 +123,7 @@ CREATE [GLOBAL] [AGGREGATE] [ALIAS] FUNCTION function_name
 
    ```sql
    CREATE GLOBAL ALIAS FUNCTION id_masking(INT) WITH PARAMETER(id) AS CONCAT(LEFT(id, 3), '****', RIGHT(id, 4));
-   ```` 
+   ``` 
    
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
@@ -57,7 +57,7 @@ DROP [GLOBAL] FUNCTION function_name
 
     ```sql
     DROP GLOBAL FUNCTION my_add(INT, INT)
-    ````      
+    ```      
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
@@ -46,7 +46,7 @@ SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS [FROM db]
 
     ```sql
      SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS FROM test;
-    ````
+    ```
 
 2. 查看全局的转换情况
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
@@ -38,7 +38,7 @@ SHOW DATABASES
 
 ```sql
 SHOW DATABASES [FROM catalog] [filter expr];
-````
+```
 
 说明:
 1. `SHOW DATABASES` 会展示当前所有的数据库名称.
@@ -51,45 +51,45 @@ SHOW DATABASES [FROM catalog] [filter expr];
 
    ```sql
    SHOW DATABASES;
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | test               |
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 2. 会展示`hms_catalog`中所有的数据库名称.
 
    ```sql
    SHOW DATABASES from hms_catalog;
-   ````
+   ```
 
-   ````
+   ```
   +---------------+
   | Database      |
   +---------------+
   | default       |
   | tpch          |
   +---------------+
-   ````
+   ```
 
 3. 展示当前所有经过表示式`like 'infor%'`过滤后的数据库名称.
 
    ```sql
    SHOW DATABASES like 'infor%';
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database ：查看指定数据库下的作业。 如果未指定，则使用当前数据库。
 - WHERE：您可以过滤结果列，目前仅支持以下列：
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`：作业唯一 ID。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
@@ -59,19 +59,19 @@ IndexName = rollup_name
 
     ```sql
     SHOW TABLETS FROM example_db.table_name;
-    ````
+    ```
 
 2. 列出指定partitions的所有tablets
 
     ```sql
     SHOW TABLETS FROM example_db.table_name PARTITIONS(p1, p2);
-    ````
+    ```
 
 3. 列出某个backend上状态为DECOMMISSION的tablets
 
     ```sql
     SHOW TABLETS FROM example_db.table_name WHERE state="DECOMMISSION" AND BackendId=11003;
-    ````
+    ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
@@ -40,7 +40,7 @@ SHOW TYPECAST
 
 ```sql
 SHOW TYPE_CAST [IN|FROM db]
-````
+```
 
  Parameters
 
@@ -48,7 +48,7 @@ SHOW TYPE_CAST [IN|FROM db]
 
 ### Example
 
-````sql
+```sql
 mysql> show type_cast in testDb\G
 **************************** 1. row ******************** ******
 Origin Type: TIMEV2
@@ -61,7 +61,7 @@ Origin Type: TIMEV2
   Cast Type: TIMEV2
 
 3 rows in set (0.00 sec)
-````
+```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Utility-Statements/USE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Utility-Statements/USE.md
@@ -57,7 +57,7 @@ USE <[CATALOG_NAME].DATABASE_NAME>
     ```sql
     mysql> use hms_catalog.demo;
     Database changed
-    ````
+    ```
 ### Keywords
 
     USE

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/table-design/data-partition.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/table-design/data-partition.md
@@ -201,7 +201,7 @@ PARTITION BY RANGE(col1[, col2, ...])
 
 示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(`date`)
 (
     PARTITION `p201701` VALUES [("2017-01-01"),  ("2017-02-01")),
@@ -249,7 +249,7 @@ PARTITION BY RANGE(date_col)
 
 示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(age)
 (
     FROM (1) TO (100) INTERVAL 10
@@ -263,7 +263,7 @@ PARTITION BY RANGE(`date`)
 
 4.MULTI RANGE：批量创建 RANGE 分区，定义分区的左闭右开区间。示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(col)                                                                                                                                                                                                                
 (                                                                                                                                                                                                                                      
    FROM ("2000-11-14") TO ("2021-11-14") INTERVAL 1 YEAR,                                                                                                                                                                              
@@ -282,7 +282,7 @@ Partition 支持通过 `VALUES IN (...)` 来指定每个分区包含的枚举值
 
 举例如下：
 
-```Bash
+```shell
 PARTITION BY LIST(city)
 (
     PARTITION `p_cn` VALUES IN ("Beijing", "Shanghai", "Hong Kong"),

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/auth/certificate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/auth/certificate.md
@@ -41,7 +41,7 @@ Doris 开启 SSL 功能需要配置 CA 密钥证书和 Server 端密钥证书，
 
 1. 生成 CA、Server 端和 Client 端的密钥和证书
 
-```BASH
+```shell
 # 生成CA certificate
 openssl genrsa 2048 > ca-key.pem
 openssl req -new -x509 -nodes -days 3600 \
@@ -66,13 +66,13 @@ openssl x509 -req -in client-req.pem -days 3600 \
 
 2. 验证创建的证书。
 
-```bash
+```shell
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
 3. 将您的 CA 密钥和证书和 Sever 端密钥和证书分别合并到 PKCS#12 (P12) 包中。您也可以指定某个证书格式，默认 PKCS12，可以通过修改 conf/fe.conf 配置文件，添加参数 ssl_trust_store_type 指定证书格式
 
-```bash
+```shell
 # 打包CA密钥和证书
 openssl pkcs12 -inkey ca-key.pem -in ca.pem -export -out ca_certificate.p12
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/auth/ldap.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/auth/ldap.md
@@ -128,13 +128,13 @@ set ldap_admin_password = password('ldap_admin_password');
 
   例如在 linux 或者 mac 环境中可以使用：
 
-  ```bash
+  ```shell
   echo "export LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN=1" >> ～/.bash_profile && source ～/.bash_profile
   ```
 
 - 每次登录 Doris 时添加参数 `--enable-cleartext-plugin`
 
-  ```bash
+  ```shell
   mysql -hDORIS_HOST -PDORIS_PORT -u user -p --enable-cleartext-plugin
   
   输入 ldap 密码
@@ -196,13 +196,13 @@ LDAP 密码验证和组授权是 Doris 密码验证和授权的补充，开启 L
 
     使用以下命令登录 Doris 可以登录 `jack@'172.10.1.10'` 账户：
 
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
     ```
 
     使用以下命令将登录失败：
     
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
     ```
 
@@ -212,7 +212,7 @@ LDAP 密码验证和组授权是 Doris 密码验证和授权的补充，开启 L
 
     使用以下命令创建临时用户并登录 jack@'%'，临时用户具有基本权限 DatabasePrivs：Select_priv，用户退出登录后 Doris 将删除该临时用户：
     
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
     ```
 
@@ -222,7 +222,7 @@ LDAP 密码验证和组授权是 Doris 密码验证和授权的补充，开启 L
 
     使用 Doris 密码登录账户，成功：
     
-    ```bash
+    ```shell
     mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/check-tablet-segment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/check-tablet-segment.md
@@ -69,7 +69,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/check_tablet_segment_lost?repair=false
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/compaction-run.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/compaction-run.md
@@ -135,6 +135,6 @@ under the License.
 
 ### Examples
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/compaction/run?tablet_id=10015&compact_type=cumulative"
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/compaction-status.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/compaction-status.md
@@ -114,6 +114,6 @@ under the License.
 
 ## Examples
 
-```bash
+```shell
 curl http://192.168.10.24:8040/api/compaction/show?tablet_id=10015
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/config.md
@@ -91,15 +91,15 @@ under the License.
 ## Examples
 
 
-```bash
+```shell
 curl "http://127.0.0.1:8040/api/show_config"
 ```
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/update_config?agent_task_trace_threshold_sec=2&persist=true"
 
 ```
 
-```bash
+```shell
 curl -X POST "http://127.0.0.1:8040/api/update_config?agent_task_trace_threshold_sec=2&enable_merge_on_write_correctness_check=true&persist=true"
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/download.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/download.md
@@ -53,7 +53,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/_load_error_log?file=a&token=1"
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/health.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/health.md
@@ -49,7 +49,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/health
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/meta.md
@@ -66,7 +66,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/metrics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/metrics.md
@@ -63,7 +63,7 @@ prometheus 监控采集接口
 ## Examples
 
 
-    ```bash
+    ```shell
         curl "http://127.0.0.1:8040/metrics?type=json&with_tablet=true"
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/pad-rowset.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/pad-rowset.md
@@ -61,7 +61,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl -X POST "http://127.0.0.1:8040/api/pad_rowset?tablet_id=123456&start_version=1111111&end_version=1111112"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/reset-rpc-channel.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/reset-rpc-channel.md
@@ -60,11 +60,11 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/reset_rpc_channel/all
     ```
     
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/reset_rpc_channel/1.1.1.1:8080,2.2.2.2:8080
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/snapshot.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/snapshot.md
@@ -55,7 +55,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/snapshot?tablet_id=123456&schema_hash=1111111"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/tablet-distribution.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/tablet-distribution.md
@@ -85,7 +85,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/tablets_distribution?group_by=partition&partition_id=123"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/tablet-info.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/tablet-info.md
@@ -71,7 +71,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl http://127.0.0.1:8040/api/tablets_json?limit=123
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/tablet-migration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/tablet-migration.md
@@ -104,7 +104,7 @@ under the License.
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/tablet_migration?goal=run&tablet_id=123&schema_hash=333&disk=/disk1"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/tablet-reload.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/be/tablet-reload.md
@@ -51,13 +51,13 @@ under the License.
 
 ## Response
 
-    ```bash
+    ```shell
     load header succeed
     ```
 ## Examples
 
 
-    ```bash
+    ```shell
     curl "http://127.0.0.1:8040/api/reload_tablet?tablet_id=123456&schema_hash=1111111&path=/abc"
 
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/cluster-management/load-balancing.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/cluster-management/load-balancing.md
@@ -51,7 +51,7 @@ Doris 的 FE 进程负责接收用户连接和查询请求，其本身是可以�
 
 ### 安装 ProxySQL（yum 方式）
 
-```bash
+```shell
 配置yum源
 # vim /etc/yum.repos.d/proxysql.repo
 
@@ -91,7 +91,7 @@ ProxySQL 有配置文件 `/etc/proxysql.cnf` 和配置数据库文件`/var/lib/p
 
 这里主要是几个参数，在下面已经注释出来了，可以根据自己的需要进行修改
 
-```bash
+```shell
 # egrep -v "^#|^$" /etc/proxysql.cnf
 datadir="/var/lib/proxysql"         #数据目录
 admin_variables=
@@ -508,7 +508,7 @@ IP: 172.31.7.119
 
 ### 安装依赖
 
-```bash
+```shell
 sudo apt-get install build-essential
 sudo apt-get install libpcre3 libpcre3-dev 
 sudo apt-get install zlib1g-dev
@@ -517,7 +517,7 @@ sudo apt-get install openssl libssl-dev
 
 ### 安装 Nginx
 
-```bash
+```shell
 sudo wget http://nginx.org/download/nginx-1.18.0.tar.gz
 sudo tar zxvf nginx-1.18.0.tar.gz
 cd nginx-1.18.0
@@ -529,13 +529,13 @@ sudo make && make install
 
 这里是新建了一个配置文件
 
-```bash
+```shell
 vim /usr/local/nginx/conf/default.conf
 ```
 
 然后在里面加上下面的内容
 
-```bash
+```shell
 events {
 worker_connections 1024;
 }

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/data-admin/ccr.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/data-admin/ccr.md
@@ -75,7 +75,7 @@ enable_feature_binlog=true
 
 1. 构建 CCR syncer
 
-    ```Bash
+    ```shell
     git clone https://github.com/selectdb/ccr-syncer
 
     cd ccr-syncer
@@ -87,7 +87,7 @@ enable_feature_binlog=true
 
 2. 启动和停止 syncer
 
-    ```Bash
+    ```shell
     # 启动
     cd bin && sh start_syncer.sh --daemon
 
@@ -97,7 +97,7 @@ enable_feature_binlog=true
 
 **5. 打开源集群中同步库/表的 Binlog**
 
-```Bash
+```shell
 -- 如果是整库同步，可以执行如下脚本，使得该库下面所有的表都要打开 binlog.enable
 vim shell/enable_db_binlog.sh
 修改源集群的 host、port、user、password、db
@@ -109,7 +109,7 @@ ALTER TABLE enable_binlog SET ("binlog.enable" = "true");
 
 **6. 向 syncer 发起同步任务**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -135,7 +135,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 同步任务的参数说明：
 
-```Bash
+```shell
 name: CCR同步任务的名称，唯一即可
 host、port：对应集群 Master FE的host和mysql(jdbc) 的端口
 user、password：syncer以何种身份去开启事务、拉取数据等
@@ -280,7 +280,7 @@ bash bin/start_syncer.sh --pid_dir /path/to/pids
 
 在编译完成后的输出路径下，文件结构大致如下所示：
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -316,7 +316,7 @@ output_dir
 
 指定 pid 文件所在目录，上述三种关闭方法都依赖于 pid 文件的所在目录执行
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --pid_dir /path/to/pids
 ```
 
@@ -328,7 +328,7 @@ bash bin/stop_syncer.sh --pid_dir /path/to/pids
 
 关闭 pid_dir 路径下 host:port 对应的 Syncer
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --host 127.0.0.1 --port 9190
 ```
 
@@ -342,7 +342,7 @@ host 与 port 都不为空时**方法 1**才能生效
 
 关闭 pid_dir 路径下指定 pid 文件名对应的 Syncer
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 ```
 
@@ -352,7 +352,7 @@ bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 
 **请求的通用模板**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d {json_body} http://ccr_syncer_host:ccr_syncer_port/operator
 ```
 
@@ -376,7 +376,7 @@ or
 
 ​    创建 CCR 任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "ccr_test",
         "src": {
@@ -418,7 +418,7 @@ or
 
 ​    查看同步进度
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/get_lag
@@ -430,7 +430,7 @@ or
 
 ​    暂停同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/pause 
@@ -440,7 +440,7 @@ or
 
 ​    恢复同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/resume
@@ -450,7 +450,7 @@ or
 
 ​    删除同步任务
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/delete
@@ -460,7 +460,7 @@ or
 
     获取版本信息
 
-    ```Bash
+    ```shell
     curl http://ccr_syncer_host:ccr_syncer_port/version
 
     # > return
@@ -471,7 +471,7 @@ or
 
     查看 job 的状态
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/job_status
@@ -490,7 +490,7 @@ or
 
     不做 sync，此时用户可以将源和目的集群互换
 
-    ```Bash
+    ```shell
     curl -X POST -H "Content-Type: application/json" -d '{
         "name": "job_name"
     }' http://ccr_syncer_host:ccr_syncer_port/desync
@@ -500,7 +500,7 @@ or
 
     展示已经创建的所有任务
 
-    ```Bash
+    ```shell
     curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
     {"success":true,"jobs":["ccr_db_table_alias"]}
@@ -512,7 +512,7 @@ or
 
 在编译完成后的输出路径下，文件结构大致如下所示：
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -530,7 +530,7 @@ output_dir
 
 **使用说明**
 
-```Bash
+```shell
 bash bin/enable_db_binlog.sh -h host -p port -u user -P password -d db
 ```
 
@@ -586,7 +586,7 @@ Syncer 高可用依赖 mysql，如果使用 mysql 作为后端存储，Syncer �
 
 BE 端配置参数
 
-```Bash
+```shell
 download_binlog_rate_limit_kbs=1024 # 这就是限制到1MB，这个是单个be对所有关于binlog 包括local snapshot的配置
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/log-management/fe-log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/log-management/fe-log.md
@@ -130,7 +130,7 @@ FE 的 Debug 级别日志可以通过修改配置文件开启，也可以通过�
 
    通过以下 API 也可以在运行时修改日志级别。无需重启 FE 节点。
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?add_verbose=org.apache.doris.catalog.Catalog
    ```
 
@@ -153,7 +153,7 @@ FE 的 Debug 级别日志可以通过修改配置文件开启，也可以通过�
 
    也可以通过以下 API 关闭 Debug 日志：
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?del_verbose=org.apache.doris.catalog.Catalog
    ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/maint-monitor/automatic-service-start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/maint-monitor/automatic-service-start.md
@@ -162,20 +162,20 @@ doris   ALL=(ALL)       NOPASSWD:DORISCTL
 
     添加或修改配置文件后，需要重新加载
 
-    ```bash
+    ```shell
     systemctl daemon-reload
     ```
 
     设置自启动，实质就是在 /etc/systemd/system/multi-user.target.wants/ 添加服务文件的链接
 
-    ```bash
+    ```shell
     systemctl enable doris-fe
     systemctl enable doris-be
     ```
 
 8. 服务启动
 
-    ```bash
+    ```shell
     systemctl start doris-fe
     systemctl start doris-be
     ```
@@ -190,14 +190,14 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 1. yum 安装 supervisor
     
-    ```bash
+    ```shell
     yum install epel-release
     yum install -y supervisor
     ```
 
 2. 启动服务并查看状态
 
-    ```bash
+    ```shell
     systemctl enable supervisord # 开机自启动
     systemctl start supervisord # 启动 supervisord 服务
     systemctl status supervisord # 查看 supervisord 服务状态
@@ -206,7 +206,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 3. 配置 BE 进程管理
 
-    ```bash
+    ```shell
     修改 start_be.sh 脚本，去掉最后的 & 符号
 
     vim /path/doris/be/bin/start_be.sh
@@ -216,7 +216,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 BE 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-be.ini
 
     [program:doris_be]      
@@ -239,7 +239,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 4. 配置 FE 进程管理
 
-    ```bash
+    ```shell
     修改 start_fe.sh 脚本，去掉最后的 & 符号
 
     vim /path/doris/fe/bin/start_fe.sh 
@@ -249,7 +249,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 FE 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-fe.ini
 
     [program:PaloFe]
@@ -273,7 +273,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 5. 配置 Broker 进程管理
 
-    ```bash
+    ```shell
     修改 start_broker.sh 脚本，去掉最后的 & 符号
 
     vim /path/apache_hdfs_broker/bin/start_broker.sh
@@ -283,7 +283,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
     创建 Broker 的 supervisor 进程管理配置文件
 
-    ```bash
+    ```shell
     vim /etc/supervisord.d/doris-broker.ini
 
     [program:BrokerBootstrap]
@@ -307,7 +307,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 6. 首先确定 Doris 服务是停止状态，然后使用 supervisor 将 Doris 自动拉起，然后确定进程是否正常启动
     
-    ```bash
+    ```shell
     supervisorctl reload # 重新加载 Supervisor 中的所有配置文件
     supervisorctl status # 查看 supervisor 状态，验证 Doris 服务进程是否正常启动
 
@@ -321,7 +321,7 @@ Supervisor 配置自动拉起可以使用 yum 命令直接安装，也可以通�
 
 - 如果使用 yum 安装的 supervisor 启动报错 :  pkg_resources.DistributionNotFound: The 'supervisor==3.4.0' distribution was not found
 
-    ```bash
+    ```shell
     这个是 python 版本不兼容问题，通过 yum 命令直接安装的 supervisor 只支持 python2 版本，所以需要将 /usr/bin/supervisord 和 /usr/bin/supervisorctl 中文件内容开头 #!/usr/bin/python 改为 #!/usr/bin/python2，前提是要装 python2 版本
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/maint-monitor/tablet-local-debug.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/maint-monitor/tablet-local-debug.md
@@ -100,7 +100,7 @@ PROPERTIES (
 
 该目下会有一个 tablet id 命名的目录，将这个目录整体打包后备用。（注意，该目录最多保留 60 分钟，之后会自动删除）。
 
-```bash
+```shell
 cd /path/to/be/storage/snapshot/20220830101353.2.3600
 tar czf 10020.tar.gz 10020/
 ```
@@ -178,13 +178,13 @@ tar czf 10020.tar.gz 10020/
 
     同时，我们还需要到调试环境 BE 节点的数据目录下，确认新的 tablet 所在的 shard id：
     
-    ```bash
+    ```shell
     cd /path/to/storage/data/*/10017 && pwd
     ```
     
     这个命令会进入 10017 这个 tablet 所在目录并展示路径。这里我们会看到类似如下的路径：
     
-    ```bash
+    ```shell
     /path/to/storage/data/0/10017
     ```
     
@@ -208,7 +208,7 @@ tar czf 10020.tar.gz 10020/
     
     通过 `meta_tool` 工具删除原来的 tablet meta。该工具位于 `be/lib` 目录下。
     
-    ```bash
+    ```shell
     ./lib/meta_tool --root_path=/path/to/storage --operation=delete_meta --tablet_id=10017 --schema_hash=44622287
     ```
     
@@ -216,7 +216,7 @@ tar czf 10020.tar.gz 10020/
     
     通过 `meta_tool` 工具加载新的 tablet meta。
     
-    ```bash
+    ```shell
     ./lib/meta_tool --root_path=/path/to/storage --operation=load_meta --json_meta_path=/path/to/10017.hdr.json
     ```
     

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/maint-monitor/tablet-meta-tool.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/maint-monitor/tablet-meta-tool.md
@@ -89,7 +89,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./lib/meta_tool --operation=load_meta --root_path=/path/to/root_path --json_meta_path=path
 ```
 
@@ -99,13 +99,13 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 删除单个 tablet 元数据：
 
-```bash
+```shell
 ./lib/meta_tool --operation=delete_meta --root_path=/path/to/root_path --tablet_id=xxx --schema_hash=xxx
 ```
 
 删除一组 tablet 元数据：
 
-```bash
+```shell
 ./lib/meta_tool --operation=batch_delete_meta --tablet_file=/path/to/tablet_file.txt
 ```
 
@@ -117,7 +117,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 `tablet_file` 文件示例：
 
-```bash
+```shell
 /output/be/data/,14217,352781111
 /output/be/data/,14219,352781111
 /output/be/data/,14223,352781111
@@ -134,7 +134,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./lib/meta_tool --operation=show_meta --root_path=/path/to/root_path --pb_header_path=path
 ```
 
@@ -144,7 +144,7 @@ root_path: 在 be.conf 中配置的对应的 root_path 路径。
 
 命令：
 
-```bash
+```shell
 ./meta_tool --operation=show_segment_footer --file=/path/to/segment/file
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/plugin-development-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/plugin-development-manual.md
@@ -74,7 +74,7 @@ auditodemo/:
 
 `plugin.properties` 内容示例：
 
-```bash
+```shell
 ### required:
 #
 # the plugin name
@@ -113,13 +113,13 @@ soName = example.so
 
 我们可以通过以下命令在 `fe_plugins` 目录创建一个子模块用户实现创建和创建工程。其中 `doris-fe-test` 为插件名称。
 
-```bash
+```shell
 mvn archetype: generate -DarchetypeCatalog = internal -DgroupId = org.apache -DartifactId = doris-fe-test -DinteractiveMode = false
 ```
 
 这个命令会创建一个新的 maven 工程，并且自动向 `fe_plugins/pom.xml` 中添加一个子模块：
 
-```bash
+```shell
     .....
     <groupId>org.apache</groupId>
     <artifactId>doris-fe-plugins</artifactId>
@@ -135,7 +135,7 @@ mvn archetype: generate -DarchetypeCatalog = internal -DgroupId = org.apache -Da
 
 新的工程目录结构如下：
 
-```bash
+```shell
 -doris-fe-test/
 -pom.xml
 -src/

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/before-deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/before-deployment.md
@@ -172,7 +172,7 @@ Welcome to the fdbcli. For help, type `help'.
 
 以下是一个基于 8 核 CPU、32GB 内存和一块 500GB SSD 数据盘的机器的`foundationdb.conf`示例（请确保正确设置 `data` 和 `log` 的存放路径；目前，数据盘一般挂载在 `mnt` 上）：
 
-```Bash
+```shell
 # foundationdb.conf
 ##
 ## Configuration file for FoundationDB server processes
@@ -258,7 +258,7 @@ chmod -R 777 /etc/foundationdb
 
 然后重启 FoundationDB 服务：
 
-```Bash
+```shell
 # for service
 user@host$ sudo service foundationdb restart
 
@@ -309,7 +309,7 @@ chmod -R 777 /etc/foundationdb
 
 随后在本机重启 FoundationDB 服务。
 
-```Bash
+```shell
 # for service
 user@host$ sudo service foundationdb restart
 
@@ -398,7 +398,7 @@ OpenJDK 17 需安装到所有的节点上，可通过以下链接获取安装：
 
 然后，将下载好的 OpenJDK 安装包直接解压到安装路径即可：
 
-```Bash
+```shell
 tar xf openjdk-17.0.1_linux-x64_bin.tar.gz  -C /opt/
 
 # 启动 meta-service 或者 recycler 之前

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/compilation-and-deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/compilation-and-deployment.md
@@ -30,13 +30,13 @@ under the License.
 
 存算分离和存算一体模式下的编译方式相似，均使用代码库自带的 `build.sh` 脚本编译，新增的 Meta Service 模块使用参数`--cloud` 即可编出（二进制名为 `doris_cloud`）。
 
-```Bash
+```shell
 sh build.sh --fe --be --cloud 
 ```
 
 不同于存算一体模式，存算分离模式编译后，可在 `output` 目录下发现一个 `ms` 目录。
 
-```Bash
+```shell
 output
 ├── be
 ├── fe
@@ -61,7 +61,7 @@ cp -r ms re
 - `bin/start.sh --version`
 - `lib/doris_cloud --version`
 
-```Bash
+```shell
 $ lib/doris_cloud --version
 version:{doris_cloud-0.0.0-debug} code_version:{commit=b9c1d057f07dd874ad32501ff43701247179adcb time=2024-03-24 20:44:50 +0800} build_info:{initiator=gavinchou@VM-10-7-centos build_at=2024-03-24 20:44:50 +0800 build_on=NAME="TencentOS Server" VERSION="3.1 (Final)" }
 ```
@@ -85,7 +85,7 @@ fdb_cluster = xxx:yyy@127.0.0.1:4500
 
 **示例**
 
-```Bash
+```shell
 cat /etc/foundationdb/fdb.cluster
 
 DO NOT EDIT!
@@ -108,7 +108,7 @@ fdb_cluster = xxx:yyy@127.0.0.1:4500
 
 **示例**
 
-```Bash
+```shell
 cat /etc/foundationdb/fdb.cluster
 
 DO NOT EDIT!

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/creating-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/creating-cluster.md
@@ -84,7 +84,7 @@ Doris 存算分离模式采用服务发现的机制进行工作，创建存算�
 
 **示例**
 
-```Bash
+```shell
 curl -s "127.0.0.1:5000/MetaService/http/create_instance?token=greedisgood9999" -d \
 '{
   "instance_id": "sample_instance_id",
@@ -357,7 +357,7 @@ GRANT
 
 **示例**
 
-```Bash
+```shell
 grant usage_priv on storage vault my_storage_vault to user1
 ```
 
@@ -376,7 +376,7 @@ REVOKE
 
 **示例**
 
-```Bash
+```shell
 revoke usage_priv on storage vault my_storage_vault from user1
 ```
 
@@ -405,7 +405,7 @@ revoke usage_priv on storage vault my_storage_vault from user1
 
 以下为添加一个 FE 的示例：
 
-```Bash
+```shell
 # 添加 FE
 curl '127.0.0.1:5000/MetaService/http/add_cluster?token=greedisgood9999' -d '{
     "instance_id":"sample_instance_id",
@@ -467,7 +467,7 @@ curl '127.0.0.1:5000/MetaService/http/get_cluster?token=greedisgood9999' -d '{
 
 如下是创建包含 1 个 BE 的 计算集群：
 
-```Bash
+```shell
 # 172.19.0.11
 # 添加 BE
 curl '127.0.0.1:5000/MetaService/http/add_cluster?token=greedisgood9999' -d '{

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/file-cache.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/file-cache.md
@@ -66,7 +66,7 @@ Doris 支持 LRU 和 TTL 两种缓存管理策略。
 
 - `file_cache_ttl_seconds` : 新导入的数据期望在缓存中保留的时间，单位为秒。
 
-```Bash
+```shell
 CREATE TABLE IF NOT EXISTS customer (
   C_CUSTKEY     INTEGER NOT NULL,
   C_NAME        VARCHAR(25) NOT NULL,
@@ -208,7 +208,7 @@ mysql> show warm up job where id = 13418;
 
 在 LRU 缓存策略下，大表数据如果被查询访问，可能会替换掉需要常驻缓存的小表数据，造成性能波动。为了解决这个问题，用户采取 TTL 缓存策略，将两张表的 TTL 时间分别设置为 1 年和 1 天。
 
-```Bash
+```shell
 ALTER TABLE dimension_table set ("file_cache_ttl_seconds"="31536000");
 
 ALTER TABLE fact_table set ("file_cache_ttl_seconds"="86400");

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/managing-compute-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/managing-compute-cluster.md
@@ -330,7 +330,7 @@ Query OK, 0 rows affected (0.01 sec)
 USE { [catalog_name.]database_name[@cluster_name] | @cluster_name }
 ```
 
-若数据库或计算集群名称包含是保留关键字，需用反引号将相应的名称 ```` 包围。
+若数据库或计算集群名称包含是保留关键字，需用反引号将相应的名称 \``` 包围。
 
 **示例**
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/meta-service-api.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/compute-storage-decoupled/meta-service-api.md
@@ -60,7 +60,7 @@ PUT /MetaService/http/v1/create_instance?token=<token> HTTP/1.1
 
 - 创建基于 HDFS 为存储后端的请求语法
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token> HTTP/1.1
 Content-Length: <ContentLength>
 Content-Type: text/plain
@@ -140,7 +140,7 @@ Content-Type: text/plain
 
 - 创建基于对象存储为存储后端的请求语法
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token HTTP/1.1
 Content-Length: <ContentLength>
 Content-Type: text/plain
@@ -183,7 +183,7 @@ Content-Type: text/plain
 
 - 创建基于对象存储为存储后端的请求示例
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=greedisgood9999 HTTP/1.1
 Content-Length: 441
 Content-Type: text/plain
@@ -248,7 +248,7 @@ Content-Type: text/plain
 
 - 请求语法
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token HTTP/1.1
 Content-Length: <ContentLength
 Content-Type: text/plain

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/delete/batch-delete-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/delete/batch-delete-manual.md
@@ -161,19 +161,19 @@ mysql DESC test;
 
 **1. 正常导入数据：**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: APPEND"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
 其中的 APPEND 条件可以省略，与下面的语句效果相同：
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
 **2. 将与导入数据 Key 相同的数据全部删除**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
@@ -208,7 +208,7 @@ curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, ci
 
 **3. 将导入数据中与`site_id=1` 的行的 Key 列相同的行**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv" -H "merge_type: MERGE" -H "delete: siteid=1"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 
@@ -247,7 +247,7 @@ curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, ci
 
 **4. 当存在 sequence 列时，将与导入数据 Key 相同的数据全部删除**
 
-```Bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: name, gender, age" -H "function_column.sequence_col: age" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/load-atomicity.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/load-atomicity.md
@@ -188,7 +188,7 @@ Empty set (0.019 sec)
 
 **1. 在 HTTP Header 中设置 `two_phase_commit:true` 启用两阶段提交。**
 
-```Bash
+```shell
 curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt http://fe_host:http_port/api/{db}/{table}/_stream_load
 {
     "TxnId": 18036,
@@ -214,7 +214,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 可以使用事务 id 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18036" -H "txn_operation:commit" http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -224,7 +224,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 也可以使用 label 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:commit"  http://fe_host:http_port/api/{db}/{table}/_stream_load_2pc
   {
       "status": "Success",
@@ -236,7 +236,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 可以使用事务 id 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "txn_id:18037" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -246,7 +246,7 @@ curl  --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt h
 
 - 也可以使用 label 指定事务
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd  -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/load-data-convert.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/load-data-convert.md
@@ -60,7 +60,7 @@ WITH BROKER bos
 
 ### STREAM LOAD
 
-```Bash
+```shell
 curl
 --location-trusted
 -u user:passwd
@@ -96,7 +96,7 @@ Stream load 不支持前置过滤。
 
 示例：
 
-```Bash
+```shell
 curl
 --location-trusted
 -u user:passwd

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/load-json-format.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/load-json-format.md
@@ -236,7 +236,7 @@ k2 int, k1 int
 
 导入语句 1（以 Stream Load 为例）：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -254,7 +254,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", 
 
 导入语句 2：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, k1" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -270,7 +270,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", 
 
 当然，如其他导入一样，可以在 Columns 中进行列的转换操作。示例如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, tmp_k1, k1 = tmp_k1 * 100" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -294,7 +294,7 @@ k2 int, k1 int, k1_copy int
 ```
 如果你想将 json 中的某一字段多次赋予给表中几列，那么可以在 jsonPaths 中多次指定该列，并且依次指定映射顺序。示例如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\", \"$.k1\"]" -H "columns: k2,k1,k1_copy" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -324,7 +324,7 @@ k2 int, k1 int, k1_nested1 int, k1_nested2 int
 ```
 如果你想将 json 中嵌套的多级同名字段赋予给表中不同的列，那么可以在 jsonPaths 中指定该列，并且依次指定映射顺序。示例如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\",\"$.k3.k1\",\"$.k3.k1_nested.k1\" -H "columns: k2,k1,k1_nested1,k1_nested2" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -387,7 +387,7 @@ Doris 支持通过 JSON root 抽取 JSON 中指定的数据。
 
 导入语句如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -421,7 +421,7 @@ curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: tru
 
 这是因为通过导入语句中的信息，Doris 并不知道“缺失的列是表中的 k2 列”。如果要对以上数据按照期望结果导入，则导入语句如下：
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -H "jsonpaths: [\"$.k1\", \"$.k2\"]" -H "columns: k1, tmp_k2, k2 = ifnull(tmp_k2, 'x')" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -447,7 +447,7 @@ code    INT     NULL
 
    - 不指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -459,7 +459,7 @@ code    INT     NULL
 
    - 指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -477,7 +477,7 @@ code    INT     NULL
 
    - 指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\"]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -508,7 +508,7 @@ code    INT     NULL
 
    - 指定 JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
      ```
 
@@ -534,7 +534,7 @@ code    INT     NULL
 
 StreamLoad 导入：
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -551,7 +551,7 @@ curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: 
 
 数据依然是示例 3 中的多行数据，现需要对导入数据中的 `code` 列加 1 后导入。
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" -H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -577,7 +577,7 @@ curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\
 {"k1": 40, "k2": ["10000000000000000000.1111111222222222"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H ":0.01" -H "format:json" -H "timeout:300" -T test_decimal.json http://localhost:8035/api/example_db/array_test_decimal/_stream_load
 ```
 
@@ -597,7 +597,7 @@ MySQL > select * from array_test_decimal;
 {"k1": 999, "k2": ["76959836937749932879763573681792701709", "26017042825937891692910431521038521227"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_largeint.json http://localhost:8035/api/example_db/array_test_largeint/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/load-strict-mode.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/load-strict-mode.md
@@ -58,7 +58,7 @@ under the License.
 
 2. [STREAM LOAD](../../sql-manual/sql-statements/Data-Manipulation-Statements/Load/STREAM-LOAD)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "strict_mode: true" \
    -T 1.txt \
@@ -171,7 +171,7 @@ mysql> desc user_profile;
 18,9999999,2023-07-03 12:00:03
 ```
 
-```bash
+```shell
 curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:false" -H "column_separator:," -H "columns:id,balance,last_access_time" -T /tmp/test.csv http://host:port/api/db1/user_profile/_stream_load
 ```
 
@@ -179,7 +179,7 @@ curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:false
 
 而当用户使用严格模式的 Stream Load 部分列更新向表中插入上述数据时
 
-``` bash
+```shell
 curl  --location-trusted -u root -H "partial_columns:true" -H "strict_mode:true" -H "column_separator:," -H "columns:id,balance,last_access_time" -T /tmp/test.csv http://host:port/api/db1/user_profile/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/stream-load-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/stream-load-manual.md
@@ -120,7 +120,7 @@ Stream Load 需要对目标表的 INSERT 权限。如果没有 INSERT 权限，�
 
     通过 `curl` 命令可以提交 Stream Load 导入作业。
 
-    ```Bash
+    ```shell
     curl --location-trusted -u <doris_user>:<doris_password> \
         -H "Expect:100-continue" \
         -H "column_separator:," \
@@ -203,7 +203,7 @@ Stream Load 需要对目标表的 INSERT 权限。如果没有 INSERT 权限，�
 
     通过 `curl` 命令可以提交 Stream Load 导入作业。
 
-    ```Bash
+    ```shell
     curl --location-trusted -u <doris_user>:<doris_password> \
         -H "label:124" \
         -H "Expect:100-continue" \
@@ -264,7 +264,7 @@ mysql> show stream load from testdb;
 
 Stream Load 导入语法如下：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
   -H "Expect:100-continue" [-H ""...] \
   -T <file_path> \
@@ -408,7 +408,7 @@ Stream Load 是一种同步的导入方式，导入结果会通过创建导入�
 :::
 
 使用 `curl` 来使用 Stream Load 的 http stream 模式：
-```Bash
+```shell
 curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -XPUT http://fe_host:http_port/api/_http_stream
 ```
 
@@ -416,7 +416,7 @@ curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -
 
 load_sql 举例：
 
-```Bash
+```shell
 insert into db.table (col, ...) select stream_col, ... from http_stream("property1"="value1");
 ```
 
@@ -462,7 +462,7 @@ Doris 的导入任务可以容忍一部分格式错误的数据。容忍率通�
 
 通过以下命令可以指定 max_filter_ratio 容忍度为 0.4 创建 stream load 导入任务：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "max_filter_ratio:0.4" \
@@ -492,7 +492,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 将本地文件中的数据导入到表中的 p1, p2 分区，允许 20% 的错误率。
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:123" \
     -H "Expect:100-continue" \
@@ -520,7 +520,7 @@ Stream Load 是基于 HTTP 的协议进行导入，所以是支持使用程序�
 
 下面通过 `bash` 的命令管道来举例这种使用方式，这种导入的数据就是程序流式生成的，而不是本地文件。
 
-```Bash
+```shell
 seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -544,7 +544,7 @@ curl --location-trusted -u root -T test.csv  -H "label:1" -H "format:csv_with_na
 
 在 Stream Load 中有三种导入类型：APPEND、DELETE 与 MERGE。可以通过指定参数 merge_type 进行调整。如想指定将与导入数据 Key 相同的数据全部删除，可以使用以下命令：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: DELETE" \
@@ -587,7 +587,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 指定 merge_type 为 MERGE，可以将导入的数据 MERGE 到表中。MERGE 语义需要结合 DELETE 条件联合使用，表示满足 DELETE 条件的数据按照 DELETE 语义处理，其余按照 APPEND 语义添加到表中，如下面操作表示删除 siteid 为 1 的行，其余数据添加到表中：
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: MERGE" \
@@ -779,7 +779,7 @@ JSON 数据格式：
 
 导入命令：
 
-```Bash
+```shell
 curl --location-trusted -u root -T test.json -H "label:1" -H "format:json" -H 'columns: id, order_code, create_time=CURRENT_TIMESTAMP()' http://host:port/api/testDb/testTbl/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/update/unique-update-transaction.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/update/unique-update-transaction.md
@@ -108,7 +108,7 @@ sequence_type 用来指定 sequence 列的类型，可以为整型和时间类�
 
 stream load 的写法是在 header 中的`function_column.sequence_col`字段添加隐藏列对应的 source_sequence 的映射，示例
 
-```Bash
+```shell
 curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -227,7 +227,7 @@ MySQL  desc test_table;
 
 此处以 stream load 为例
 
-```Bash
+```shell
 curl --location-trusted -u root: -T testData http://host:port/api/test/test_table/_stream_load
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/db-connect/database-connect.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/db-connect/database-connect.md
@@ -33,14 +33,14 @@ Apache Doris 采用 MySQL 网络连接协议，兼容 MySQL 生态的命令行�
 
 解压下载的 MySQL 客户端，在 `bin/` 目录下可以找到 `mysql` 命令行工具。然后执行下面的命令连接 Doris。
 
-```Bash
+```shell
 # FE_IP 为 FE 的监听地址， FE_QUERY_PORT 为 FE 的 MYSQL 协议服务的端口，在 fe.conf 中对应 query_port, 默认为 9030.
 mysql -h FE_IP -P FE_QUERY_PORT -u USER_NAME 
 ```
 
 登录后，显示如下。
 
-```Bash
+```shell
 Welcome to the MySQL monitor.  Commands end with ; or \g.                                                                                                                                                                                  
 Your MySQL connection id is 236                                                                                                                                                                                                            
 Server version: 5.7.99 Doris version doris-2.0.3-rc06-37d31a5                                                                                                                                                                              

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-access-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-access-cluster.md
@@ -36,13 +36,13 @@ Doris 在 Kubernetes 上默认提供 ClusterIP 访问模式。无需进行修改
 
 在部署集群后，通过以下命令可以查看 Doris Operator 暴露的 service：
 
-```bash
+```shell
 kubectl -n doris get svc
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                               AGE
 doriscluster-sample-be-internal   ClusterIP   None          <none>        9050/TCP                              9m
 doriscluster-sample-be-service    ClusterIP   10.1.68.128   <none>        9060/TCP,8040/TCP,9050/TCP,8060/TCP   9m
@@ -59,13 +59,13 @@ doriscluster-sample-fe-service    ClusterIP   10.1.118.16   <none>        8030/T
 
 使用以下命令，可以在当前的 Kubernetes 集群中创建一个包含 mysql client 的 pod：
 
-```bash
+```shell
 kubectl run mysql-client --image=mysql:5.7 -it --rm --restart=Never --namespace=doris -- /bin/bash
 ```
 
 在集群内的容器中，可以使用对外暴露的后缀为 `service` 的服务名访问 Doris 集群：
 
-```bash
+```shell
 ## 使用 service 类型 pod name 访问 Doris 集群
 mysql -uroot -P9030 -hdoriscluster-sample-fe-service
 ```
@@ -145,13 +145,13 @@ spec:
 
 在部署集群后，通过以下命令可以查看 Doris Operator 暴露的 service：
 
-```bash
+```shell
 kubectl get service
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                                       AGE
 kubernetes                        ClusterIP   10.152.183.1     <none>        443/TCP                                                       169d
 doriscluster-sample-fe-internal   ClusterIP   None             <none>        9030/TCP                                                      2d
@@ -162,13 +162,13 @@ doriscluster-sample-be-service    NodePort    10.152.183.244   <none>        906
 
 Doris 的 Query Port 端口默认为 9030，在本地中被映射到本地端口 31545。在访问 Doris 集群时，同时需要获取到对应的 IP 地址，可以通过以下命令查看：
 
-```bash
+```shell
 kubectl get nodes -owide
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME   STATUS   ROLES           AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION          CONTAINER-RUNTIME
 r60    Ready    control-plane   14d   v1.28.2   192.168.88.60   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
 r61    Ready    <none>          14d   v1.28.2   192.168.88.61   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
@@ -178,7 +178,7 @@ r63    Ready    <none>          14d   v1.28.2   192.168.88.63   <none>        Ce
 
 在 NodePort 模式下，可以根据任何 node 节点的宿主机 IP 与端口映射访问 Kubernetes 集群内的服务。在本例中可以使用任一的 node 节点 IP，192.168.88.61、192.168.88.62、192.168.88.63 访问 Doris 服务。如在下例中使用了 node 节点 192.168.88.62 与映射出的 query port 端口 31545 访问集群：
 
-```bash
+```shell
 mysql -h 192.168.88.62 -P 31545 -uroot
 ```
 
@@ -194,7 +194,7 @@ mysql -h 192.168.88.62 -P 31545 -uroot
 
 在上例返回结果中，可以直接在同一个 Kubernetes 集群内的 Pod 中通过 curl 命令获取返回结果：
 
-```bash
+```shell
 curl http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local:8040/api/_load_error_log?file=__shard_1/error_log_insert_stmt_af474190276a2e9c-49bb9d175b8e968e_af474190276a2e9c_49bb9d175b8e968e
 ```
 
@@ -245,7 +245,7 @@ spec:
 
 按照上例中的 service 将 CR 中的 ${podName} 替换成 doriscluster-sample-be-2，将 ${ServiceType} 替换为 NodePort。通过 kubectl apply 命令，在于 doris 集群相同的 namespace 中创建 service 服务。
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -253,13 +253,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 使用以下命令查看上述部署 Service 分配的 NodePort 端口：
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
 doriscluster-detail-error         NodePort    10.152.183.35    <none>        8040:31201/TCP     32s
 ```
@@ -268,13 +268,13 @@ doriscluster-detail-error         NodePort    10.152.183.35    <none>        804
 
 获取 K8s 管控的宿主机地址：
 
-```bash
+```shell
 kubectl get node -owide
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME             STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION       CONTAINER-RUNTIME
 vm-10-8-centos   Ready    <none>   226d   v1.28.7   10.16.10.8    <none>        TencentOS Server 3.1 (Final)   5.4.119-19-0009.3    containerd://1.6.28
 vm-10-7-centos   Ready    <none>   19d    v1.28.7   10.16.10.7    <none>        TencentOS Server 3.1 (Final)   5.4.119-19.0009.25   containerd://1.6.28
@@ -301,7 +301,7 @@ http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluste
 
 上述地址的域名地址为 `doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local` 在 `Kubernetes` 上 `Doris Operator` 部署的 pod 使用的域名中，三级域名为  pod 的名称。将上述模板中 {podName} 替换为真实的 `pod` 名称，将 {serviceType} 替换为 `LoadBalancer` ，更改后保存到新建的 `stream_load_get_error.yaml` 文件中。使用如下命令部署 service：
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -309,13 +309,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 使用如下命令查看上述部署 Service 分配的  LoadBalaner 地址 EXTERNAL-IP ,以下为在 aws eks 测试实例：
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                         TYPE          CLUSTER-IP       EXTERNAL-IP                                                              PORT(S)           AGE
 doriscluster-detail-error    LoadBalancer  172.20.183.136   ac4828493dgrftb884g67wg4tb68gyut-1137856348.us-east-1.elb.amazonaws.com  8040:32003/TCP    14s
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-config-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-config-cluster.md
@@ -98,13 +98,13 @@ feSpec:
 
 其中，需要在 ${storageClassName} 指定 [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) 的名称。可以通过 以下命令查看当前 Kubernetes 集群内支持的 StorageClass：
 
-```bash
+```shell
 kubectl get sc
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                          PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
 openebs-hostpath              openebs.io/local               Delete          WaitForFirstConsumer   false                  212d
 openebs-device                openebs.io/local               Delete          WaitForFirstConsumer   false                  212d

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-doris-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-doris-cluster.md
@@ -36,13 +36,13 @@ under the License.
 
 1. 创建 namespace：
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 2. 部署 Doris 集群
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -61,7 +61,7 @@ selectdb/doris.be-ubuntu:2.0.2
 
 将镜像下载到本地后打包成 tar 文件
 
-```bash
+```shell
 ## download docker image
 docker pull selectdb/doris.fe-ubuntu:2.0.2
 docker pull selectdb/doris.be-ubuntu:2.0.2
@@ -73,7 +73,7 @@ docker save -o doris.be-ubuntu-v2.0.2.tar docker pull selectdb/doris.be-ubuntu:2
 
 将 image tar 包上传到服务器上，执行 docker load 命令：
 
-```bash
+```shell
 ## load docker image
 docker load -i doris.fe-ubuntu-v2.0.2.tar
 docker load -i doris.be-ubuntu-v2.0.2.tar
@@ -81,13 +81,13 @@ docker load -i doris.be-ubuntu-v2.0.2.tar
 
 2. 创建 namespace：
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 3. 部署 Doris 集群
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -101,13 +101,13 @@ kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 
 安装 [doriscluster](https://artifacthub.io/packages/helm/doris/doris)，使用默认配置此部署仅部署 3 个 FE 和 3 个 BE 组件，使用默认 `storageClass` 实现 PV 动态供给。
 
-```bash
+```shell
 helm install doriscluster doris-repo/doris
 ```
 
 如果需要自定义资源和集群形态，请根据 [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) 的各个资源配置的注解自定义资源配置，并执行如下命令:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-repo/doris
 ```
 
@@ -115,13 +115,13 @@ helm install -f values.yaml doriscluster doris-repo/doris
 
 通过 `kubectl get pods` 命令可以查看 pod 部署状态。当 `doriscluster` 的 Pod 处于 `Running` 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -137,7 +137,7 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 下载 `doris-{chart_version}.tgz` 安装 Doris Cluster chart。如需要下载 2.0.6 版本的 Doris 集群可以使用以下命令：
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-2.0.6.tgz
 ```
 
@@ -145,13 +145,13 @@ wget https://charts.selectdb.com/doris-2.0.6.tgz
 
 通过 `helm install` 命令可以安装 Doris 集群。
 
-```bash
+```shell
 helm install doriscluster doris-1.4.0.tgz
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-1.4.0.tgz
 ```
 
@@ -159,13 +159,13 @@ helm install -f values.yaml doriscluster doris-1.4.0.tgz
 
 通过 `kubectl get pods` 命令可以查看 pod 部署状态。当 `doriscluster` 的 Pod 处于 `Running` 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -181,13 +181,13 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 集群部署资源下发后，可以通过以下命令检查集群状态。
 
-```bash
+```shell
 kubectl get pods -n ${namespace}
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                       READY   STATUS    RESTARTS   AGE
 doriscluster-sample-fe-0   1/1     Running   0          20m
 doriscluster-sample-be-0   1/1     Running   0          19m
@@ -199,13 +199,13 @@ doriscluster-sample-be-0   1/1     Running   0          19m
 
 Doris Operator 会收集集群服务的状态显示到下发的资源中。Doris Operator 定义了 `DorisCluster` 类型资源名称的简写 `dcr`，在使用资源类型查看集群状态时可用简写替代。
 
-```bash
+```shell
 kubectl get dcr
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                  FESTATUS    BESTATUS    CNSTATUS   BROKERSTATUS
 doriscluster-sample   available   available
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-operator.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-operator.md
@@ -30,32 +30,32 @@ Doris Operator 使用自定义资源定义（Custom Resource Definition, CRD）�
 
 通过以下命令可以在 Kubernetes 环境中部署 Doris Cluster CRD：
 
-```bash
+```shell
 kubectl create -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 ```
 
 如果没有外网，先将 CRD 文件下载到本地：
 
-```bash
+```shell
 wget https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 kubectl create -f ./doris.selectdb.com_dorisclusters.yaml
 ```
 
 以下是期望输出结果：
 
-```bash
+```shell
 customresourcedefinition.apiextensions.k8s.io/dorisclusters.doris.selectdb.com created
 ```
 
 在创建了 Doris Cluster CRD 后，可以通过以下命令查看创建的 CRD。
 
-```bash
+```shell
 kubectl get crd | grep doris
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 ```
 
@@ -67,13 +67,13 @@ dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 
 使用以下命令可以在 Kubernetes 集群中部署 Doris Operator：
 
-```bash
+```shell
 kubectl apply -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/operator/operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -93,13 +93,13 @@ deployment.apps/doris-operator created
 
 在修改 operator.yaml 文件后，可以使用以下命令部署 Doris Operator 服务：
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -115,13 +115,13 @@ deployment.apps/doris-operator created
 
 如果服务器没有连通外网，需要先下载对应的 operator 镜像文件。Doris Operator 用到以下的镜像：
 
-```bash
+```shell
 selectdb/doris.k8s-operator:latest
 ```
 
 在可以连通外网的服务器中运行以下的命令，可以将镜像下载下来：
 
-```bash
+```shell
 ## download doris operator image
 docker pull selectdb/doris.k8s-operator:latest
 ## save the doris operator image as a tar package
@@ -130,7 +130,7 @@ docker save -o doris.k8s-operator-latest.tar selectdb/doris.k8s-operator:latest
 
 将已打包的 tar 文件放置到所有的 Kubernetes node 节点中，运行以下命令上传镜像：
 
-```bash
+```shell
 docker load -i doris.k8s-operator-latest.tar
 ```
 
@@ -140,7 +140,7 @@ docker load -i doris.k8s-operator-latest.tar
 
 Doris Operator 在 Kubernetes 集群中是一个无状态的 Deployment，可以根据需求修改如 `limits`、`replica`、`label`、`namespace` 等项目。如需要指定某一版本的 doirs operator 镜像，可以在上传镜像后对 operator.yaml 文件做如下修改：
 
-```bash
+```shell
 ...
 containers:
   - command:
@@ -161,13 +161,13 @@ containers:
 
 在修改 Doris Operator 模板后，可以使用 apply 命令部署 Operator：
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 以下为期望输出结果：
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -187,13 +187,13 @@ Helm Chart 是一系列描述 Kubernetes 相关资源的 YAML 文件的封装。
 
 通过 `repo add` 命令添加远程仓库
 
-```bash
+```shell
 helm repo add doris-repo https://charts.selectdb.com
 ```
 
 通过 `repo update` 命令更新最新版本的 chart
 
-```bash
+```shell
 helm repo update doris-repo
 ```
 
@@ -201,25 +201,25 @@ helm repo update doris-repo
 
 通过 `helm install` 命令可以使用默认配置在 doris 的 namespace 中安装 Doris Operator
 
-```bash
+```shell
 helm install operator doris-repo/doris-operator
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-repo/doris-operator
 ```
 
 通过 `kubectl get pods` 命令查看 Pod 的部署状态。当 Doris Operator 的 Pod 处于 Running 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -232,7 +232,7 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 下载 `doris-operator-{chart_version}.tgz` 安装 Doris Operator chart。如需要下载 1.4.0 版本的 Doris Operator 可以使用以下命令：
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 ```
 
@@ -240,25 +240,25 @@ wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 
 通过 `helm install` 命令可以安装 Doris Operator。
 
-```bash
+```shell
 helm install operator doris-operator-1.4.0.tgz
 ```
 
 如果需要自定义装配 [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values) ，可以参考如下命令:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-operator-1.4.0.tgz
 ```
 
 通过 `kubectl get pods` 命令查看 Pod 的部署状态。当 Doris Operator 的 Pod 处于 Running 状态且 Pod 内所有容器都已经就绪，即部署成功。
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -267,13 +267,13 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 当部署 Operator 服务后，可以通过以下命令查看服务状态。
 
-```bash
+```shell
 kubectl get pod -n doris
 ```
 
 返回结果如下：
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-6f47594455-p5tp7   1/1     Running   0          11s
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/k8s-deploy/install-env.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/k8s-deploy/install-env.md
@@ -39,7 +39,7 @@ under the License.
 
 在 Kubernetes 上部署 Doris 集群，建议关闭防火墙配置：
 
-```bash
+```shell
 systemctl stop firewalld
 systemctl disable firewalld
 ```
@@ -56,7 +56,7 @@ systemctl disable firewalld
 
 通过以下命令可以永久关闭 swap 分区。
 
-```bash
+```shell
 echo "vm.swappiness = 0">> /etc/sysctl.conf
 swapoff -a && swapon -a
 sysctl -p
@@ -64,7 +64,7 @@ sysctl -p
 
 ### 设置系统最大打开文件句柄数
 
-```bash
+```shell
 vi /etc/security/limits.conf 
 * soft nofile 65536
 * hard nofile 65536
@@ -74,7 +74,7 @@ vi /etc/security/limits.conf
 
 修改虚拟内存区域至少 2000000
 
-```bash
+```shell
 sysctl -w vm.max_map_count=2000000
 ```
 
@@ -82,7 +82,7 @@ sysctl -w vm.max_map_count=2000000
 
 在部署 Doris 时，建议关闭透明大页。
 
-```bash
+```shell
 echo never > /sys/kernel/mm/transparent_hugepage/enabled
 echo never > /sys/kernel/mm/transparent_hugepage/defrag
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/run-docker-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/run-docker-cluster.md
@@ -89,7 +89,7 @@ Docker Version：20.10 及以后版本
 
 3. 编写 Dockerfile
 
-```Bash
+```shell
 # 选择基础镜像
 FROM openjdk:8u342-jdk
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/standard-deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/cluster-deployment/standard-deployment.md
@@ -308,7 +308,7 @@ FE 的配置文件在 FE 部署路径下的 conf 目录中，启动 FE 节点前
 
 通过以下命令可以启动 FE 进程
 
-```Bash
+```shell
 bin/start_fe.sh --daemon
 ```
 
@@ -377,7 +377,7 @@ ALTER SYSTEM ADD OBSERVER "<fe_ip_address>:<fe_edit_log_port>"
 
 通过以下命令，可以启动 FE Follower 节点，并自动同步元数据。
 
-```Bash
+```shell
 bin/start_fe.sh --helper <helper_fe_ip>:<fe_edit_log_port> --daemon
 ```
 
@@ -605,7 +605,7 @@ Doris 作为一个分布式数据库，一般拥有众多 BE 节点，Doris 采�
 
 可以通过下面的命令来检查 Doris 是否启动成功
 
-```Bash
+```shell
 # 重试执行下面命令，如果返回"msg":"success"，则说明已经启动成功
 server1:apache-doris/fe doris$ curl http://127.0.0.1:8030/api/bootstrap
 {"msg":"success","code":0,"data":{"replayedJournalId":0,"queryPort":0,"rpcPort":0,"version":""},"count":0}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/source-install/compilation-arm.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/source-install/compilation-arm.md
@@ -62,7 +62,7 @@ import TabItem from '@theme/TabItem';
 
 **1.  创建软件下载安装包根目录和软件安装根目录**
 
-```Bash
+```shell
 # 创建软件下载安装包根目录
 mkdir /opt/tools
 
@@ -72,7 +72,7 @@ mkdir /opt/software
 
 **2.  安装依赖项**
 
-```Bash
+```shell
 ### Git ###
 # 省去编译麻烦，直接使用 yum 安装
 yum install -y git
@@ -119,7 +119,7 @@ wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz && \
 
 **3.  配置环境变量**
 
-```Bash
+```shell
 # 配置环境变量
 vim /etc/profile.d/doris.sh
 export JAVA_HOME=/opt/software/jdk8
@@ -146,13 +146,13 @@ gcc --version
 
 **1.  更新 apt-get 软件库**
 
-```Bash
+```shell
 apt-get update
 ```
 
 **2.  重新配置 shell**
 
-```Bash
+```shell
 # Ubuntu 的 shell 默认安装的是 dash，而不是 bash，要切换成 bash 才能执行，运行以下命令查看 sh 的详细信息，确认 shell 对应的程序是哪个：
 ls -al /bin/sh
 
@@ -163,7 +163,7 @@ sudo dpkg-reconfigure dash
 
 **3.  创建软件下载安装包根目录和软件安装根目录**
 
-```Bash
+```shell
 # 创建软件下载安装包根目录
 mkdir /opt/tools
 
@@ -173,7 +173,7 @@ mkdir /opt/software
 
 **4.  安装依赖项**
 
-```Bash
+```shell
 ### Git ###
 # 省去编译麻烦，直接使用 apt-get 安装
 apt-get -y install git
@@ -229,7 +229,7 @@ wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz && \
 
 **5.  配置环境变量**
 
-```Bash
+```shell
 # 配置环境变量
 vim /etc/profile.d/doris.sh
 export JAVA_HOME=/opt/software/jdk8
@@ -258,7 +258,7 @@ gcc --version
 
 在 ARM 平台编译 Doris 时，请关闭 AVX2 和 LIBUNWIND 三方库：
 
-```Bash
+```shell
 export USE_AVX2=OFF
 export USE_UNWIND=OFF
 ```
@@ -275,7 +275,7 @@ export USE_UNWIND=OFF
 
 解决方案：使用第三方库下载仓库    
 
-```Bash
+```shell
 export REPOSITORY_URL=https://doris-thirdparty-repo.bj.bcebos.com/thirdparty
 sh /opt/doris/thirdparty/build-thirdparty.sh
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/source-install/compilation-mac.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/source-install/compilation-mac.md
@@ -91,7 +91,7 @@ cd output/fe/bin
 
 可以在 [Apache Doris Third Party Prebuilt](https://github.com/apache/doris-thirdparty/releases/tag/automation) 页面直接下载预编译好的第三方库，省去编译第三方库的过程，参考下面的命令。
 
-```Bash
+```shell
 cd thirdparty
 rm -rf installed
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/source-install/compilation-with-docker.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/source-install/compilation-with-docker.md
@@ -34,7 +34,7 @@ under the License.
 
 比如在 CentOS 下，执行命令安装 Docker
 
-```Bash
+```shell
 yum install docker
 ```
 
@@ -53,7 +53,7 @@ yum install docker
 
 下面就以编译 Doris 2.0 版本作为介绍，下载并检查 Docker 镜像
 
-```Bash
+```shell
 # 可以选择 docker.io/apache/doris:build-env-for-2.0
 $ docker pull apache/doris:build-env-for-2.0
 
@@ -75,7 +75,7 @@ apache/doris    build-env-for-2.0    f29cf1979dba    3 days ago    3.3GB
 
 -   最新版本的 `apache/doris:build-env-ldb-toolchain-latest` 镜像中同时包含 JDK 8 和 JDK 17。2.1（含）之前的版本，请使用 JDK 8。3.0（含）之后的版本或 master 分支，请使用 JDK 17。
 
-```Bash
+```shell
 # 切换到 JDK 8
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0
 export PATH=$JAVA_HOME/bin/:$PATH

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/source-install/compilation-with-ldb-toolchain.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/install/source-install/compilation-with-ldb-toolchain.md
@@ -118,7 +118,7 @@ Doris 源码编译时首先会下载三方库进行编译，可以参考下文�
 
 **1.  进入 Doris 源码目录，执行如下命令查看编译机器是否支持 AVX2 指令集**
 
-```Bash
+```shell
 $ cat /proc/cpuinfo | grep avx2
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/lakehouse/database/es.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/lakehouse/database/es.md
@@ -124,7 +124,7 @@ Elasticsearch 没有明确的数组类型，但是它的某个字段可以含有
 
 该结构的数组字段可以通过使用以下命令将字段属性定义添加到目标索引映射的`_meta.doris`属性来定义。
 
-```bash
+```shell
 # ES 7.x and above
 curl -X PUT "localhost:9200/doc/_mapping?pretty" -H 'Content-Type:application/json' -d '
 {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
@@ -36,7 +36,7 @@ DROP ROLE
 
 ```sql
   DROP ROLE [IF EXISTS] role1;
-````
+```
 
 删除角色不会影响以前属于角色的用户的权限。 它仅相当于解耦来自用户的角色。 用户从角色获得的权限不会改变
 
@@ -46,7 +46,7 @@ DROP ROLE
 
 ```sql
 DROP ROLE role1;
-````
+```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
@@ -141,31 +141,31 @@ role_list 是需要赋予的角色列表，以逗号分隔，指定的角色必�
 
     ```sql
     GRANT 'role1','role2' TO 'jack'@'%';
-    ````
+    ```
 
 8. 将指定 workload group‘g1’授予用户 jack
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO 'jack'@'%';
-    ````
+    ```
 
 9. 匹配所有 workload group 授予用户 jack
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP '%' TO 'jack'@'%';
-    ````
+    ```
 
 10. 将指定 workload group‘g1’授予角色 my_role
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO ROLE 'my_role';
-    ````
+    ```
 
 11. 允许 jack 查看 db1 下 view1 的创建语句
 
     ```sql
     GRANT SHOW_VIEW_PRIV ON db1.view1 TO 'jack'@'%';
-    ````
+    ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
@@ -47,7 +47,7 @@ ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
-````
+```
 
  说明：
 
@@ -74,7 +74,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
    ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a");
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-   ````
+   ```
 
 2. 修改 BE 的查询禁用属性
    
@@ -84,7 +84,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
 
     ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_query" = "true");
-    ````   
+    ```   
 
 3. 修改 BE 的导入禁用属性
    
@@ -94,7 +94,7 @@ ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
 
     ```sql
    ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_load" = "true");
-    ````   
+    ```   
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
@@ -123,7 +123,7 @@ CREATE [GLOBAL] [AGGREGATE] [ALIAS] FUNCTION function_name
 
    ```sql
    CREATE GLOBAL ALIAS FUNCTION id_masking(INT) WITH PARAMETER(id) AS CONCAT(LEFT(id, 3), '****', RIGHT(id, 4));
-   ```` 
+   ``` 
    
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
@@ -57,7 +57,7 @@ DROP [GLOBAL] FUNCTION function_name
 
     ```sql
     DROP GLOBAL FUNCTION my_add(INT, INT)
-    ````      
+    ```      
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
@@ -46,7 +46,7 @@ SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS [FROM db]
 
     ```sql
      SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS FROM test;
-    ````
+    ```
 
 2. 查看全局的转换情况
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
@@ -38,7 +38,7 @@ SHOW DATABASES
 
 ```sql
 SHOW DATABASES [FROM catalog] [filter expr];
-````
+```
 
 说明:
 1. `SHOW DATABASES` 会展示当前所有的数据库名称.
@@ -51,45 +51,45 @@ SHOW DATABASES [FROM catalog] [filter expr];
 
    ```sql
    SHOW DATABASES;
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | test               |
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 2. 会展示`hms_catalog`中所有的数据库名称.
 
    ```sql
    SHOW DATABASES from hms_catalog;
-   ````
+   ```
 
-   ````
+   ```
   +---------------+
   | Database      |
   +---------------+
   | default       |
   | tpch          |
   +---------------+
-   ````
+   ```
 
 3. 展示当前所有经过表示式`like 'infor%'`过滤后的数据库名称.
 
    ```sql
    SHOW DATABASES like 'infor%';
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database ：查看指定数据库下的作业。 如果未指定，则使用当前数据库。
 - WHERE：您可以过滤结果列，目前仅支持以下列：
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`：作业唯一 ID。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
@@ -59,19 +59,19 @@ IndexName = rollup_name
 
     ```sql
     SHOW TABLETS FROM example_db.table_name;
-    ````
+    ```
 
 2. 列出指定partitions的所有tablets
 
     ```sql
     SHOW TABLETS FROM example_db.table_name PARTITIONS(p1, p2);
-    ````
+    ```
 
 3. 列出某个backend上状态为DECOMMISSION的tablets
 
     ```sql
     SHOW TABLETS FROM example_db.table_name WHERE state="DECOMMISSION" AND BackendId=11003;
-    ````
+    ```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
@@ -40,7 +40,7 @@ SHOW TYPECAST
 
 ```sql
 SHOW TYPE_CAST [IN|FROM db]
-````
+```
 
  Parameters
 
@@ -48,7 +48,7 @@ SHOW TYPE_CAST [IN|FROM db]
 
 ### Example
 
-````sql
+```sql
 mysql> show type_cast in testDb\G
 **************************** 1. row ******************** ******
 Origin Type: TIMEV2
@@ -61,7 +61,7 @@ Origin Type: TIMEV2
   Cast Type: TIMEV2
 
 3 rows in set (0.00 sec)
-````
+```
 
 ### Keywords
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Utility-Statements/USE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-statements/Utility-Statements/USE.md
@@ -57,7 +57,7 @@ USE <[CATALOG_NAME].DATABASE_NAME>
     ```sql
     mysql> use hms_catalog.demo;
     Database changed
-    ````
+    ```
 ### Keywords
 
     USE

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/table-design/data-partition.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/table-design/data-partition.md
@@ -201,7 +201,7 @@ PARTITION BY RANGE(col1[, col2, ...])
 
 示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(`date`)
 (
     PARTITION `p201701` VALUES [("2017-01-01"),  ("2017-02-01")),
@@ -249,7 +249,7 @@ PARTITION BY RANGE(date_col)
 
 示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(age)
 (
     FROM (1) TO (100) INTERVAL 10
@@ -263,7 +263,7 @@ PARTITION BY RANGE(`date`)
 
 4.MULTI RANGE：批量创建 RANGE 分区，定义分区的左闭右开区间。示例如下：
 
-```Bash
+```shell
 PARTITION BY RANGE(col)                                                                                                                                                                                                                
 (                                                                                                                                                                                                                                      
    FROM ("2000-11-14") TO ("2021-11-14") INTERVAL 1 YEAR,                                                                                                                                                                              
@@ -282,7 +282,7 @@ Partition 支持通过 `VALUES IN (...)` 来指定每个分区包含的枚举值
 
 举例如下：
 
-```Bash
+```shell
 PARTITION BY LIST(city)
 (
     PARTITION `p_cn` VALUES IN ("Beijing", "Shanghai", "Hong Kong"),

--- a/versioned_docs/version-1.2/admin-manual/certificate.md
+++ b/versioned_docs/version-1.2/admin-manual/certificate.md
@@ -37,7 +37,7 @@ Enabling SSL functionality in Doris requires configuring both a CA key certifica
 In addition to the Doris default certificate file, you can also generate a custom certificate file through `openssl`. Here are the steps (refer to [Creating SSL Certificates and Keys Using OpenSSL](https://dev.mysql.com/doc/refman/8.0/en/creating-ssl-files-using-openssl.html)):
 
 1. Generate the CA, server-side, and client-side keys and certificates:
-```bash
+```shell
 # Generate the CA certificate
 openssl genrsa 2048 > ca-key.pem
 openssl req -new -x509 -nodes -days 3600 \
@@ -61,12 +61,12 @@ openssl x509 -req -in client-req.pem -days 3600 \
 ```
 
 2. Verify the created certificates:
-```bash
+```shell
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
 3. Combine your key and certificate in a PKCS#12 (P12) bundle.
-```bash
+```shell
 # Package the CA key and certificate
 openssl pkcs12 -inkey ca-key.pem -in ca.pem -export -out ca_certificate.p12
 

--- a/versioned_docs/version-1.2/admin-manual/cluster-management/load-balancing.md
+++ b/versioned_docs/version-1.2/admin-manual/cluster-management/load-balancing.md
@@ -487,7 +487,7 @@ IP: 172.31.7.119
 
 ### Install dependencies
 
-```bash
+```shell
 sudo apt-get install build-essential
 sudo apt-get install libpcre3 libpcre3-dev 
 sudo apt-get install zlib1g-dev
@@ -496,7 +496,7 @@ sudo apt-get install openssl libssl-dev
 
 ### Install Nginx
 
-```bash
+```shell
 sudo wget http://nginx.org/download/nginx-1.18.0.tar.gz
 sudo tar zxvf nginx-1.18.0.tar.gz
 cd nginx-1.18.0
@@ -508,13 +508,13 @@ sudo make && make install
 
 Here is a new configuration file
 
-```bash
+```shell
 vim /usr/local/nginx/conf/default.conf
 ```
 
 Then add the following in it
 
-```bash
+```shell
 events {  
 worker_connections 1024;  
 }  
@@ -538,7 +538,7 @@ stream {
 
 Start the specified configuration file
 
-```bash
+```shell
 cd /usr/local/nginx
 /usr/local/nginx/sbin/nginx -c conf.d/default.conf
 ```

--- a/versioned_docs/version-1.2/admin-manual/privilege-ldap/ldap.md
+++ b/versioned_docs/version-1.2/admin-manual/privilege-ldap/ldap.md
@@ -82,7 +82,7 @@ Client-side LDAP authentication requires the mysql client-side explicit authenti
 
 * Set the environment variable LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN to value 1.
   For example, in a linux or max environment you can use the command:
-  ```bash
+  ```shell
   echo "export LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN=1" >> ～/.bash_profile && source ～/.bash_profile
   ```
 
@@ -118,12 +118,12 @@ For example:
 Doris account exists: jack@'172.10.1.10', password: 123456  
 LDAP user node presence attribute: uid: jack user password: abcdef  
 The jack@'172.10.1.10' account can be logged into by logging into Doris using the following command:
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
 Login will fail with the following command:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 
@@ -131,7 +131,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 
 LDAP user node presence attribute: uid: jack User password: abcdef  
 Use the following command to create a temporary user and log in to jack@'%', the temporary user has basic privileges DatabasePrivs: Select_priv, Doris will delete the temporary user after the user logs out and logs in:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
@@ -139,7 +139,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 
 Doris account exists: jack@'172.10.1.10', password: 123456  
 Login to the account using the Doris password, successfully:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 

--- a/versioned_docs/version-1.2/advanced/alter-table/schema-change.md
+++ b/versioned_docs/version-1.2/advanced/alter-table/schema-change.md
@@ -196,7 +196,7 @@ The modification statement is as follows, we will change the degree of the k3 co
 
 ```sql
 alter table example_tbl modify column k3 varchar(50) key null comment 'to 50'
-````
+```
 
 When done, the Schema becomes:
 
@@ -215,7 +215,7 @@ Because the Schema Chanage job is an asynchronous operation, only one Schema cha
 
 ```sql
 SHOW ALTER TABLE COLUMN\G;
-````
+```
 
 ## Notice
 

--- a/versioned_docs/version-1.2/advanced/best-practice/debug-log.md
+++ b/versioned_docs/version-1.2/advanced/best-practice/debug-log.md
@@ -41,7 +41,7 @@ The Debug level log of FE can be turned on by modifying the configuration file, 
 
    Add the configuration item `sys_log_verbose_modules` to fe.conf. An example is as follows:
 
-   ````text
+   ```text
    # Only enable Debug log for class org.apache.doris.catalog.Catalog
    sys_log_verbose_modules=org.apache.doris.catalog.Catalog
    
@@ -50,7 +50,7 @@ The Debug level log of FE can be turned on by modifying the configuration file, 
    
    # Enable Debug logs for all classes under package org
    sys_log_verbose_modules=org
-   ````
+   ```
 
    Add configuration items and restart the FE node to take effect.
 
@@ -72,13 +72,13 @@ The Debug level log of FE can be turned on by modifying the configuration file, 
 
    The log level can also be modified at runtime via the following API. There is no need to restart the FE node.
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?add_verbose=org.apache.doris.catalog.Catalog
-   ````
+   ```
 
    The username and password are the root or admin users who log in to Doris. The `add_verbose` parameter specifies the package or class name to enable Debug logging. Returns if successful:
 
-   ````json
+   ```json
    {
        "msg": "success",
        "code": 0,
@@ -91,13 +91,13 @@ The Debug level log of FE can be turned on by modifying the configuration file, 
        },
        "count": 0
    }
-   ````
+   ```
 
    Debug logging can also be turned off via the following API:
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?del_verbose=org.apache.doris.catalog.Catalog
-   ````
+   ```
 
    The `del_verbose` parameter specifies the package or class name for which to turn off Debug logging.
 
@@ -105,16 +105,16 @@ The Debug level log of FE can be turned on by modifying the configuration file, 
 
 BE's Debug log currently only supports modifying and restarting the BE node through the configuration file to take effect.
 
-````text
+```text
 sys_log_verbose_modules=plan_fragment_executor,olap_scan_node
 sys_log_verbose_level=3
-````
+```
 
 `sys_log_verbose_modules` specifies the file name to be opened, which can be specified by the wildcard *. for example:
 
-````text
+```text
 sys_log_verbose_modules=*
-````
+```
 
 Indicates that all DEBUG logs are enabled.
 

--- a/versioned_docs/version-1.2/advanced/best-practice/import-analysis.md
+++ b/versioned_docs/version-1.2/advanced/best-practice/import-analysis.md
@@ -45,7 +45,7 @@ The execution process of a [Broker Load](../../data-operate/import/import-way/br
 ┌────────────────┐
 │BrokerScanNode│
 └────────────────┘
-````
+```
 
 BrokerScanNode is mainly responsible for reading the source data and sending it to OlapTableSink, and OlapTableSink is responsible for sending data to the corresponding node according to the partition and bucketing rules, and the corresponding node is responsible for the actual data writing.
 
@@ -59,7 +59,7 @@ The user can open the session variable `is_report_success` with the following co
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Then submit a Broker Load import request and wait until the import execution completes. Doris will generate a Profile for this import. Profile contains the execution details of importing each subtask and Instance, which helps us analyze import bottlenecks.
 
@@ -105,7 +105,7 @@ WaitAndFetchResultTime: NULL
        FetchResultTime: 0ns
        WriteResultTime: 0ns
 WaitAndFetchResultTime: N/A
-````
+```
 
 This command will list all currently saved import profiles. Each line corresponds to one import. where the QueryId column is the ID of the import job. This ID can also be viewed through the SHOW LOAD statement. We can select the QueryId corresponding to the Profile we want to see to see the specific situation.
 
@@ -124,7 +124,7 @@ This command will list all currently saved import profiles. Each line correspond
    +-----------------------------------+------------+
    | 980014623046410a-af5d36f23381017f | 3m14s      |
    +-----------------------------------+------------+
-   ````
+   ```
 
 As shown in the figure above, it means that the import job `980014623046410a-af5d36f23381017f` has a total of one subtask, in which ActiveTime indicates the execution time of the longest instance in this subtask.
 
@@ -144,7 +144,7 @@ As shown in the figure above, it means that the import job `980014623046410a-af5
    | 980014623046410a-88e260f0c43031f4 | 10.81.85.89:9067 | 3m10s      |
    | 980014623046410a-88e260f0c43031f5 | 10.81.85.89:9067 | 3m14s      |
    +-----------------------------------+------------------+------------+
-   ````
+   ```
 
 This shows the time-consuming of four instances of the subtask 980014623046410a-af5d36f23381017f, and also shows the execution node where the instance is located.
 
@@ -195,7 +195,7 @@ This shows the time-consuming of four instances of the subtask 980014623046410a-
    │ - TotalReadThroughput: 30.39858627319336 MB/sec│
    │ - WaitScannerTime: 56s528ms │
    └------------------------------------------------- ----┘
-   ````
+   ```
 
 The figure above shows the specific profiles of each operator of Instance 980014623046410a-af5d36f23381017f in subtask 980014623046410a-88e260f0c43031f5.
 

--- a/versioned_docs/version-1.2/advanced/best-practice/query-analysis.md
+++ b/versioned_docs/version-1.2/advanced/best-practice/query-analysis.md
@@ -37,7 +37,7 @@ For example, if the user specifies a Join operator, the query planner needs to d
 
 Doris' query planning process is to first convert an SQL statement into a single-machine execution plan tree.
 
-````text
+```text
      ┌────┐
      │Sort│
      └────┘
@@ -53,11 +53,11 @@ Doris' query planning process is to first convert an SQL statement into a single
 ┌──────┐ ┌──────┐
 │Scan-1│ │Scan-2│
 └──────┘ └──────┘
-````
+```
 
 After that, the query planner will convert the single-machine query plan into a distributed query plan according to the specific operator execution mode and the specific distribution of data. The distributed query plan is composed of multiple fragments, each fragment is responsible for a part of the query plan, and the data is transmitted between the fragments through the ExchangeNode operator.
 
-````text
+```text
         ┌────┐
         │Sort│
         │F1 │
@@ -87,7 +87,7 @@ After that, the query planner will convert the single-machine query plan into a 
             │Scan-2│
             │F2 │
             └──────┘
-````
+```
 
 As shown above, we divided the stand-alone plan into two Fragments: F1 and F2. Data is transmitted between two Fragments through an ExchangeNode.
 
@@ -467,7 +467,7 @@ The user can open the session variable `is_report_success` with the following co
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Then execute the query, and Doris will generate a Profile of the query. Profile contains the specific execution of a query for each node, which helps us analyze query bottlenecks.
 
@@ -485,7 +485,7 @@ mysql> show query profile "/"\G
    EndTime: 2021-04-08 11:30:50
  TotalTime: 9ms
 QueryState: EOF
-````
+```
 
 This command will list all currently saved profiles. Each row corresponds to a query. We can select the QueryId corresponding to the Profile we want to see to see the specific situation.
 
@@ -664,7 +664,7 @@ This shows the execution nodes and time consumption of all three Instances on Fr
    │ - RowsReturnedRate: 0 │
    │ - SendersBlockedTotalTimer(*): 0ns │
    └────────────────────────────────────────────────────┘
-   ````
+   ```
 
    The above figure shows the specific profiles of each operator of Instance c257c52f93e149ee-ace8ac14e8c9ff03 in Fragment 1.
 

--- a/versioned_docs/version-1.2/advanced/variables.md
+++ b/versioned_docs/version-1.2/advanced/variables.md
@@ -582,19 +582,19 @@ Translated with www.DeepL.com/Translator (free version)
 
 	Default password expiration time. The default value is 0, which means no expiration. The unit is days. This parameter is only enabled if the user's password expiration property has a value of DEFAULT. like:
 
-   ````
+   ```
    CREATE USER user1 IDENTIFIED BY "12345" PASSWORD_EXPIRE DEFAULT;
    ALTER USER user1 PASSWORD_EXPIRE DEFAULT;
-   ````
+   ```
 
 * `password_history`
 
 	The default number of historical passwords. The default value is 0, which means no limit. This parameter is enabled only when the user's password history attribute is the DEFAULT value. like:
 
-   ````
+   ```
    CREATE USER user1 IDENTIFIED BY "12345" PASSWORD_HISTORY DEFAULT;
    ALTER USER user1 PASSWORD_HISTORY DEFAULT;
-   ````
+   ```
 
 * `validate_password_policy`
 

--- a/versioned_docs/version-1.2/data-operate/export/export-manual.md
+++ b/versioned_docs/version-1.2/data-operate/export/export-manual.md
@@ -204,7 +204,7 @@ After submitting a job, the job can be canceled by using the  [CANCEL EXPORT](..
 CANCEL EXPORT
 FROM example_db
 WHERE LABEL like "%example%";
-````
+```
 
 ## Best Practices
 

--- a/versioned_docs/version-1.2/data-operate/import/import-scenes/external-table-load.md
+++ b/versioned_docs/version-1.2/data-operate/import/import-scenes/external-table-load.md
@@ -62,7 +62,7 @@ Here is just an example of how to use it.
        "odbc_type" = "oracle",
        "driver" = "Oracle"
    );
-   ````
+   ```
 
 Here we have created a Resource named `oracle_test_odbc`, whose type is `odbc_catalog`, indicating that this is a Resource used to store ODBC information. `odbc_type` is `oracle`, indicating that this OBDC Resource is used to connect to the Oracle database. For other types of resources, see the [resource management](../../../advanced/resource.md) documentation for details.
 
@@ -82,7 +82,7 @@ PROPERTIES (
     "database" = "oracle",
     "table" = "baseall"
 );
-````
+```
 
 Here we create an `ext_oracle_demo` external table and reference the `oracle_test_odbc` Resource created earlier
 
@@ -105,7 +105,7 @@ Here we create an `ext_oracle_demo` external table and reference the `oracle_tes
    PROPERTIES (
        "replication_num" = "1"
    );
-   ````
+   ```
 
    For detailed instructions on creating Doris tables, see [CREATE-TABLE](../../../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE.md) syntax help.
 
@@ -113,7 +113,7 @@ Here we create an `ext_oracle_demo` external table and reference the `oracle_tes
 
    ```sql
    INSERT INTO doris_oralce_tbl SELECT k1,k2,k3 FROM ext_oracle_demo limit 200
-   ````
+   ```
    
    The INSERT command is a synchronous command, and a successful return indicates that the import was successful.
 

--- a/versioned_docs/version-1.2/data-operate/import/import-scenes/jdbc-load.md
+++ b/versioned_docs/version-1.2/data-operate/import/import-scenes/jdbc-load.md
@@ -33,7 +33,7 @@ The INSERT statement is used in a similar way to the INSERT statement used in da
 ```sql
 * INSERT INTO table SELECT ...
 * INSERT INTO table VALUES(...)
-````
+```
 
 Here we only introduce the second way. For a detailed description of the INSERT command, see the [INSERT](../../../sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/INSERT.md) command documentation.
 
@@ -43,7 +43,7 @@ Single write means that the user directly executes an INSERT command. An example
 
 ```sql
 INSERT INTO example_tbl (col1, col2, col3) VALUES (1000, "test", 3.25);
-````
+```
 
 For Doris, an INSERT command is a complete import transaction.
 
@@ -58,7 +58,7 @@ INSERT INTO example_tbl VALUES
 (1000, "baidu1", 3.25)
 (2000, "baidu2", 4.25)
 (3000, "baidu3", 5.25);
-````
+```
 
 We recommend that the number of inserts in a batch be as large as possible, such as thousands or even 10,000 at a time. Or you can use PreparedStatement to perform batch inserts through the following procedure.
 
@@ -66,7 +66,7 @@ We recommend that the number of inserts in a batch be as large as possible, such
 
 Here we give a simple JDBC batch INSERT code example:
 
-````java
+```java
 package demo.doris;
 
 import java.sql.Connection;
@@ -131,7 +131,7 @@ public class DorisJDBCDemo {
         }
     }
 }
-````
+```
 
 Please note the following:
 
@@ -146,7 +146,7 @@ Please note the following:
    (1000, "baidu1", 3.25)
    (2000, "baidu2", 4.25)
    (3000, "baidu3", 5.25);
-   ````
+   ```
 
 2. Batch size
 

--- a/versioned_docs/version-1.2/data-operate/import/import-scenes/kafka-load.md
+++ b/versioned_docs/version-1.2/data-operate/import/import-scenes/kafka-load.md
@@ -56,7 +56,7 @@ Accessing an SSL-authenticated Kafka cluster requires the user to provide a cert
   CREATE FILE "ca.pem" PROPERTIES("url" = "https://example_url/kafka-key/ca.pem", "catalog" = "kafka");
   CREATE FILE "client.key" PROPERTIES("url" = "https://example_urlkafka-key/client.key", "catalog" = "kafka");
   CREATE FILE "client.pem" PROPERTIES("url" = "https://example_url/kafka-key/client.pem", "catalog" = "kafka");
-  ````
+  ```
 
 After the upload is complete, you can view the uploaded files through the [SHOW FILES](../../../sql-manual/sql-reference/Show-Statements/SHOW-FILE.md) command.
 
@@ -83,7 +83,7 @@ For specific commands to create routine import tasks, see [ROUTINE LOAD](../../.
        "property.client.id" = "xxx",
        "property.kafka_default_offsets" = "OFFSET_BEGINNING"
    );
-   ````
+   ```
 
    - `max_batch_interval/max_batch_rows/max_batch_size` is used to control the running period of a subtask. The running period of a subtask is determined by the longest running time, the maximum number of rows consumed, and the maximum amount of data consumed.
 
@@ -108,7 +108,7 @@ For specific commands to create routine import tasks, see [ROUTINE LOAD](../../.
       "property.ssl.key.location" = "FILE:client.key",
       "property.ssl.key.password" = "abcdefg"
    );
-   ````
+   ```
 
 ### View import job status
 

--- a/versioned_docs/version-1.2/data-operate/import/import-scenes/load-data-convert.md
+++ b/versioned_docs/version-1.2/data-operate/import/import-scenes/load-data-convert.md
@@ -46,11 +46,11 @@ under the License.
   (
       ...
   );
-  ````
+  ```
 
 - [STREAM LOAD](../../../sql-manual/sql-reference/Data-Manipulation-Statements/Load/STREAM-LOAD.md)
 
-  ```bash
+  ```shell
   curl
   --location-trusted
   -u user:passwd
@@ -58,7 +58,7 @@ under the License.
   -H "where: k1 > k2"
   -T file.txt
   http://host:port/api/testDb/testTbl/_stream_load
-  ````
+  ```
 
 - [ROUTINE LOAD](../../../sql-manual/sql-reference/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md)
 
@@ -68,33 +68,33 @@ under the License.
   PRECEDING FILTER k1 = 1,
   WHERE k1 > k2
   ...
-  ````
+  ```
 
 The above import methods all support column mapping, transformation and filtering operations on the source data:
 
 - Pre-filtering: filter the read raw data once.
 
-  ````text
+  ```text
   PRECEDING FILTER k1 = 1
-  ````
+  ```
 
 - Mapping: Define the columns in the source data. If the defined column name is the same as the column in the table, it is directly mapped to the column in the table. If different, the defined column can be used for subsequent transformation operations. As in the example above:
 
-  ````text
+  ```text
   (k1, k2, tmpk3)
-  ````
+  ```
 
 - Conversion: Convert the mapped columns in the first step, you can use built-in expressions, functions, and custom functions for conversion, and remap them to the corresponding columns in the table. As in the example above:
 
-  ````text
+  ```text
   k3 = tmpk3 + 1
-  ````
+  ```
 
 - Post filtering: Filter the mapped and transformed columns by expressions. Filtered data rows are not imported into the system. As in the example above:
 
-  ````text
+  ```text
   WHERE k1 > k2
-  ````
+  ```
 
 ## column mapping
 
@@ -115,34 +115,34 @@ Assuming that the source file has 4 columns, the contents are as follows (the he
 
    Suppose there are 4 columns `k1,k2,k3,k4` in the table. The import mapping relationship we want is as follows:
 
-   ````text
+   ```text
    column 1 -> k1
    column 2 -> k3
    column 3 -> k2
    column 4 -> k4
-   ````
+   ```
 
    Then the column mapping should be written in the following order:
 
-   ````text
+   ```text
    (k1, k3, k2, k4)
-   ````
+   ```
 
 2. There are more columns in the source file than in the table
 
    Suppose there are 3 columns `k1,k2,k3` in the table. The import mapping relationship we want is as follows:
 
-   ````text
+   ```text
    column 1 -> k1
    column 2 -> k3
    column 3 -> k2
-   ````
+   ```
 
    Then the column mapping should be written in the following order:
 
-   ````text
+   ```text
    (k1, k3, k2, tmpk4)
-   ````
+   ```
 
    where `tmpk4` is a custom column name that does not exist in the table. Doris ignores this non-existing column name.
 
@@ -150,19 +150,19 @@ Assuming that the source file has 4 columns, the contents are as follows (the he
 
    Suppose there are 5 columns `k1,k2,k3,k4,k5` in the table. The import mapping relationship we want is as follows:
 
-   ````text
+   ```text
    column 1 -> k1
    column 2 -> k3
    column 3 -> k2
-   ````
+   ```
 
    Here we only use the first 3 columns from the source file. The two columns `k4,k5` want to be filled with default values.
 
    Then the column mapping should be written in the following order:
 
-   ````text
+   ```text
    (k1, k3, k2)
-   ````
+   ```
 
    If the `k4,k5` columns have default values, the default values will be populated. Otherwise, if it is a `nullable` column, it will be populated with a `null` value. Otherwise, the import job will report an error.
 
@@ -201,18 +201,18 @@ Assuming that the source file has 4 columns, the contents are as follows (the he
 
    Suppose there are 4 columns `k1,k2,k3,k4` in the table. Our desired import mapping and transformation relationship is as follows:
 
-   ````text
+   ```text
    column 1 -> k1
    column 2 * 100 -> k3
    column 3 -> k2
    column 4 -> k4
-   ````
+   ```
 
    Then the column mapping should be written in the following order:
 
-   ````text
+   ```text
    (k1, tmpk3, k2, k4, k3 = tmpk3 * 100)
-   ````
+   ```
 
    This is equivalent to us naming the second column in the source file `tmpk3`, and specifying that the value of the `k3` column in the table is `tmpk3 * 100`. The data in the final table is as follows:
 
@@ -227,18 +227,18 @@ Assuming that the source file has 4 columns, the contents are as follows (the he
 
    Suppose there are 4 columns `k1,k2,k3,k4` in the table. We hope that `beijing, shanghai, guangzhou, chongqing` in the source data are converted to the corresponding region ids and imported:
 
-   ````text
+   ```text
    column 1 -> k1
    column 2 -> k2
    Column 3 after region id conversion -> k3
    column 4 -> k4
-   ````
+   ```
 
    Then the column mapping should be written in the following order:
 
-   ````text
+   ```text
    (k1, k2, tmpk3, k4, k3 = case tmpk3 when "beijing" then 1 when "shanghai" then 2 when "guangzhou" then 3 when "chongqing" then 4 else null end)
-   ````
+   ```
 
    The data in the final table is as follows:
 
@@ -253,18 +253,18 @@ Assuming that the source file has 4 columns, the contents are as follows (the he
 
    Suppose there are 4 columns `k1,k2,k3,k4` in the table. While converting the region id, we also want to convert the null value of the k1 column in the source data to 0 and import:
 
-   ````text
+   ```text
    Column 1 is converted to 0 if it is null -> k1
    column 2 -> k2
    column 3 -> k3
    column 4 -> k4
-   ````
+   ```
 
    Then the column mapping should be written in the following order:
 
-   ````text
+   ```text
    (tmpk1, k2, tmpk3, k4, k1 = ifnull(tmpk1, 0), k3 = case tmpk3 when "beijing" then 1 when "shanghai" then 2 when "guangzhou" then 3 when "chongqing" then 4 else null end)
-   ````
+   ```
 
    The data in the final table is as follows:
 
@@ -292,9 +292,9 @@ Assuming that the source file has 4 columns, the contents are as follows (the he
 
    Suppose there are 4 columns `k1,k2,k3,k4` in the table. We can define filter conditions directly with default column mapping and transformation. If we want to import only the data rows whose fourth column in the source file is greater than 1.2, the filter conditions are as follows:
 
-   ````text
+   ```text
    where k4 > 1.2
-   ````
+   ```
 
    The data in the final table is as follows:
 
@@ -309,10 +309,10 @@ Assuming that the source file has 4 columns, the contents are as follows (the he
 
    Suppose there are 4 columns `k1,k2,k3,k4` in the table. In the **column conversion** example, we converted province names to ids. Here we want to filter out the data with id 3. Then the conversion and filter conditions are as follows:
 
-   ````text
+   ```text
    (k1, k2, tmpk3, k4, k3 = case tmpk3 when "beijing" then 1 when "shanghai" then 2 when "guangzhou" then 3 when "chongqing" then 4 else null end)
    where k3 != 3
-   ````
+   ```
 
    The data in the final table is as follows:
 
@@ -328,9 +328,9 @@ Assuming that the source file has 4 columns, the contents are as follows (the he
 
    Suppose there are 4 columns `k1,k2,k3,k4` in the table. We want to filter out the data whose `k1` column is `null`, and at the same time filter out the data whose `k4` column is less than 1.2, the filter conditions are as follows:
 
-   ````text
+   ```text
    where k1 is not null and k4 >= 1.2
-   ````
+   ```
 
    The data in the final table is as follows:
 
@@ -359,8 +359,8 @@ Doris's import task allows the user to set a maximum error rate (`max_filter_rat
 
 The error rate is calculated as:
 
-````text
+```text
 #Filtered Rows / (#Filtered Rows + #Loaded Rows)
-````
+```
 
 That is to say, `Unselected Rows` will not participate in the calculation of the error rate.

--- a/versioned_docs/version-1.2/data-operate/import/import-scenes/load-strict-mode.md
+++ b/versioned_docs/version-1.2/data-operate/import/import-scenes/load-strict-mode.md
@@ -55,16 +55,16 @@ Different import methods set strict mode in different ways.
    (
        "strict_mode" = "true"
    )
-   ````
+   ```
 
 2. [STREAM LOAD](../../../sql-manual/sql-reference/Data-Manipulation-Statements/Load/STREAM-LOAD.md)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "strict_mode: true" \
    -T 1.txt \
    http://host:port/api/example_db/my_table/_stream_load
-   ````
+   ```
 
 3. [ROUTINE LOAD](../../../sql-manual/sql-reference/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md)
 
@@ -79,7 +79,7 @@ Different import methods set strict mode in different ways.
        "kafka_broker_list" = "broker1:9092,broker2:9092,broker3:9092",
        "kafka_topic" = "my_topic"
    );
-   ````
+   ```
 
 4. [INSERT](../../../sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/INSERT.md)
 
@@ -88,7 +88,7 @@ Different import methods set strict mode in different ways.
    ```sql
    SET enable_insert_strict = true;
    INSERT INTO my_table ...;
-   ````
+   ```
 
 ## The role of strict mode
 

--- a/versioned_docs/version-1.2/data-operate/import/import-scenes/local-file-load.md
+++ b/versioned_docs/version-1.2/data-operate/import/import-scenes/local-file-load.md
@@ -49,9 +49,9 @@ At the end of the document, we give a code example of importing data using Java
 
 The request body of Stream Load is as follows:
 
-````text
+```text
 PUT /api/{db}/{table}/_stream_load
-````
+```
 
 1. Create a table
 
@@ -66,15 +66,15 @@ PUT /api/{db}/{table}/_stream_load
    )
    unique key(id)
    DISTRIBUTED BY HASH(id) BUCKETS 3;
-   ````
+   ```
 
 2. Import data
 
    Execute the following curl command to import the local file:
 
-   ````text
+   ```text
     curl -u user:passwd -H "label:load_local_file_test" -T /path/to/local/demo.txt http://host:port/api/demo/load_local_file_test/_stream_load
-   ````
+   ```
 
    - user:passwd is the user created in Doris. The initial user is admin/root, and the password is blank in the initial state.
    - host:port is the HTTP protocol port of BE, the default is 8040, which can be viewed on the Doris cluster WEB UI page.
@@ -86,7 +86,7 @@ PUT /api/{db}/{table}/_stream_load
 
    The Stream Load command is a synchronous command, and a successful return indicates that the import is successful. If the imported data is large, a longer waiting time may be required. Examples are as follows:
 
-   ````json
+   ```json
    {
        "TxnId": 1003,
        "Label": "load_local_file_test",
@@ -105,7 +105,7 @@ PUT /api/{db}/{table}/_stream_load
        "CommitAndPublishTimeMs": 106,
        "ErrorURL": "http://192.168.1.1:8042/api/_load_error_log?file=__shard_0/error_log_insert_stmt_db18266d4d9b4ee5-abb00ddd64bdf005_db18266d4d9b4ee5_abb00ddd64bdf005"
    }
-   ````
+   ```
 
    - The status of the `Status` field is `Success`, which means the import is successful.
    - For details of other fields, please refer to the [Stream Load](../../../sql-manual/sql-reference/Data-Manipulation-Statements/Load/STREAM-LOAD.md) command documentation.
@@ -119,7 +119,7 @@ PUT /api/{db}/{table}/_stream_load
 
 Here is a simple JAVA example to execute Stream Load:
 
-````java
+```java
 package demo.doris;
 
 import org.apache.commons.codec.binary.Base64;
@@ -212,7 +212,7 @@ public class DorisStreamLoader {
         loader.load(file);
     }
 }
-````
+```
 
 > Note: The version of http client here is 4.5.13
 > ```xml

--- a/versioned_docs/version-1.2/data-operate/import/import-way/broker-load-manual.md
+++ b/versioned_docs/version-1.2/data-operate/import/import-way/broker-load-manual.md
@@ -103,17 +103,17 @@ CREATE TABLE `ods_demo_detail`(
 PARTITIONED BY (day string)
 row format delimited fields terminated by ','
 lines terminated by '\n'
-````
+```
 
 Then use Hive's Load command to import your data into the Hive table
 
-````
+```
 load data local inpath '/opt/custorm' into table ods_demo_detail;
-````
+```
 
 2. Create a Doris table, refer to the specific table syntax: [CREATE TABLE](../../../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE.md)
 
-````
+```
 CREATE TABLE `doris_ods_test_detail` (
   `rq` date NULL,
   `id` varchar(32) NOT NULL,
@@ -145,7 +145,7 @@ PROPERTIES (
 "in_memory" = "false",
 "storage_format" = "V2"
 );
-````
+```
 
 3. Start importing data
 
@@ -172,7 +172,7 @@ PROPERTIES
     "timeout"="1200",
     "max_filter_ratio"="0.1"
 );
-````
+```
 
 ### Hive partition table import (ORC format)
 1. Create Hive partition table, ORC format
@@ -197,7 +197,7 @@ PARTITIONED BY (day string)
 row format delimited fields terminated by ','
 lines terminated by '\n'
 STORED AS ORC
-````
+```
 
 2. Create a Doris table. The table creation statement here is the same as the Doris table creation statement above. Please refer to the above .
 
@@ -225,7 +225,7 @@ STORED AS ORC
        "timeout"="1200",
        "max_filter_ratio"="0.1"
    );
-   ````
+   ```
 
    **Notice:**
 
@@ -254,7 +254,7 @@ LOAD LABEL demo.label_20220402
             "timeout"="1200",
             "max_filter_ratio"="0.1"
         );
-````
+```
 
 The specific parameters here can refer to: [Broker](../../../advanced/broker.md) and [Broker Load](../../../sql-manual/sql-reference-v2 /Data-Manipulation-Statements/Load/BROKER-LOAD.md) documentation
 
@@ -283,7 +283,7 @@ LoadFinishTime: 2022-04-01 18:59:11
            URL: NULL
     JobDetails: {"Unfinished backends":{"5072bde59b74b65-8d2c0ee5b029adc0":[]},"ScannedRows":27,"TaskNumber":1,"All backends":{"5072bde59b74b65-8d2c0ee5b029adc0":[36728051]},"FileNumber ":1,"FileSize":5540}
 1 row in set (0.01 sec)
-````
+```
 
 ## Cancel import
 
@@ -293,7 +293,7 @@ For example: cancel the import job with the label broker_load_2022_03_23 on the 
 
 ```sql
 CANCEL LOAD FROM demo WHERE LABEL = "broker_load_2022_03_23";
-````
+```
 ## Relevant system configuration
 
 ### Broker parameters
@@ -308,20 +308,20 @@ The following configurations belong to the system-level configuration of Broker 
 
   The first two configurations limit the minimum and maximum amount of data processed by a single BE. The third configuration limits the maximum number of concurrent imports for a job. The minimum amount of data processed, the maximum number of concurrency, the size of the source file and the number of BEs in the current cluster ** together determine the number of concurrent imports**.
 
-  ````text
+  ```text
   The number of concurrent imports this time = Math.min (source file size/minimum processing capacity, maximum concurrent number, current number of BE nodes)
   The processing volume of a single BE imported this time = the size of the source file / the number of concurrent imports this time
-  ````
+  ```
 
   Usually the maximum amount of data supported by an import job is `max_bytes_per_broker_scanner * number of BE nodes`. If you need to import a larger amount of data, you need to adjust the size of the `max_bytes_per_broker_scanner` parameter appropriately.
 
   default allocation:
 
-  ````text
+  ```text
   Parameter name: min_bytes_per_broker_scanner, the default is 64MB, the unit is bytes.
   Parameter name: max_broker_concurrency, default 10.
   Parameter name: max_bytes_per_broker_scanner, the default is 3G, the unit is bytes.
-  ````
+  ```
 
 ## Best Practices
 
@@ -343,7 +343,7 @@ Only the case of a single BE is discussed here. If the user cluster has multiple
 
   1. Modify the maximum scan amount and maximum concurrent number of a single BE according to the current number of BEs and the size of the original file.
 
-     ````text
+     ```text
      Modify the configuration in fe.conf
      max_broker_concurrency = number of BEs
      The amount of data processed by a single BE of the current import task = original file size / max_broker_concurrency
@@ -352,7 +352,7 @@ Only the case of a single BE is discussed here. If the user cluster has multiple
      For example, for a 100G file, the number of BEs in the cluster is 10
      max_broker_concurrency = 10
      max_bytes_per_broker_scanner >= 10G = 100G / 10
-     ````
+     ```
 
      After modification, all BEs will process the import task concurrently, each BE processing part of the original file.
 
@@ -360,12 +360,12 @@ Only the case of a single BE is discussed here. If the user cluster has multiple
 
   2. Customize the timeout time of the current import task when creating an import
 
-     ````text
+     ```text
      The amount of data processed by a single BE of the current import task / the slowest import speed of the user Doris cluster (MB/s) >= the timeout time of the current import task >= the amount of data processed by a single BE of the current import task / 10M/s
      
      For example, for a 100G file, the number of BEs in the cluster is 10
      timeout >= 1000s = 10G / 10M/s
-     ````
+     ```
 
   3. When the user finds that the timeout time calculated in the second step exceeds the default import timeout time of 4 hours
 
@@ -373,13 +373,13 @@ Only the case of a single BE is discussed here. If the user cluster has multiple
 
      The expected maximum import file data volume of the Doris cluster can be calculated by the following formula:
 
-     ````text
+     ```text
      Expected maximum import file data volume = 14400s * 10M/s * number of BEs
      For example: the number of BEs in the cluster is 10
      Expected maximum import file data volume = 14400s * 10M/s * 10 = 1440000M ≈ 1440G
      
      Note: The average user's environment may not reach the speed of 10M/s, so it is recommended that files over 500G be divided and imported.
-     ````
+     ```
 
 ### Job scheduling
 
@@ -421,14 +421,14 @@ Currently the Profile can only be viewed after the job has been successfully exe
 
   If it is data in PARQUET or ORC format, the column name of the file header needs to be consistent with the column name in the doris table, such as:
 
-  ````text
+  ```text
   (tmp_c1,tmp_c2)
   SET
   (
       id=tmp_c2,
       name=tmp_c1
   )
-  ````
+  ```
 
   Represents getting the column with (tmp_c1, tmp_c2) as the column name in parquet or orc, which is mapped to the (id, name) column in the doris table. If set is not set, the column in column is used as the map.
 

--- a/versioned_docs/version-1.2/data-operate/import/import-way/load-json-format.md
+++ b/versioned_docs/version-1.2/data-operate/import/import-way/load-json-format.md
@@ -46,21 +46,21 @@ Currently only the following two JSON formats are supported:
 
    JSON format with Array as root node. Each element in the Array represents a row of data to be imported, usually an Object. An example is as follows:
 
-   ````json
+   ```json
    [
        { "id": 123, "city" : "beijing"},
        { "id": 456, "city" : "shanghai"},
        ...
    ]
-   ````
+   ```
 
-   ````json
+   ```json
    [
        { "id": 123, "city" : { "name" : "beijing", "region" : "haidian"}},
        { "id": 456, "city" : { "name" : "beijing", "region" : "chaoyang"}},
        ...
    ]
-   ````
+   ```
 
    This method is typically used for Stream Load import methods to represent multiple rows of data in a batch of imported data.
 
@@ -69,13 +69,13 @@ Currently only the following two JSON formats are supported:
 2. A single row of data represented by Object
    JSON format with Object as root node. The entire Object represents a row of data to be imported. An example is as follows:
 
-   ````json
+   ```json
    { "id": 123, "city" : "beijing"}
-   ````
+   ```
    
-   ````json
+   ```json
    { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
-   ````
+   ```
    
    This method is usually used for the Routine Load import method, such as representing a message in Kafka, that is, a row of data.
 
@@ -83,11 +83,11 @@ Currently only the following two JSON formats are supported:
    
    A row of data represented by Object represents a row of data to be imported. The example is as follows:
    
-   ````json
+   ```json
    { "id": 123, "city" : "beijing"}
    { "id": 456, "city" : "shanghai"}
    ...
-   ````
+   ```
    
    This method is typically used for Stream Load import methods to represent multiple rows of data in a batch of imported data.
    
@@ -121,17 +121,17 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is as follows:
 
-  ````json
+  ```json
   { "id": 123, "city" : "beijing"}
-  ````
+  ```
 
   Then Doris will use `id`, `city` for matching, and get the final data `123` and `beijing`.
 
   If the JSON data is as follows:
 
-  ````json
+  ```json
   { "id": 123, "name" : "beijing"}
-  ````
+  ```
 
   Then use `id`, `city` for matching, and get the final data `123` and `null`.
 
@@ -139,13 +139,13 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   Specify a set of JSON Path in the form of a JSON data. Each element in the array represents a column to extract. An example is as follows:
 
-  ````json
+  ```json
   ["$.id", "$.name"]
-  ````
+  ```
 
-  ````json
+  ```json
   ["$.id.sub_id", "$.name[0]", "$.city[0]"]
-  ````
+  ```
 
   Doris will use the specified JSON Path for data matching and extraction.
 
@@ -155,21 +155,21 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
-  ````
+  ```
 
   JSON Path is `["$.city"]`. The matched elements are:
 
-  ````json
+  ```json
   { "name" : "beijing", "region" : "haidian" }
-  ````
+  ```
 
   The element will be converted to a string for subsequent import operations:
 
-  ````json
+  ```json
   "{'name':'beijing','region':'haidian'}"
-  ````
+  ```
 
 - match failed
 
@@ -177,41 +177,41 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "name" : "beijing"}
-  ````
+  ```
 
   JSON Path is `["$.id", "$.info"]`. The matched elements are `123` and `null`.
 
   Doris currently does not distinguish between null values represented in JSON data and null values produced when a match fails. Suppose the JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "name" : null }
-  ````
+  ```
 
   The same result would be obtained with the following two JSON Paths: `123` and `null`.
 
-  ````json
+  ```json
   ["$.id", "$.name"]
-  ````
+  ```
 
-  ````json
+  ```json
   ["$.id", "$.info"]
-  ````
+  ```
 
 - Exact match failed
 
   In order to prevent misoperation caused by some parameter setting errors. When Doris tries to match a row of data, if all columns fail to match, it considers this to be an error row. Suppose the Json data is:
 
-  ````json
+  ```json
   { "id": 123, "city" : "beijing" }
-  ````
+  ```
 
   If the JSON Path is written incorrectly as (or if the JSON Path is not specified, the columns in the table do not contain `id` and `city`):
 
-  ````json
+  ```json
   ["$.ad", "$.infa"]
-  ````
+  ```
 
   would cause the exact match to fail, and the line would be marked as an error line instead of yielding `null, null`.
 
@@ -223,65 +223,65 @@ In other words, it is equivalent to rearranging the columns of a JSON format dat
 
 Data content:
 
-````json
+```json
 {"k1": 1, "k2": 2}
-````
+```
 
 Table Structure:
 
-````
+```
 k2 int, k1 int
-````
+```
 
 Import statement 1 (take Stream Load as an example):
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -T example.json http:/ /127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 In import statement 1, only JSON Path is specified, and Columns is not specified. The role of JSON Path is to extract the JSON data in the order of the fields in the JSON Path, and then write it in the order of the table structure. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1 | k2 |
 +------+------+
 | 2 | 1 |
 +------+------+
-````
+```
 
 You can see that the actual k1 column imports the value of the "k2" column in the JSON data. This is because the field name in JSON is not equivalent to the field name in the table structure. We need to explicitly specify the mapping between the two.
 
 Import statement 2:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, k1 " -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Compared with the import statement 1, the Columns field is added here to describe the mapping relationship of the columns, in the order of `k2, k1`. That is, after extracting in the order of fields in JSON Path, specify the value of column k2 in the table for the first column, and the value of column k1 in the table for the second column. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1 | k2 |
 +------+------+
 | 1 | 2 |
 +------+------+
-````
+```
 
 Of course, as with other imports, column transformations can be performed in Columns. An example is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, tmp_k1 , k1 = tmp_k1 * 100" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 The above example will import the value of k1 multiplied by 100. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1 | k2 |
 +------+------+
 | 100 | 2 |
 +------+------+
-````
+```
 
 ## JSON root
 
@@ -319,26 +319,26 @@ Doris supports extracting data specified in JSON through JSON root.
 
 Example data is as follows:
 
-````json
+```json
 [
     {"k1": 1, "k2": "a"},
     {"k1": 2},
     {"k1": 3, "k2": "c"}
 ]
-````
+```
 
 
 The table structure is: `k1 int null, k2 varchar(32) null default "x"`
 
 The import statement is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 The import results that users may expect are as follows, that is, for missing columns, fill in the default values.
 
-````text
+```text
 +------+------+
 | k1 | k2 |
 +------+------+
@@ -348,11 +348,11 @@ The import results that users may expect are as follows, that is, for missing co
 +------+------+
 |3|c|
 +------+------+
-````
+```
 
 But the actual import result is as follows, that is, for the missing column, NULL is added.
 
-````text
+```text
 +------+------+
 | k1 | k2 |
 +------+------+
@@ -362,13 +362,13 @@ But the actual import result is as follows, that is, for the missing column, NUL
 +------+------+
 |3|c|
 +------+------+
-````
+```
 
 This is because Doris doesn't know "the missing column is column k2 in the table" from the information in the import statement. If you want to import the above data according to the expected result, the import statement is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -H "jsonpaths: [\"$.k1\", \"$.k2\"]" - H "columns: k1, tmp_k2, k2 = ifnull(tmp_k2, 'x')" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 ## Application example
 
@@ -378,63 +378,63 @@ Because of the inseparability of the JSON format, when using Stream Load to impo
 
 Suppose the table structure is:
 
-````text
+```text
 id INT NOT NULL,
 city VARHCAR NULL,
 code INT NULL
-````
+```
 
 1. Import a single row of data 1
 
-   ````json
+   ```json
    {"id": 100, "city": "beijing", "code" : 1}
-   ````
+   ```
 
    - do not specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
 2. Import a single row of data 2
 
-   ````json
+   ```json
    {"id": 100, "content": {"city": "beijing", "code": 1}}
-   ````
+   ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\ "]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
 3. Import multiple rows of data as Array
 
-   ````json
+   ```json
    [
        {"id": 100, "city": "beijing", "code" : 1},
        {"id": 101, "city": "shanghai"},
@@ -449,24 +449,24 @@ code INT NULL
            "code" : 6
        }
    ]
-   ````
+   ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
      101 shanghai NULL
      102 tianjin 3
      103 chongqing 4
      104 ["zhejiang","guangzhou"] 5
      105 {"order1":["guangzhou"]} 6
-     ````
+     ```
 
 4. Import multi-line data as multi-line Object
 
@@ -479,7 +479,7 @@ code INT NULL
 
  	 StreamLoad import：
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 	   Import result:
@@ -493,20 +493,20 @@ curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: 
 
 The data is still the multi-line data in Example 3, and now it is necessary to add 1 to the `code` column in the imported data before importing.
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Import result:
 
-````text
+```text
 100 beijing 2
 101 shanghai NULL
 102 tianjin 4
 103 chongqing 5
 104 ["zhejiang","guangzhou"] 6
 105 {"order1":["guangzhou"]} 7
-````
+```
 
 6. Import Array by JSON
 Since the Rapidjson handles decimal and largeint numbers which will cause precision problems, 
@@ -520,7 +520,7 @@ we suggest you to use JSON string to import data to `array<decimal>` or `array<l
 {"k1": 40, "k2": ["10000000000000000000.1111111222222222"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_decimal.json http://localhost:8035/api/example_db/array_test_decimal/_stream_load
 ```
 
@@ -540,7 +540,7 @@ MySQL > select * from array_test_decimal;
 {"k1": 999, "k2": ["76959836937749932879763573681792701709", "26017042825937891692910431521038521227"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_largeint.json http://localhost:8035/api/example_db/array_test_largeint/_stream_load
 ```
 

--- a/versioned_docs/version-1.2/data-operate/import/import-way/spark-load-manual.md
+++ b/versioned_docs/version-1.2/data-operate/import/import-way/spark-load-manual.md
@@ -589,7 +589,7 @@ PROPERTIES
 (
     "timeout" = "3600"
 );
-````
+```
 
 
 

--- a/versioned_docs/version-1.2/data-operate/update-delete/batch-delete-manual.md
+++ b/versioned_docs/version-1.2/data-operate/update-delete/batch-delete-manual.md
@@ -226,7 +226,7 @@ After load:
 
 4. When the table has the sequence column, delete all data with the same key as the imported data
 
-```bash
+```shell
 curl --location-trusted -u root: -H "column_separator:," -H "columns: name, gender, age" -H "function_column.sequence_col: age" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
 ```
 

--- a/versioned_docs/version-1.2/data-table/basic-usage.md
+++ b/versioned_docs/version-1.2/data-table/basic-usage.md
@@ -289,7 +289,7 @@ The Stream Load method transfers data to Doris via HTTP protocol. It can import 
 
 Example 1: Use "table1_20170707" as the Label, import the local file `table1_data` into `table1`.
 
-```bash
+```shell
 curl --location-trusted -u test:test_passwd -H "label:table1_20170707" -H "column_separator:," -T table1_data http://FE_HOST:8030/api/example_db/table1/_stream_load
 ```
 
@@ -308,7 +308,7 @@ The local file `table1_data` uses `,` as the separator between data. The details
 
 Example 2: Use "table2_20170707" as the Label, import the local file `table2_data` into `table2`.
 
-```bash
+```shell
 curl --location-trusted -u test:test -H "label:table2_20170707" -H "column_separator:|" -T table2_data http://127.0.0.1:8030/api/example_db/table2/_stream_load
 ```
 

--- a/versioned_docs/version-1.2/install/source-install/compilation-arm.md
+++ b/versioned_docs/version-1.2/install/source-install/compilation-arm.md
@@ -102,14 +102,14 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   mkdir /opt/tools
   # Create root directory for software installation
   mkdir /opt/software
-  ````
+  ```
 
 - Git
 
   ```shell
   # yum install (save the trouble of compilation)
   yum install -y git
-  ````
+  ```
 
 - JDK8 (2 methods)
 
@@ -122,7 +122,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   wget https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/jdk-8u291-linux-aarch64.tar.gz && \
   tar -zxvf jdk-8u291-linux-aarch64.tar.gz && \
   mv jdk1.8.0_291 /opt/software/jdk8
-  ````
+  ```
 
 - Maven
 
@@ -132,7 +132,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   wget https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
   tar -zxvf apache-maven-3.6.3-bin.tar.gz && \
   mv apache-maven-3.6.3 /opt/software/maven
-  ````
+  ```
 
 - NodeJS
 
@@ -142,7 +142,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   wget https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/node-v16.3.0-linux-arm64.tar.xz && \
   tar -xvf node-v16.3.0-linux-arm64.tar.xz && \
   mv node-v16.3.0-linux-arm64 /opt/software/nodejs
-  ````
+  ```
 
 - ldb-toolchain
 
@@ -151,7 +151,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   # Download ldb-toolchain ARM version
   wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.9.1/ldb_toolchain_gen.aarch64.sh && \
   sh ldb_toolchain_gen.aarch64.sh /opt/software/ldb_toolchain/
-  ````
+  ```
 
 - Configure environment variables
 
@@ -176,7 +176,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   > v16.3.0
   gcc --version
   > gcc-11
-  ````
+  ```
 
 - Install other environments and components
 
@@ -193,7 +193,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
       ./configure && \
       make && \
       make install
-  ````
+  ```
 
 ##### Ubuntu 20.04
 
@@ -201,7 +201,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
 
   ```shell
   apt-get update
-  ````
+  ```
 
 - Check the shell command set
 
@@ -209,13 +209,13 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
 
   ```shell
   ls -al /bin/sh
-  ````
+  ```
 
   The shell can be switched back to bash by:
 
   ```shell
   sudo dpkg-reconfigure dash
-  ````
+  ```
 
   Then select no to confirm.
 
@@ -228,14 +228,14 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   mkdir /opt/tools
   # Create root directory for software installation
   mkdir /opt/software
-  ````
+  ```
 
 - Git
 
   ```shell
   # apt-get install, which can save the trouble of compilation
   apt-get -y install git
-  ````
+  ```
 
 - JDK8
 
@@ -245,7 +245,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   wget https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/jdk-8u291-linux-aarch64.tar.gz && \
   tar -zxvf jdk-8u291-linux-aarch64.tar.gz && \
   mv jdk1.8.0_291 /opt/software/jdk8
-  ````
+  ```
 
 - Maven
 
@@ -255,7 +255,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   wget https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
   tar -zxvf apache-maven-3.6.3-bin.tar.gz && \
   mv apache-maven-3.6.3 /opt/software/maven
-  ````
+  ```
 
 - NodeJS
 
@@ -265,7 +265,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   wget https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/node-v16.3.0-linux-arm64.tar.xz && \
   tar -xvf node-v16.3.0-linux-arm64.tar.xz && \
   mv node-v16.3.0-linux-arm64 /opt/software/nodejs
-  ````
+  ```
 
 - ldb-toolchain
 
@@ -274,7 +274,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   # Download ldb-toolchain ARM version
   wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.9.1/ldb_toolchain_gen.aarch64.sh && \
   sh ldb_toolchain_gen.aarch64.sh /opt/software/ldb_toolchain/
-  ````
+  ```
 
 - Configure environment variables
 
@@ -299,7 +299,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
   > v16.3.0
   gcc --version
      > gcc-11
-     ````
+     ```
 
 - Install other environments and components
 
@@ -327,7 +327,7 @@ Note that you need to download the corresponding aarch64 versions of jdk and nod
       ./configure && \
       make && \
       make install
-  ````
+  ```
 
 #### Download Source Code
 
@@ -344,7 +344,7 @@ If there is data returned, that means AVX2 is supported; otherwise, AVX2 is not 
 
 ```shell
 cat /proc/cpuinfo | grep avx2
-````
+```
 
 ##### Execute compilation
 
@@ -353,7 +353,7 @@ cat /proc/cpuinfo | grep avx2
 sh build.sh
 # For machines that do not support the AVX2 instruction set, use the following command to compile
 USE_AVX2=OFF sh build.sh
-````
+```
 
 ### FAQ
 
@@ -376,7 +376,7 @@ USE_AVX2=OFF sh build.sh
         ```shell
         export REPOSITORY_URL=https://doris-thirdparty-repo.bj.bcebos.com/thirdparty
         sh /opt/doris/thirdparty/build-thirdparty.sh
-        ````
+        ```
 
         REPOSITORY_URL contains all third-party library source packages and their historical versions.
 
@@ -403,7 +403,7 @@ USE_AVX2=OFF sh build.sh
      whereis python
      # Establish soft connection
      sudo ln -s /usr/bin/python2.7 /usr/bin/python
-     ````
+     ```
 
 3. There is no output directory after compilation
 
@@ -419,7 +419,7 @@ USE_AVX2=OFF sh build.sh
 
      ```shell
      sh build.sh --clean
-     ````
+     ```
 
 4. spark-dpp compilation fails
 
@@ -517,7 +517,7 @@ USE_AVX2=OFF sh build.sh
      ```shell
      cp /opt/software/ldb_toolchain/share/aclocal/pkg.m4 /opt/incubator-doris/thirdparty/src/libxml2-v2.9.10/m4
      sh /opt/incubator-doris/thirdparty/build-thirdparty.sh
-     ````
+     ```
    
 9. Failed to execute test CURL_HAS_TLS_PROXY
 
@@ -555,7 +555,7 @@ USE_AVX2=OFF sh build.sh
      # Test
      gcc --version
      > gcc-11
-     ````
+     ```
 
 10. Other problems
 

--- a/versioned_docs/version-1.2/install/standard-deployment.md
+++ b/versioned_docs/version-1.2/install/standard-deployment.md
@@ -55,11 +55,11 @@ Doris, as an open source OLAP database with an MPP architecture, can run on most
 
 **Set the maximum number of open file descriptors in the system**
 
-````
+```
 vi /etc/security/limits.conf
 * soft nofile 65536
 * hard nofile 65536
-````
+```
 
 ##### Clock synchronization
 
@@ -316,7 +316,7 @@ Broker is deployed as a plug-in, which is independent of Doris. If you need to i
 
 	After the BE process starts, if there have been data there before, it might need several minutes for data index loading.
 
-	If BE is started for the first time or the BE has not joined any cluster, the BE log will periodically scroll the words `waiting to receive first heartbeat from frontend`, meaning that BE has not received the Master's address through FE's heartbeat and is waiting passively. Such error log will disappear after sending the heartbeat by ADD BACKEND in FE. If the word `````master client', get client from cache failed. host:, port: 0, code: 7````` appears after receiving the heartbeat, it indicates that FE has successfully connected BE, but BE cannot actively connect FE. You may  need to check the connectivity of rpc_port from BE to FE.
+	If BE is started for the first time or the BE has not joined any cluster, the BE log will periodically scroll the words `waiting to receive first heartbeat from frontend`, meaning that BE has not received the Master's address through FE's heartbeat and is waiting passively. Such error log will disappear after sending the heartbeat by ADD BACKEND in FE. If the word ```master client', get client from cache failed. host:, port: 0, code: 7``` appears after receiving the heartbeat, it indicates that FE has successfully connected BE, but BE cannot actively connect FE. You may  need to check the connectivity of rpc_port from BE to FE.
 
 	If BE has been added to the cluster, the heartbeat log from FE will be scrolled every five seconds: ```get heartbeat, host:xx. xx.xx.xx, port:9020, cluster id:xxxxxxx```, indicating that the heartbeat is normal.
 

--- a/versioned_docs/version-1.2/lakehouse/multi-catalog/es.md
+++ b/versioned_docs/version-1.2/lakehouse/multi-catalog/es.md
@@ -119,7 +119,7 @@ For example, suppose there is an index `doc` containing the following data struc
 The array fields of this structure can be defined by using the following command to add the field property definition 
 to the `_meta.doris` property of the target index mapping.
 
-```bash
+```shell
 # ES 7.x and above
 curl -X PUT "localhost:9200/doc/_mapping?pretty" -H 'Content-Type:application/json' -d '
 {

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/CREATE-ROLE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/CREATE-ROLE.md
@@ -36,7 +36,7 @@ The statement user creates a role
 
 ```sql
   CREATE ROLE rol_name;
-````
+```
 
 This statement creates an unprivileged role, which can be subsequently granted with the GRANT command.
 
@@ -46,7 +46,7 @@ This statement creates an unprivileged role, which can be subsequently granted w
 
     ```sql
     CREATE ROLE role1;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/DROP-ROLE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/DROP-ROLE.md
@@ -32,7 +32,7 @@ The statement user removes a role
 
 ```sql
   DROP ROLE [IF EXISTS] role1;
-````
+```
 
 Deleting a role does not affect the permissions of users who previously belonged to the role. It is only equivalent to decoupling the role from the user. The permissions that the user has obtained from the role will not change
 
@@ -42,7 +42,7 @@ Deleting a role does not affect the permissions of users who previously belonged
 
 ```sql
 DROP ROLE role1;
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/DROP-USER.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/DROP-USER.md
@@ -41,7 +41,7 @@ Delete a user
     
          user@'host'
          user@['domain']
-````
+```
 
   Delete the specified user identitiy.
 
@@ -51,7 +51,7 @@ Delete a user
 
     ```sql
     DROP USER 'jack'@'192.%'
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/GRANT.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/GRANT.md
@@ -47,7 +47,7 @@ GRANT privilege_list ON priv_level TO user_identity [ROLE role_name]
 GRANT privilege_list ON RESOURCE resource_name TO user_identity [ROLE role_name]
 
 GRANT role_list TO user_identity
-````
+```
 
 privilege_list is a list of privileges to be granted, separated by commas. Currently Doris supports the following permissions:
 
@@ -100,37 +100,37 @@ role_list is the list of roles to be assigned, separated by commas,the specified
 
    ```sql
    GRANT SELECT_PRIV ON *.*.* TO 'jack'@'%';
-   ````
+   ```
 
 2. Grant permissions to the specified database table to the user
 
    ```sql
    GRANT SELECT_PRIV,ALTER_PRIV,LOAD_PRIV ON ctl1.db1.tbl1 TO 'jack'@'192.8.%';
-   ````
+   ```
 
 3. Grant permissions to the specified database table to the role
 
    ```sql
    GRANT LOAD_PRIV ON ctl1.db1.* TO ROLE 'my_role';
-   ````
+   ```
 
 4. Grant access to all resources to users
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE * TO 'jack'@'%';
-   ````
+   ```
 
 5. Grant the user permission to use the specified resource
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE 'spark_resource' TO 'jack'@'%';
-   ````
+   ```
 
 6. Grant access to specified resources to roles
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE 'spark_resource' TO ROLE 'my_role';
-   ````
+   ```
 
 7. Grant the specified role to a user
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/LDAP.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/LDAP.md
@@ -36,7 +36,7 @@ SET LDAP_ADMIN_PASSWORD
 
 ```sql
   SET LDAP_ADMIN_PASSWORD = PASSWORD('plain password')
-````
+```
 
   The SET LDAP_ADMIN_PASSWORD command is used to set the LDAP administrator password. When using LDAP authentication, doris needs to use the administrator account and password to query the LDAP service for login user information.
 
@@ -46,7 +46,7 @@ SET LDAP_ADMIN_PASSWORD
 
 ```sql
 SET LDAP_ADMIN_PASSWORD = PASSWORD('123456')
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/REVOKE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/REVOKE.md
@@ -47,7 +47,7 @@ REVOKE privilege_list ON db_name[.tbl_name] FROM user_identity [ROLE role_name]
 REVOKE privilege_list ON RESOURCE resource_name FROM user_identity [ROLE role_name]
 
 REVOKE role_list FROM user_identity
-````
+```
 
 user_identity:
 
@@ -63,13 +63,13 @@ role_list is the list of roles to be revoked, separated by commas. The specified
 
     ```sql
     REVOKE SELECT_PRIV ON db1.* FROM 'jack'@'192.%';
-    ````
+    ```
 
 2. Revoke user jack resource spark_resource permission
 
     ```sql
     REVOKE USAGE_PRIV ON RESOURCE 'spark_resource' FROM 'jack'@'192.%';
-    ````
+    ```
 3. Revoke the roles role1 and role2 previously granted to jack
 
     ```sql

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/SET-PASSWORD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/SET-PASSWORD.md
@@ -37,7 +37,7 @@ The SET PASSWORD command can be used to modify a user's login password. If the [
 ```sql
 SET PASSWORD [FOR user_identity] =
     [PASSWORD('plain password')]|['hashed password']
-````
+```
 
 Note that the user_identity here must exactly match the user_identity specified when creating a user with CREATE USER, otherwise an error will be reported that the user does not exist. If user_identity is not specified, the current user is 'username'@'ip', which may not match any user_identity. Current users can be viewed through SHOW GRANTS.
 
@@ -51,14 +51,14 @@ To modify the passwords of other users, administrator privileges are required.
    ```sql
    SET PASSWORD = PASSWORD('123456')
    SET PASSWORD = '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9'
-   ````
+   ```
 
 2. Modify the specified user password
 
    ```sql
    SET PASSWORD FOR 'jack'@'192.%' = PASSWORD('123456')
    SET PASSWORD FOR 'jack'@['domain'] = '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9'
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/SET-PROPERTY.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Account-Management-Statements/SET-PROPERTY.md
@@ -36,7 +36,7 @@ Set user attributes, including resources assigned to users, importing clusters, 
 
 ```sql
 SET PROPERTY [FOR 'user'] 'key' = 'value' [, 'key' = 'value']
-````
+```
 
 The user attribute set here is for user, not user_identity. That is, if two users 'jack'@'%' and 'jack'@'192.%' are created through the CREATE USER statement, the SET PROPERTY statement can only be used for the user jack, not 'jack'@'% ' or 'jack'@'192.%'
 
@@ -88,19 +88,19 @@ Data, etl program automatically retains the next use.
 
    ```sql
    SET PROPERTY FOR 'jack' 'max_user_connections' = '1000';
-   ````
+   ```
 
 2. Modify the cpu_share of user jack to 1000
 
    ```sql
    SET PROPERTY FOR 'jack' 'resource.cpu_share' = '1000';
-   ````
+   ```
 
 3. Modify the weight of the jack user's normal group
 
    ```sql
    SET PROPERTY FOR 'jack' 'quota.normal' = '400';
-   ````
+   ```
 
 4. Add import cluster for user jack
 
@@ -108,61 +108,61 @@ Data, etl program automatically retains the next use.
    SET PROPERTY FOR 'jack'
        'load_cluster.{cluster_name}.hadoop_palo_path' = '/user/doris/doris_path',
        'load_cluster.{cluster_name}.hadoop_configs' = 'fs.default.name=hdfs://dpp.cluster.com:port;mapred.job.tracker=dpp.cluster.com:port;hadoop.job.ugi=user ,password;mapred.job.queue.name=job_queue_name_in_hadoop;mapred.job.priority=HIGH;';
-   ````
+   ```
 
 5. Delete the imported cluster under user jack.
 
    ```sql
    SET PROPERTY FOR 'jack' 'load_cluster.{cluster_name}' = '';
-   ````
+   ```
 
 6. Modify the default import cluster of user jack
 
    ```sql
    SET PROPERTY FOR 'jack' 'default_load_cluster' = '{cluster_name}';
-   ````
+   ```
 
 7. Change the cluster priority of user jack to HIGH
 
    ```sql
    SET PROPERTY FOR 'jack' 'load_cluster.{cluster_name}.priority' = 'HIGH';
-   ````
+   ```
 
 8. Modify the number of available instances for user jack's query to 3000
 
    ```sql
    SET PROPERTY FOR 'jack' 'max_query_instances' = '3000';
-   ````
+   ```
 
 9. Modify the sql block rule of user jack
 
    ```sql
    SET PROPERTY FOR 'jack' 'sql_block_rules' = 'rule1, rule2';
-   ````
+   ```
 
 10. Modify the cpu usage limit of user jack
 
     ```sql
     SET PROPERTY FOR 'jack' 'cpu_resource_limit' = '2';
-    ````
+    ```
 
 11. Modify the user's resource tag permissions
 
     ```sql
     SET PROPERTY FOR 'jack' 'resource_tags.location' = 'group_a, group_b';
-    ````
+    ```
 
 12. Modify the user's query memory usage limit, in bytes
 
     ```sql
     SET PROPERTY FOR 'jack' 'exec_mem_limit' = '2147483648';
-    ````
+    ```
 
 13. Modify the user's query timeout limit, in second
 
     ```sql
     SET PROPERTY FOR 'jack' 'query_timeout' = '500';
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 -- Add nodes (add this method if you do not use the multi-tenancy function)
    ALTER SYSTEM ADD BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
  illustrate:
 
@@ -53,7 +53,7 @@ grammar:
 
     ```sql
     ALTER SYSTEM ADD BACKEND "host:port";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BROKER.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BROKER.md
@@ -39,7 +39,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host2:broker_ipc_port2",...;
-````
+```
 
 ### Example
 
@@ -47,7 +47,7 @@ ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host
 
     ```sql
      ALTER SYSTEM ADD BROKER "host1:port", "host2:port";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-FOLLOWER.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-FOLLOWER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD FOLLOWER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM ADD FOLLOWER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-OBSERVER.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-OBSERVER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD OBSERVER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM ADD OBSERVER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DECOMMISSION-BACKEND.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DECOMMISSION-BACKEND.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
   illustrate:
 
@@ -53,7 +53,7 @@ ALTER SYSTEM DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"..
 
     ```sql
     ALTER SYSTEM DECOMMISSION BACKEND "host1:port", "host2:port";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BACKEND.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BACKEND.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM DROP BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...]
-````
+```
 
 illustrate:
 
@@ -52,7 +52,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM DROP BACKEND "host1:port", "host2:port";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BROKER.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BROKER.md
@@ -42,7 +42,7 @@ grammar:
 ALTER SYSTEM DROP ALL BROKER broker_name
 -- Delete a Broker node
 ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
-````
+```
 
 ### Example
 
@@ -50,13 +50,13 @@ ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
 
     ```sql
     ALTER SYSTEM DROP ALL BROKER broker_name
-    ````
+    ```
 
 2. Delete a Broker node
 
     ```sql
     ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-OBSERVER.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-OBSERVER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM DROP OBSERVER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM DROP OBSERVER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
@@ -39,7 +39,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
-````
+```
 
   illustrate:
 
@@ -61,19 +61,19 @@ Note:
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("tag.location" = "group_a");
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-    ````
+    ```
 
 2. Modify the query disable property of BE
 
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("disable_query" = "true");
-    ````
+    ```
 
 3. Modify the import disable property of BE
 
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("disable_load" = "true");
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/CANCEL-ALTER-SYSTEM.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Cluster-Management-Statements/CANCEL-ALTER-SYSTEM.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 CANCEL DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ CANCEL DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
 
       ```sql
       CANCEL DECOMMISSION BACKEND "host1:port", "host2:port";
-      ````
+      ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-SQL-BLOCK-RULE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 ALTER SQL_BLOCK_RULE rule_name
 [PROPERTIES ("key"="value", ...)];
-````
+```
 
 illustrate:
 
@@ -52,18 +52,18 @@ illustrate:
 
 ```sql
 ALTER SQL_BLOCK_RULE test_rule PROPERTIES("sql"="select \\* from test_table","enable"="true")
-````
+```
 
 2. If a rule sets partition_num, then sql or sqlHash cannot be modified
 
 ```sql
 ALTER SQL_BLOCK_RULE test_rule2 PROPERTIES("partition_num" = "10","tablet_num"="300","enable"="true")
-````
+```
 
 ### Keywords
 
-````text
+```text
 ALTER,SQL_BLOCK_RULE
-````
+```
 
 ### Best Practice

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN.md
@@ -219,7 +219,7 @@ ORDER BY (k3,k1,k2,v2,v1) FROM example_rollup_index;
 
 ```sql
 alter table example_tbl modify column k3 varchar(50) key null comment 'to 50'
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
@@ -161,7 +161,7 @@ ALTER TABLE example_db.mysql_table SET ("replication_num" = "2");
 ALTER TABLE example_db.mysql_table SET ("default.replication_num" = "2");
 ALTER TABLE example_db.mysql_table SET ("replication_allocation" = "tag.location.tag1: 1");
 ALTER TABLE example_db.mysql_table SET ("default.replication_allocation" = "tag.location.tag1: 1");
-````
+```
 
 Note:
 1. The property with the default prefix indicates the default replica distribution for the modified table. This modification does not modify the current actual replica distribution of the table, but only affects the replica distribution of newly created partitions on the partitioned table.

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-DATABASE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-DATABASE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 CREATE DATABASE [IF NOT EXISTS] db_name
     [PROPERTIES ("key"="value", ...)];
-````
+```
 
 `PROPERTIES` Additional information about the database, which can be defaulted.
 
@@ -51,7 +51,7 @@ CREATE DATABASE [IF NOT EXISTS] db_name
     "iceberg.hive.metastore.uris" = "thrift://127.0.0.1:9083",
     "iceberg.catalog.type" = "HIVE_CATALOG"
   )
-  ````
+  ```
 
   illustrate:
   
@@ -65,7 +65,7 @@ CREATE DATABASE [IF NOT EXISTS] db_name
 
    ```sql
    CREATE DATABASE db_test;
-   ````
+   ```
 
 2. Create a new Iceberg database iceberg_test
 
@@ -76,13 +76,13 @@ CREATE DATABASE [IF NOT EXISTS] db_name
    "iceberg.hive.metastore.uris" = "thrift://127.0.0.1:9083",
    "iceberg.catalog.type" = "HIVE_CATALOG"
    );
-   ````
+   ```
 
 ### Keywords
 
-````text
+```text
 CREATE, DATABASE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-ENCRYPT-KEY.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-ENCRYPT-KEY.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 CREATE ENCRYPTKEY key_name AS "key_string"
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ If `key_name` contains the database name, then the custom key will be created in
 
    ```sql
    CREATE ENCRYPTKEY my_key AS "ABCD123456789";
-   ````
+   ```
 
 2. Use a custom key
 
@@ -76,7 +76,7 @@ If `key_name` contains the database name, then the custom key will be created in
    | Doris is Great |
    +------------------------------------------------- -------------------+
    1 row in set (0.01 sec)
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FILE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FILE.md
@@ -46,7 +46,7 @@ grammar:
 ```sql
 CREATE FILE "file_name" [IN database]
         [properties]
-````
+```
 
 illustrate:
 
@@ -68,7 +68,7 @@ illustrate:
        "url" = "https://test.bj.bcebos.com/kafka-key/ca.pem",
        "catalog" = "kafka"
    );
-   ````
+   ```
 
 2. Create a file client.key, classified as my_catalog
 
@@ -81,13 +81,13 @@ illustrate:
        "catalog" = "my_catalog",
        "md5" = "b5bb901bf10f99205b39a46ac3557dd9"
    );
-   ````
+   ```
 
 ### Keywords
 
-````text
+```text
 CREATE, FILE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FUNCTION.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FUNCTION.md
@@ -45,7 +45,7 @@ CREATE [GLOBAL] [AGGREGATE] [ALIAS] FUNCTION function_name
     [INTERMEDIATE inter_type]
     [WITH PARAMETER(param [,...]) AS origin_function]
     [PROPERTIES ("key" = "value" [, ...]) ]
-````
+```
 
 Parameter Description:
 
@@ -108,7 +108,7 @@ Parameter Description:
    "symbol" = "_ZN9doris_udf6AddUdfEPNS_15FunctionContextERKNS_6IntValES4_",
    "object_file" = "http://host:port/libmyadd.so"
    );
-   ````
+   ```
 
 2. Create a custom scalar function with prepare/close functions
 
@@ -119,7 +119,7 @@ Parameter Description:
    "close_fn" = "_ZN9doris_udf12AddUdf_closeEPNS_15FunctionContextENS0_18FunctionStateScopeE",
    "object_file" = "http://host:port/libmyadd.so"
    );
-   ````
+   ```
 
 3. Create a custom aggregate function
 
@@ -131,7 +131,7 @@ Parameter Description:
             "finalize_fn"="_ZN9doris_udf13CountFinalizeEPNS_15FunctionContextERKNS_9BigIntValE",
             "object_file"="http://host:port/libudasample.so"
    );
-   ````
+   ```
 
 
 4. Create a scalar function with variable length arguments
@@ -141,13 +141,13 @@ Parameter Description:
    "symbol" = "_ZN9doris_udf6StrConcatUdfEPNS_15FunctionContextERKNS_6IntValES4_",
    "object_file" = "http://host:port/libmyStrConcat.so"
    );
-   ````
+   ```
 
 5. Create a custom alias function
 
    ```sql
    CREATE ALIAS FUNCTION id_masking(INT) WITH PARAMETER(id) AS CONCAT(LEFT(id, 3), '****', RIGHT(id, 4));
-   ````
+   ```
 
 6. Create a global custom scalar function
 
@@ -156,13 +156,13 @@ Parameter Description:
    "symbol" = "_ZN9doris_udf6AddUdfEPNS_15FunctionContextERKNS_6IntValES4_",
    "object_file" = "http://host:port/libmyadd.so"
    );
-   ````
+   ```
 
 7. Create a global custom alias function
 
    ```sql
    CREATE GLOBAL ALIAS FUNCTION id_masking(INT) WITH PARAMETER(id) AS CONCAT(LEFT(id, 3), '****', RIGHT(id, 4));
-   ```` 
+   ``` 
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-INDEX.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-INDEX.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 CREATE INDEX [IF NOT EXISTS] index_name ON table_name (column [, ...],) [USING BITMAP] [COMMENT 'balabala'];
-````
+```
 Notice:
 - Currently only supports bitmap indexes
 - BITMAP indexes are only created on a single column
@@ -48,14 +48,14 @@ Notice:
 
     ```sql
     CREATE INDEX [IF NOT EXISTS] index_name ON table1 (siteid) USING BITMAP COMMENT 'balabala';
-    ````
+    ```
 
 
 ### Keywords
 
-````text
+```text
 CREATE, INDEX
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-MATERIALIZED-VIEW.md
@@ -41,7 +41,7 @@ grammar:
 ```sql
 CREATE MATERIALIZED VIEW [MV name] as [query]
 [PROPERTIES ("key" = "value")]
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ illustrate:
   FROM [Base view name]
   GROUP BY column_name[, column_name ...]
   ORDER BY column_name[, column_name ...]
-  ````
+  ```
 
   The syntax is the same as the query syntax.
 
@@ -73,16 +73,16 @@ illustrate:
 
   Declare some configuration of the materialized view, optional.
 
-  ````text
+  ```text
   PROPERTIES ("key" = "value", "key" = "value" ...)
-  ````
+  ```
 
   The following configurations can be declared here:
 
-  ````text
+  ```text
    short_key: The number of sorting columns.
    timeout: The timeout for materialized view construction.
-  ````
+  ```
 
 ### Example
 
@@ -98,7 +98,7 @@ mysql> desc duplicate_table;
 | k3 | BIGINT | Yes | true | N/A | |
 | k4 | BIGINT | Yes | true | N/A | |
 +-------+--------+------+------+---------+-------+
-````
+```
 ```sql
 create table duplicate_table(
 	k1 int null,
@@ -117,49 +117,49 @@ attention：If the materialized view contains partitioned and distributed column
    ```sql
    create materialized view k2_k1 as
    select k2, k1 from duplicate_table;
-   ````
+   ```
 
    The schema of the materialized view is as follows, the materialized view contains only two columns k1, k2 without any aggregation
 
-   ````text
+   ```text
    +-------+-------+--------+------+------+ ---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------+ ---------+-------+
    | k2_k1 | k2 | INT | Yes | true | N/A | |
    | | k1 | INT | Yes | true | N/A | |
    +-------+-------+--------+------+------+ ---------+-------+
-   ````
+   ```
 
 2. Create a materialized view with k2 as the sort column
 
    ```sql
    create materialized view k2_order as
    select k2, k1 from duplicate_table order by k2;
-   ````
+   ```
 
    The schema of the materialized view is shown in the figure below. The materialized view contains only two columns k2, k1, where k2 is the sorting column without any aggregation.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
    | k2_order | k2 | INT | Yes | true | N/A | |
    | | k1 | INT | Yes | false | N/A | NONE |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 3. Create a materialized view with k1, k2 grouping and k3 column aggregated by SUM
 
    ```sql
    create materialized view k1_k2_sumk3 as
    select k1, k2, sum(k3) from duplicate_table group by k1, k2;
-   ````
+   ```
 
    The schema of the materialized view is shown in the figure below. The materialized view contains two columns k1, k2, sum(k3) where k1, k2 are the grouping columns, and sum(k3) is the sum value of the k3 column grouped by k1, k2.
 
    Since the materialized view does not declare a sorting column, and the materialized view has aggregated data, the system defaults to supplement the grouping columns k1 and k2 as sorting columns.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
@@ -167,18 +167,18 @@ attention：If the materialized view contains partitioned and distributed column
    | | k2 | INT | Yes | true | N/A | |
    | | k3 | BIGINT | Yes | false | N/A | SUM |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 4. Create a materialized view that removes duplicate rows
 
    ```sql
    create materialized view deduplicate as
    select k1, k2, k3, k4 from duplicate_table group by k1, k2, k3, k4;
-   ````
+   ```
 
    The materialized view schema is as shown below. The materialized view contains columns k1, k2, k3, and k4, and there are no duplicate rows.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
@@ -187,13 +187,13 @@ attention：If the materialized view contains partitioned and distributed column
    | | k3 | BIGINT | Yes | true | N/A | |
    | | k4 | BIGINT | Yes | true | N/A | |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 5. Create a non-aggregate materialized view that does not declare a sort column
 
    The schema of all_type_table is as follows
 
-   ````
+   ```
    +-------+--------------+------+-------+---------+- ------+
    | Field | Type | Null | Key | Default | Extra |
    +-------+--------------+------+-------+---------+- ------+
@@ -205,14 +205,14 @@ attention：If the materialized view contains partitioned and distributed column
    | k6 | DOUBLE | Yes | false | N/A | NONE |
    | k7 | VARCHAR(20) | Yes | false | N/A | NONE |
    +-------+--------------+------+-------+---------+- ------+
-   ````
+   ```
 
    The materialized view contains k3, k4, k5, k6, k7 columns, and does not declare a sort column, the creation statement is as follows:
 
    ```sql
    create materialized view mv_1 as
    select k3, k4, k5, k6, k7 from all_type_table;
-   ````
+   ```
 
    The default added sorting column of the system is k3, k4, k5 three columns. The sum of the bytes of these three column types is 4(INT) + 8(BIGINT) + 16(DECIMAL) = 28 < 36. So the addition is that these three columns are used as sorting columns. The schema of the materialized view is as follows, you can see that the key field of the k3, k4, k5 columns is true, that is, the sorting column. The key field of the k6, k7 columns is false, which is a non-sorted column.
 
@@ -226,7 +226,7 @@ attention：If the materialized view contains partitioned and distributed column
    | | k6 | DOUBLE | Yes | false | N/A | NONE |
    | | k7 | VARCHAR(20) | Yes | false | N/A | NONE |
    +----------------+-------+--------------+------+-- -----+---------+-------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-RESOURCE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-RESOURCE.md
@@ -40,7 +40,7 @@ grammar:
 ```sql
 CREATE [EXTERNAL] RESOURCE "resource_name"
 PROPERTIES ("key"="value", ...);
-````
+```
 
 illustrate:
 
@@ -69,7 +69,7 @@ illustrate:
      "broker.username" = "user0",
      "broker.password" = "password0"
    );
-   ````
+   ```
 
    Spark related parameters are as follows:
    - spark.master: Required, currently supports yarn, spark://host:port.
@@ -100,7 +100,7 @@ illustrate:
    "odbc_type" = "oracle",
    "driver" = "Oracle 19 ODBC driver"
    );
-   ````
+   ```
 
    The relevant parameters of ODBC are as follows:
    - hosts: IP address of the external database

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-SQL-BLOCK-RULE.md
@@ -45,7 +45,7 @@ grammar:
 ```sql
 CREATE SQL_BLOCK_RULE rule_name
 [PROPERTIES ("key"="value", ...)];
-````
+```
 
 Parameter Description:
 
@@ -68,7 +68,7 @@ Parameter Description:
     "global"="false",
     "enable"="true"
     );
-    ````
+    ```
 
     >Notes:
     >
@@ -79,7 +79,7 @@ Parameter Description:
     ```sql
     select * from order_analysis;
     ERROR 1064 (HY000): errCode = 2, detailMessage = sql match regex sql block rule: order_analysis_rule
-    ````
+    ```
 
 
 2. Create test_rule2, limit the maximum number of scanned partitions to 30, and limit the maximum scan base to 10 billion rows. The example is as follows:
@@ -92,7 +92,7 @@ Parameter Description:
     "global" = "false",
     "enable" = "true"
     );
-   ````
+   ```
 3. Create SQL BLOCK RULE with special chars
 
     ```sql
@@ -110,9 +110,9 @@ Parameter Description:
 
 ### Keywords
 
-````text
+```text
 CREATE, SQL_BLCOK_RULE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-LIKE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-LIKE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 CREATE [EXTERNAL] TABLE [IF NOT EXISTS] [database.]table_name LIKE [database.]table_name [WITH ROLLUP (r1,r2,r3,...)]
-````
+```
 
 illustrate: 
 
@@ -53,43 +53,43 @@ illustrate:
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1
-    ````
+    ```
 
 2. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1
-    ````
+    ```
 
 3. Create an empty table with the same table structure as table1 under the test1 library, the table name is table2, and copy the two rollups of r1 and r2 of table1 at the same time
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1 WITH ROLLUP (r1,r2)
-    ````
+    ```
 
 4. Create an empty table with the same table structure as table1 under the test1 library, the table name is table2, and copy all the rollups of table1 at the same time
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1 WITH ROLLUP
-    ````
+    ```
 
 5. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2, and copy the two rollups of r1 and r2 of table1 at the same time
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1 WITH ROLLUP (r1,r2)
-    ````
+    ```
 
 6. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2, and copy all the rollups of table1 at the same time
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1 WITH ROLLUP
-    ````
+    ```
 
 7. Create an empty table under the test1 library with the same table structure as the MySQL outer table1, the table name is table2
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-VIEW.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-VIEW.md
@@ -40,7 +40,7 @@ CREATE VIEW [IF NOT EXISTS]
  [db_name.]view_name
  (column1[ COMMENT "col comment"][, column2, ...])
 AS query_stmt
-````
+```
 
 
 illustrate:
@@ -57,7 +57,7 @@ illustrate:
     AS
     SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table
     WHERE k1 = 20160112 GROUP BY k1,k2,k3;
-    ````
+    ```
     
 2. Create a view with a comment
 
@@ -73,7 +73,7 @@ illustrate:
     AS
     SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table
     WHERE k1 = 20160112 GROUP BY k1,k2,k3;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-DATABASE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-DATABASE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP DATABASE [IF EXISTS] db_name [FORCE];
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
    
      ```sql
      DROP DATABASE db_test;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-ENCRYPT-KEY.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-ENCRYPT-KEY.md
@@ -36,7 +36,7 @@ grammar:
 
 ```sql
 DROP ENCRYPTKEY key_name
-````
+```
 
 Parameter Description:
 
@@ -52,7 +52,7 @@ Executing this command requires the user to have `ADMIN` privileges.
 
     ```sql
     DROP ENCRYPTKEY my_key;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FILE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FILE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 DROP FILE "file_name" [FROM database]
 [properties]
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ illustrate:
 
      ```sql
      DROP FILE "ca.pem" properties("catalog" = "kafka");
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FUNCTION.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FUNCTION.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 DROP [GLOBAL] FUNCTION function_name
      (arg_type [, ...])
-````
+```
 
 Parameter Description:
 
@@ -52,12 +52,12 @@ Parameter Description:
 
     ```sql
     DROP FUNCTION my_add(INT, INT)
-    ````
+    ```
 2. Delete a global function
 
     ```sql
     DROP GLOBAL FUNCTION my_add(INT, INT)
-    ````   
+    ```   
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-INDEX.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-INDEX.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP INDEX [IF EXISTS] index_name ON [db_name.]table_name;
-````
+```
 
 ### Example
 
@@ -45,7 +45,7 @@ DROP INDEX [IF EXISTS] index_name ON [db_name.]table_name;
 
     ```sql
     DROP INDEX [IF NOT EXISTS] index_name ON table1 ;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-MATERIALIZED-VIEW.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DROP MATERIALIZED VIEW [IF EXISTS] mv_name ON table_name;
-````
+```
 
 
 1. IF EXISTS:
@@ -70,17 +70,17 @@ mysql> desc all_type_table all;
 | k1_sumk2 | k1 | TINYINT | Yes | true | N/A | |
 | | k2 | SMALLINT | Yes | false | N/A | SUM |
 +----------------+-------+----------+------+------ -+---------+-------+
-````
+```
 
 1. Drop the materialized view named k1_sumk2 of the table all_type_table
 
    ```sql
    drop materialized view k1_sumk2 on all_type_table;
-   ````
+   ```
 
    The table structure after the materialized view is deleted
 
-   ````text
+   ```text
    +----------------+-------+----------+------+------ -+---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +----------------+-------+----------+------+------ -+---------+-------+
@@ -92,14 +92,14 @@ mysql> desc all_type_table all;
    | | k6 | FLOAT | Yes | false | N/A | NONE |
    | | k7 | DOUBLE | Yes | false | N/A | NONE |
    +----------------+-------+----------+------+------ -+---------+-------+
-   ````
+   ```
 
 2. Drop a non-existent materialized view in the table all_type_table
 
    ```sql
    drop materialized view k1_k2 on all_type_table;
    ERROR 1064 (HY000): errCode = 2, detailMessage = Materialized view [k1_k2] does not exist in table [all_type_table]
-   ````
+   ```
 
    The delete request reports an error directly
 
@@ -108,7 +108,7 @@ mysql> desc all_type_table all;
    ```sql
    drop materialized view if exists k1_k2 on all_type_table;
    Query OK, 0 rows affected (0.00 sec)
-   ````
+   ```
 
     If it exists, delete it, if it does not exist, no error is reported.
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-RESOURCE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-RESOURCE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP RESOURCE 'resource_name'
-````
+```
 
 Note: ODBC/S3 resources in use cannot be deleted.
 
@@ -47,7 +47,7 @@ Note: ODBC/S3 resources in use cannot be deleted.
    
      ```sql
      DROP RESOURCE 'spark0';
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-SQL-BLOCK-RULE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DROP SQL_BLOCK_RULE test_rule1,...
-````
+```
 
 ### Example
 
@@ -47,12 +47,12 @@ DROP SQL_BLOCK_RULE test_rule1,...
     ```sql
     mysql> DROP SQL_BLOCK_RULE test_rule1,test_rule2;
     Query OK, 0 rows affected (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 
-````text
+```text
 DROP, SQL_BLOCK_RULE
-````
+```
 
 ### Best Practice

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-TABLE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-TABLE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP TABLE [IF EXISTS] [db_name.]table_name [FORCE];
-````
+```
 
 
 illustrate:
@@ -51,13 +51,13 @@ illustrate:
    
      ```sql
      DROP TABLE my_table;
-     ````
+     ```
     
 2. If it exists, delete the table of the specified database
    
      ```sql
      DROP TABLE IF EXISTS example_db.my_table;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/TRUNCATE-TABLE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Definition-Statements/Drop/TRUNCATE-TABLE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 TRUNCATE TABLE [db.]tbl[ PARTITION(p1, p2, ...)];
-````
+```
 
 illustrate:
 
@@ -53,13 +53,13 @@ illustrate:
 
      ```sql
      TRUNCATE TABLE example_db.tbl;
-     ````
+     ```
 
 2. Empty p1 and p2 partitions of table tbl
 
      ```sql
      TRUNCATE TABLE tbl PARTITION(p1, p2);
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/ALTER-ROUTINE-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/ALTER-ROUTINE-LOAD.md
@@ -43,7 +43,7 @@ ALTER ROUTINE LOAD FOR [db.]job_name
 [job_properties]
 FROM data_source
 [data_source_properties]
-````
+```
 
 1. `[db.]job_name`
 
@@ -101,7 +101,7 @@ FROM data_source
    (
        "desired_concurrent_number" = "1"
    );
-   ````
+   ```
 
 2. Modify `desired_concurrent_number` to 10, modify the offset of the partition, and modify the group id.
 
@@ -117,7 +117,7 @@ FROM data_source
        "kafka_offsets" = "100, 200, 100",
        "property.group.id" = "new_group"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/BROKER-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/BROKER-LOAD.md
@@ -74,7 +74,7 @@ WITH BROKER broker_name
   [DELETE ON expr]
   [ORDER BY source_sequence]
   [PROPERTIES ("key1"="value1", ...)]
-  ````
+  ```
 
   - `[MERGE|APPEND|DELETE]`
 
@@ -142,13 +142,13 @@ WITH BROKER broker_name
 
   Specifies the information required by the broker. This information is usually used by the broker to be able to access remote storage systems. Such as BOS or HDFS. See the [Broker](../../../../advanced/broker.md) documentation for specific information.
 
-  ````text
+  ```text
   (
       "key1" = "val1",
       "key2" = "val2",
       ...
   )
-  ````
+  ```
 
 - `load_properties`
 
@@ -204,7 +204,7 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    Import the file `file.txt`, separated by commas, into the table `my_table`.
 
@@ -232,7 +232,7 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    Import two batches of files `file-10*` and `file-20*` using wildcard matching. Imported into two tables `my_table1` and `my_table2` respectively. Where `my_table1` specifies to import into partition `p1`, and will import the values of the second and third columns in the source file +1.
 
@@ -255,7 +255,7 @@ WITH BROKER broker_name
        "dfs.namenode.rpc-address.my_ha.my_namenode2" = "nn2_host:rpc_port",
        "dfs.client.failover.proxy.provider.my_ha" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
    );
-   ````
+   ```
 
    Specify the delimiter as Hive's default delimiter `\\x01`, and use the wildcard * to specify all files in all directories under the `data` directory. Use simple authentication while configuring namenode HA.
 
@@ -274,7 +274,7 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
 5. Import the data and extract the partition field in the file path
 
@@ -292,18 +292,18 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    The columns in the `my_table` table are `k1, k2, k3, city, utc_date`.
 
    The `hdfs://hdfs_host:hdfs_port/user/doris/data/input/dir/city=beijing` directory includes the following files:
 
-   ````text
+   ```text
    hdfs://hdfs_host:hdfs_port/input/city=beijing/utc_date=2020-10-01/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=beijing/utc_date=2020-10-02/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=tianji/utc_date=2020-10-03/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=tianji/utc_date=2020-10-04/0000.csv
-   ````
+   ```
 
    The file only contains three columns of `k1, k2, k3`, and the two columns of `city, utc_date` will be extracted from the file path.
 
@@ -326,7 +326,7 @@ WITH BROKER broker_name
        "username"="user",
        "password"="pass"
    );
-   ````
+   ```
 
    Only in the original data, k1 = 1, and after transformation, rows with k1 > k2 will be imported.
 
@@ -349,22 +349,22 @@ WITH BROKER broker_name
        "username"="user",
        "password"="pass"
    );
-   ````
+   ```
 
    There are the following files in the path:
 
-   ````text
+   ```text
    /user/data/data_time=2020-02-17 00%3A00%3A00/test.txt
    /user/data/data_time=2020-02-18 00%3A00%3A00/test.txt
-   ````
+   ```
 
    The table structure is:
 
-   ````text
+   ```text
    data_time DATETIME,
    k2 INT,
    k3 INT
-   ````
+   ```
 
 8. Import a batch of data from HDFS, specify the timeout and filter ratio. Broker with clear text my_hdfs_broker. Simple authentication. And delete the columns in the original data that match the columns with v2 greater than 100 in the imported data, and other columns are imported normally
 
@@ -386,7 +386,7 @@ WITH BROKER broker_name
         "timeout" = "3600",
         "max_filter_ratio" = "0.1"
     );
-    ````
+    ```
 
    Import using the MERGE method. `my_table` must be a table with Unique Key. When the value of the v2 column in the imported data is greater than 100, the row is considered a delete row.
 
@@ -408,7 +408,7 @@ WITH BROKER broker_name
         "hadoop.username"="user",
         "password"="pass"
     )
-    ````
+    ```
 
    `my_table` must be an Unqiue Key model table with Sequence Col specified. The data will be ordered according to the value of the `source_sequence` column in the source data.
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CANCEL-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CANCEL-LOAD.md
@@ -50,7 +50,7 @@ Notice: Cancel by State is supported since 1.2.0.
     CANCEL LOAD
     FROM example_db
     WHERE LABEL = "example_db_test_load_label";
-    ````
+    ```
 
 2. Cancel all import jobs containing example* on the database example*db.
 
@@ -58,7 +58,7 @@ Notice: Cancel by State is supported since 1.2.0.
     CANCEL LOAD
     FROM example_db
     WHERE LABEL like "example_";
-    ````
+    ```
 
 <version since="1.2.0">
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md
@@ -63,7 +63,7 @@ FROM data_source [data_source_properties]
 
   Used to describe imported data. The composition is as follows:
 
-  ````SQL
+  ```SQL
   [column_separator],
   [columns_mapping],
   [preceding_filter],
@@ -71,7 +71,7 @@ FROM data_source [data_source_properties]
   [partitions],
   [DELETE ON],
   [ORDER BY]
-  ````
+  ```
 
   - `column_separator`
 
@@ -115,12 +115,12 @@ FROM data_source [data_source_properties]
 
   Common parameters for specifying routine import jobs.
 
-  ````text
+  ```text
   PROPERTIES (
       "key1" = "val1",
       "key2" = "val2"
   )
-  ````
+  ```
 
   Currently we support the following parameters:
 
@@ -142,11 +142,11 @@ FROM data_source [data_source_properties]
 
      These three parameters are used to control the execution time and processing volume of a subtask. When either one reaches the threshold, the task ends.
 
-     ````text
+     ```text
      "max_batch_interval" = "20",
      "max_batch_rows" = "300000",
      "max_batch_size" = "209715200"
-     ````
+     ```
 
   3. `max_error_number`
 
@@ -230,13 +230,13 @@ FROM data_source [data_source_properties]
 
   The type of data source. Currently supports:
 
-  ````text
+  ```text
   FROM KAFKA
   (
       "key1" = "val1",
       "key2" = "val2"
   )
-  ````
+  ```
 
   `data_source_properties` supports the following data source properties:
 
@@ -264,15 +264,15 @@ FROM data_source [data_source_properties]
 
      If not specified, all partitions under topic will be subscribed from `OFFSET_END` by default.
 
-     ````text
+     ```text
      "kafka_partitions" = "0,1,2,3",
      "kafka_offsets" = "101,0,OFFSET_BEGINNING,OFFSET_END"
-     ````
+     ```
 
-     ````text
+     ```text
      "kafka_partitions" = "0,1,2,3",
      "kafka_offsets" = "2021-05-22 11:00:00,2021-05-22 11:00:00,2021-05-22 11:00:00"
-     ````
+     ```
 
      Note that the time format cannot be mixed with the OFFSET format.
 
@@ -286,20 +286,20 @@ FROM data_source [data_source_properties]
 
      For more supported custom parameters, please refer to the configuration items on the client side in the official CONFIGURATION document of librdkafka. Such as:
 
-     ````text
+     ```text
      "property.client.id" = "12345",
      "property.ssl.ca.location" = "FILE:ca.pem"
-     ````
+     ```
 
      1. When connecting to Kafka using SSL, you need to specify the following parameters:
 
-        ````text
+        ```text
         "property.security.protocol" = "ssl",
         "property.ssl.ca.location" = "FILE:ca.pem",
         "property.ssl.certificate.location" = "FILE:client.pem",
         "property.ssl.key.location" = "FILE:client.key",
         "property.ssl.key.password" = "abcdefg"
-        ````
+        ```
 
         in:
 
@@ -307,11 +307,11 @@ FROM data_source [data_source_properties]
 
         If client authentication is enabled on the Kafka server side, thenAlso set:
 
-        ````text
+        ```text
         "property.ssl.certificate.location"
         "property.ssl.key.location"
         "property.ssl.key.password"
-        ````
+        ```
 
         They are used to specify the client's public key, private key, and password for the private key, respectively.
 
@@ -323,9 +323,9 @@ FROM data_source [data_source_properties]
 
         Example:
 
-        ````text
+        ```text
         "property.kafka_default_offsets" = "OFFSET_BEGINNING"
-        ````
+        ```
 - <version since="1.2.3" type="inline"> comment </version>
   Comment for the routine load job.
 ### Example
@@ -354,7 +354,7 @@ FROM data_source [data_source_properties]
        "property.client.id" = "xxx",
        "property.kafka_default_offsets" = "OFFSET_BEGINNING"
    );
-   ````
+   ```
 
 2. Create a Kafka routine import task named test1 for example_tbl of example_db. Import tasks are in strict mode.
 
@@ -380,7 +380,7 @@ FROM data_source [data_source_properties]
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 3. Import data from the Kafka cluster through SSL authentication. Also set the client.id parameter. The import task is in non-strict mode and the time zone is Africa/Abidjan
 
@@ -410,7 +410,7 @@ FROM data_source [data_source_properties]
        "property.ssl.key.password" = "abcdefg",
        "property.client.id" = "my_client_id"
    );
-   ````
+   ```
 
 4. Import data in Json format. By default, the field name in Json is used as the column name mapping. Specify to import three partitions 0, 1, and 2, and the starting offsets are all 0
 
@@ -435,7 +435,7 @@ FROM data_source [data_source_properties]
        "kafka_partitions" = "0,1,2",
        "kafka_offsets" = "0,0,0"
    );
-   ````
+   ```
 
 5. Import Json data, extract fields through Jsonpaths, and specify the root node of the Json document
 
@@ -463,7 +463,7 @@ FROM data_source [data_source_properties]
        "kafka_partitions" = "0,1,2",
        "kafka_offsets" = "0,0,0"
    );
-   ````
+   ```
 
 6. Create a Kafka routine import task named test1 for example_tbl of example_db. And use conditional filtering.
 
@@ -490,7 +490,7 @@ FROM data_source [data_source_properties]
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 7. Import data to Unique with sequence column Key model table
 
@@ -514,7 +514,7 @@ FROM data_source [data_source_properties]
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 8. Consume from a specified point in time
 
@@ -534,7 +534,7 @@ FROM data_source [data_source_properties]
        "kafka_topic" = "my_topic",
        "kafka_default_offset" = "2021-05-21 10:00:00"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CREATE-SYNC-JOB.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CREATE-SYNC-JOB.md
@@ -48,7 +48,7 @@ CREATE SYNC [db.]job_name
  ...
  )
 binlog_desc
-````
+```
 
 1. `job_name`
 
@@ -63,7 +63,7 @@ binlog_desc
    ```sql
    FROM mysql_db.src_tbl INTO des_tbl
    [columns_mapping]
-   ````
+   ```
    
    1. `mysql_db.src_tbl`
    
@@ -81,7 +81,7 @@ binlog_desc
    
       Example:
    
-      ````
+      ```
       Suppose the target table column is (k1, k2, v1),
       
       Change the order of columns k1 and k2
@@ -89,7 +89,7 @@ binlog_desc
       
       Ignore the fourth column of the source data
       (k2, k1, v1, dummy_column)
-      ````
+      ```
    
 3. `binlog_desc`
 
@@ -103,7 +103,7 @@ binlog_desc
        "key1" = "value1",
        "key2" = "value2"
    )
-   ````
+   ```
 
    1. The properties corresponding to the Canal data source, prefixed with `canal.`
 
@@ -119,7 +119,7 @@ binlog_desc
 
 1. Simply create a data synchronization job named `job1` for `test_tbl` of `test_db`, connect to the local Canal server, corresponding to the Mysql source table `mysql_db1.tbl1`.
 
-   ````SQL
+   ```SQL
    CREATE SYNC `test_db`.`job1`
    (
    FROM `mysql_db1`.`tbl1` INTO `test_tbl`
@@ -133,11 +133,11 @@ binlog_desc
    "canal.username" = "",
    "canal.password" = ""
    );
-   ````
+   ```
 
 2. Create a data synchronization job named `job1` for multiple tables of `test_db`, corresponding to multiple Mysql source tables one-to-one, and explicitly specify the column mapping.
 
-   ````SQL
+   ```SQL
    CREATE SYNC `test_db`.`job1`
    (
    FROM `mysql_db`.`t1` INTO `test1` (k1, k2, v1) ,
@@ -152,7 +152,7 @@ binlog_desc
    "canal.username" = "username",
    "canal.password" = "password"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/MULTI-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/MULTI-LOAD.md
@@ -34,7 +34,7 @@ MULTI LOAD
 
 Users submit multiple import jobs through the HTTP protocol. Multi Load can ensure the atomic effect of multiple import jobs
 
-````
+```
 Syntax:
     curl --location-trusted -u user:passwd -XPOST http://host:port/api/{db}/_multi_start?label=xxx
     curl --location-trusted -u user:passwd -T data.file http://host:port/api/{db}/{table1}/_load?label=xxx\&sub_label=yyy
@@ -91,11 +91,11 @@ NOTE:
 
     3. Supports the use of curl to import data into Doris in a way similar to streaming, but only after the streaming ends Doris
     The real import behavior will occur, and the amount of data in this way cannot be too large.
-````
+```
 
 ### Example
 
-````
+```
 1. Import the data in the local file 'testData1' into the table 'testTbl1' in the database 'testDb', and
 Import the data of 'testData2' into table 'testTbl2' in 'testDb' (user is in defalut_cluster)
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_start?label=123
@@ -112,7 +112,7 @@ Import the data of 'testData2' into table 'testTbl2' in 'testDb' (user is in def
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_start?label=123
     curl --location-trusted -u root -T testData1 http://host:port/api/testDb/testTbl1/_load?label=123\&sub_label=1
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_desc?label=123
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/PAUSE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/PAUSE-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ Used to pause a Routine Load job. A suspended job can be rerun with the RESUME c
 
 ```sql
 PAUSE [ALL] ROUTINE LOAD FOR job_name
-````
+```
 
 ### Example
 
@@ -44,13 +44,13 @@ PAUSE [ALL] ROUTINE LOAD FOR job_name
 
     ```sql
     PAUSE ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 2. Pause all routine import jobs.
 
     ```sql
     PAUSE ALL ROUTINE LOAD;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/PAUSE-SYNC-JOB.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/PAUSE-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 PAUSE SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ PAUSE SYNC JOB [db.]job_name
 
     ```sql
     PAUSE SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/RESUME-ROUTINE-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/RESUME-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ Used to restart a suspended Routine Load job. The restarted job will continue to
 
 ```sql
 RESUME [ALL] ROUTINE LOAD FOR job_name
-````
+```
 
 ### Example
 
@@ -44,13 +44,13 @@ RESUME [ALL] ROUTINE LOAD FOR job_name
 
     ```sql
     RESUME ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 2. Restart all routine import jobs.
 
     ```sql
     RESUME ALL ROUTINE LOAD;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/RESUME-SYNC-JOB.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/RESUME-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 RESUME SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ RESUME SYNC JOB [db.]job_name
 
     ```sql
     RESUME SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STOP-ROUTINE-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STOP-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ User stops a Routine Load job. A stopped job cannot be rerun.
 
 ```sql
 STOP ROUTINE LOAD FOR job_name;
-````
+```
 
 ### Example
 
@@ -44,7 +44,7 @@ STOP ROUTINE LOAD FOR job_name;
 
     ```sql
     STOP ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STOP-SYNC-JOB.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STOP-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 STOP SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ STOP SYNC JOB [db.]job_name
 
     ```sql
     STOP SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STREAM-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STREAM-LOAD.md
@@ -34,9 +34,9 @@ STREAM LOAD
 
 stream-load: load data to table in streaming
 
-````
+```
 curl --location-trusted -u user:passwd [-H ""...] -T data.file -XPUT http://fe_host:http_port/api/{db}/{table}/_stream_load
-````
+```
 
 This statement is used to import data into the specified table. The difference from ordinary Load is that this import method is synchronous import.
 
@@ -105,20 +105,20 @@ Parameter introduction:
 
     Simple mode: The simple mode is not set the jsonpaths parameter. In this mode, the json data is required to be an object type, for example:
 
-       ````
+       ```
     {"k1":1, "k2":2, "k3":"hello"}, where k1, k2, k3 are column names.
-       ````
+       ```
 
     Matching mode: It is relatively complex for json data and needs to match the corresponding value through the jsonpaths parameter.
 
 14. strip_outer_array: Boolean type, true indicates that the json data starts with an array object and flattens the array object, the default value is false. E.g:
 
-     ````
+     ```
       [
        {"k1" : 1, "v1" : 2},
        {"k1" : 3, "v1" : 4}
       ]
-    ````
+    ```
     When strip_outer_array is true, the final import into doris will generate two rows of data.
 
 
@@ -171,9 +171,9 @@ separated by commas.
 
 ERRORS:
         Import error details can be viewed with the following statement:
-        ````
+        ```
         SHOW LOAD WARNINGS ON 'url'
-        ````
+        ```
         where url is the url given by ErrorURL.
 
 24. compress_type
@@ -189,56 +189,56 @@ ERRORS:
 
 1. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', and use Label for deduplication. Specify a timeout of 100 seconds
 
-   ````
+   ```
        curl --location-trusted -u root -H "label:123" -H "timeout:100" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 2. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', use Label for deduplication, and only import data whose k1 is equal to 20180601
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "where: k1=20180601" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 3. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', allowing a 20% error rate (the user is in the defalut_cluster)
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 4. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', allow a 20% error rate, and specify the column name of the file (the user is in the defalut_cluster)
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -H "columns: k2, k1, v1" -T testData http://host:port/api/testDb/testTbl /_stream_load
-   ````
+   ```
 
 5. Import the data in the local file 'testData' into the p1, p2 partitions of the table 'testTbl' in the database 'testDb', allowing a 20% error rate.
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -H "partitions: p1, p2" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 6. Import using streaming (user is in defalut_cluster)
 
-    ````
+    ```
     seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/ _stream_load
-    ````
+    ```
 
 7. Import a table containing HLL columns, which can be columns in the table or columns in the data to generate HLL columns, or use hll_empty to supplement columns that are not in the data
 
-   ````
+   ```
    curl --location-trusted -u root -H "columns: k1, k2, v1=hll_hash(k1), v2=hll_empty()" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 8. Import data for strict mode filtering and set the time zone to Africa/Abidjan
 
-   ````
+   ```
    curl --location-trusted -u root -H "strict_mode: true" -H "timezone: Africa/Abidjan" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 9. Import a table with a BITMAP column, which can be a column in the table or a column in the data to generate a BITMAP column, or use bitmap_empty to fill an empty Bitmap
-   ````
+   ```
     curl --location-trusted -u root -H "columns: k1, k2, v1=to_bitmap(k1), v2=bitmap_empty()" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 10. Simple mode, import json data
     Table Structure:
@@ -249,39 +249,39 @@ ERRORS:
     `price` double NULL COMMENT ""
 
     json data format:
-    ````
+    ```
     {"category":"C++","author":"avc","title":"C++ primer","price":895}
-    ````
+    ```
     
     Import command:
     
-    ````
+    ```
     curl --location-trusted -u root -H "label:123" -H "format: json" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
     In order to improve throughput, it supports importing multiple pieces of json data at one time, each line is a json object, and \n is used as a newline by default. You need to set read_json_by_line to true. The json data format is as follows:
 
-    ````
+    ```
     {"category":"C++","author":"avc","title":"C++ primer","price":89.5}
     {"category":"Java","author":"avc","title":"Effective Java","price":95}
     {"category":"Linux","author":"avc","title":"Linux kernel","price":195}
-    ````
+    ```
     
 11. Match pattern, import json data
     json data format:
 
-    ````
+    ```
     [
     {"category":"xuxb111","author":"1avc","title":"SayingsoftheCentury","price":895},{"category":"xuxb222","author":"2avc"," title":"SayingsoftheCentury","price":895},
     {"category":"xuxb333","author":"3avc","title":"SayingsoftheCentury","price":895}
     ]
-    ````
+    ```
 
     Precise import by specifying jsonpath, such as importing only three attributes of category, author, and price
 
-    ````
+    ```
     curl --location-trusted -u root -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\" $.price\",\"$.author\"]" -H "strip_outer_array: true" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
 
     illustrate:
         1) If the json data starts with an array, and each object in the array is a record, you need to set strip_outer_array to true, which means flatten the array.
@@ -290,7 +290,7 @@ ERRORS:
 12. User specified json root node
     json data format:
 
-    ````
+    ```
     {
      "RECORDS":[
     {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
@@ -298,31 +298,31 @@ ERRORS:
     {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
     ]
     }
-    ````
+    ```
 
     Precise import by specifying jsonpath, such as importing only three attributes of category, author, and price
     
-    ````
+    ```
     curl --location-trusted -u root -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\" $.price\",\"$.author\"]" -H "strip_outer_array: true" -H "json_root: $.RECORDS" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
 13. Delete the data with the same import key as this batch
 
-    ````
+    ```
     curl --location-trusted -u root -H "merge_type: DELETE" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
 
 14. Delete the columns in this batch of data that match the data whose flag is listed as true, and append other rows normally
     
-    ````
+    ```
     curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv, flag" -H "merge_type: MERGE" -H "delete: flag=1" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
 15. Import data into UNIQUE_KEYS table with sequence column
     
-    ````
+    ```
     curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/ _stream_load
-    ````
+    ```
 
 16. csv file line header filter import
 
@@ -348,7 +348,7 @@ ERRORS:
 
    Stream Load is a synchronous import process. The successful execution of the statement means that the data is imported successfully. The imported execution result will be returned synchronously through the HTTP return value. And display it in Json format. An example is as follows:
 
-   ````json
+   ```json
    {
        "TxnId": 17,
        "Label": "707717c0-271a-44c5-be0b-4e71bfeacaa5",
@@ -366,7 +366,7 @@ ERRORS:
        "WriteDataTimeMs": 3,
        "CommitAndPublishTimeMs": 18
    }
-   ````
+   ```
 
    The field definitions are as follows:
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/CANCEL-EXPORT.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/CANCEL-EXPORT.md
@@ -50,7 +50,7 @@ WHERE [LABEL = "export_label" | LABEL like "label_pattern" | STATE = "PENDING/IN
     CANCEL EXPORT
     FROM example_db
     WHERE LABEL = "example_db_test_export_label" and STATE = "EXPORTING";
-    ````
+    ```
 
 2. Cancel all export jobs containing example* on the database example*db.
 
@@ -58,7 +58,7 @@ WHERE [LABEL = "export_label" | LABEL like "label_pattern" | STATE = "PENDING/IN
     CANCEL EXPORT
     FROM example_db
     WHERE LABEL like "%example%";
-    ````
+    ```
 
 3. Cancel all export jobs which state are "PENDING"
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/DELETE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/DELETE.md
@@ -99,21 +99,21 @@ DELETE FROM table_name
    ```sql
    DELETE FROM my_table PARTITION p1
        WHERE k1 = 3;
-   ````
+   ```
 
 2. Delete the data rows where the value of column k1 is greater than or equal to 3 and the value of column k2 is "abc" in my_table partition p1
 
    ```sql
    DELETE FROM my_table PARTITION p1
    WHERE k1 >= 3 AND k2 = "abc";
-   ````
+   ```
 
 3. Delete the data rows where the value of column k1 is greater than or equal to 3 and the value of column k2 is "abc" in my_table partition p1, p2
 
    ```sql
    DELETE FROM my_table PARTITIONS (p1, p2)
    WHERE k1 >= 3 AND k2 = "abc";
-   ````
+   ```
 
 <version since="dev">
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/EXPORT.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/EXPORT.md
@@ -65,7 +65,7 @@ illustrate:
 
   ```sql
   [PROPERTIES ("key"="value", ...)]
-  ````
+  ```
 
   The following parameters can be specified:
 
@@ -82,15 +82,15 @@ illustrate:
 
   ```sql
   WITH BROKER hdfs|s3 ("key"="value"[,...])
-  ````
+  ```
 
  1. If the export is to Amazon S3, you need to provide the following properties
 
-````
+```
 fs.s3a.access.key: AmazonS3 access key
 fs.s3a.secret.key: AmazonS3 secret key
 fs.s3a.endpoint: AmazonS3 endpoint
-````
+```
 
  2. If you use the S3 protocol to directly connect to the remote storage, you need to specify the following properties
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/INSERT.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/INSERT.md
@@ -41,7 +41,7 @@ INSERT INTO table_name
     [ (column [, ...]) ]
     [ [ hint [, ...] ] ]
     { VALUES ( { expression | DEFAULT } [, ...] ) [, ...] | query }
-````
+```
 
  Parameters
 
@@ -79,7 +79,7 @@ INSERT INTO test VALUES (1, 2);
 INSERT INTO test (c1, c2) VALUES (1, 2);
 INSERT INTO test (c1, c2) VALUES (1, DEFAULT);
 INSERT INTO test (c1) VALUES (1);
-````
+```
 
 The first and second statements have the same effect. When no target column is specified, the column order in the table is used as the default target column.
 The third and fourth statements express the same meaning, use the default value of the `c2` column to complete the data import.
@@ -91,7 +91,7 @@ INSERT INTO test VALUES (1, 2), (3, 2 + 2);
 INSERT INTO test (c1, c2) VALUES (1, 2), (3, 2 * 2);
 INSERT INTO test (c1) VALUES (1), (3);
 INSERT INTO test (c1, c2) VALUES (1, DEFAULT), (3, DEFAULT);
-````
+```
 
 The first and second statements have the same effect, import two pieces of data into the `test` table at one time
 The effect of the third and fourth statements is known, and the default value of the `c2` column is used to import two pieces of data into the `test` table
@@ -101,14 +101,14 @@ The effect of the third and fourth statements is known, and the default value of
 ```sql
 INSERT INTO test SELECT * FROM test2;
 INSERT INTO test (c1, c2) SELECT * from test2;
-````
+```
 
 4. Import a query result into the `test` table, specifying the partition and label
 
 ```sql
 INSERT INTO test PARTITION(p1, p2) WITH LABEL `label1` SELECT * FROM test2;
 INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
-````
+```
 
 Asynchronous import is actually a synchronous import encapsulated into asynchronous. Filling in streaming and not filling in **execution efficiency is the same**.
 
@@ -157,17 +157,17 @@ Since the previous import methods of Doris are all asynchronous import methods, 
          mysql> insert into tbl1 select * from tbl2;
          Query OK, 2 rows affected, 2 warnings (0.31 sec)
          {'label':'insert_f0747f0e-7a35-46e2-affa-13a235f4020d', 'status':'committed', 'txnId':'4005'}
-         ````
+         ```
 
          `Query OK` indicates successful execution. `4 rows affected` means that a total of 4 rows of data were imported. `2 warnings` indicates the number of lines to be filtered.
 
          Also returns a json string:
 
-         ````json
+         ```json
          {'label':'my_label1', 'status':'visible', 'txnId':'4005'}
          {'label':'insert_f0747f0e-7a35-46e2-affa-13a235f4020d', 'status':'committed', 'txnId':'4005'}
          {'label':'my_label1', 'status':'visible', 'txnId':'4005', 'err':'some other error'}
-         ````
+         ```
 
          `label` is a user-specified label or an automatically generated label. Label is the ID of this Insert Into import job. Each import job has a unique Label within a single database.
 
@@ -181,7 +181,7 @@ Since the previous import methods of Doris are all asynchronous import methods, 
 
          ```sql
          show load where label="xxx";
-         ````
+         ```
 
          The URL in the returned result can be used to query the wrong data. For details, see the summary of **Viewing Error Lines** later.
 
@@ -191,7 +191,7 @@ Since the previous import methods of Doris are all asynchronous import methods, 
 
          ```sql
          show transaction where id=4005;
-         ````
+         ```
 
          If the `TransactionStatus` column in the returned result is `visible`, the representation data is visible.
 
@@ -208,7 +208,7 @@ Since the previous import methods of Doris are all asynchronous import methods, 
 
       ```sql
       show load warnings on "url";
-      ````
+      ```
 
       You can view the specific error line.
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
@@ -322,7 +322,7 @@ A CTE can refer to itself to define a recursive CTE. Common applications of recu
      
      SELECT college, region, seed FROM tournament
        ORDER BY 2, 3;
-     ````
+     ```
 
    - If ORDER BY appears in a subquery and also applies to the outer query, the outermost ORDER BY takes precedence.
 
@@ -330,7 +330,7 @@ A CTE can refer to itself to define a recursive CTE. Common applications of recu
 
      ```sql
      SELECT a, COUNT(b) FROM test_table GROUP BY a ORDER BY NULL;
-     ````
+     ```
 
      
 
@@ -344,7 +344,7 @@ A CTE can refer to itself to define a recursive CTE. Common applications of recu
 
      ```sql
      SELECT COUNT(col1) AS col2 FROM t GROUP BY col2 HAVING col2 = 2;
-     ````
+     ```
 
    - Remember not to use HAVING where WHERE should be used. HAVING is paired with GROUP BY.
 
@@ -353,7 +353,7 @@ A CTE can refer to itself to define a recursive CTE. Common applications of recu
      ```sql
      SELECT user, MAX(salary) FROM users
        GROUP BY user HAVING MAX(salary) > 10;
-     ````
+     ```
 
    - The LIMIT clause can be used to constrain the number of rows returned by a SELECT statement. LIMIT can have one or two arguments, both of which must be non-negative integers.
 
@@ -363,7 +363,7 @@ A CTE can refer to itself to define a recursive CTE. Common applications of recu
      /*Then if you want to retrieve all rows after a certain offset is set, you can set a very large constant for the second parameter. The following query fetches all data from row 96 onwards */
      SELECT * FROM tbl LIMIT 95,18446744073709551615;
      /*If LIMIT has only one parameter, the parameter specifies the number of rows that should be retrieved, and the offset defaults to 0, that is, starting from the first row*/
-     ````
+     ```
 
    - SELECT...INTO allows query results to be written to a file
 
@@ -404,7 +404,7 @@ A CTE can refer to itself to define a recursive CTE. Common applications of recu
        | 21 |
        +-------------+
        4 rows in set (0.01 sec)
-       ````
+       ```
    
 6. JOIN
    

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/OUTFILE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Data-Manipulation-Statements/OUTFILE.md
@@ -35,12 +35,12 @@ This statement is used to export query results to a file using the `SELECT INTO 
     
 grammar:
 
-````
+```
 query_stmt
 INTO OUTFILE "file_path"
 [format_as]
 [properties]
-````
+```
 
 illustrate:
 
@@ -122,7 +122,7 @@ illustrate:
        "line_delimiter" = "\n",
        "max_file_size" = "100MB"
    );
-   ````
+   ```
 
    If the final generated file is not larger than 100MB, it will be: `result_0.csv`.
    If larger than 100MB, it may be `result_0.csv, result_1.csv, ...`.
@@ -141,7 +141,7 @@ illustrate:
        "broker.kerberos_keytab" = "/home/doris/my.keytab",
        "schema"="required,int32,c1;required,byte_array,c2;required,byte_array,c2"
    );
-   ````
+   ```
 
    Exporting query results to parquet files requires explicit `schema`.
 
@@ -166,7 +166,7 @@ illustrate:
        "broker.dfs.namenode.rpc-address.my_ha.my_namenode2" = "nn2_host:rpc_port",
        "broker.dfs.client.failover.proxy.provider" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
    );
-   ````
+   ```
 
    If the final generated file is not larger than 1GB, it will be: `result_0.csv`.
    If larger than 1GB, it may be `result_0.csv, result_1.csv, ...`.
@@ -186,7 +186,7 @@ illustrate:
        "broker.bos_secret_accesskey" = "yyyyyyyyyyyyyyyyyyyyyyyyy",
        "schema"="required,int32,k1;required,byte_array,k2"
    );
-   ````
+   ```
 
 5. Export the query result of the select statement to the file `s3a://${bucket_name}/path/result.txt`. Specify the export format as csv.
    After the export is complete, an identity file is generated.
@@ -206,7 +206,7 @@ illustrate:
        "max_file_size" = "1024MB",
        "success_file_name" = "SUCCESS"
    )
-   ````
+   ```
 
    If the final generated file is not larger than 1GB, it will be: `my_file_0.csv`.
    If larger than 1GB, it may be `my_file_0.csv, result_1.csv, ...`.
@@ -229,7 +229,7 @@ illustrate:
        "AWS_SECRET_KEY" = "xxx",
        "AWS_REGION" = "bd"
    )
-   ````
+   ```
 
    The resulting file is prefixed with `my_file_{fragment_instance_id}_`.
 
@@ -248,7 +248,7 @@ illustrate:
        "AWS_SECRET_KEY" = "xxx",
        "AWS_REGION" = "bd"
    )
-   ````
+   ```
 
 8. Use hdfs export to export simple query results to the file `hdfs://${host}:${fileSystem_port}/path/to/result.txt`. Specify the export format as CSV and the user name as work. Specify the column separator as `,` and the row separator as `\n`.
 
@@ -305,7 +305,7 @@ illustrate:
        "max_file_size" = "1024MB",
        "success_file_name" = "SUCCESS"
    )
-   ````
+   ```
 
 ### keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-CANCEL-REPAIR.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-CANCEL-REPAIR.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN CANCEL REPAIR TABLE table_name[ PARTITION (p1,...)];
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
 
      ```sql
       ADMIN CANCEL REPAIR TABLE tbl PARTITION(p1);
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-CLEAN-TRASH.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-CLEAN-TRASH.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 ADMIN CLEAN TRASH [ON ("BackendHost1:BackendHeartBeatPort1", "BackendHost2:BackendHeartBeatPort2", ...)];
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-REPAIR-TABLE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-REPAIR-TABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN REPAIR TABLE table_name[ PARTITION (p1,...)]
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SET-CONFIG.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SET-CONFIG.md
@@ -39,7 +39,7 @@ grammar:
 
 ```sql
   ADMIN SET FRONTEND CONFIG ("key" = "value");
-````
+```
 
 ### Example
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SET-REPLICA-STATUS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SET-REPLICA-STATUS.md
@@ -41,7 +41,7 @@ grammar:
 ```sql
 ADMIN SET REPLICA STATUS
         PROPERTIES ("key" = "value", ...);
-````
+```
 
  The following properties are currently supported:
 
@@ -61,13 +61,13 @@ If the specified replica does not exist, or the status is already bad, it will b
 
        ```sql
     ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "bad");
-       ````
+       ```
 
 2. Set the replica status of tablet 10003 on BE 10001 to ok.
 
    ```sql
    ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "ok");
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-CONFIG.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-CONFIG.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
  ADMIN SHOW FRONTEND CONFIG [LIKE "pattern"];
-````
+```
 
 The columns in the results have the following meanings:
 
@@ -59,7 +59,7 @@ The columns in the results have the following meanings:
 
 2. Use the like predicate to search the configuration of the current Fe node
 
-   ````
+   ```
    mysql> ADMIN SHOW FRONTEND CONFIG LIKE '%check_java_version%';
    +--------------------+-------+---------+---------- -+------------+---------+
    | Key | Value | Type | IsMutable | MasterOnly | Comment |
@@ -67,7 +67,7 @@ The columns in the results have the following meanings:
    | check_java_version | true | boolean | false | false | |
    +--------------------+-------+---------+---------- -+------------+---------+
    1 row in set (0.01 sec)
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-REPLICA-DISTRIBUTION.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-REPLICA-DISTRIBUTION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN SHOW REPLICA DISTRIBUTION FROM [db_name.]tbl_name [PARTITION (p1, ...)];
-````
+```
 
 illustrate:
 
@@ -50,13 +50,13 @@ illustrate:
 
     ```sql
     ADMIN SHOW REPLICA DISTRIBUTION FROM tbl1;
-    ````
+    ```
 
   2. View the replica distribution of the partitions of the table
 
       ```sql
      ADMIN SHOW REPLICA DISTRIBUTION FROM db1.tbl1 PARTITION(p1, p2);
-      ````
+      ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-REPLICA-STATUS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-REPLICA-STATUS.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
  ADMIN SHOW REPLICA STATUS FROM [db_name.]tbl_name [PARTITION (p1, ...)]
 [where_clause];
-````
+```
 
 illustrate
 
@@ -59,21 +59,21 @@ illustrate
 
    ```sql
    ADMIN SHOW REPLICA STATUS FROM db1.tbl1;
-   ````
+   ```
 
 2. View a copy of a table with a partition status of VERSION_ERROR
 
    ```sql
    ADMIN SHOW REPLICA STATUS FROM tbl1 PARTITION (p1, p2)
    WHERE STATUS = "VERSION_ERROR";
-   ````
+   ```
 
 3. View all unhealthy replicas of the table
 
    ```sql
    ADMIN SHOW REPLICA STATUS FROM tbl1
    WHERE STATUS != "OK";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/INSTALL-PLUGIN.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/INSTALL-PLUGIN.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 INSTALL PLUGIN FROM [source] [PROPERTIES ("key"="value", ...)]
-````
+```
 
 source supports three types:
 
@@ -52,19 +52,19 @@ source supports three types:
 
     ```sql
     INSTALL PLUGIN FROM "/home/users/doris/auditdemo.zip";
-    ````
+    ```
 
 2. Install the plugin in a local directory:
 
     ```sql
     INSTALL PLUGIN FROM "/home/users/doris/auditdemo/";
-    ````
+    ```
 
 3. Download and install a plugin:
 
     ```sql
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip";
-    ````
+    ```
 
     Note than an md5 file with the same name as the `.zip` file needs to be placed, such as `http://mywebsite.com/plugin.zip.md5` . 
     The content is the MD5 value of the .zip file.
@@ -73,7 +73,7 @@ source supports three types:
 
     ```sql
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip" PROPERTIES("md5sum" = "73877f6029216f4314d712086a146570");
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/KILL.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/KILL.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 KILL [CONNECTION | QUERY] processlist_id
-````
+```
 
 ### Example
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/SET-VARIABLE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/SET-VARIABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SET variable_assignment [, variable_assignment] ...
-````
+```
 
 illustrate:
 
@@ -73,15 +73,15 @@ Variables that only support global effects include:
 
 1. Set the time zone to Dongba District
 
-   ````
+   ```
    SET time_zone = "Asia/Shanghai";
-   ````
+   ```
 
 2. Set the global execution memory size
 
-   ````
+   ```
    SET GLOBAL exec_mem_limit = 137438953472
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/UNINSTALL-PLUGIN.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Database-Administration-Statements/UNINSTALL-PLUGIN.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 UNINSTALL PLUGIN plugin_name;
-````
+```
 
   plugin_name can be viewed with the `SHOW PLUGINS;` command.
 
@@ -50,7 +50,7 @@ Only non-builtin plugins can be uninstalled.
 
     ```sql
     UNINSTALL PLUGIN auditdemo;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ALTER-TABLE-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ALTER-TABLE-MATERIALIZED-VIEW.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database: View jobs under the specified database. If not specified, the current database is used.
 - WHERE: You can filter the result column, currently only the following columns are supported:
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`: Job unique ID.
 
@@ -110,7 +110,7 @@ RollupIndexName: r1
 
    ```sql
    SHOW ALTER TABLE MATERIALIZED VIEW FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ALTER.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ALTER.md
@@ -36,7 +36,7 @@ This statement is used to display the execution of various modification tasks cu
 
 ```sql
 SHOW ALTER [CLUSTER | TABLE [COLUMN | ROLLUP] [FROM db_name]];
-````
+```
 
 TABLE COLUMN: show ALTER tasks that modify columns
                       Support syntax [WHERE TableName|CreateTime|FinishTime|State] [ORDER BY] [LIMIT]
@@ -50,25 +50,25 @@ TABLE COLUMN: show ALTER tasks that modify columns
 
    ```sql
     SHOW ALTER TABLE COLUMN;
-   ````
+   ```
 
 2. Display the task execution status of the last modified column of a table
 
    ```sql
    SHOW ALTER TABLE COLUMN WHERE TableName = "table1" ORDER BY CreateTime DESC LIMIT 1;
-   ````
+   ```
 
 3. Display the task execution of creating or deleting ROLLUP index for the specified db
 
    ```sql
    SHOW ALTER TABLE ROLLUP FROM example_db;
-   ````
+   ```
 
 4. Show tasks related to cluster operations (only for administrators! To be implemented...)
 
-   ````
+   ```
    SHOW ALTER CLUSTER;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
@@ -36,7 +36,7 @@ This statement is used to view the BE nodes in the cluster
 
 ```sql
  SHOW BACKENDS;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-BACKUP.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-BACKUP.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
  SHOW BACKUP [FROM db_name]
-````
+```
 
 illustrate:
 
@@ -71,7 +71,7 @@ illustrate:
 
    ```sql
     SHOW BACKUP FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-BROKER.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-BROKER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW BROKER;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-COLUMNS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-COLUMNS.md
@@ -46,7 +46,7 @@ SHOW [FULL] COLUMNS FROM tbl;
 
     ```sql
      SHOW FULL COLUMNS FROM tbl;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-DATABASE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-DATABASE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE DATABASE db_name;
-````
+```
 
 illustrate:
 
@@ -56,7 +56,7 @@ illustrate:
     | test | CREATE DATABASE `test` |
     +----------+----------------------------+
     1 row in set (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-FUNCTION.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-FUNCTION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE [GLOBAL] FUNCTION function_name(arg_type [, ...]) [FROM db_name]];
-````
+```
 
 illustrate:
 1. `global`: The show function is global 
@@ -54,12 +54,12 @@ illustrate:
 
     ```sql
     SHOW CREATE FUNCTION my_add(INT, INT)
-    ````
+    ```
 2. Show the creation statement of the specified global function
 
     ```sql
     SHOW CREATE GLOBAL FUNCTION my_add(INT, INT)
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-LOAD.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE LOAD for load_name;
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
 
     ```sql
     SHOW CREATE LOAD for test_load
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-REPOSITORY.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-REPOSITORY.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE REPOSITORY for repository_name;
-````
+```
 
 illustrate:
 -  `repository_name`: repository name
@@ -49,7 +49,7 @@ illustrate:
 
     ```sql
     SHOW CREATE REPOSITORY for test_repository
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-ROUTINE-LOAD.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW [ALL] CREATE ROUTINE LOAD for load_name;
-````
+```
 
 illustrate:
 
@@ -53,7 +53,7 @@ illustrate:
 
     ```sql
     SHOW CREATE ROUTINE LOAD for test_load
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-TABLE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-TABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE TABLE [DBNAME.]TABLE_NAME
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     SHOW CREATE TABLE demo.tb1
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DATA.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DATA.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATA [FROM db_name[.table_name]] [ORDER BY ...];
-````
+```
 
 illustrate:
 
@@ -60,9 +60,9 @@ illustrate:
 
    ```sql
    SHOW DATA;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-------------+--------------+
    | TableName | Size        | ReplicaCount |
    +-----------+-------------+--------------+
@@ -72,15 +72,15 @@ illustrate:
    | Quota     | 1024.000 GB | 1073741824   |
    | Left      | 1021.921 GB | 1073741815   |
    +-----------+-------------+--------------+
-   ````
+   ```
 
 2. Display the subdivided data volume, the number of replicas and the number of statistical rows of the specified table under the specified db
 
    ```sql
    SHOW DATA FROM example_db.test;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-----------+-----------+--------------+----------+
    | TableName | IndexName | Size      | ReplicaCount | RowCount |
    +-----------+-----------+-----------+--------------+----------+
@@ -89,15 +89,15 @@ illustrate:
    |           | test2     | 50.000MB  | 30           | 50000    |
    |           | Total     | 80.000    | 90           |          |
    +-----------+-----------+-----------+--------------+----------+
-   ````
+   ```
 
 3. It can be combined and sorted according to the amount of data, the number of copies, the number of statistical rows, etc.
 
    ```sql
    SHOW DATA ORDER BY ReplicaCount desc,Size asc;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-------------+--------------+
    | TableName | Size        | ReplicaCount |
    +-----------+-------------+--------------+
@@ -109,7 +109,7 @@ illustrate:
    | Quota     | 1024.000 GB | 1073741824   |
    | Left      | 1024.000 GB | 1073741734   |
    +-----------+-------------+--------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DATABASE-ID.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DATABASE-ID.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATABASE [database_id]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DATABASE [database_id]
 
     ```sql
     SHOW DATABASE 1001;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DATABASES.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DATABASES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATABASES [FROM catalog] [filter expr];
-````
+```
 
 illustrate:
 1. `SHOW DATABASES` will get all database names from current catalog.
@@ -51,45 +51,45 @@ illustrate:
 
    ```sql
    SHOW DATABASES;
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | test               |
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 2. Display all database names from the catalog named 'hms_catalog'.
 
    ```sql
    SHOW DATABASES from hms_catalog;
-   ````
+   ```
 
-   ````
+   ```
   +---------------+
   | Database      |
   +---------------+
   | default       |
   | tpch          |
   +---------------+
-   ````
+   ```
 
 3. Display the filtered database names from current catalog with the expr 'like'.
 
    ```sql
    SHOW DATABASES like 'infor%';
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DELETE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DELETE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DELETE [FROM db_name]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DELETE [FROM db_name]
 
       ```sql
       SHOW DELETE FROM database;
-      ````
+      ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DYNAMIC-PARTITION.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-DYNAMIC-PARTITION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DYNAMIC PARTITION TABLES [FROM db_name];
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DYNAMIC PARTITION TABLES [FROM db_name];
 
      ```sql
      SHOW DYNAMIC PARTITION TABLES FROM database;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ENCRYPT-KEY.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ENCRYPT-KEY.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW ENCRYPTKEYS [IN|FROM db] [LIKE 'key_pattern']
-````
+```
 
 parameter
 
@@ -65,7 +65,7 @@ parameter
     | example_db.my_key | ABCD123456789     |
     +-------------------+-------------------+
     1 row in set (0.00 sec)
- ````
+ ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-EXPORT.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-EXPORT.md
@@ -47,7 +47,7 @@ SHOW EXPORT
    ]
 [ORDER BY...]
 [LIMIT limit];
-````
+```
 
 illustrate:
       1. If db_name is not specified, the current default db is used
@@ -61,31 +61,31 @@ illustrate:
 
    ```sql
    SHOW EXPORT;
-   ````
+   ```
 
 2. Display the export tasks of the specified db, sorted by StartTime in descending order
 
    ```sql
     SHOW EXPORT FROM example_db ORDER BY StartTime DESC;
-   ````
+   ```
 
 3. Display the export tasks of the specified db, the state is "exporting", and sort by StartTime in descending order
 
    ```sql
    SHOW EXPORT FROM example_db WHERE STATE = "exporting" ORDER BY StartTime DESC;
-   ````
+   ```
 
 4. Display the export task of the specified db and specified job_id
 
    ```sql
      SHOW EXPORT FROM example_db WHERE ID = job_id;
-   ````
+   ```
 
 5. Display the specified db and specify the export task of the label
 
    ```sql
     SHOW EXPORT FROM example_db WHERE LABEL = "mylabel";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-FILE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-FILE.md
@@ -38,18 +38,18 @@ grammar:
 
 ```sql
 SHOW FILE [FROM database];
-````
+```
 
 illustrate:
 
-````text
+```text
 FileId: file ID, globally unique
 DbName: the name of the database to which it belongs
 Catalog: Custom Category
 FileName: file name
 FileSize: file size, in bytes
 MD5: MD5 of the file
-````
+```
 
 ### Example
 
@@ -57,7 +57,7 @@ MD5: MD5 of the file
 
      ```sql
      SHOW FILE FROM my_database;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-FRONTENDS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-FRONTENDS.md
@@ -38,7 +38,7 @@ This statement is used to view FE nodes
 
 ```sql
 SHOW FRONTENDS;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-FUNCTIONS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-FUNCTIONS.md
@@ -40,7 +40,7 @@ grammar
 
 ```sql
 SHOW [FULL] [BUILTIN] FUNCTIONS [IN|FROM db] [LIKE 'function_pattern']
-````
+```
 
 Parameters
 
@@ -53,7 +53,7 @@ grammar
 
 ```sql
 SHOW GLOBAL [FULL] FUNCTIONS [LIKE 'function_pattern']
-````
+```
 
 Parameters
 
@@ -65,7 +65,7 @@ Parameters
 
 ### Example
 
-````sql
+```sql
 mysql> show full functions in testDb\G
 **************************** 1. row ******************** ******
         Signature: my_add(INT,INT)
@@ -122,7 +122,7 @@ mysql> show global functions ;
 +---------------+
 2 rows in set (0.00 sec)    
     
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-GRANTS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-GRANTS.md
@@ -52,19 +52,19 @@ illustrate:
 
     ```sql
     SHOW ALL GRANTS;
-    ````
+    ```
 
 2. View the permissions of the specified user
 
     ```sql
     SHOW GRANTS FOR jack@'%';
-    ````
+    ```
 
 3. View the permissions of the current user
 
     ```sql
     SHOW GRANTS;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-INDEX.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-INDEX.md
@@ -36,19 +36,19 @@ SHOW INDEX
 
 grammar:
 
-````SQL
+```SQL
 SHOW INDEX[ES] FROM [db_name.]table_name [FROM database];
 or
 SHOW KEY[S] FROM [db_name.]table_name [FROM database];
-````
+```
 
 ### Example
 
   1. Display the lower index of the specified table_name
 
-     ````SQL
+     ```SQL
       SHOW INDEX FROM example_db.table_name;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-LAST-INSERT.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-LAST-INSERT.md
@@ -39,11 +39,11 @@ grammar:
 
 ```sql
 SHOW LAST INSERT
-````
+```
 
 Example of returned result:
 
-````
+```
      TransactionId: 64067
              Label: insert_ba8f33aea9544866-8ed77e2844d0cc9b
           Database: default_cluster:db1
@@ -51,7 +51,7 @@ Example of returned result:
 TransactionStatus: VISIBLE
         LoadedRows: 2
       FilteredRows: 0
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-LOAD-PROFILE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-LOAD-PROFILE.md
@@ -36,13 +36,13 @@ This statement is used to view the Profile information of the import operation. 
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Versions 0.15 and later perform the following settings:
 
 ```sql
 SET [GLOBAL] enable_profile=true;
-````
+```
 
 grammar:
 
@@ -56,7 +56,7 @@ show load profile "/[queryId]/[TaskId]"
 show load profile "/[queryId]/[TaskId]/[FragmentId]/"
 
 show load profile "/[queryId]/[TaskId]/[FragmentId]/[InstanceId]"
-````
+```
 
 This command will list all currently saved import profiles. Each line corresponds to one import. where the QueryId column is the ID of the import job. This ID can also be viewed through the SHOW LOAD statement. We can select the QueryId corresponding to the Profile we want to see to see the specific situation
 
@@ -102,7 +102,7 @@ WaitAndFetchResultTime: NULL
        FetchResultTime: 0ns
        WriteResultTime: 0ns
 WaitAndFetchResultTime: N/A
-   ````
+   ```
 
 2. View an overview of the subtasks with imported jobs:
 
@@ -113,7 +113,7 @@ WaitAndFetchResultTime: N/A
    +-----------------------------------+------------+
    | 980014623046410a-af5d36f23381017f | 3m14s      |
    +-----------------------------------+------------+
-   ````
+   ```
    
 3. View the plan tree of the specified subtask
 
@@ -173,7 +173,7 @@ WaitAndFetchResultTime: N/A
    | 980014623046410a-88e260f0c43031f4 | 10.81.85.89:9067 | 3m10s      |
    | 980014623046410a-88e260f0c43031f5 | 10.81.85.89:9067 | 3m14s      |
    +-----------------------------------+------------------+------------+
-   ````
+   ```
 
 4. Continue to view the detailed Profile of each operator on a specific Instance
 
@@ -221,7 +221,7 @@ WaitAndFetchResultTime: N/A
    │      - TotalReadThroughput: 30.39858627319336 MB/sec│
    │      - WaitScannerTime: 56s528ms                    │
    └-----------------------------------------------------┘
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-LOAD-WARNINGS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-LOAD-WARNINGS.md
@@ -44,7 +44,7 @@ SHOW LOAD WARNINGS
     [LABEL[="your_label"]]
     [LOAD_JOB_ID = ["job id"]]
 ]
-````
+```
 
 1) If db_name is not specified, the current default db is used
 1) If LABEL = is used, it matches the specified label exactly
@@ -56,7 +56,7 @@ SHOW LOAD WARNINGS
 
     ```sql
     SHOW LOAD WARNINGS FROM demo WHERE LABEL = "load_demo_20210112"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-LOAD.md
@@ -46,7 +46,7 @@ SHOW LOAD
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -68,7 +68,7 @@ illustrate:
 
    ```sql
    SHOW LOAD WARNINGS ON 'url'
-   ````
+   ```
 
 ### Example
 
@@ -76,38 +76,38 @@ illustrate:
 
    ```sql
    SHOW LOAD;
-   ````
+   ```
 
 2. Display the import tasks of the specified db, the label contains the string "2014_01_02", and display the oldest 10
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 3. Display the import tasks of the specified db, specify the label as "load_example_db_20140102" and sort by LoadStartTime in descending order
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL = "load_example_db_20140102" ORDER BY LoadStartTime DESC;
-   ````
+   ```
 
 4. Display the import task of the specified db, specify the label as "load_example_db_20140102", the state as "loading", and sort by LoadStartTime in descending order
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL = "load_example_db_20140102" AND STATE = "loading" ORDER BY LoadStartTime DESC;
-   ````
+   ```
 
 5. Display the import tasks of the specified db and sort them in descending order by LoadStartTime, and display 10 query results starting from offset 5
 
    ```sql
    SHOW LOAD FROM example_db ORDER BY LoadStartTime DESC limit 5,10;
    SHOW LOAD FROM example_db ORDER BY LoadStartTime DESC limit 10 offset 5;
-   ````
+   ```
 
 6. Small batch import is a command to check the import status
 
-   ````
+   ```
    curl --location-trusted -u {user}:{passwd} http://{hostname}:{port}/api/{database}/_load_info?label={labelname}
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-MIGRATIONS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-MIGRATIONS.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW MIGRATIONS
-````
+```
 
 ### Example
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-PARTITION-ID.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-PARTITION-ID.md
@@ -45,7 +45,7 @@ SHOW PARTITION [partition_id]
 
     ```sql
     SHOW PARTITION 10002;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-PARTITIONS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-PARTITIONS.md
@@ -36,9 +36,9 @@ SHOW PARTITIONS
 
 grammar:
 
-````SQL
+```SQL
   SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT];
-````
+```
 
 illustrate:
 
@@ -49,27 +49,27 @@ illustrate:
 
 1. Display all non-temporary partition information of the specified table under the specified db
 
-````SQL
+```SQL
   SHOW PARTITIONS FROM example_db.table_name;
-````
+```
 
 2. Display all temporary partition information of the specified table under the specified db
 
-    ````SQL
+    ```SQL
     SHOW TEMPORARY PARTITIONS FROM example_db.table_name;
-    ````
+    ```
 
 3. Display the information of the specified non-temporary partition of the specified table under the specified db
 
-    ````SQL
+    ```SQL
      SHOW PARTITIONS FROM example_db.table_name WHERE PartitionName = "p1";
-    ````
+    ```
 
 4. Display the latest non-temporary partition information of the specified table under the specified db
 
-    ````SQL
+    ```SQL
     SHOW PARTITIONS FROM example_db.table_name ORDER BY PartitionId DESC LIMIT 1;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-PLUGINS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-PLUGINS.md
@@ -36,9 +36,9 @@ This statement is used to display installed plugins
 
 grammar:
 
-````SQL
+```SQL
 SHOW PLUGINS
-````
+```
 
 This command will display all user-installed and system built-in plugins
 
@@ -46,9 +46,9 @@ This command will display all user-installed and system built-in plugins
 
 1. Show installed plugins:
 
-    ````SQL
+    ```SQL
     SHOW PLUGINS;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-PROC.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-PROC.md
@@ -49,7 +49,7 @@ After connecting to Doris through the MySQL client, you can execute the SHOW PRO
 
 The results of the show proc statement are presented in a two-dimensional table. And usually the first column of the result table is the next subdirectory of proc.
 
-````none
+```none
 mysql> show proc "/";
 +---------------------------+
 | name                      |
@@ -79,7 +79,7 @@ mysql> show proc "/";
 | trash                     |
 +---------------------------+
 23 rows in set (0.00 sec)
-````
+```
 
 illustrate:
 
@@ -122,7 +122,7 @@ illustrate:
    | 10124   | test_parquet_import  | 1        | NULL                | 1            | NORMAL | OLAP | NULL                     | 1            |
    +---------+----------------------+----------+---------------------+--------------+--------+------+--------------------------+--------------+
    4 rows in set (0.00 sec)
-   ````
+   ```
 
 2. Display information about the number of all database tables in the cluster.
 
@@ -135,11 +135,11 @@ illustrate:
    | Total | 1                    | 4        | 12           | 12       | 21        | 21         |
    +-------+----------------------+----------+--------------+----------+-----------+------------+
    2 rows in set (0.00 sec)
-   ````
+   ```
 
 3. The following command can view the existing Group information in the cluster.
 
-   ````
+   ```
    SHOW PROC '/colocation_group';
    
    +-------------+--------------+--------------+------------+----------------+----------+----------+
@@ -147,7 +147,7 @@ illustrate:
    +-------------+--------------+--------------+------------+----------------+----------+----------+
    | 10005.10008 | 10005_group1 | 10007, 10040 | 10         | 3              | int(11)  | true     |
    +-------------+--------------+--------------+------------+----------------+----------+----------+
-   ````
+   ```
 
    - GroupId: The cluster-wide unique identifier of a group, the first half is the db id, and the second half is the group id.
    - GroupName: The full name of the Group.
@@ -174,7 +174,7 @@ illustrate:
    | 6           | 10003, 10004, 10001 |
    | 7           | 10003, 10004, 10002 |
    +-------------+---------------------+
-   ````
+   ```
 
    - BucketIndex: The index of the bucket sequence.
    - BackendIds: The list of BE node IDs where the data shards in the bucket are located.
@@ -214,7 +214,7 @@ illustrate:
    | Total                   | 0         | 0        |
    +-------------------------+-----------+----------+
    26 rows in set (0.01 sec)
-   ````
+   ```
 
 5. Display the replica status of the entire cluster.
    ```sql

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-PROCESSLIST.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-PROCESSLIST.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [FULL] PROCESSLIST
-````
+```
 
 illustrate:
 
@@ -65,9 +65,9 @@ Other types can refer to [MySQL official website for explanation](https://dev.my
 
 1. View the threads running by the current user
 
-   ````SQL
+   ```SQL
    SHOW PROCESSLIST
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-REPOSITORIES.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-REPOSITORIES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW REPOSITORIES;
-````
+```
 
 illustrate:
 
@@ -57,7 +57,7 @@ illustrate:
 
 ```sql
   SHOW REPOSITORIES;
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-RESOURCES.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-RESOURCES.md
@@ -45,7 +45,7 @@ SHOW RESOURCES
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -62,19 +62,19 @@ illustrate:
 
    ```sql
    SHOW RESOURCES;
-   ````
+   ```
 
 1. Display the specified Resource, the name contains the string "20140102", and display 10 attributes
 
    ```sql
    SHOW RESOURCES WHERE NAME LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 1. Display the specified Resource, specify the name as "20140102" and sort by KEY in descending order
 
    ```sql
    SHOW RESOURCES WHERE NAME = "20140102" ORDER BY `KEY` DESC;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-RESTORE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-RESTORE.md
@@ -36,9 +36,9 @@ This statement is used to view RESTORE tasks
 
 grammar:
 
-````SQL
+```SQL
 SHOW RESTORE [FROM DB_NAME]
-````
+```
 
 illustrate:
         1. Only the most recent RESTORE task is saved in Doris.
@@ -74,7 +74,7 @@ illustrate:
 
    ```sql
    SHOW RESTORE FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ROLES.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ROLES.md
@@ -36,17 +36,17 @@ This statement is used to display all created role information, including role n
 
 grammar:
 
-````SQL
+```SQL
 SHOW ROLES
-````
+```
 
 ### Example
 
 1. View created roles
 
-    ````SQL
+    ```SQL
     SHOW ROLES
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
@@ -39,11 +39,11 @@ View the currently running subtasks of a specified Routine Load job.
 ```sql
 SHOW ROUTINE LOAD TASK
 WHERE JobName = "job_name";
-````
+```
 
 The returned results are as follows:
 
-````text
+```text
               TaskId: d67ce537f1be4b86-abf47530b79ab8e6
                TxnId: 4
            TxnStatus: UNKNOWN
@@ -53,7 +53,7 @@ The returned results are as follows:
              Timeout: 20
                 BeId: 10002
 DataSourceProperties: {"0":19}
-````
+```
 
 - `TaskId`: The unique ID of the subtask.
 - `TxnId`: The import transaction ID corresponding to the subtask.
@@ -71,7 +71,7 @@ DataSourceProperties: {"0":19}
 
    ```sql
    SHOW ROUTINE LOAD TASK WHERE JobName = "test1";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD.md
@@ -38,11 +38,11 @@ grammar:
 
 ```sql
 SHOW [ALL] ROUTINE LOAD [FOR jobName];
-````
+```
 
 Result description:
 
-````
+```
                   Id: job ID
                 Name: job name
           CreateTime: job creation time
@@ -62,7 +62,7 @@ DataSourceProperties: Data source configuration details
 ReasonOfStateChanged: The reason for the job state change
         ErrorLogUrls: The viewing address of the filtered unqualified data
             OtherMsg: other error messages
-````
+```
 
 * State
 
@@ -87,39 +87,39 @@ ReasonOfStateChanged: The reason for the job state change
 
    ```sql
    SHOW ALL ROUTINE LOAD FOR test1;
-   ````
+   ```
 
 2. Show the currently running routine import job named test1
 
    ```sql
    SHOW ROUTINE LOAD FOR test1;
-   ````
+   ```
 
 3. Display all routine import jobs (including stopped or canceled jobs) under example_db. The result is one or more lines.
 
    ```sql
    use example_db;
    SHOW ALL ROUTINE LOAD;
-   ````
+   ```
 
 4. Display all running routine import jobs under example_db
 
    ```sql
    use example_db;
    SHOW ROUTINE LOAD;
-   ````
+   ```
 
 5. Display the currently running routine import job named test1 under example_db
 
    ```sql
    SHOW ROUTINE LOAD FOR example_db.test1;
-   ````
+   ```
 
 6. Displays all routine import jobs named test1 under example_db (including stopped or canceled jobs). The result is one or more lines.
 
    ```sql
    SHOW ALL ROUTINE LOAD FOR example_db.test1;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-SMALL-FILES.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-SMALL-FILES.md
@@ -36,7 +36,7 @@ This statement is used to display files created by the CREATE FILE command withi
 
 ```sql
 SHOW FILE [FROM database];
-````
+```
 
 Return result description:
 
@@ -53,7 +53,7 @@ Return result description:
 
     ```sql
     SHOW FILE FROM my_database;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-SNAPSHOT.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-SNAPSHOT.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW SNAPSHOT ON `repo_name`
 [WHERE SNAPSHOT = "snapshot" [AND TIMESTAMP = "backup_timestamp"]];
-````
+```
 
 illustrate:
 
@@ -57,20 +57,20 @@ illustrate:
 
    ```sql
    SHOW SNAPSHOT ON example_repo;
-   ````
+   ```
 
 2. View only the backup named backup1 in the repository example_repo:
 
    ```sql
    SHOW SNAPSHOT ON example_repo WHERE SNAPSHOT = "backup1";
-   ````
+   ```
 
 3. View the details of the backup named backup1 in the warehouse example_repo with the time version "2018-05-05-15-34-26":
 
    ```sql
    SHOW SNAPSHOT ON example_repo
    WHERE SNAPSHOT = "backup1" AND TIMESTAMP = "2018-05-05-15-34-26";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-SQL-BLOCK-RULE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
-````
+```
 
 ### Example
 
@@ -53,7 +53,7 @@ SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
     | test_rule2 | NULL | NULL | 30 | 0 | 10000000000 | false | true |
     +------------+----------------------------+---------+- -------------+------------+-------------+--------+- -------+
     2 rows in set (0.01 sec)
-    ````
+    ```
     
 2. Make a rule name query
 
@@ -66,7 +66,7 @@ SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
     +------------+------+---------+---------------+---- -------+-------------+--------+--------+
     1 row in set (0.00 sec)
     
-    ````
+    ```
     
 
 ### Keywords

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-STATUS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-STATUS.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database: View jobs under the specified database. If not specified, the current database is used.
 - WHERE: You can filter the result column, currently only the following columns are supported:
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`: Job unique ID.
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-STREAM-LOAD.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-STREAM-LOAD.md
@@ -46,7 +46,7 @@ SHOW STREAM LOAD
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -65,32 +65,32 @@ illustrate:
 
    ```sql
      SHOW STREAM LOAD;
-   ````
+   ```
 
 2. Display the Stream Load task of the specified db, the label contains the string "2014_01_02", and display the oldest 10
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE LABEL LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 3. Display the Stream Load task of the specified db and specify the label as "load_example_db_20140102"
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE LABEL = "load_example_db_20140102";
-   ````
+   ```
 
 4. Display the Stream Load task of the specified db, specify the status as "success", and sort by StartTime in descending order
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE STATUS = "success" ORDER BY StartTime DESC;
-   ````
+   ```
 
 5. Display the import tasks of the specified db and sort them in descending order of StartTime, and display 10 query results starting from offset 5
 
    ```sql
    SHOW STREAM LOAD FROM example_db ORDER BY StartTime DESC limit 5,10;
    SHOW STREAM LOAD FROM example_db ORDER BY StartTime DESC limit 10 offset 5;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-SYNC-JOB.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-SYNC-JOB.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW SYNC JOB [FROM db_name]
-````
+```
 
 ### Example
 
@@ -48,13 +48,13 @@ SHOW SYNC JOB [FROM db_name]
 
     ```sql
     SHOW SYNC JOB;
-    ````
+    ```
 
 2. Display the status of all data synchronization jobs under the database `test_db`.
 
     ```sql
     SHOW SYNC JOB FROM `test_db`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLE-ID.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLE-ID.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TABLE [table_id]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW TABLE [table_id]
 
      ```sql
      SHOW TABLE 10001;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLE-STATUS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLE-STATUS.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW TABLE STATUS
 [FROM db] [LIKE "pattern"]
-````
+```
 
 illustrate:
 
@@ -51,13 +51,13 @@ illustrate:
 
      ```sql
      SHOW TABLE STATUS;
-     ````
+     ```
 
   2. View the information of the table whose name contains example under the specified database
 
      ```sql
      SHOW TABLE STATUS FROM db LIKE "%example%";
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLES.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [FULL] TABLES [LIKE]
-````
+```
 
 illustrate:
 
@@ -60,7 +60,7 @@ illustrate:
      | left_table                      |
      +---------------------------------+
      5 rows in set (0.00 sec)
-     ````
+     ```
 
 2. Fuzzy query by table name
 
@@ -73,7 +73,7 @@ illustrate:
     | cmy2           |
     +----------------+
     2 rows in set (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLET.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLET.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TABLET tablet_id
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW TABLET tablet_id
 
     ```sql
     SHOW TABLET 10000;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLETS.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TABLETS.md
@@ -42,7 +42,7 @@ SHOW TABLETS FROM [database.]table [PARTITIONS(p1,p2)]
 [WHERE where_condition]
 [ORDER BY col_name]
 [LIMIT [offset,] row_count]
-````
+```
 
 1. **Syntax Description:**
 
@@ -61,19 +61,19 @@ or compound them with operator `AND`.
 
     ```sql
     SHOW TABLETS FROM example_db.table_name;
-    ````
+    ```
 
 2. list all tablets of the specified partitions
 
     ```sql
     SHOW TABLETS FROM example_db.table_name PARTITIONS(p1, p2);
-    ````
+    ```
 
 3. list all DECOMMISSION tablets on the specified backend
 
     ```sql
     SHOW TABLETS FROM example_db.table_name WHERE state="DECOMMISSION" AND BackendId=11003;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TRANSACTION.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TRANSACTION.md
@@ -42,11 +42,11 @@ SHOW TRANSACTION
 WHERE
 [id=transaction_id]
 [label = label_name];
-````
+```
 
 Example of returned result:
 
-````
+```
      TransactionId: 4005
              Label: insert_8d807d5d-bcdd-46eb-be6d-3fa87aa4952d
        Coordinator: FE: 10.74.167.16
@@ -59,7 +59,7 @@ Example of returned result:
 ErrorReplicasCount: 0
         ListenerId: -1
          TimeoutMs: 300000
-````
+```
 
 * TransactionId: transaction id
 * Label: the label corresponding to the import task
@@ -84,19 +84,19 @@ ErrorReplicasCount: 0
 
    ```sql
    SHOW TRANSACTION WHERE ID=4005;
-   ````
+   ```
 
 2. In the specified db, view the transaction with id 4005:
 
    ```sql
    SHOW TRANSACTION FROM db WHERE ID=4005;
-   ````
+   ```
 
 3. View the transaction whose label is label_name:
 
    ```sql
    SHOW TRANSACTION WHERE LABEL = 'label_name';
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TRASH.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TRASH.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TRASH [ON BackendHost:BackendHeartBeatPort];
-````
+```
 
 illustrate:
 
@@ -51,13 +51,13 @@ illustrate:
 
    ```sql
     SHOW TRASH;
-   ````
+   ```
 
 2. View the space occupied by garbage data of '192.168.0.1:9050' (specific disk information will be displayed).
 
    ```sql
    SHOW TRASH ON "192.168.0.1:9050";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TYPECAST.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-TYPECAST.md
@@ -40,7 +40,7 @@ grammar
 
 ```sql
 SHOW TYPE_CAST [IN|FROM db]
-````
+```
 
  Parameters
 
@@ -48,7 +48,7 @@ SHOW TYPE_CAST [IN|FROM db]
 
 ### Example
 
-````sql
+```sql
 mysql> show type_cast in testDb\G
 **************************** 1. row ******************** ******
 Origin Type: TIMEV2
@@ -61,7 +61,7 @@ Origin Type: TIMEV2
   Cast Type: TIMEV2
 
 3 rows in set (0.00 sec)
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-VARIABLES.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-VARIABLES.md
@@ -36,10 +36,10 @@ This statement is used to display Doris system variables, which can be queried b
 
 grammar:
 
-````sql
+```sql
 SHOW [GLOBAL | SESSION] VARIABLES
      [LIKE 'pattern' | WHERE expr]
-````
+```
 
 illustrate:
 
@@ -54,19 +54,19 @@ illustrate:
 
     ```sql
     show variables like 'max_connections';
-    ````
+    ```
 
 2. Matching through the percent sign (%) wildcard can match multiple items
 
     ```sql
     show variables like '%connec%';
-    ````
+    ```
 
 3. Use the Where clause for matching queries
 
     ```sql
     show variables where variable_name = 'version';
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-VIEW.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Show-Statements/SHOW-VIEW.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
   SHOW VIEW { FROM | IN } table [ FROM db ]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ grammar:
 
     ```sql
     SHOW VIEW FROM testTbl;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Utility-Statements/DESCRIBE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Utility-Statements/DESCRIBE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DESC[RIBE] [db_name.]table_name [ALL];
-````
+```
 
 illustrate:
 
@@ -50,13 +50,13 @@ illustrate:
 
     ```sql
     DESC table_name;
-    ````
+    ```
 
 2. Display the schema of all indexes of the table
 
     ```sql
     DESC db1.table_name ALL;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Utility-Statements/HELP.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Utility-Statements/HELP.md
@@ -36,9 +36,9 @@ The directory of help can be queried by changing the command
 
 grammar:
 
-```` sql
+``` sql
 HELP <item>
-````
+```
 
 All Doris commands can be listed with `help`
 
@@ -72,7 +72,7 @@ nowarning (\w) Don't show warnings after every statement.
 resetconnection(\x) Clean session context.
 
 For server side help, type 'help contents'
-````
+```
 
 Get the Doris SQL help contents via `help contents`
 
@@ -83,7 +83,7 @@ where <item> is one of the following
 categories:
    sql-functions
    sql-statements
-````
+```
 
 ### Example
 
@@ -91,19 +91,19 @@ categories:
 
    ```sql
    help contents
-   ````
+   ```
 
 2. The command to list all function directories of the Doris cluster
 
    ```sql
    help sql-functions
-   ````
+   ```
 
 3. List all functions under the date function
 
    ```sql
    help date-time-functions
-   ````
+   ```
 
 
 ### Keywords

--- a/versioned_docs/version-1.2/sql-manual/sql-reference/Utility-Statements/USE.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-reference/Utility-Statements/USE.md
@@ -36,9 +36,9 @@ The USE command allows us to use the database
 
 grammar:
 
-````SQL
+```SQL
 USE <[CATALOG_NAME].DATABASE_NAME>
-````
+```
 
 illustrate:
 1. `USE CATALOG_NAME.DATABASE_NAME` will switch the current catalog into `CATALOG_NAME` and then change the current database into `DATABASE_NAME`
@@ -50,13 +50,13 @@ illustrate:
     ```sql
     mysql> use demo;
     Database changed
-    ````
+    ```
 2. If the demo database exists in catalog hms_catalog, try switching the catalog and accessing it:
 
     ```sql
     mysql> use hms_catalog.demo;
     Database changed
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/admin-manual/cluster-management/load-balancing.md
+++ b/versioned_docs/version-2.0/admin-manual/cluster-management/load-balancing.md
@@ -487,7 +487,7 @@ IP: 172.31.7.119
 
 ### Install dependencies
 
-```bash
+```shell
 sudo apt-get install build-essential
 sudo apt-get install libpcre3 libpcre3-dev 
 sudo apt-get install zlib1g-dev
@@ -496,7 +496,7 @@ sudo apt-get install openssl libssl-dev
 
 ### Install Nginx
 
-```bash
+```shell
 sudo wget http://nginx.org/download/nginx-1.18.0.tar.gz
 sudo tar zxvf nginx-1.18.0.tar.gz
 cd nginx-1.18.0
@@ -508,13 +508,13 @@ sudo make && make install
 
 Here is a new configuration file
 
-```bash
+```shell
 vim /usr/local/nginx/conf/default.conf
 ```
 
 Then add the following in it
 
-```bash
+```shell
 events {  
 worker_connections 1024;  
 }  
@@ -538,7 +538,7 @@ stream {
 
 Start the specified configuration file
 
-```bash
+```shell
 cd /usr/local/nginx
 /usr/local/nginx/sbin/nginx -c conf.d/default.conf
 ```

--- a/versioned_docs/version-2.0/admin-manual/data-admin/ccr.md
+++ b/versioned_docs/version-2.0/admin-manual/data-admin/ccr.md
@@ -70,7 +70,7 @@ enable_feature_binlog=true
 
 ​Build CCR syncer
 
-```Bash
+```shell
 git clone https://github.com/selectdb/ccr-syncer
 cd ccr-syncer   
 bash build.sh <-j NUM_OF_THREAD> <--output SYNCER_OUTPUT_DIR>
@@ -81,7 +81,7 @@ cd SYNCER_OUTPUT_DIR# Contact the Doris community for a free CCR binary package
 Start and stop syncer
 
 
-```Bash
+```shell
 # Start
 cd bin && sh start_syncer.sh --daemon
    
@@ -91,7 +91,7 @@ sh stop_syncer.sh
 
 5. Enable binlog in the source cluster.
 
-```Bash
+```shell
 -- If you want to synchronize the entire database, you can execute the following script:
 vim shell/enable_db_binlog.sh
 Modify host, port, user, password, and db in the source cluster
@@ -103,7 +103,7 @@ ALTER TABLE enable_binlog SET ("binlog.enable" = "true");
 
 6. Launch a synchronization task to the syncer
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -129,7 +129,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Parameter description:
 
-```Bash
+```shell
 name: name of the CCR synchronization task, should be unique
 host, port: host and mysql(jdbc) port for the master FE for the corresponding cluster
 user, password: the credentials used by the syncer to initiate transactions, fetch data, etc.
@@ -271,7 +271,7 @@ Stop the syncer according to the process number in the pid file under the defaul
 
 The file structure can be seen under the output path after compilation:
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -306,7 +306,7 @@ Follow the default configurations.
 
 Specify the directory where the pid file is located. The above three stopping methods all depend on the directory where the pid file is located for execution.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --pid_dir /path/to/pids
 ```
 
@@ -318,7 +318,7 @@ The default value is `SYNCER_OUTPUT_DIR/bin`.
 
 Stop the syncer corresponding to host: port in the pid_dir path.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --host 127.0.0.1 --port 9190
 ```
 
@@ -328,7 +328,7 @@ The default value of host is 127.0.0.1, and the default value of port is empty. 
 
 Stop the syncer corresponding to the specified pid file name in the pid_dir path.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 ```
 
@@ -338,7 +338,7 @@ The file names should be wrapped in `" "` and separated with spaces.
 
 **Template for requests**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d {json_body} http://ccr_syncer_host:ccr_syncer_port/operator
 ```
 
@@ -362,7 +362,7 @@ or
 
 Create CCR tasks
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -398,7 +398,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 View the synchronization progress.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/get_lag
@@ -410,7 +410,7 @@ The job_name is the name specified when create_ccr.
 
 Pause synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/pause 
@@ -420,7 +420,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Resume synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/resume
@@ -430,7 +430,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Delete synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/delete
@@ -440,7 +440,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 View version information.
 
-```Bash
+```shell
 curl http://ccr_syncer_host:ccr_syncer_port/version
 
 # > return
@@ -451,7 +451,7 @@ curl http://ccr_syncer_host:ccr_syncer_port/version
 
 View job status.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/job_status
@@ -470,7 +470,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 No sync. Users can swap the source and target clusters.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/desync
@@ -480,7 +480,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 List all created tasks.
 
-```Bash
+```shell
 curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
 {"success":true,"jobs":["ccr_db_table_alias"]}
@@ -492,7 +492,7 @@ curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
 The file structure can be seen under the output path after compilation:
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -509,7 +509,7 @@ output_dir
 
 **Usage**
 
-```Bash
+```shell
 bash bin/enable_db_binlog.sh -h host -p port -u user -P password -d db
 ```
 
@@ -556,7 +556,7 @@ Minimum required version: V2.0.3
 
 BE-side configuration parameter
 
-```Bash
+```shell
 download_binlog_rate_limit_kbs=1024 # This configuration limits the size to 1MB. It applies to all binlogs, including local snapshots, in a single BE.
 ```
 

--- a/versioned_docs/version-2.0/admin-manual/maint-monitor/debug-log.md
+++ b/versioned_docs/version-2.0/admin-manual/maint-monitor/debug-log.md
@@ -41,7 +41,7 @@ The Debug level log of FE can be turned on by modifying the configuration file, 
 
    Add the configuration item `sys_log_verbose_modules` to fe.conf. An example is as follows:
 
-   ````text
+   ```text
    # Only enable Debug log for class org.apache.doris.catalog.Catalog
    sys_log_verbose_modules=org.apache.doris.catalog.Catalog
    
@@ -50,7 +50,7 @@ The Debug level log of FE can be turned on by modifying the configuration file, 
    
    # Enable Debug logs for all classes under package org
    sys_log_verbose_modules=org
-   ````
+   ```
 
    Add configuration items and restart the FE node to take effect.
 
@@ -72,13 +72,13 @@ The Debug level log of FE can be turned on by modifying the configuration file, 
 
    The log level can also be modified at runtime via the following API. There is no need to restart the FE node.
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?add_verbose=org.apache.doris.catalog.Catalog
-   ````
+   ```
 
    The username and password are the root or admin users who log in to Doris. The `add_verbose` parameter specifies the package or class name to enable Debug logging. Returns if successful:
 
-   ````json
+   ```json
    {
        "msg": "success",
        "code": 0,
@@ -91,13 +91,13 @@ The Debug level log of FE can be turned on by modifying the configuration file, 
        },
        "count": 0
    }
-   ````
+   ```
 
    Debug logging can also be turned off via the following API:
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?del_verbose=org.apache.doris.catalog.Catalog
-   ````
+   ```
 
    The `del_verbose` parameter specifies the package or class name for which to turn off Debug logging.
 
@@ -105,16 +105,16 @@ The Debug level log of FE can be turned on by modifying the configuration file, 
 
 BE's Debug log currently only supports modifying and restarting the BE node through the configuration file to take effect.
 
-````text
+```text
 sys_log_verbose_modules=plan_fragment_executor,olap_scan_node
 sys_log_verbose_level=3
-````
+```
 
 `sys_log_verbose_modules` specifies the file name to be opened, which can be specified by the wildcard *. for example:
 
-````text
+```text
 sys_log_verbose_modules=*
-````
+```
 
 Indicates that all DEBUG logs are enabled.
 

--- a/versioned_docs/version-2.0/admin-manual/privilege-ldap/certificate.md
+++ b/versioned_docs/version-2.0/admin-manual/privilege-ldap/certificate.md
@@ -39,7 +39,7 @@ In addition to the Doris default certificate file, you can also generate a custo
 
 1. Generate the CA, server-side, and client-side keys and certificates:
 
-```bash
+```shell
 # Generate the CA certificate
 openssl genrsa 2048 > ca-key.pem
 openssl req -new -x509 -nodes -days 3600 \
@@ -64,13 +64,13 @@ openssl x509 -req -in client-req.pem -days 3600 \
 
 2. Verify the created certificates:
 
-```bash
+```shell
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
 3. Combine your key and certificate in a PKCS#12 (P12) bundle. You can also specify a certificate format (PKCS12 by default). You can modify the conf/fe.conf configuration file and add parameter ssl_trust_store_type to specify the certificate format.
 
-```bash
+```shell
 # Package the CA key and certificate
 openssl pkcs12 -inkey ca-key.pem -in ca.pem -export -out ca_certificate.p12
 

--- a/versioned_docs/version-2.0/admin-manual/privilege-ldap/ldap.md
+++ b/versioned_docs/version-2.0/admin-manual/privilege-ldap/ldap.md
@@ -108,7 +108,7 @@ Client-side LDAP authentication requires the mysql client-side explicit authenti
 
 * Set the environment variable LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN to value 1.
   For example, in a linux or max environment you can use the command:
-  ```bash
+  ```shell
   echo "export LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN=1" >> ～/.bash_profile && source ～/.bash_profile
   ```
 
@@ -168,12 +168,12 @@ For example:
 Doris account exists: jack@'172.10.1.10', password: 123456  
 LDAP user node presence attribute: uid: jack user password: abcdef  
 The jack@'172.10.1.10' account can be logged into by logging into Doris using the following command:
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
 Login will fail with the following command:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 
@@ -181,7 +181,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 
 LDAP user node presence attribute: uid: jack User password: abcdef  
 Use the following command to create a temporary user and log in to jack@'%', the temporary user has basic privileges DatabasePrivs: Select_priv, Doris will delete the temporary user after the user logs out and logs in:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
@@ -189,7 +189,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 
 Doris account exists: jack@'172.10.1.10', password: 123456  
 Login to the account using the Doris password, successfully:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 

--- a/versioned_docs/version-2.0/data-operate/delete/batch-delete-manual.md
+++ b/versioned_docs/version-2.0/data-operate/delete/batch-delete-manual.md
@@ -262,7 +262,7 @@ mysql DESC test;
 
 4. When the table has the sequence column, delete all data with the same key as the imported data
 
-    ```bash
+    ```shell
     curl --location-trusted -u root: -H "column_separator:," -H "columns: name, gender, age" -H "function_column.sequence_col: age" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
     ```
 

--- a/versioned_docs/version-2.0/data-operate/import/load-atomicity.md
+++ b/versioned_docs/version-2.0/data-operate/import/load-atomicity.md
@@ -126,7 +126,7 @@ Empty set (0.019 sec)
 
 **1. Enable two-phase commit by setting `two_phase_commit:true` in the HTTP Header.**
 
-```Bash
+```shell
 curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt http://fe_host:http_port/api/{db}/{table}/_stream_load
 {
     "TxnId": 18036,
@@ -152,7 +152,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the Transaction ID:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18036" -H "txn_operation:commit" http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -162,7 +162,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the label:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:commit"  http://fe_host:http_port/api/{db}/{table}/_stream_load_2pc
   {
       "status": "Success",
@@ -174,7 +174,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the Transaction ID:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18037" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -184,7 +184,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the label:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",

--- a/versioned_docs/version-2.0/data-operate/import/load-data-convert.md
+++ b/versioned_docs/version-2.0/data-operate/import/load-data-convert.md
@@ -60,7 +60,7 @@ WITH BROKER bos
 
 ### STREAM LOAD
 
-```bash
+```shell
 curl
 --location-trusted
 -u user:passwd
@@ -96,7 +96,7 @@ Stream load does not support preceding filtering.
 
 Example:
 
-```bash
+```shell
 curl
 --location-trusted
 -u user:passwd

--- a/versioned_docs/version-2.0/data-operate/import/load-json-format.md
+++ b/versioned_docs/version-2.0/data-operate/import/load-json-format.md
@@ -45,21 +45,21 @@ Currently only the following two JSON formats are supported:
 
    JSON format with Array as root node. Each element in the Array represents a row of data to be imported, usually an Object. An example is as follows:
 
-   ````json
+   ```json
    [
        { "id": 123, "city" : "beijing"},
        { "id": 456, "city" : "shanghai"},
        ...
    ]
-   ````
+   ```
 
-   ````json
+   ```json
    [
        { "id": 123, "city" : { "name" : "beijing", "region" : "haidian"}},
        { "id": 456, "city" : { "name" : "beijing", "region" : "chaoyang"}},
        ...
    ]
-   ````
+   ```
 
    This method is typically used for Stream Load import methods to represent multiple rows of data in a batch of imported data.
 
@@ -68,13 +68,13 @@ Currently only the following two JSON formats are supported:
 2. A single row of data represented by Object
    JSON format with Object as root node. The entire Object represents a row of data to be imported. An example is as follows:
 
-   ````json
+   ```json
    { "id": 123, "city" : "beijing"}
-   ````
+   ```
    
-   ````json
+   ```json
    { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
-   ````
+   ```
    
    This method is usually used for the Routine Load import method, such as representing a message in Kafka, that is, a row of data.
 
@@ -82,11 +82,11 @@ Currently only the following two JSON formats are supported:
    
    A row of data represented by Object represents a row of data to be imported. The example is as follows:
    
-   ````json
+   ```json
    { "id": 123, "city" : "beijing"}
    { "id": 456, "city" : "shanghai"}
    ...
-   ````
+   ```
    
    This method is typically used for Stream Load import methods to represent multiple rows of data in a batch of imported data.
    
@@ -120,17 +120,17 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is as follows:
 
-  ````json
+  ```json
   { "id": 123, "city" : "beijing"}
-  ````
+  ```
 
   Then Doris will use `id`, `city` for matching, and get the final data `123` and `beijing`.
 
   If the JSON data is as follows:
 
-  ````json
+  ```json
   { "id": 123, "name" : "beijing"}
-  ````
+  ```
 
   Then use `id`, `city` for matching, and get the final data `123` and `null`.
 
@@ -138,13 +138,13 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   Specify a set of JSON Path in the form of a JSON data. Each element in the array represents a column to extract. An example is as follows:
 
-  ````json
+  ```json
   ["$.id", "$.name"]
-  ````
+  ```
 
-  ````json
+  ```json
   ["$.id.sub_id", "$.name[0]", "$.city[0]"]
-  ````
+  ```
 
   Doris will use the specified JSON Path for data matching and extraction.
 
@@ -154,21 +154,21 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
-  ````
+  ```
 
   JSON Path is `["$.city"]`. The matched elements are:
 
-  ````json
+  ```json
   { "name" : "beijing", "region" : "haidian" }
-  ````
+  ```
 
   The element will be converted to a string for subsequent import operations:
 
-  ````json
+  ```json
   "{'name':'beijing','region':'haidian'}"
-  ````
+  ```
 
 - match failed
 
@@ -176,41 +176,41 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "name" : "beijing"}
-  ````
+  ```
 
   JSON Path is `["$.id", "$.info"]`. The matched elements are `123` and `null`.
 
   Doris currently does not distinguish between null values represented in JSON data and null values produced when a match fails. Suppose the JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "name" : null }
-  ````
+  ```
 
   The same result would be obtained with the following two JSON Paths: `123` and `null`.
 
-  ````json
+  ```json
   ["$.id", "$.name"]
-  ````
+  ```
 
-  ````json
+  ```json
   ["$.id", "$.info"]
-  ````
+  ```
 
 - Exact match failed
 
   In order to prevent misoperation caused by some parameter setting errors. When Doris tries to match a row of data, if all columns fail to match, it considers this to be an error row. Suppose the Json data is:
 
-  ````json
+  ```json
   { "id": 123, "city" : "beijing" }
-  ````
+  ```
 
   If the JSON Path is written incorrectly as (or if the JSON Path is not specified, the columns in the table do not contain `id` and `city`):
 
-  ````json
+  ```json
   ["$.ad", "$.infa"]
-  ````
+  ```
 
   would cause the exact match to fail, and the line would be marked as an error line instead of yielding `null, null`.
 
@@ -222,65 +222,65 @@ In other words, it is equivalent to rearranging the columns of a JSON format dat
 
 Data content:
 
-````json
+```json
 {"k1": 1, "k2": 2}
-````
+```
 
 Table Structure:
 
-````
+```
 k2 int, k1 int
-````
+```
 
 Import statement 1 (take Stream Load as an example):
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -T example.json http:/ /127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 In import statement 1, only JSON Path is specified, and Columns is not specified. The role of JSON Path is to extract the JSON data in the order of the fields in the JSON Path, and then write it in the order of the table structure. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1 | k2 |
 +------+------+
 | 2 | 1 |
 +------+------+
-````
+```
 
 You can see that the actual k1 column imports the value of the "k2" column in the JSON data. This is because the field name in JSON is not equivalent to the field name in the table structure. We need to explicitly specify the mapping between the two.
 
 Import statement 2:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, k1 " -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Compared with the import statement 1, the Columns field is added here to describe the mapping relationship of the columns, in the order of `k2, k1`. That is, after extracting in the order of fields in JSON Path, specify the value of column k2 in the table for the first column, and the value of column k1 in the table for the second column. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1 | k2 |
 +------+------+
 | 1 | 2 |
 +------+------+
-````
+```
 
 Of course, as with other imports, column transformations can be performed in Columns. An example is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, tmp_k1 , k1 = tmp_k1 * 100" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 The above example will import the value of k1 multiplied by 100. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1 | k2 |
 +------+------+
 | 100 | 2 |
 +------+------+
-````
+```
 
 ## JSON root
 
@@ -318,26 +318,26 @@ Doris supports extracting data specified in JSON through JSON root.
 
 Example data is as follows:
 
-````json
+```json
 [
     {"k1": 1, "k2": "a"},
     {"k1": 2},
     {"k1": 3, "k2": "c"}
 ]
-````
+```
 
 
 The table structure is: `k1 int null, k2 varchar(32) null default "x"`
 
 The import statement is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 The import results that users may expect are as follows, that is, for missing columns, fill in the default values.
 
-````text
+```text
 +------+------+
 | k1 | k2 |
 +------+------+
@@ -347,11 +347,11 @@ The import results that users may expect are as follows, that is, for missing co
 +------+------+
 |3|c|
 +------+------+
-````
+```
 
 But the actual import result is as follows, that is, for the missing column, NULL is added.
 
-````text
+```text
 +------+------+
 | k1 | k2 |
 +------+------+
@@ -361,13 +361,13 @@ But the actual import result is as follows, that is, for the missing column, NUL
 +------+------+
 |3|c|
 +------+------+
-````
+```
 
 This is because Doris doesn't know "the missing column is column k2 in the table" from the information in the import statement. If you want to import the above data according to the expected result, the import statement is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -H "jsonpaths: [\"$.k1\", \"$.k2\"]" - H "columns: k1, tmp_k2, k2 = ifnull(tmp_k2, 'x')" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 ## Application example
 
@@ -377,63 +377,63 @@ Because of the inseparability of the JSON format, when using Stream Load to impo
 
 Suppose the table structure is:
 
-````text
+```text
 id INT NOT NULL,
 city VARHCAR NULL,
 code INT NULL
-````
+```
 
 1. Import a single row of data 1
 
-   ````json
+   ```json
    {"id": 100, "city": "beijing", "code" : 1}
-   ````
+   ```
 
    - do not specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
 2. Import a single row of data 2
 
-   ````json
+   ```json
    {"id": 100, "content": {"city": "beijing", "code": 1}}
-   ````
+   ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\ "]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
 3. Import multiple rows of data as Array
 
-   ````json
+   ```json
    [
        {"id": 100, "city": "beijing", "code" : 1},
        {"id": 101, "city": "shanghai"},
@@ -448,24 +448,24 @@ code INT NULL
            "code" : 6
        }
    ]
-   ````
+   ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
      101 shanghai NULL
      102 tianjin 3
      103 chongqing 4
      104 ["zhejiang","guangzhou"] 5
      105 {"order1":["guangzhou"]} 6
-     ````
+     ```
 
 4. Import multi-line data as multi-line Object
 
@@ -478,7 +478,7 @@ code INT NULL
 
  	 StreamLoad import:
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 	   Import result:
@@ -492,20 +492,20 @@ curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: 
 
 The data is still the multi-line data in Example 3, and now it is necessary to add 1 to the `code` column in the imported data before importing.
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Import result:
 
-````text
+```text
 100 beijing 2
 101 shanghai NULL
 102 tianjin 4
 103 chongqing 5
 104 ["zhejiang","guangzhou"] 6
 105 {"order1":["guangzhou"]} 7
-````
+```
 
 6. Import Array by JSON
 Since the Rapidjson handles decimal and largeint numbers which will cause precision problems, 
@@ -519,7 +519,7 @@ we suggest you to use JSON string to import data to `array<decimal>` or `array<l
 {"k1": 40, "k2": ["10000000000000000000.1111111222222222"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_decimal.json http://localhost:8035/api/example_db/array_test_decimal/_stream_load
 ```
 
@@ -539,7 +539,7 @@ MySQL > select * from array_test_decimal;
 {"k1": 999, "k2": ["76959836937749932879763573681792701709", "26017042825937891692910431521038521227"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_largeint.json http://localhost:8035/api/example_db/array_test_largeint/_stream_load
 ```
 

--- a/versioned_docs/version-2.0/data-operate/import/load-strict-mode.md
+++ b/versioned_docs/version-2.0/data-operate/import/load-strict-mode.md
@@ -55,16 +55,16 @@ Different import methods set strict mode in different ways.
    (
        "strict_mode" = "true"
    )
-   ````
+   ```
 
 2. [STREAM LOAD](../../sql-manual/sql-reference/Data-Manipulation-Statements/Load/STREAM-LOAD)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "strict_mode: true" \
    -T 1.txt \
    http://host:port/api/example_db/my_table/_stream_load
-   ````
+   ```
 
 3. [ROUTINE LOAD](../../sql-manual/sql-reference/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD)
 
@@ -79,7 +79,7 @@ Different import methods set strict mode in different ways.
        "kafka_broker_list" = "broker1:9092,broker2:9092,broker3:9092",
        "kafka_topic" = "my_topic"
    );
-   ````
+   ```
 
 4. [INSERT](../../sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/INSERT)
 
@@ -88,7 +88,7 @@ Different import methods set strict mode in different ways.
    ```sql
    SET enable_insert_strict = true;
    INSERT INTO my_table ...;
-   ````
+   ```
 
 ## The role of strict mode
 

--- a/versioned_docs/version-2.0/data-operate/import/stream-load-manual.md
+++ b/versioned_docs/version-2.0/data-operate/import/stream-load-manual.md
@@ -117,7 +117,7 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 
    The Stream Load job can be submitted using the `curl` command.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "column_separator:," \
@@ -200,7 +200,7 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 
    The Stream Load job can be submitted using the `curl` command.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:124" \
     -H "Expect:100-continue" \
@@ -261,7 +261,7 @@ Users cannot manually cancel a Stream Load operation. A Stream Load job will be 
 
 The syntax for Stream Load is as follows:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
   -H "Expect:100-continue" [-H ""...] \
   -T <file_path> \
@@ -399,7 +399,7 @@ When performing Stream Load using the TVF `http_stream`, the Rest API URL differ
 
 Using curl for Stream Load in http_stream Mode:
 
-```Bash
+```shell
 curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -XPUT http://fe_host:http_port/api/_http_stream
 ```
 
@@ -407,7 +407,7 @@ Adding a SQL parameter in the header to replace the previous parameters such as 
 
 Example of load SQL:
 
-```Bash
+```shell
 insert into db.table (col, ...) select stream_col, ... from http_stream("property1"="value1");
 ```
 
@@ -454,7 +454,7 @@ Load job can tolerate a certain amount of data with formatting errors. The toler
 
 You can use the following command to specify a `max_filter_ratio` tolerance of 0.4 for creating a Stream Load job:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "max_filter_ratio:0.4" \
@@ -484,7 +484,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 Loading data from local files into partitions p1 and p2 of the table, allowing a 20% error rate.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:123" \
     -H "Expect:100-continue" \
@@ -512,7 +512,7 @@ Stream Load is based on the HTTP protocol for importing, which supports using pr
 
 The following example demonstrates this usage through a bash command pipeline. The imported data is generated streamingly by the program rather than from a local file.
 
-```Bash
+```shell
 seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -536,7 +536,7 @@ curl --location-trusted -u root -T test.csv  -H "label:1" -H "format:csv_with_na
 
 In stream load, there are three import types: APPEND, DELETE, and MERGE. These can be adjusted by specifying the parameter `merge_type`. If you want to specify that all data with the same key as the imported data should be deleted, you can use the following command:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: DELETE" \
@@ -579,7 +579,7 @@ After importing, the original table data will be deleted, resulting in the follo
 
 By specifying `merge_type` as MERGE, the imported data can be merged into the table. The MERGE semantics need to be used in combination with the DELETE condition, which means that data satisfying the DELETE condition is processed according to the DELETE semantics, and the rest is added to the table according to the APPEND semantics. The following operation represents deleting the row with `siteid` of 1, and adding the rest of the data to the table:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: MERGE" \
@@ -771,7 +771,7 @@ JSON data type:
 
 Command:
 
-```Bash
+```shell
 curl --location-trusted -u root -T test.json -H "label:1" -H "format:json" -H 'columns: id, order_code, create_time=CURRENT_TIMESTAMP()' http://host:port/api/testDb/testTbl/_stream_load
 ```
 

--- a/versioned_docs/version-2.0/data-operate/update/unique-update-transaction.md
+++ b/versioned_docs/version-2.0/data-operate/update/unique-update-transaction.md
@@ -109,7 +109,7 @@ PROPERTIES (
 
 The syntax for stream load is to add the mapping of the hidden column `function_column.sequence_col` to the `source_sequence` in the header. Example:
 
-```Bash
+```shell
 curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -228,7 +228,7 @@ Load the following data:
 
 Here is an example using Stream Load:
 
-```Bash
+```shell
 curl --location-trusted -u root: -T testData http://host:port/api/test/test_table/_stream_load
 ```
 

--- a/versioned_docs/version-2.0/db-connect/database-connect.md
+++ b/versioned_docs/version-2.0/db-connect/database-connect.md
@@ -32,14 +32,14 @@ Download MySQL Client from the MySQL official website or use the pre-installed [
 
 Extract the downloaded MySQL client. In the `bin/` directory, find the `mysql` command-line tool. Execute the following command to connect to Doris:
 
-```Bash
+```shell
 # FE_IP represents the listening address of the FE node, while FE_QUERY_PORT represents the port of the MySQL protocol service of the FE. This corresponds to the query_port parameter in fe.conf and it defaults to 9030.
 mysql -h FE_IP -P FE_QUERY_PORT -u USER_NAME 
 ```
 
 After login, the following message will be displayed.
 
-```Bash
+```shell
 Welcome to the MySQL monitor.  Commands end with ; or \g.                               
 Your MySQL connection id is 236                                                         
 Server version: 5.7.99 Doris version doris-2.0.3-rc06-37d31a5                           

--- a/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/helm-chart-deploy.md
+++ b/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/helm-chart-deploy.md
@@ -32,15 +32,15 @@ Helm Chart makes it easy to deploy Doris clusters and skip difficult configurati
 
 This [Doris repository](https://artifacthub.io/packages/search?ts_query_web=doris&sort=relevance&page=1) have resources about RBAC , deployment ...etc for doris-operator running.
 1. Add the Doris repository
-```Bash
+```shell
 $ helm repo add doris-repo https://charts.selectdb.com
 ```
 2. Update the Chart to the latest version
-```Bash
+```shell
 $ helm repo update doris-repo
 ```
 3. Check the Helm Chart Repo is the latest version
-```Bash
+```shell
 $ helm search repo doris-repo
 NAME                          CHART VERSION    APP VERSION   DESCRIPTION
 doris-repo/doris-operator     1.3.1            1.3.1         Doris-operator for doris creat ...
@@ -51,17 +51,17 @@ doris-repo/doris              1.3.1            2.0.3         Apache Doris is an 
 
 ### 1. Install
 - Install [doris-operator](https://artifacthub.io/packages/helm/doris/doris-operator)，with default config  in a namespace named `doris`
-```Bash
+```shell
 $ helm install operator doris-repo/doris-operator
 ```
 - The repo defines the basic function for running doris-operator, Please use next command to deploy operator, when you have completed customization of [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values)
-```Bash
+```shell
 $ helm install -f values.yaml operator doris-repo/doris-operator 
 ```
 ### 2. Validate installation Status
 Check the deployment status of Pods through the `kubectl get pods` command.
 Observe that the Pod of doris-operator is in the Running state and all containers in the Pod are ready, that means, the deployment is successful.
-```Bash
+```shell
 $ kubectl get pod --namespace doris
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
@@ -71,11 +71,11 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 ### 1. Install
 - Use default config for deploying [doriscluster](https://artifacthub.io/packages/helm/doris/doris). This only deploys 3 FE and 3 BE components and using default `storageClass` for providing persistent volume.
-```Bash
+```shell
 $ helm install doriscluster doris-repo/doris
 ```
 - Custom Doris deploying, specify resources or different deployment type, please customize the resource configuration according to the annotations of each resource configuration in [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) and use next command for deploying.
-```Bash
+```shell
 $ helm install -f values.yaml doriscluster doris-repo/doris 
 ```
 ### 2. Validate installation Status
@@ -83,7 +83,7 @@ After executing the installation command, deployment and distribution, service d
 Check the deployment status of Pods through the `kubectl get pods` command.
 
 Observe that the Pod of `doriscluster` is in the `Running` state and all containers in the Pod are ready, that means, the deployment is successful.
-```Bash
+```shell
 $  kubectl get pod --namespace doris
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
@@ -98,11 +98,11 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 ### Uninstall doriscluster
 Please confirm the Doris is not used, when using next command to uninstall `doriscluster`.
-```bash
+```shell
 $ helm uninstall doriscluster
 ```
 ### Uninstall doris-operator
 Please confirm that Doris is not running in Kubernetes, use next command to uninstall `doris-operator`.
-```bash
+```shell
 $ helm uninstall operator
 ```

--- a/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/install-access-cluster.md
+++ b/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/install-access-cluster.md
@@ -35,13 +35,13 @@ Doris provides ClusterIP access mode by default on Kubernetes. No modification i
 
 After deploying the cluster, you can view the services exposed by Doris Operator through the following command:
 
-```bash
+```shell
 kubectl -n doris get svc
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                               AGE
 doriscluster-sample-be-internal   ClusterIP   None          <none>        9050/TCP                              9m
 doriscluster-sample-be-service    ClusterIP   10.1.68.128   <none>        9060/TCP,8040/TCP,9050/TCP,8060/TCP   9m
@@ -58,13 +58,13 @@ In the above results, FE and BE have two types of Services, with the suffixes in
 
 Use the following command to create a pod containing the mysql client in the current Kubernetes cluster:
 
-```bash
+```shell
 kubectl run mysql-client --image=mysql:5.7 -it --rm --restart=Never --namespace=doris -- /bin/bash
 ```
 
 In the container in the cluster, you can use the externally exposed service name with the suffix `service` to access the Doris cluster:
 
-```bash
+```shell
 ## Use service type pod name to access the Doris cluster
 mysql -uroot -P9030 -hdoriscluster-sample-fe-service
 ```
@@ -143,13 +143,13 @@ spec:
 
 After deploying the cluster, you can view the services exposed by Doris Operator through the following command:
 
-```bash
+```shell
 kubectl get service
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME TYPE CLUSTER-IP EXTERNAL-IP PORT(S) AGE
 kubernetes ClusterIP 10.152.183.1 <none> 443/TCP 169d
 doriscluster-sample-fe-internal ClusterIP None <none> 9030/TCP 2d
@@ -160,13 +160,13 @@ doriscluster-sample-be-service NodePort 10.152.183.244 <none> 9060:30940/TCP,804
 
 Doris's Query Port defaults to 9030, which is mapped to local port 31545 locally. When accessing the Doris cluster, you need to obtain the corresponding IP address, which can be viewed with the following command:
 
-```bash
+```shell
 kubectl get nodes -owide
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME   STATUS   ROLES           AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION          CONTAINER-RUNTIME
 r60    Ready    control-plane   14d   v1.28.2   192.168.88.60   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
 r61    Ready    <none>          14d   v1.28.2   192.168.88.61   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
@@ -176,7 +176,7 @@ r63    Ready    <none>          14d   v1.28.2   192.168.88.63   <none>        Ce
 
 In NodePort mode, you can access services in the Kubernetes cluster based on the host IP and port mapping of any node. In this example, you can use any node IP, 192.168.88.61, 192.168.88.62, 192.168.88.63, to access the Doris service. For example, in the following example, the node node 192.168.88.62 and the mapped query port port 31545 are used to access the cluster:
 
-```bash
+```shell
 mysql -h 192.168.88.62 -P 31545 -uroot
 ```
 
@@ -192,7 +192,7 @@ If you perform Stream Load inside Kubernetes, you can directly use the error add
 
 In the return result of the above example, you can directly obtain the return result through the curl command in the Pod in the same Kubernetes cluster:
 
-```bash
+```shell
 curl http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local:8040/api/_load_error_log?file=__shard_1/error_log_insert_stmt_af474190276a2e9c-49bb9d175b8e968e_af474190276a2e9c_49bb9d175b8e968e
 ```
 
@@ -243,7 +243,7 @@ Since the pod name returned by each stream load may be different, please delete 
 
 Follow the service in the above example, replace ${podName} in CR with doriscluster-sample-be-2, and replace ${ServiceType} with NodePort. Use the kubectl apply command to create the service service in the same namespace of the doris cluster.
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -251,13 +251,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 Use the following command to view the NodePort assigned by the above deployment Service:
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
 doriscluster-detail-error         NodePort    10.152.183.35    <none>        8040:31201/TCP     32s
 ```
@@ -266,13 +266,13 @@ The BE port accessed by `Stream Load` is 8040, and the host port (NodePort) corr
 
 Get the host address controlled by K8s:
 
-```bash
+```shell
 kubectl get node -owide
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME             STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION       CONTAINER-RUNTIME
 vm-10-8-centos   Ready    <none>   226d   v1.28.7   10.16.10.8    <none>        TencentOS Server 3.1 (Final)   5.4.119-19-0009.3    containerd://1.6.28
 vm-10-7-centos   Ready    <none>   19d    v1.28.7   10.16.10.7    <none>        TencentOS Server 3.1 (Final)   5.4.119-19.0009.25   containerd://1.6.28
@@ -298,7 +298,7 @@ http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluste
 
 The domain name address of the above address is `doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local`. Among the domain names used by pods deployed by `Doris Operator` on `Kubernetes`, the third level The domain name is the name of the pod. Replace {podName} in the above template with the real `pod` name, replace {serviceType} with `LoadBalancer`, and save the changes to the newly created `stream_load_get_error.yaml` file. Use the following command to deploy service:
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -306,13 +306,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 Use the following command to view the LoadBalaner address EXTERNAL-IP assigned by the above deployment Service. The following is a test instance in aws eks:
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                         TYPE          CLUSTER-IP       EXTERNAL-IP                                                              PORT(S)           AGE
 doriscluster-detail-error    LoadBalancer  172.20.183.136   ac4828493dgrftb884g67wg4tb68gyut-1137856348.us-east-1.elb.amazonaws.com  8040:32003/TCP    14s
 ```

--- a/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/install-config-cluster.md
+++ b/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/install-config-cluster.md
@@ -99,13 +99,13 @@ feSpec:
 
 Among them, the name of [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) needs to be specified in ${storageClassName}. You can use the following command to view the StorageClass supported in the current Kubernetes cluster:
 
-```bash
+```shell
 kubectl get sc
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                          PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
 openebs-hostpath              openebs.io/local               Delete          WaitForFirstConsumer   false                  212d
 openebs-device                openebs.io/local               Delete          WaitForFirstConsumer   false                  212d

--- a/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/install-doris-cluster.md
+++ b/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/install-doris-cluster.md
@@ -36,13 +36,13 @@ Deploying a cluster online requires the following steps:
 
 1. Create namespace:
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 2. Deploy Doris cluster
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -61,7 +61,7 @@ selectdb/doris.be-ubuntu:2.0.2
 
 Download the image locally and package it into a tar file
 
-```bash
+```shell
 ## download docker image
 docker pull selectdb/doris.fe-ubuntu:2.0.2
 docker pull selectdb/doris.be-ubuntu:2.0.2
@@ -73,7 +73,7 @@ docker save -o doris.be-ubuntu-v2.0.2.tar docker pull selectdb/doris.be-ubuntu:2
 
 Upload the image tar package to the server and execute the docker load command:
 
-```bash
+```shell
 ## load docker image
 docker load -i doris.fe-ubuntu-v2.0.2.tar
 docker load -i doris.be-ubuntu-v2.0.2.tar
@@ -81,13 +81,13 @@ docker load -i doris.be-ubuntu-v2.0.2.tar
 
 2. Create namespace:
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 3. Deploy Doris cluster
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -101,13 +101,13 @@ Before installation, you need to add a deployment warehouse. If it has been adde
 
 Install [doriscluster](https://artifacthub.io/packages/helm/doris/doris), using the default configuration this deployment only deploys 3 FE and 3 BE components, using the default `storageClass` to implement PV dynamic provisioning.
 
-```bash
+```shell
 helm install doriscluster doris-repo/doris
 ```
 
 If you need to customize resources and cluster shapes, please customize the resource configuration according to the annotations of each resource configuration in [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) and execute The following command:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-repo/doris
 ```
 
@@ -115,13 +115,13 @@ helm install -f values.yaml doriscluster doris-repo/doris
 
 You can check the pod deployment status through the `kubectl get pods` command. When the Pod of `doriscluster` is in `Running` state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -137,7 +137,7 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 Download `doris-{chart_version}.tgz` to install Doris Cluster chart. If you need to download the 2.0.6 version of the Doris cluster, you can use the following command:
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-2.0.6.tgz
 ```
 
@@ -145,13 +145,13 @@ wget https://charts.selectdb.com/doris-2.0.6.tgz
 
 Doris cluster can be installed through the `helm install` command.
 
-```bash
+```shell
 helm install doriscluster doris-1.4.0.tgz
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-1.4.0.tgz
 ```
 
@@ -159,13 +159,13 @@ helm install -f values.yaml doriscluster doris-1.4.0.tgz
 
 You can check the pod deployment status through the `kubectl get pods` command. When the Pod of `doriscluster` is in `Running` state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -181,13 +181,13 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 After the cluster deployment resources are delivered, you can check the cluster status by running the following command.
 
-```bash
+```shell
 kubectl get pods -n ${namespace}
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                       READY   STATUS    RESTARTS   AGE
 doriscluster-sample-fe-0   1/1     Running   0          20m
 doriscluster-sample-be-0   1/1     Running   0          19m
@@ -199,13 +199,13 @@ When the `STATUS` of all pods is in the `Running` state, and all containers in t
 
 Doris Operator will collect the status of cluster services and display them in the distributed resources. Doris Operator defines the abbreviation `dcr` for the `DorisCluster` type resource name, which can be replaced by the abbreviation when using the resource type to view the cluster status.
 
-```bash
+```shell
 kubectl get dcr
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                  FESTATUS    BESTATUS    CNSTATUS   BROKERSTATUS
 doriscluster-sample   available   available
 ```

--- a/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/install-env.md
+++ b/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/install-env.md
@@ -39,7 +39,7 @@ under the License.
 
 When deploying a Doris cluster on Kubernetes, it is recommended to turn off the firewall configuration:
 
-```bash
+```shell
 systemctl stop firewalld
 systemctl disable firewalld
 ```
@@ -56,7 +56,7 @@ When deploying Doris, it is recommended to turn off the swap partition.
 
 The swap partition can be permanently shut down with the following command.
 
-```bash
+```shell
 echo "vm.swappiness = 0">> /etc/sysctl.conf
 swapoff -a && swapon -a
 sysctl -p
@@ -64,7 +64,7 @@ sysctl -p
 
 ### Set the maximum number of open file handles in the system
 
-```bash
+```shell
 vi /etc/security/limits.conf 
 * soft nofile 65536
 * hard nofile 65536
@@ -74,7 +74,7 @@ vi /etc/security/limits.conf
 
 Modify the virtual memory area to at least 2000000
 
-```bash
+```shell
 sysctl -w vm.max_map_count=2000000
 ```
 
@@ -82,7 +82,7 @@ sysctl -w vm.max_map_count=2000000
 
 When deploying Doris, it is recommended to turn off transparent huge pages.
 
-```bash
+```shell
 echo never > /sys/kernel/mm/transparent_hugepage/enabled
 echo never > /sys/kernel/mm/transparent_hugepage/defrag
 ```

--- a/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/install-operator.md
+++ b/versioned_docs/version-2.0/install/cluster-deployment/k8s-deploy/install-operator.md
@@ -29,32 +29,32 @@ Doris Operator extends Kubernetes with Custom Resource Definition (CRD). The CRD
 
 Doris Cluster CRD can be deployed in a Kubernetes environment with the following command:
 
-```bash
+```shell
 kubectl create -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 ```
 
 If there is no external network, download the CRD file to your local computer first:
 
-```bash
+```shell
 wget https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 kubectl create -f ./doris.selectdb.com_dorisclusters.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 customresourcedefinition.apiextensions.k8s.io/dorisclusters.doris.selectdb.com created
 ```
 
 After the Doris Cluster CRD is created, you can view the created CRD with the following command.
 
-```bash
+```shell
 kubectl get crd | grep doris
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 ```
 
@@ -66,13 +66,13 @@ You can directly pull the Doris Operator template in the warehouse for quick dep
 
 Doris Operator can be deployed in a Kubernetes cluster using the following command:
 
-```bash
+```shell
 kubectl apply -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/operator/operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -91,13 +91,13 @@ The minimum requirements for deploying operator services are specified in the op
 
 After modifying the operator.yaml file, you can deploy the Doris Operator service using the following command:
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -113,13 +113,13 @@ deployment.apps/doris-operator created
 
 If the server is not connected to the external network, you need to download the corresponding operator image file first. Doris Operator uses the following images:
 
-```bash
+```shell
 selectdb/doris.k8s-operator:latest
 ```
 
 Run the following command on a server that can connect to the external network to download the image:
 
-```bash
+```shell
 ## download doris operator image
 docker pull selectdb/doris.k8s-operator:latest
 ## save the doris operator image as a tar package
@@ -128,7 +128,7 @@ docker save -o doris.k8s-operator-latest.tar selectdb/doris.k8s-operator:latest
 
 Place the packaged tar file into all Kubernetes nodes and run the following command to upload the image:
 
-```bash
+```shell
 docker load -i doris.k8s-operator-latest.tar
 ```
 
@@ -138,7 +138,7 @@ After downloading the operator.yaml file, you can modify the template according 
 
 Doris Operator is a stateless Deployment in the Kubernetes cluster. Items such as `limits`, `replica`, `label`, `namespace` and other items can be modified according to needs. If you need to specify a certain version of the doirs operator image, you can make the following modifications to the operator.yaml file after uploading the image:
 
-```bash
+```shell
 ...
 containers:
   - command:
@@ -158,13 +158,13 @@ containers:
 
 After modifying the Doris Operator template, you can use the apply command to deploy the Operator:
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -184,13 +184,13 @@ Helm Chart is an encapsulation of a series of YAML files that describe Kubernete
 
 Add the remote repository through the `repo add` command
 
-```bash
+```shell
 helm repo add doris-repo https://charts.selectdb.com
 ```
 
 Update the latest version of the chart through the `repo update` command
 
-```bash
+```shell
 helm repo update doris-repo
 ```
 
@@ -198,25 +198,25 @@ helm repo update doris-repo
 
 Doris Operator can be installed in the doris namespace using the default configuration through the `helm install` command.
 
-```bash
+```shell
 helm install operator doris-repo/doris-operator
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-repo/doris-operator
 ```
 
 Check the deployment status of Pods through the `kubectl get pods` command. When the Doris Operator's Pod is in the Running state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -229,7 +229,7 @@ If the server cannot connect to the external network, you need to download the c
 
 Download `doris-operator-{chart_version}.tgz` to install Doris Operator chart. If you need to download version 1.4.0 of Doris Operator, you can use the following command:
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 ```
 
@@ -237,25 +237,25 @@ wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 
 Doris Operator can be installed through the `helm install` command.
 
-```bash
+```shell
 helm install operator doris-operator-1.4.0.tgz
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-operator-1.4.0.tgz
 ```
 
 Check the deployment status of Pods through the `kubectl get pods` command. When the Doris Operator's Pod is in the Running state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -264,13 +264,13 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 After deploying the Operator service, you can check the service status through the following command.
 
-```bash
+```shell
 kubectl get pod -n doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-6f47594455-p5tp7   1/1     Running   0          11s
 ```

--- a/versioned_docs/version-2.0/install/cluster-deployment/run-docker-cluster.md
+++ b/versioned_docs/version-2.0/install/cluster-deployment/run-docker-cluster.md
@@ -81,7 +81,7 @@ Download the [official binary package](https://doris.apache.org/zh-CN/download/)
 
 3. Write Dockerfile
 
-```Bash
+```shell
 # Choose a base image
 FROM openjdk:8u342-jdk
 

--- a/versioned_docs/version-2.0/install/cluster-deployment/standard-deployment.md
+++ b/versioned_docs/version-2.0/install/cluster-deployment/standard-deployment.md
@@ -285,7 +285,7 @@ This is a CIDR representation that specifies the IP used by the FE. In environme
 
 Start FE process by executing the following command
 
-```Bash
+```shell
 bin/start_fe.sh --daemon
 ```
 
@@ -348,7 +348,7 @@ ALTER SYSTEM ADD OBSERVER "<fe_ip_address>:<fe_edit_log_port>"
 
 Execute the following command to start FE Follower node and synchronize metadata automatically.
 
-```Bash
+```shell
 bin/start_fe.sh --helper <helper_fe_ip>:<fe_edit_log_port> --daemon
 ```
 
@@ -567,7 +567,7 @@ As a distributed database, Doris generally has many BE nodes. Doris adds BE node
 
 You can use the following command to check if the FE has started successfully.
 
-```Bash
+```shell
 # Retry the following command, if it returns "msg":"success"，the FE has started successfully.
 server1:apache-doris/fe doris$ curl http://127.0.0.1:8030/api/bootstrap
 {"msg":"success","code":0,"data":{"replayedJournalId":0,"queryPort":0,"rpcPort":0,"version":""},"count":0}

--- a/versioned_docs/version-2.0/install/source-install/compilation-arm.md
+++ b/versioned_docs/version-2.0/install/source-install/compilation-arm.md
@@ -58,7 +58,7 @@ Please note that this document is provided as a guide only. Compiling in differe
 
 1. **Create a root directory for software package and a root directory for software installation.**
 
-```Bash
+```shell
 # Create a root directory for software package.
 mkdir /opt/tools
 
@@ -68,7 +68,7 @@ mkdir /opt/software
 
 2. **Install dependencies.**
 
-```Bash
+```shell
 ### Git ###
 # Use yum install to save the trouble of compilation.
 yum install -y git
@@ -115,7 +115,7 @@ wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz && \
 
 3. **Configure environment variables**
 
-```Bash
+```shell
 # Configure the environment variables.
 vim /etc/profile.d/doris.sh
 export JAVA_HOME=/opt/software/jdk8
@@ -142,13 +142,13 @@ gcc --version
 
 1. **Update apt-get software library**
 
-```Bash
+```shell
 apt-get update
 ```
 
 2. **Reconfigure shell**
 
-```Bash
+```shell
 # By default, Ubuntu's shell is set to dash instead of bash, so please switch to bash before continuing. Run the following command to view detailed information about shell and confirm which program it corresponds to.
 ls -al /bin/sh
 
@@ -159,7 +159,7 @@ sudo dpkg-reconfigure dash
 
 3. **Create a root directory for software package and a root directory for software installation.**
 
-```Bash
+```shell
 # Create a root directory for software package.
 mkdir /opt/tools
 
@@ -169,7 +169,7 @@ mkdir /opt/software
 
 4. **Install dependencies.**
 
-```Bash
+```shell
 ### Git ###
 # Use apt-get install to save the trouble of compilation.
 apt-get -y install git
@@ -225,7 +225,7 @@ wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz && \
 
 5. **Configure environment variables**
 
-```Bash
+```shell
 # Configure the environment variables.
 vim /etc/profile.d/doris.sh
 export JAVA_HOME=/opt/software/jdk8
@@ -256,7 +256,7 @@ It is recommended to use LDB Toolchain for compilation with ARM environment.
 
 When compiling Doris on an ARM platform, please disable the AVX2 and LIBUNWIND third-party libraries.
 
-```Bash
+```shell
 export USE_AVX2=OFF
 export USE_UNWIND=OFF
 ```
@@ -273,7 +273,7 @@ Cause: Something wrong with dependency download for the third-party library
 
 Solution: Use a third-party library download repository.
 
-```Bash
+```shell
 export REPOSITORY_URL=https://doris-thirdparty-repo.bj.bcebos.com/thirdparty
 sh /opt/doris/thirdparty/build-thirdparty.sh
 ```

--- a/versioned_docs/version-2.0/install/source-install/compilation-mac.md
+++ b/versioned_docs/version-2.0/install/source-install/compilation-mac.md
@@ -92,7 +92,7 @@ cd output/fe/bin
 
 Download the pre-compiled third-party libraries from [Apache Doris Third Party Prebuilt](https://github.com/apache/doris-thirdparty/releases/tag/automation). Refer to the command below: 
 
-```Bash
+```shell
 cd thirdparty
 rm -rf installed
 

--- a/versioned_docs/version-2.0/install/source-install/compilation-with-docker.md
+++ b/versioned_docs/version-2.0/install/source-install/compilation-with-docker.md
@@ -32,7 +32,7 @@ This guide is about how to compile Doris using the official compilation image pr
 
 In CentOS, execute the following command: 
 
-```Bash
+```shell
 yum install docker
 ```
 
@@ -51,7 +51,7 @@ For different versions of Doris, you need to download different build images. Th
 
 Take Doris 2.0 as an example, download and check the correponding Docker image.
 
-```Bash
+```shell
 # Choose docker.io/apache/doris:build-env-for-2.0
 $ docker pull apache/doris:build-env-for-2.0
 

--- a/versioned_docs/version-2.0/install/source-install/compilation-with-ldb-toolchain.md
+++ b/versioned_docs/version-2.0/install/source-install/compilation-with-ldb-toolchain.md
@@ -118,7 +118,7 @@ The first step of compiling Doris source code is to first download third-party l
 
 1. **Enter the Doris source code directory and execute the following command to check if the compilation machine supports the AVX2 instruction set.**
 
-```Bash
+```shell
 $ cat /proc/cpuinfo | grep avx2
 ```
 

--- a/versioned_docs/version-2.0/lakehouse/database/es.md
+++ b/versioned_docs/version-2.0/lakehouse/database/es.md
@@ -122,7 +122,7 @@ For example, suppose there is an index `doc` containing the following data struc
 The array fields of this structure can be defined by using the following command to add the field property definition 
 to the `_meta.doris` property of the target index mapping.
 
-```bash
+```shell
 # ES 7.x and above
 curl -X PUT "localhost:9200/doc/_mapping?pretty" -H 'Content-Type:application/json' -d '
 {

--- a/versioned_docs/version-2.0/practical-guide/log-storage-analysis.md
+++ b/versioned_docs/version-2.0/practical-guide/log-storage-analysis.md
@@ -398,7 +398,7 @@ output {
 
 3. Run Logstash according to the command below, collect logs, and output to Apache Doris.
 
-```Bash  
+```shell  
 ./bin/logstash -f logstash_demo.conf
 ```
 
@@ -465,7 +465,7 @@ headers:
 
 3. Run Filebeat according to the command below, collect logs, and output to Apache Doris.
 
-    ```Bash  
+    ```shell  
     chmod +x filebeat-doris-1.0.0  
     ./filebeat-doris-1.0.0 -c filebeat_demo.yml
     ```
@@ -509,7 +509,7 @@ For more information about Kafka, see [Routine Load](../data-operate/import/rout
 
 In addition to integrating common log collectors, you can also customize programs to import log data into Apache Doris using the Stream Load HTTP API. Refer to the following code:
 
-```Bash  
+```shell  
 curl   
 --location-trusted   
 -u username:password   

--- a/versioned_docs/version-2.0/query/query-analysis/import-analysis.md
+++ b/versioned_docs/version-2.0/query/query-analysis/import-analysis.md
@@ -45,7 +45,7 @@ The execution process of a [Broker Load](../../data-operate/import/broker-load-m
 ┌────────────────┐
 │BrokerScanNode│
 └────────────────┘
-````
+```
 
 BrokerScanNode is mainly responsible for reading the source data and sending it to OlapTableSink, and OlapTableSink is responsible for sending data to the corresponding node according to the partition and bucketing rules, and the corresponding node is responsible for the actual data writing.
 
@@ -59,7 +59,7 @@ The user can open the session variable `is_report_success` with the following co
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Then submit a Broker Load import request and wait until the import execution completes. Doris will generate a Profile for this import. Profile contains the execution details of importing each subtask and Instance, which helps us analyze import bottlenecks.
 
@@ -105,7 +105,7 @@ WaitAndFetchResultTime: NULL
        FetchResultTime: 0ns
        WriteResultTime: 0ns
 WaitAndFetchResultTime: N/A
-````
+```
 
 This command will list all currently saved import profiles. Each line corresponds to one import. where the QueryId column is the ID of the import job. This ID can also be viewed through the SHOW LOAD statement. We can select the QueryId corresponding to the Profile we want to see to see the specific situation.
 
@@ -124,7 +124,7 @@ This command will list all currently saved import profiles. Each line correspond
    +-----------------------------------+------------+
    | 980014623046410a-af5d36f23381017f | 3m14s      |
    +-----------------------------------+------------+
-   ````
+   ```
 
 As shown in the figure above, it means that the import job `980014623046410a-af5d36f23381017f` has a total of one subtask, in which ActiveTime indicates the execution time of the longest instance in this subtask.
 
@@ -144,7 +144,7 @@ As shown in the figure above, it means that the import job `980014623046410a-af5
    | 980014623046410a-88e260f0c43031f4 | 10.81.85.89:9067 | 3m10s      |
    | 980014623046410a-88e260f0c43031f5 | 10.81.85.89:9067 | 3m14s      |
    +-----------------------------------+------------------+------------+
-   ````
+   ```
 
 This shows the time-consuming of four instances of the subtask 980014623046410a-af5d36f23381017f, and also shows the execution node where the instance is located.
 
@@ -195,7 +195,7 @@ This shows the time-consuming of four instances of the subtask 980014623046410a-
    │ - TotalReadThroughput: 30.39858627319336 MB/sec│
    │ - WaitScannerTime: 56s528ms │
    └------------------------------------------------- ----┘
-   ````
+   ```
 
 The figure above shows the specific profiles of each operator of Instance 980014623046410a-af5d36f23381017f in subtask 980014623046410a-88e260f0c43031f5.
 

--- a/versioned_docs/version-2.0/query/query-analysis/query-analytics.md
+++ b/versioned_docs/version-2.0/query/query-analysis/query-analytics.md
@@ -37,7 +37,7 @@ For example, if the user specifies a Join operator, the query planner needs to d
 
 Doris' query planning process is to first convert an SQL statement into a single-machine execution plan tree.
 
-````text
+```text
      ┌────┐
      │Sort│
      └────┘
@@ -53,11 +53,11 @@ Doris' query planning process is to first convert an SQL statement into a single
 ┌──────┐ ┌──────┐
 │Scan-1│ │Scan-2│
 └──────┘ └──────┘
-````
+```
 
 After that, the query planner will convert the single-machine query plan into a distributed query plan according to the specific operator execution mode and the specific distribution of data. The distributed query plan is composed of multiple fragments, each fragment is responsible for a part of the query plan, and the data is transmitted between the fragments through the ExchangeNode operator.
 
-````text
+```text
         ┌────┐
         │Sort│
         │F1 │
@@ -87,7 +87,7 @@ After that, the query planner will convert the single-machine query plan into a 
             │Scan-2│
             │F2 │
             └──────┘
-````
+```
 
 As shown above, we divided the stand-alone plan into two Fragments: F1 and F2. Data is transmitted between two Fragments through an ExchangeNode.
 
@@ -472,7 +472,7 @@ The user can open the session variable `is_report_success` with the following co
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Then execute the query, and Doris will generate a Profile of the query. Profile contains the specific execution of a query for each node, which helps us analyze query bottlenecks.
 
@@ -490,7 +490,7 @@ mysql> show query profile "/"\G
    EndTime: 2021-04-08 11:30:50
  TotalTime: 9ms
 QueryState: EOF
-````
+```
 
 This command will list all currently saved profiles. Each row corresponds to a query. We can select the QueryId corresponding to the Profile we want to see to see the specific situation.
 
@@ -669,7 +669,7 @@ This shows the execution nodes and time consumption of all three Instances on Fr
    │ - RowsReturnedRate: 0 │
    │ - SendersBlockedTotalTimer(*): 0ns │
    └────────────────────────────────────────────────────┘
-   ````
+   ```
 
    The above figure shows the specific profiles of each operator of Instance c257c52f93e149ee-ace8ac14e8c9ff03 in Fragment 1.
 

--- a/versioned_docs/version-2.0/query/query-variables/variables.md
+++ b/versioned_docs/version-2.0/query/query-variables/variables.md
@@ -583,19 +583,19 @@ Note that the comment must start with /*+ and can only follow the SELECT.
 
 	Default password expiration time. The default value is 0, which means no expiration. The unit is days. This parameter is only enabled if the user's password expiration property has a value of DEFAULT. like:
 
-   ````
+   ```
    CREATE USER user1 IDENTIFIED BY "12345" PASSWORD_EXPIRE DEFAULT;
    ALTER USER user1 PASSWORD_EXPIRE DEFAULT;
-   ````
+   ```
 
 * `password_history`
 
 	The default number of historical passwords. The default value is 0, which means no limit. This parameter is enabled only when the user's password history attribute is the DEFAULT value. like:
 
-   ````
+   ```
    CREATE USER user1 IDENTIFIED BY "12345" PASSWORD_HISTORY DEFAULT;
    ALTER USER user1 PASSWORD_HISTORY DEFAULT;
-   ````
+   ```
 
 * `validate_password_policy`
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/CREATE-ROLE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/CREATE-ROLE.md
@@ -36,7 +36,7 @@ The statement user creates a role
 
 ```sql
   CREATE ROLE rol_name;
-````
+```
 
 This statement creates an unprivileged role, which can be subsequently granted with the GRANT command.
 
@@ -46,7 +46,7 @@ This statement creates an unprivileged role, which can be subsequently granted w
 
     ```sql
     CREATE ROLE role1;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/DROP-ROLE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/DROP-ROLE.md
@@ -32,7 +32,7 @@ The statement user removes a role
 
 ```sql
   DROP ROLE [IF EXISTS] role1;
-````
+```
 
 Deleting a role does not affect the permissions of users who previously belonged to the role. It is only equivalent to decoupling the role from the user. The permissions that the user has obtained from the role will not change
 
@@ -42,7 +42,7 @@ Deleting a role does not affect the permissions of users who previously belonged
 
 ```sql
 DROP ROLE role1;
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/DROP-USER.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/DROP-USER.md
@@ -41,7 +41,7 @@ Delete a user
     
          user@'host'
          user@['domain']
-````
+```
 
   Delete the specified user identitiy.
 
@@ -51,7 +51,7 @@ Delete a user
 
     ```sql
     DROP USER 'jack'@'192.%'
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/GRANT.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/GRANT.md
@@ -47,7 +47,7 @@ GRANT privilege_list ON priv_level TO user_identity [ROLE role_name]
 GRANT privilege_list ON RESOURCE resource_name TO user_identity [ROLE role_name]
 
 GRANT role_list TO user_identity
-````
+```
 
 GRANT privilege_list ON WORKLOAD GROUP workload_group_name TO user_identity [ROLE role_name]
 
@@ -105,37 +105,37 @@ role_list is the list of roles to be assigned, separated by commas,the specified
 
    ```sql
    GRANT SELECT_PRIV ON *.*.* TO 'jack'@'%';
-   ````
+   ```
 
 2. Grant permissions to the specified database table to the user
 
    ```sql
    GRANT SELECT_PRIV,ALTER_PRIV,LOAD_PRIV ON ctl1.db1.tbl1 TO 'jack'@'192.8.%';
-   ````
+   ```
 
 3. Grant permissions to the specified database table to the role
 
    ```sql
    GRANT LOAD_PRIV ON ctl1.db1.* TO ROLE 'my_role';
-   ````
+   ```
 
 4. Grant access to all resources to users
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE * TO 'jack'@'%';
-   ````
+   ```
 
 5. Grant the user permission to use the specified resource
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE 'spark_resource' TO 'jack'@'%';
-   ````
+   ```
 
 6. Grant access to specified resources to roles
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE 'spark_resource' TO ROLE 'my_role';
-   ````
+   ```
    
 :::tip Tips
 This feature is supported since the Apache Doris 2.0 version
@@ -145,7 +145,7 @@ This feature is supported since the Apache Doris 2.0 version
 
     ```sql
     GRANT 'role1','role2' TO 'jack'@'%';
-    ````
+    ```
 
  
 
@@ -153,25 +153,25 @@ This feature is supported since the Apache Doris 2.0 version
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO 'jack'@'%'.
-    ````
+    ```
 
 9. match all workload groups granted to user jack
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP '%' TO 'jack'@'%'.
-    ````
+    ```
 
 10. grant the workload group 'g1' to the role my_role
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO ROLE 'my_role'.
-    ````
+    ```
 
 11. Allow jack to view the creation statement of view1 under db1
 
     ```sql
     GRANT SHOW_VIEW_PRIV ON db1.view1 TO 'jack'@'%';
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/LDAP.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/LDAP.md
@@ -36,7 +36,7 @@ SET LDAP_ADMIN_PASSWORD
 
 ```sql
   SET LDAP_ADMIN_PASSWORD = PASSWORD('plain password')
-````
+```
 
   The SET LDAP_ADMIN_PASSWORD command is used to set the LDAP administrator password. When using LDAP authentication, doris needs to use the administrator account and password to query the LDAP service for login user information.
 
@@ -46,7 +46,7 @@ SET LDAP_ADMIN_PASSWORD
 
 ```sql
 SET LDAP_ADMIN_PASSWORD = PASSWORD('123456')
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/REVOKE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/REVOKE.md
@@ -47,7 +47,7 @@ REVOKE privilege_list ON db_name[.tbl_name] FROM user_identity [ROLE role_name]
 REVOKE privilege_list ON RESOURCE resource_name FROM user_identity [ROLE role_name]
 
 REVOKE role_list FROM user_identity
-````
+```
 
 user_identity:
 
@@ -63,13 +63,13 @@ role_list is the list of roles to be revoked, separated by commas. The specified
 
     ```sql
     REVOKE SELECT_PRIV ON db1.* FROM 'jack'@'192.%';
-    ````
+    ```
 
 2. Revoke user jack resource spark_resource permission
 
     ```sql
     REVOKE USAGE_PRIV ON RESOURCE 'spark_resource' FROM 'jack'@'192.%';
-    ````
+    ```
 3. Revoke the roles role1 and role2 previously granted to jack
 
     ```sql

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/SET-PASSWORD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/SET-PASSWORD.md
@@ -37,7 +37,7 @@ The SET PASSWORD command can be used to modify a user's login password. If the [
 ```sql
 SET PASSWORD [FOR user_identity] =
     [PASSWORD('plain password')]|['hashed password']
-````
+```
 
 Note that the user_identity here must exactly match the user_identity specified when creating a user with CREATE USER, otherwise an error will be reported that the user does not exist. If user_identity is not specified, the current user is 'username'@'ip', which may not match any user_identity. Current users can be viewed through SHOW GRANTS.
 
@@ -51,14 +51,14 @@ To modify the passwords of other users, administrator privileges are required.
    ```sql
    SET PASSWORD = PASSWORD('123456')
    SET PASSWORD = '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9'
-   ````
+   ```
 
 2. Modify the specified user password
 
    ```sql
    SET PASSWORD FOR 'jack'@'192.%' = PASSWORD('123456')
    SET PASSWORD FOR 'jack'@['domain'] = '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9'
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/SET-PROPERTY.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Account-Management-Statements/SET-PROPERTY.md
@@ -36,7 +36,7 @@ Set user attributes, including resources assigned to users, importing clusters, 
 
 ```sql
 SET PROPERTY [FOR 'user'] 'key' = 'value' [, 'key' = 'value']
-````
+```
 
 The user attribute set here is for user, not user_identity. That is, if two users 'jack'@'%' and 'jack'@'192.%' are created through the CREATE USER statement, the SET PROPERTY statement can only be used for the user jack, not 'jack'@'% ' or 'jack'@'192.%'
 
@@ -66,43 +66,43 @@ Super user privileges:
 
    ```sql
    SET PROPERTY FOR 'jack' 'max_user_connections' = '1000';
-   ````
+   ```
 
 2. Modify the number of available instances for user jack's query to 3000
 
    ```sql
    SET PROPERTY FOR 'jack' 'max_query_instances' = '3000';
-   ````
+   ```
 
 3. Modify the sql block rule of user jack
 
    ```sql
    SET PROPERTY FOR 'jack' 'sql_block_rules' = 'rule1, rule2';
-   ````
+   ```
 
 4. Modify the cpu usage limit of user jack
 
     ```sql
     SET PROPERTY FOR 'jack' 'cpu_resource_limit' = '2';
-    ````
+    ```
 
 5. Modify the user's resource tag permissions
 
     ```sql
     SET PROPERTY FOR 'jack' 'resource_tags.location' = 'group_a, group_b';
-    ````
+    ```
 
 6. Modify the user's query memory usage limit, in bytes
 
     ```sql
     SET PROPERTY FOR 'jack' 'exec_mem_limit' = '2147483648';
-    ````
+    ```
 
 7. Modify the user's query timeout limit, in second
 
     ```sql
     SET PROPERTY FOR 'jack' 'query_timeout' = '500';
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 -- Add nodes (add this method if you do not use the multi-tenancy function)
    ALTER SYSTEM ADD BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
  illustrate:
 
@@ -53,7 +53,7 @@ grammar:
 
     ```sql
     ALTER SYSTEM ADD BACKEND "host:port";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BROKER.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BROKER.md
@@ -39,7 +39,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host2:broker_ipc_port2",...;
-````
+```
 
 ### Example
 
@@ -47,7 +47,7 @@ ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host
 
     ```sql
      ALTER SYSTEM ADD BROKER "host1:port", "host2:port";
-    ````
+    ```
 2. When fe enable fqdn([fqdn](../../../admin-manual/cluster-management/fqdn.md)),add one Broker
 
    ```sql

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-FOLLOWER.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-FOLLOWER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD FOLLOWER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM ADD FOLLOWER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-OBSERVER.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-ADD-OBSERVER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD OBSERVER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM ADD OBSERVER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DECOMMISSION-BACKEND.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DECOMMISSION-BACKEND.md
@@ -40,13 +40,13 @@ grammar:
 
 ```sql
 ALTER SYSTEM DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM DECOMMISSION BACKEND "id1","id2"...;
-````
+```
 
   illustrate:
 
@@ -61,11 +61,11 @@ ALTER SYSTEM DECOMMISSION BACKEND "id1","id2"...;
 
     ```sql
     ALTER SYSTEM DECOMMISSION BACKEND "host1:port", "host2:port";
-    ````
+    ```
 
     ```sql
     ALTER SYSTEM DECOMMISSION BACKEND "id1", "id2";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BACKEND.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BACKEND.md
@@ -40,12 +40,12 @@ grammar:
 
 ```sql
 ALTER SYSTEM DROP BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...]
-````
+```
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM DROP BACKEND "id1","id2"...;
-````
+```
 
 illustrate:
 
@@ -59,11 +59,11 @@ illustrate:
 
     ```sql
     ALTER SYSTEM DROP BACKEND "host1:port", "host2:port";
-    ````
+    ```
 
     ```sql
     ALTER SYSTEM DROP BACKEND "ids1", "ids2";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BROKER.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BROKER.md
@@ -42,7 +42,7 @@ grammar:
 ALTER SYSTEM DROP ALL BROKER broker_name
 -- Delete a Broker node
 ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
-````
+```
 
 ### Example
 
@@ -50,13 +50,13 @@ ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
 
     ```sql
     ALTER SYSTEM DROP ALL BROKER broker_name
-    ````
+    ```
 
 2. Delete a Broker node
 
     ```sql
     ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-OBSERVER.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-DROP-OBSERVER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM DROP OBSERVER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM DROP OBSERVER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
@@ -41,13 +41,13 @@ grammar:
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
-````
+```
 
   illustrate:
 
@@ -69,32 +69,32 @@ Note:
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("tag.location" = "group_a");
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a");
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-    ````
+    ```
 
 2. Modify the query disable property of BE
 
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("disable_query" = "true");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_query" = "true");
-    ````
+    ```
 
 3. Modify the import disable property of BE
 
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("disable_load" = "true");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_load" = "true");
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/CANCEL-ALTER-SYSTEM.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Cluster-Management-Statements/CANCEL-ALTER-SYSTEM.md
@@ -40,13 +40,13 @@ grammar:
 
 ```sql
 CANCEL DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 CANCEL DECOMMISSION BACKEND "id1","id2","id3...";
-````
+```
 
 ### Example
 
@@ -54,7 +54,7 @@ CANCEL DECOMMISSION BACKEND "id1","id2","id3...";
 
       ```sql
       CANCEL DECOMMISSION BACKEND "host1:port", "host2:port";
-      ````
+      ```
 
  2. Cancel the offline operation of the node with backend_id 1:
     

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-SQL-BLOCK-RULE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 ALTER SQL_BLOCK_RULE rule_name
 [PROPERTIES ("key"="value", ...)];
-````
+```
 
 illustrate:
 
@@ -52,18 +52,18 @@ illustrate:
 
 ```sql
 ALTER SQL_BLOCK_RULE test_rule PROPERTIES("sql"="select \\* from test_table","enable"="true")
-````
+```
 
 2. If a rule sets partition_num, then sql or sqlHash cannot be modified
 
 ```sql
 ALTER SQL_BLOCK_RULE test_rule2 PROPERTIES("partition_num" = "10","tablet_num"="300","enable"="true")
-````
+```
 
 ### Keywords
 
-````text
+```text
 ALTER,SQL_BLOCK_RULE
-````
+```
 
 ### Best Practice

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN.md
@@ -220,7 +220,7 @@ ORDER BY (k3,k1,k2,v2,v1) FROM example_rollup_index;
 
 ```sql
 alter table example_tbl modify column k3 varchar(50) key null comment 'to 50'
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
@@ -161,7 +161,7 @@ ALTER TABLE example_db.mysql_table SET ("replication_num" = "2");
 ALTER TABLE example_db.mysql_table SET ("default.replication_num" = "2");
 ALTER TABLE example_db.mysql_table SET ("replication_allocation" = "tag.location.default: 1");
 ALTER TABLE example_db.mysql_table SET ("default.replication_allocation" = "tag.location.default: 1");
-````
+```
 
 Note:
 1. The property with the default prefix indicates the default replica distribution for the modified table. This modification does not modify the current actual replica distribution of the table, but only affects the replica distribution of newly created partitions on the partitioned table.

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-DATABASE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-DATABASE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 CREATE DATABASE [IF NOT EXISTS] db_name
     [PROPERTIES ("key"="value", ...)];
-````
+```
 
 `PROPERTIES` Additional information about the database, which can be defaulted.
 
@@ -51,7 +51,7 @@ CREATE DATABASE [IF NOT EXISTS] db_name
     "iceberg.hive.metastore.uris" = "thrift://127.0.0.1:9083",
     "iceberg.catalog.type" = "HIVE_CATALOG"
   )
-  ````
+  ```
 
   illustrate:
   
@@ -73,7 +73,7 @@ CREATE DATABASE [IF NOT EXISTS] db_name
 
    ```sql
    CREATE DATABASE db_test;
-   ````
+   ```
 
 2. Create a new Iceberg database iceberg_test
 
@@ -84,13 +84,13 @@ CREATE DATABASE [IF NOT EXISTS] db_name
    "iceberg.hive.metastore.uris" = "thrift://127.0.0.1:9083",
    "iceberg.catalog.type" = "HIVE_CATALOG"
    );
-   ````
+   ```
 
 ### Keywords
 
-````text
+```text
 CREATE, DATABASE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-ENCRYPT-KEY.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-ENCRYPT-KEY.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 CREATE ENCRYPTKEY key_name AS "key_string"
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ If `key_name` contains the database name, then the custom key will be created in
 
    ```sql
    CREATE ENCRYPTKEY my_key AS "ABCD123456789";
-   ````
+   ```
 
 2. Use a custom key
 
@@ -76,7 +76,7 @@ If `key_name` contains the database name, then the custom key will be created in
    | Doris is Great |
    +------------------------------------------------- -------------------+
    1 row in set (0.01 sec)
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-EXTERNAL-TABLE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-EXTERNAL-TABLE.md
@@ -47,7 +47,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
    "database" = "database_name",
    "table" = "table_name"
    )
-   ````
+   ```
    and there is an optional propertiy "charset" which can set character fom mysql connection, default value is "utf8". You can set another value "utf8mb4" instead of "utf8" when you need.
 
    Notice:
@@ -65,7 +65,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
    "column_separator" = "value_separator"
    "line_delimiter" = "value_delimiter"
    )
-   ````
+   ```
 
    In addition, you need to provide the Property information required by the Broker, and pass it through the BROKER PROPERTIES, for example, HDFS needs to pass in
 
@@ -74,7 +74,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
      "username" = "name",
      "password" = "password"
    )
-   ````
+   ```
 
    According to different Broker types, the content that needs to be passed in is also different.
 
@@ -91,7 +91,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
    "table" = "hive_table_name",
    "hive.metastore.uris" = "thrift://127.0.0.1:9083"
    )
-   ````
+   ```
 
    Where database is the name of the library corresponding to the hive table, table is the name of the hive table, and hive.metastore.uris is the address of the hive metastore service.
 
@@ -104,7 +104,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
    "iceberg.hive.metastore.uris" = "thrift://127.0.0.1:9083",
    "iceberg.catalog.type" = "HIVE_CATALOG"
    )
-   ````
+   ```
 
    Where database is the library name corresponding to Iceberg;
    table is the corresponding table name in Iceberg;
@@ -119,7 +119,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
    "hudi.table" = "hudi_table_in_hive_metastore",
    "hudi.hive.metastore.uris" = "thrift://127.0.0.1:9083"
    )
-   ````
+   ```
 
    Where hudi.database is the corresponding database name in HiveMetaStore;
    hudi.table is the corresponding table name in HiveMetaStore;
@@ -151,7 +151,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
    "table" = "mysql_table_test",
    "charset" = "utf8mb4"
    )
-   ````
+   ```
 
    Create mysql table through External Catalog Resource
 
@@ -183,7 +183,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
    "database" = "mysql_db_test",
    "table" = "mysql_table_test"
    )
-   ````
+   ```
 
 2. Create a broker external table with data files stored on HDFS, the data is split with "|", and "\n" is newline
 
@@ -206,7 +206,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
    "username" = "hdfs_user",
    "password" = "hdfs_password"
    )
-   ````
+   ```
 
 3. Create a hive external table
 
@@ -224,7 +224,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
      "table" = "hive_table_name",
      "hive.metastore.uris" = "thrift://127.0.0.1:9083"
    );
-   ````
+   ```
 
 4. Create an Iceberg skin
 
@@ -237,7 +237,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
    "iceberg.hive.metastore.uris" = "thrift://127.0.0.1:9083",
    "iceberg.catalog.type" = "HIVE_CATALOG"
    );
-   ````
+   ```
 
 5. Create an Hudi external table
 
@@ -250,7 +250,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
    "hudi.table" = "hudi_table_in_hive_metastore",
    "hudi.hive.metastore.uris" = "thrift://127.0.0.1:9083"
    );
-   ````
+   ```
 
    create hudi table with schema
    ```sql
@@ -264,7 +264,7 @@ Which type of external table is mainly identified by the ENGINE type, currently 
    "hudi.table" = "hudi_table_in_hive_metastore",
    "hudi.hive.metastore.uris" = "thrift://127.0.0.1:9083"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FILE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FILE.md
@@ -46,7 +46,7 @@ grammar:
 ```sql
 CREATE FILE "file_name" [IN database]
 PROPERTIES("key"="value", ...)
-````
+```
 
 illustrate:
 
@@ -68,7 +68,7 @@ illustrate:
        "url" = "https://test.bj.bcebos.com/kafka-key/ca.pem",
        "catalog" = "kafka"
    );
-   ````
+   ```
 
 2. Create a file client.key, classified as my_catalog
 
@@ -81,13 +81,13 @@ illustrate:
        "catalog" = "my_catalog",
        "md5" = "b5bb901bf10f99205b39a46ac3557dd9"
    );
-   ````
+   ```
 
 ### Keywords
 
-````text
+```text
 CREATE, FILE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FUNCTION.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-FUNCTION.md
@@ -45,7 +45,7 @@ CREATE [GLOBAL] [AGGREGATE] [ALIAS] FUNCTION function_name
     [INTERMEDIATE inter_type]
     [WITH PARAMETER(param [,...]) AS origin_function]
     [PROPERTIES ("key" = "value" [, ...]) ]
-````
+```
 
 Parameter Description:
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-INDEX.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-INDEX.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 CREATE INDEX [IF NOT EXISTS] index_name ON table_name (column [, ...],) [USING INVERTED] [COMMENT 'balabala'];
-````
+```
 Notice:
 - INVERTED indexes are only created on a single column
 
@@ -47,14 +47,14 @@ Notice:
 
     ```sql
     CREATE INDEX [IF NOT EXISTS] index_name ON table1 (siteid) USING INVERTED COMMENT 'balabala';
-    ````
+    ```
 
 
 ### Keywords
 
-````text
+```text
 CREATE, INDEX
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-MATERIALIZED-VIEW.md
@@ -41,7 +41,7 @@ grammar:
 ```sql
 CREATE MATERIALIZED VIEW < MV name > as < query >
 [PROPERTIES ("key" = "value")]
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ illustrate:
   FROM [Base view name]
   GROUP BY column_name[, column_name ...]
   ORDER BY column_name[, column_name ...]
-  ````
+  ```
 
   The syntax is the same as the query syntax.
 
@@ -73,16 +73,16 @@ illustrate:
 
   Declare some configuration of the materialized view, optional.
 
-  ````text
+  ```text
   PROPERTIES ("key" = "value", "key" = "value" ...)
-  ````
+  ```
 
   The following configurations can be declared here:
 
-  ````text
+  ```text
    short_key: The number of sorting columns.
    timeout: The timeout for materialized view construction.
-  ````
+  ```
 
 ### Example
 
@@ -98,7 +98,7 @@ mysql> desc duplicate_table;
 | k3 | BIGINT | Yes | true | N/A | |
 | k4 | BIGINT | Yes | true | N/A | |
 +-------+--------+------+------+---------+-------+
-````
+```
 ```sql
 create table duplicate_table(
 	k1 int null,
@@ -117,49 +117,49 @@ attention：If the materialized view contains partitioned and distributed column
    ```sql
    create materialized view k2_k1 as
    select k2, k1 from duplicate_table;
-   ````
+   ```
 
    The schema of the materialized view is as follows, the materialized view contains only two columns k1, k2 without any aggregation
 
-   ````text
+   ```text
    +-------+-------+--------+------+------+ ---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------+ ---------+-------+
    | k2_k1 | k2 | INT | Yes | true | N/A | |
    | | k1 | INT | Yes | true | N/A | |
    +-------+-------+--------+------+------+ ---------+-------+
-   ````
+   ```
 
 2. Create a materialized view with k2 as the sort column
 
    ```sql
    create materialized view k2_order as
    select k2, k1 from duplicate_table order by k2;
-   ````
+   ```
 
    The schema of the materialized view is shown in the figure below. The materialized view contains only two columns k2, k1, where k2 is the sorting column without any aggregation.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
    | k2_order | k2 | INT | Yes | true | N/A | |
    | | k1 | INT | Yes | false | N/A | NONE |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 3. Create a materialized view with k1, k2 grouping and k3 column aggregated by SUM
 
    ```sql
    create materialized view k1_k2_sumk3 as
    select k1, k2, sum(k3) from duplicate_table group by k1, k2;
-   ````
+   ```
 
    The schema of the materialized view is shown in the figure below. The materialized view contains two columns k1, k2, sum(k3) where k1, k2 are the grouping columns, and sum(k3) is the sum value of the k3 column grouped by k1, k2.
 
    Since the materialized view does not declare a sorting column, and the materialized view has aggregated data, the system defaults to supplement the grouping columns k1 and k2 as sorting columns.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
@@ -167,18 +167,18 @@ attention：If the materialized view contains partitioned and distributed column
    | | k2 | INT | Yes | true | N/A | |
    | | k3 | BIGINT | Yes | false | N/A | SUM |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 4. Create a materialized view that removes duplicate rows
 
    ```sql
    create materialized view deduplicate as
    select k1, k2, k3, k4 from duplicate_table group by k1, k2, k3, k4;
-   ````
+   ```
 
    The materialized view schema is as shown below. The materialized view contains columns k1, k2, k3, and k4, and there are no duplicate rows.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
@@ -187,13 +187,13 @@ attention：If the materialized view contains partitioned and distributed column
    | | k3 | BIGINT | Yes | true | N/A | |
    | | k4 | BIGINT | Yes | true | N/A | |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 5. Create a non-aggregate materialized view that does not declare a sort column
 
    The schema of all_type_table is as follows
 
-   ````
+   ```
    +-------+--------------+------+-------+---------+- ------+
    | Field | Type | Null | Key | Default | Extra |
    +-------+--------------+------+-------+---------+- ------+
@@ -205,14 +205,14 @@ attention：If the materialized view contains partitioned and distributed column
    | k6 | DOUBLE | Yes | false | N/A | NONE |
    | k7 | VARCHAR(20) | Yes | false | N/A | NONE |
    +-------+--------------+------+-------+---------+- ------+
-   ````
+   ```
 
    The materialized view contains k3, k4, k5, k6, k7 columns, and does not declare a sort column, the creation statement is as follows:
 
    ```sql
    create materialized view mv_1 as
    select k3, k4, k5, k6, k7 from all_type_table;
-   ````
+   ```
 
    The default added sorting column of the system is k3, k4, k5 three columns. The sum of the bytes of these three column types is 4(INT) + 8(BIGINT) + 16(DECIMAL) = 28 < 36. So the addition is that these three columns are used as sorting columns. The schema of the materialized view is as follows, you can see that the key field of the k3, k4, k5 columns is true, that is, the sorting column. The key field of the k6, k7 columns is false, which is a non-sorted column.
 
@@ -226,7 +226,7 @@ attention：If the materialized view contains partitioned and distributed column
    | | k6 | DOUBLE | Yes | false | N/A | NONE |
    | | k7 | VARCHAR(20) | Yes | false | N/A | NONE |
    +----------------+-------+--------------+------+-- -----+---------+-------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-RESOURCE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-RESOURCE.md
@@ -40,7 +40,7 @@ grammar:
 ```sql
 CREATE [EXTERNAL] RESOURCE "resource_name"
 PROPERTIES ("key"="value", ...);
-````
+```
 
 illustrate:
 
@@ -69,7 +69,7 @@ illustrate:
      "broker.username" = "user0",
      "broker.password" = "password0"
    );
-   ````
+   ```
 
    Spark related parameters are as follows:
    - spark.master: Required, currently supports yarn, spark://host:port.
@@ -100,7 +100,7 @@ illustrate:
    "odbc_type" = "oracle",
    "driver" = "Oracle 19 ODBC driver"
    );
-   ````
+   ```
 
    The relevant parameters of ODBC are as follows:
    - hosts: IP address of the external database

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-SQL-BLOCK-RULE.md
@@ -45,7 +45,7 @@ grammar:
 ```sql
 CREATE SQL_BLOCK_RULE rule_name
 [PROPERTIES ("key"="value", ...)];
-````
+```
 
 Parameter Description:
 
@@ -68,7 +68,7 @@ Parameter Description:
     "global"="false",
     "enable"="true"
     );
-    ````
+    ```
 
     >Notes:
     >
@@ -79,7 +79,7 @@ Parameter Description:
     ```sql
     select * from order_analysis;
     ERROR 1064 (HY000): errCode = 2, detailMessage = sql match regex sql block rule: order_analysis_rule
-    ````
+    ```
 
 
 2. Create test_rule2, limit the maximum number of scanned partitions to 30, and limit the maximum scan base to 10 billion rows. The example is as follows:
@@ -92,7 +92,7 @@ Parameter Description:
     "global" = "false",
     "enable" = "true"
     );
-   ````
+   ```
 3. Create SQL BLOCK RULE with special chars
 
     ```sql
@@ -150,9 +150,9 @@ Here are some commonly used regular expressions:
 
 ### Keywords
 
-````text
+```text
 CREATE, SQL_BLCOK_RULE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-LIKE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-LIKE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 CREATE [EXTERNAL] TABLE [IF NOT EXISTS] [database.]table_name LIKE [database.]table_name [WITH ROLLUP (r1,r2,r3,...)]
-````
+```
 
 illustrate: 
 
@@ -53,43 +53,43 @@ illustrate:
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1
-    ````
+    ```
 
 2. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1
-    ````
+    ```
 
 3. Create an empty table with the same table structure as table1 under the test1 library, the table name is table2, and copy the two rollups of r1 and r2 of table1 at the same time
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1 WITH ROLLUP (r1,r2)
-    ````
+    ```
 
 4. Create an empty table with the same table structure as table1 under the test1 library, the table name is table2, and copy all the rollups of table1 at the same time
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1 WITH ROLLUP
-    ````
+    ```
 
 5. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2, and copy the two rollups of r1 and r2 of table1 at the same time
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1 WITH ROLLUP (r1,r2)
-    ````
+    ```
 
 6. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2, and copy all the rollups of table1 at the same time
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1 WITH ROLLUP
-    ````
+    ```
 
 7. Create an empty table under the test1 library with the same table structure as the MySQL outer table1, the table name is table2
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-VIEW.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-VIEW.md
@@ -40,7 +40,7 @@ CREATE VIEW [IF NOT EXISTS]
  [db_name.]view_name
  (column1[ COMMENT "col comment"][, column2, ...])
 AS query_stmt
-````
+```
 
 
 illustrate:
@@ -57,7 +57,7 @@ illustrate:
     AS
     SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table
     WHERE k1 = 20160112 GROUP BY k1,k2,k3;
-    ````
+    ```
     
 2. Create a view with a comment
 
@@ -73,7 +73,7 @@ illustrate:
     AS
     SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table
     WHERE k1 = 20160112 GROUP BY k1,k2,k3;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-DATABASE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-DATABASE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP DATABASE [IF EXISTS] db_name [FORCE];
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
    
      ```sql
      DROP DATABASE db_test;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-ENCRYPT-KEY.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-ENCRYPT-KEY.md
@@ -36,7 +36,7 @@ grammar:
 
 ```sql
 DROP ENCRYPTKEY key_name
-````
+```
 
 Parameter Description:
 
@@ -52,7 +52,7 @@ Executing this command requires the user to have `ADMIN` privileges.
 
     ```sql
     DROP ENCRYPTKEY my_key;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FILE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FILE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 DROP FILE "file_name" [FROM database]
 [properties]
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ illustrate:
 
      ```sql
      DROP FILE "ca.pem" properties("catalog" = "kafka");
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FUNCTION.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-FUNCTION.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 DROP [GLOBAL] FUNCTION function_name
      (arg_type [, ...])
-````
+```
 
 Parameter Description:
 
@@ -52,12 +52,12 @@ Parameter Description:
 
     ```sql
     DROP FUNCTION my_add(INT, INT)
-    ````
+    ```
 2. Delete a global function
 
     ```sql
     DROP GLOBAL FUNCTION my_add(INT, INT)
-    ````   
+    ```   
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-INDEX.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-INDEX.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP INDEX [IF EXISTS] index_name ON [db_name.]table_name;
-````
+```
 
 ### Example
 
@@ -45,7 +45,7 @@ DROP INDEX [IF EXISTS] index_name ON [db_name.]table_name;
 
     ```sql
     DROP INDEX [IF NOT EXISTS] index_name ON table1 ;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-MATERIALIZED-VIEW.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DROP MATERIALIZED VIEW [IF EXISTS] mv_name ON table_name;
-````
+```
 
 
 1. IF EXISTS:
@@ -70,17 +70,17 @@ mysql> desc all_type_table all;
 | k1_sumk2 | k1 | TINYINT | Yes | true | N/A | |
 | | k2 | SMALLINT | Yes | false | N/A | SUM |
 +----------------+-------+----------+------+------ -+---------+-------+
-````
+```
 
 1. Drop the materialized view named k1_sumk2 of the table all_type_table
 
    ```sql
    drop materialized view k1_sumk2 on all_type_table;
-   ````
+   ```
 
    The table structure after the materialized view is deleted
 
-   ````text
+   ```text
    +----------------+-------+----------+------+------ -+---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +----------------+-------+----------+------+------ -+---------+-------+
@@ -92,14 +92,14 @@ mysql> desc all_type_table all;
    | | k6 | FLOAT | Yes | false | N/A | NONE |
    | | k7 | DOUBLE | Yes | false | N/A | NONE |
    +----------------+-------+----------+------+------ -+---------+-------+
-   ````
+   ```
 
 2. Drop a non-existent materialized view in the table all_type_table
 
    ```sql
    drop materialized view k1_k2 on all_type_table;
    ERROR 1064 (HY000): errCode = 2, detailMessage = Materialized view [k1_k2] does not exist in table [all_type_table]
-   ````
+   ```
 
    The delete request reports an error directly
 
@@ -108,7 +108,7 @@ mysql> desc all_type_table all;
    ```sql
    drop materialized view if exists k1_k2 on all_type_table;
    Query OK, 0 rows affected (0.00 sec)
-   ````
+   ```
 
     If it exists, delete it, if it does not exist, no error is reported.
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-RESOURCE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-RESOURCE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP RESOURCE 'resource_name'
-````
+```
 
 Note: ODBC/S3 resources in use cannot be deleted.
 
@@ -47,7 +47,7 @@ Note: ODBC/S3 resources in use cannot be deleted.
    
      ```sql
      DROP RESOURCE 'spark0';
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-SQL-BLOCK-RULE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DROP SQL_BLOCK_RULE test_rule1,...
-````
+```
 
 ### Example
 
@@ -47,12 +47,12 @@ DROP SQL_BLOCK_RULE test_rule1,...
     ```sql
     mysql> DROP SQL_BLOCK_RULE test_rule1,test_rule2;
     Query OK, 0 rows affected (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 
-````text
+```text
 DROP, SQL_BLOCK_RULE
-````
+```
 
 ### Best Practice

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-TABLE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-TABLE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP TABLE [IF EXISTS] [db_name.]table_name [FORCE];
-````
+```
 
 
 illustrate:
@@ -51,13 +51,13 @@ illustrate:
    
      ```sql
      DROP TABLE my_table;
-     ````
+     ```
     
 2. If it exists, delete the table of the specified database
    
      ```sql
      DROP TABLE IF EXISTS example_db.my_table;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/TRUNCATE-TABLE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Definition-Statements/Drop/TRUNCATE-TABLE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 TRUNCATE TABLE [db.]tbl[ PARTITION(p1, p2, ...)];
-````
+```
 
 illustrate:
 
@@ -54,13 +54,13 @@ illustrate:
 
      ```sql
      TRUNCATE TABLE example_db.tbl;
-     ````
+     ```
 
 2. Empty p1 and p2 partitions of table tbl
 
      ```sql
      TRUNCATE TABLE tbl PARTITION(p1, p2);
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/ALTER-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/ALTER-ROUTINE-LOAD.md
@@ -43,7 +43,7 @@ ALTER ROUTINE LOAD FOR [db.]job_name
 [job_properties]
 FROM data_source
 [data_source_properties]
-````
+```
 
 1. `[db.]job_name`
 
@@ -103,7 +103,7 @@ FROM data_source
    (
        "desired_concurrent_number" = "1"
    );
-   ````
+   ```
 
 2. Modify `desired_concurrent_number` to 10, modify the offset of the partition, and modify the group id.
 
@@ -119,7 +119,7 @@ FROM data_source
        "kafka_offsets" = "100, 200, 100",
        "property.group.id" = "new_group"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CANCEL-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CANCEL-LOAD.md
@@ -50,7 +50,7 @@ Notice: Cancel by State is supported since 1.2.0.
     CANCEL LOAD
     FROM example_db
     WHERE LABEL = "example_db_test_load_label";
-    ````
+    ```
 
 2. Cancel all import jobs containing example* on the database example*db.
 
@@ -58,7 +58,7 @@ Notice: Cancel by State is supported since 1.2.0.
     CANCEL LOAD
     FROM example_db
     WHERE LABEL like "example_";
-    ````
+    ```
 
 
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md
@@ -74,7 +74,7 @@ FROM data_source [data_source_properties]
 
   Used to describe imported data. The composition is as follows:
 
-  ````SQL
+  ```SQL
   [column_separator],
   [columns_mapping],
   [preceding_filter],
@@ -82,7 +82,7 @@ FROM data_source [data_source_properties]
   [partitions],
   [DELETE ON],
   [ORDER BY]
-  ````
+  ```
 
   - `column_separator`
 
@@ -138,12 +138,12 @@ FROM data_source [data_source_properties]
 
   Common parameters for specifying routine import jobs.
 
-  ````text
+  ```text
   PROPERTIES (
       "key1" = "val1",
       "key2" = "val2"
   )
-  ````
+  ```
 
   Currently we support the following parameters:
 
@@ -165,11 +165,11 @@ FROM data_source [data_source_properties]
 
      These three parameters are used to control the execution time and processing volume of a subtask. When either one reaches the threshold, the task ends.
 
-     ````text
+     ```text
      "max_batch_interval" = "20",
      "max_batch_rows" = "300000",
      "max_batch_size" = "209715200"
-     ````
+     ```
 
   3. `max_error_number`
 
@@ -270,13 +270,13 @@ FROM data_source [data_source_properties]
 
   The type of data source. Currently supports:
 
-  ````text
+  ```text
   FROM KAFKA
   (
       "key1" = "val1",
       "key2" = "val2"
   )
-  ````
+  ```
 
   `data_source_properties` supports the following data source properties:
 
@@ -304,15 +304,15 @@ FROM data_source [data_source_properties]
 
      If not specified, all partitions under topic will be subscribed from `OFFSET_END` by default.
 
-     ````text
+     ```text
      "kafka_partitions" = "0,1,2,3",
      "kafka_offsets" = "101,0,OFFSET_BEGINNING,OFFSET_END"
-     ````
+     ```
 
-     ````text
+     ```text
      "kafka_partitions" = "0,1,2,3",
      "kafka_offsets" = "2021-05-22 11:00:00,2021-05-22 11:00:00,2021-05-22 11:00:00"
-     ````
+     ```
 
      Note that the time format cannot be mixed with the OFFSET format.
 
@@ -326,20 +326,20 @@ FROM data_source [data_source_properties]
 
      For more supported custom parameters, please refer to the configuration items on the client side in the official CONFIGURATION document of librdkafka. Such as:
 
-     ````text
+     ```text
      "property.client.id" = "12345",
      "property.ssl.ca.location" = "FILE:ca.pem"
-     ````
+     ```
 
      1. When connecting to Kafka using SSL, you need to specify the following parameters:
 
-        ````text
+        ```text
         "property.security.protocol" = "ssl",
         "property.ssl.ca.location" = "FILE:ca.pem",
         "property.ssl.certificate.location" = "FILE:client.pem",
         "property.ssl.key.location" = "FILE:client.key",
         "property.ssl.key.password" = "abcdefg"
-        ````
+        ```
 
         in:
 
@@ -347,11 +347,11 @@ FROM data_source [data_source_properties]
 
         If client authentication is enabled on the Kafka server side, thenAlso set:
 
-        ````text
+        ```text
         "property.ssl.certificate.location"
         "property.ssl.key.location"
         "property.ssl.key.password"
-        ````
+        ```
 
         They are used to specify the client's public key, private key, and password for the private key, respectively.
 
@@ -363,9 +363,9 @@ FROM data_source [data_source_properties]
 
         Example:
 
-        ````text
+        ```text
         "property.kafka_default_offsets" = "OFFSET_BEGINNING"
-        ````
+        ```
 - comment
   Comment for the routine load job.
 
@@ -398,7 +398,7 @@ This feature is supported since the Apache Doris 1.2 version
        "property.client.id" = "xxx",
        "property.kafka_default_offsets" = "OFFSET_BEGINNING"
    );
-   ````
+   ```
 
 2. Create a Kafka routine dynamic multiple tables import task named "test1" for the "example_db". Specify the column delimiter, group.id, and client.id, and automatically consume all partitions, subscribing from the position with data (OFFSET_BEGINNING).
 
@@ -448,7 +448,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 4. Import data from the Kafka cluster through SSL authentication. Also set the client.id parameter. The import task is in non-strict mode and the time zone is Africa/Abidjan
 
@@ -478,7 +478,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "property.ssl.key.password" = "abcdefg",
        "property.client.id" = "my_client_id"
    );
-   ````
+   ```
 
 5. Import data in Json format. By default, the field name in Json is used as the column name mapping. Specify to import three partitions 0, 1, and 2, and the starting offsets are all 0
 
@@ -503,7 +503,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2",
        "kafka_offsets" = "0,0,0"
    );
-   ````
+   ```
 
 6. Import Json data, extract fields through Jsonpaths, and specify the root node of the Json document
 
@@ -531,7 +531,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2",
        "kafka_offsets" = "0,0,0"
    );
-   ````
+   ```
 
 7. Create a Kafka routine import task named test1 for example_tbl of example_db. And use conditional filtering.
 
@@ -558,7 +558,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 8. Import data to Unique with sequence column Key model table
 
@@ -582,7 +582,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 9. Consume from a specified point in time
 
@@ -602,7 +602,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_topic" = "my_topic",
        "kafka_default_offsets" = "2021-05-21 10:00:00"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CREATE-SYNC-JOB.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/CREATE-SYNC-JOB.md
@@ -48,7 +48,7 @@ CREATE SYNC [db.]job_name
  ...
  )
 binlog_desc
-````
+```
 
 1. `job_name`
 
@@ -63,7 +63,7 @@ binlog_desc
    ```sql
    FROM mysql_db.src_tbl INTO des_tbl
    [columns_mapping]
-   ````
+   ```
    
    1. `mysql_db.src_tbl`
    
@@ -81,7 +81,7 @@ binlog_desc
    
       Example:
    
-      ````
+      ```
       Suppose the target table column is (k1, k2, v1),
       
       Change the order of columns k1 and k2
@@ -89,7 +89,7 @@ binlog_desc
       
       Ignore the fourth column of the source data
       (k2, k1, v1, dummy_column)
-      ````
+      ```
    
 3. `binlog_desc`
 
@@ -103,7 +103,7 @@ binlog_desc
        "key1" = "value1",
        "key2" = "value2"
    )
-   ````
+   ```
 
    1. The properties corresponding to the Canal data source, prefixed with `canal.`
 
@@ -119,7 +119,7 @@ binlog_desc
 
 1. Simply create a data synchronization job named `job1` for `test_tbl` of `test_db`, connect to the local Canal server, corresponding to the Mysql source table `mysql_db1.tbl1`.
 
-   ````SQL
+   ```SQL
    CREATE SYNC `test_db`.`job1`
    (
    FROM `mysql_db1`.`tbl1` INTO `test_tbl`
@@ -133,11 +133,11 @@ binlog_desc
    "canal.username" = "",
    "canal.password" = ""
    );
-   ````
+   ```
 
 2. Create a data synchronization job named `job1` for multiple tables of `test_db`, corresponding to multiple Mysql source tables one-to-one, and explicitly specify the column mapping.
 
-   ````SQL
+   ```SQL
    CREATE SYNC `test_db`.`job1`
    (
    FROM `mysql_db`.`t1` INTO `test1` (k1, k2, v1) ,
@@ -152,7 +152,7 @@ binlog_desc
    "canal.username" = "username",
    "canal.password" = "password"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/MULTI-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/MULTI-LOAD.md
@@ -34,7 +34,7 @@ MULTI LOAD
 
 Users submit multiple import jobs through the HTTP protocol. Multi Load can ensure the atomic effect of multiple import jobs
 
-````
+```
 Syntax:
     curl --location-trusted -u user:passwd -XPOST http://host:port/api/{db}/_multi_start?label=xxx
     curl --location-trusted -u user:passwd -T data.file http://host:port/api/{db}/{table1}/_load?label=xxx\&sub_label=yyy
@@ -91,11 +91,11 @@ NOTE:
 
     3. Supports the use of curl to import data into Doris in a way similar to streaming, but only after the streaming ends Doris
     The real import behavior will occur, and the amount of data in this way cannot be too large.
-````
+```
 
 ### Example
 
-````
+```
 1. Import the data in the local file 'testData1' into the table 'testTbl1' in the database 'testDb', and
 Import the data of 'testData2' into table 'testTbl2' in 'testDb' (user is in defalut_cluster)
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_start?label=123
@@ -112,7 +112,7 @@ Import the data of 'testData2' into table 'testTbl2' in 'testDb' (user is in def
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_start?label=123
     curl --location-trusted -u root -T testData1 http://host:port/api/testDb/testTbl1/_load?label=123\&sub_label=1
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_desc?label=123
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/PAUSE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/PAUSE-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ Used to pause a Routine Load job. A suspended job can be rerun with the RESUME c
 
 ```sql
 PAUSE [ALL] ROUTINE LOAD FOR job_name
-````
+```
 
 ### Example
 
@@ -44,13 +44,13 @@ PAUSE [ALL] ROUTINE LOAD FOR job_name
 
     ```sql
     PAUSE ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 2. Pause all routine import jobs.
 
     ```sql
     PAUSE ALL ROUTINE LOAD;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/PAUSE-SYNC-JOB.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/PAUSE-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 PAUSE SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ PAUSE SYNC JOB [db.]job_name
 
     ```sql
     PAUSE SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/RESUME-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/RESUME-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ Used to restart a suspended Routine Load job. The restarted job will continue to
 
 ```sql
 RESUME [ALL] ROUTINE LOAD FOR job_name
-````
+```
 
 ### Example
 
@@ -44,13 +44,13 @@ RESUME [ALL] ROUTINE LOAD FOR job_name
 
     ```sql
     RESUME ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 2. Restart all routine import jobs.
 
     ```sql
     RESUME ALL ROUTINE LOAD;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/RESUME-SYNC-JOB.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/RESUME-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 RESUME SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ RESUME SYNC JOB [db.]job_name
 
     ```sql
     RESUME SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STOP-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STOP-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ User stops a Routine Load job. A stopped job cannot be rerun.
 
 ```sql
 STOP ROUTINE LOAD FOR job_name;
-````
+```
 
 ### Example
 
@@ -44,7 +44,7 @@ STOP ROUTINE LOAD FOR job_name;
 
     ```sql
     STOP ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STOP-SYNC-JOB.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STOP-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 STOP SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ STOP SYNC JOB [db.]job_name
 
     ```sql
     STOP SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STREAM-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Load/STREAM-LOAD.md
@@ -34,9 +34,9 @@ STREAM LOAD
 
 stream-load: load data to table in streaming
 
-````
+```
 curl --location-trusted -u user:passwd [-H ""...] -T data.file -XPUT http://fe_host:http_port/api/{db}/{table}/_stream_load
-````
+```
 
 This statement is used to import data into the specified table. The difference from ordinary Load is that this import method is synchronous import.
 
@@ -109,20 +109,20 @@ This feature is supported since the Apache Doris 1.2 version
 
     Simple mode: The simple mode is not set the jsonpaths parameter. In this mode, the json data is required to be an object type, for example:
 
-       ````
+       ```
     {"k1":1, "k2":2, "k3":"hello"}, where k1, k2, k3 are column names.
-       ````
+       ```
 
     Matching mode: It is relatively complex for json data and needs to match the corresponding value through the jsonpaths parameter.
 
 14. strip_outer_array: Boolean type, true indicates that the json data starts with an array object and flattens the array object, the default value is false. E.g:
 
-     ````
+     ```
       [
        {"k1" : 1, "v1" : 2},
        {"k1" : 3, "v1" : 4}
       ]
-    ````
+    ```
     When strip_outer_array is true, the final import into doris will generate two rows of data.
 
 
@@ -171,56 +171,56 @@ This feature  is supported since the Apache Doris 1.2.3 version
 
 1. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', and use Label for deduplication. Specify a timeout of 100 seconds
 
-   ````
+   ```
        curl --location-trusted -u root -H "label:123" -H "timeout:100" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 2. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', use Label for deduplication, and only import data whose k1 is equal to 20180601
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "where: k1=20180601" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 3. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', allowing a 20% error rate (the user is in the defalut_cluster)
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 4. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', allow a 20% error rate, and specify the column name of the file (the user is in the defalut_cluster)
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -H "columns: k2, k1, v1" -T testData http://host:port/api/testDb/testTbl /_stream_load
-   ````
+   ```
 
 5. Import the data in the local file 'testData' into the p1, p2 partitions of the table 'testTbl' in the database 'testDb', allowing a 20% error rate.
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -H "partitions: p1, p2" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 6. Import using streaming (user is in defalut_cluster)
 
-    ````
+    ```
     seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/ _stream_load
-    ````
+    ```
 
 7. Import a table containing HLL columns, which can be columns in the table or columns in the data to generate HLL columns, or use hll_empty to supplement columns that are not in the data
 
-   ````
+   ```
    curl --location-trusted -u root -H "columns: k1, k2, v1=hll_hash(k1), v2=hll_empty()" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 8. Import data for strict mode filtering and set the time zone to Africa/Abidjan
 
-   ````
+   ```
    curl --location-trusted -u root -H "strict_mode: true" -H "timezone: Africa/Abidjan" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 9. Import a table with a BITMAP column, which can be a column in the table or a column in the data to generate a BITMAP column, or use bitmap_empty to fill an empty Bitmap
-   ````
+   ```
     curl --location-trusted -u root -H "columns: k1, k2, v1=to_bitmap(k1), v2=bitmap_empty()" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 10. Simple mode, import json data
     Table Structure:
@@ -231,39 +231,39 @@ This feature  is supported since the Apache Doris 1.2.3 version
     `price` double NULL COMMENT ""
     ```
     json data format:
-    ````
+    ```
     {"category":"C++","author":"avc","title":"C++ primer","price":895}
-    ````
+    ```
     
     Import command:
     
-    ````
+    ```
     curl --location-trusted -u root -H "label:123" -H "format: json" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
     In order to improve throughput, it supports importing multiple pieces of json data at one time, each line is a json object, and \n is used as a newline by default. You need to set read_json_by_line to true. The json data format is as follows:
 
-    ````
+    ```
     {"category":"C++","author":"avc","title":"C++ primer","price":89.5}
     {"category":"Java","author":"avc","title":"Effective Java","price":95}
     {"category":"Linux","author":"avc","title":"Linux kernel","price":195}
-    ````
+    ```
     
 11. Match pattern, import json data
     json data format:
 
-    ````
+    ```
     [
     {"category":"xuxb111","author":"1avc","title":"SayingsoftheCentury","price":895},{"category":"xuxb222","author":"2avc"," title":"SayingsoftheCentury","price":895},
     {"category":"xuxb333","author":"3avc","title":"SayingsoftheCentury","price":895}
     ]
-    ````
+    ```
 
     Precise import by specifying jsonpath, such as importing only three attributes of category, author, and price
 
-    ````
+    ```
     curl --location-trusted -u root -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\" $.price\",\"$.author\"]" -H "strip_outer_array: true" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
 
     illustrate:
         1) If the json data starts with an array, and each object in the array is a record, you need to set strip_outer_array to true, which means flatten the array.
@@ -272,7 +272,7 @@ This feature  is supported since the Apache Doris 1.2.3 version
 12. User specified json root node
     json data format:
 
-    ````
+    ```
     {
      "RECORDS":[
     {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
@@ -280,31 +280,31 @@ This feature  is supported since the Apache Doris 1.2.3 version
     {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
     ]
     }
-    ````
+    ```
 
     Precise import by specifying jsonpath, such as importing only three attributes of category, author, and price
     
-    ````
+    ```
     curl --location-trusted -u root -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\" $.price\",\"$.author\"]" -H "strip_outer_array: true" -H "json_root: $.RECORDS" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
 13. Delete the data with the same import key as this batch
 
-    ````
+    ```
     curl --location-trusted -u root -H "merge_type: DELETE" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
 
 14. Delete the columns in this batch of data that match the data whose flag is listed as true, and append other rows normally
     
-    ````
+    ```
     curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv, flag" -H "merge_type: MERGE" -H "delete: flag=1" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
 15. Import data into UNIQUE_KEYS table with sequence column
     
-    ````
+    ```
     curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/ _stream_load
-    ````
+    ```
 
 16. csv file line header filter import
 
@@ -352,7 +352,7 @@ This feature  is supported since the Apache Doris 1.2.3 version
 
    Stream Load is a synchronous import process. The successful execution of the statement means that the data is imported successfully. The imported execution result will be returned synchronously through the HTTP return value. And display it in Json format. An example is as follows:
 
-   ````json
+   ```json
    {
        "TxnId": 17,
        "Label": "707717c0-271a-44c5-be0b-4e71bfeacaa5",
@@ -370,7 +370,7 @@ This feature  is supported since the Apache Doris 1.2.3 version
        "WriteDataTimeMs": 3,
        "CommitAndPublishTimeMs": 18
    }
-   ````
+   ```
 
    The following main explanations are given for the Stream load import result parameters:
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/CANCEL-EXPORT.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/CANCEL-EXPORT.md
@@ -52,7 +52,7 @@ WHERE [LABEL = "export_label" | LABEL like "label_pattern" | STATE = "PENDING/IN
     CANCEL EXPORT
     FROM example_db
     WHERE LABEL = "example_db_test_export_label" and STATE = "EXPORTING";
-    ````
+    ```
 
 2. Cancel all export jobs containing example* on the database example*db.
 
@@ -60,7 +60,7 @@ WHERE [LABEL = "export_label" | LABEL like "label_pattern" | STATE = "PENDING/IN
     CANCEL EXPORT
     FROM example_db
     WHERE LABEL like "%example%";
-    ````
+    ```
 
 3. Cancel all export jobs which state are "PENDING"
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/DELETE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/DELETE.md
@@ -104,21 +104,21 @@ This feature is supported since the Apache Doris 1.2 version
    ```sql
    DELETE FROM my_table PARTITION p1
        WHERE k1 = 3;
-   ````
+   ```
 
 2. Delete the data rows where the value of column k1 is greater than or equal to 3 and the value of column k2 is "abc" in my_table partition p1
 
    ```sql
    DELETE FROM my_table PARTITION p1
    WHERE k1 >= 3 AND k2 = "abc";
-   ````
+   ```
 
 3. Delete the data rows where the value of column k1 is greater than or equal to 3 and the value of column k2 is "abc" in my_table partition p1, p2
 
    ```sql
    DELETE FROM my_table PARTITIONS (p1, p2)
    WHERE k1 >= 3 AND k2 = "abc";
-   ````
+   ```
 
 
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/EXPORT.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/EXPORT.md
@@ -72,7 +72,7 @@ The bottom layer of the `Export` statement actually executes the `select...outfi
 
   ```sql
   [PROPERTIES ("key"="value", ...)]
-  ````
+  ```
 
   The following parameters can be specified:
 
@@ -114,7 +114,7 @@ The bottom layer of the `Export` statement actually executes the `select...outfi
         hadoop.security.authentication: specify the authentication method as kerberos
         kerberos_principal: specifies the principal of kerberos
         kerberos_keytab: specifies the path to the keytab file of kerberos. The file must be the absolute path to the file on the server where the broker process is located. and can be accessed by the Broker process
-  ````
+  ```
 
 - `WITH HDFS`
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/INSERT.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/INSERT.md
@@ -41,7 +41,7 @@ INSERT INTO table_name
     [ (column [, ...]) ]
     [ [ hint [, ...] ] ]
     { VALUES ( { expression | DEFAULT } [, ...] ) [, ...] | query }
-````
+```
 
  Parameters
 
@@ -83,7 +83,7 @@ INSERT INTO test VALUES (1, 2);
 INSERT INTO test (c1, c2) VALUES (1, 2);
 INSERT INTO test (c1, c2) VALUES (1, DEFAULT);
 INSERT INTO test (c1) VALUES (1);
-````
+```
 
 The first and second statements have the same effect. When no target column is specified, the column order in the table is used as the default target column.
 The third and fourth statements express the same meaning, use the default value of the `c2` column to complete the data import.
@@ -95,7 +95,7 @@ INSERT INTO test VALUES (1, 2), (3, 2 + 2);
 INSERT INTO test (c1, c2) VALUES (1, 2), (3, 2 * 2);
 INSERT INTO test (c1) VALUES (1), (3);
 INSERT INTO test (c1, c2) VALUES (1, DEFAULT), (3, DEFAULT);
-````
+```
 
 The first and second statements have the same effect, import two pieces of data into the `test` table at one time
 The effect of the third and fourth statements is known, and the default value of the `c2` column is used to import two pieces of data into the `test` table
@@ -105,7 +105,7 @@ The effect of the third and fourth statements is known, and the default value of
 ```sql
 INSERT INTO test SELECT * FROM test2;
 INSERT INTO test (c1, c2) SELECT * from test2;
-````
+```
 
 4. Import a query result into the `test` table, specifying the partition and label
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
@@ -328,7 +328,7 @@ Recursive CTE is currently not supported.
      
      SELECT college, region, seed FROM tournament
        ORDER BY 2, 3;
-     ````
+     ```
 
    - If ORDER BY appears in a subquery and also applies to the outer query, the outermost ORDER BY takes precedence.
 
@@ -336,7 +336,7 @@ Recursive CTE is currently not supported.
 
      ```sql
      SELECT a, COUNT(b) FROM test_table GROUP BY a ORDER BY NULL;
-     ````
+     ```
 
      
 
@@ -350,7 +350,7 @@ Recursive CTE is currently not supported.
 
      ```sql
      SELECT COUNT(col1) AS col2 FROM t GROUP BY col2 HAVING col2 = 2;
-     ````
+     ```
 
    - Remember not to use HAVING where WHERE should be used. HAVING is paired with GROUP BY.
 
@@ -359,7 +359,7 @@ Recursive CTE is currently not supported.
      ```sql
      SELECT user, MAX(salary) FROM users
        GROUP BY user HAVING MAX(salary) > 10;
-     ````
+     ```
 
    - The LIMIT clause can be used to constrain the number of rows returned by a SELECT statement. LIMIT can have one or two arguments, both of which must be non-negative integers.
 
@@ -369,7 +369,7 @@ Recursive CTE is currently not supported.
      /*Then if you want to retrieve all rows after a certain offset is set, you can set a very large constant for the second parameter. The following query fetches all data from row 96 onwards */
      SELECT * FROM tbl LIMIT 95,18446744073709551615;
      /*If LIMIT has only one parameter, the parameter specifies the number of rows that should be retrieved, and the offset defaults to 0, that is, starting from the first row*/
-     ````
+     ```
 
    - SELECT...INTO allows query results to be written to a file
 
@@ -410,7 +410,7 @@ Recursive CTE is currently not supported.
        | 21 |
        +-------------+
        4 rows in set (0.01 sec)
-       ````
+       ```
    
 6. JOIN
    

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/OUTFILE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Data-Manipulation-Statements/OUTFILE.md
@@ -198,7 +198,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "line_delimiter" = "\n",
        "max_file_size" = "100MB"
    );
-   ````
+   ```
 
    If the final generated file is not larger than 100MB, it will be: `result_0.csv`.
    If larger than 100MB, it may be `result_0.csv, result_1.csv, ...`.
@@ -216,7 +216,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.kerberos_principal" = "doris@YOUR.COM",
        "broker.kerberos_keytab" = "/home/doris/my.keytab"
    );
-   ````
+   ```
 
 3. Export the query result of the CTE statement to the file `hdfs://path/to/result.txt`. The default export format is CSV. Use `my_broker` and set hdfs high availability information. Use the default row and column separators.
 
@@ -239,7 +239,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.dfs.namenode.rpc-address.my_ha.my_namenode2" = "nn2_host:rpc_port",
        "broker.dfs.client.failover.proxy.provider.my_ha" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
    );
-   ````
+   ```
 
    If the final generated file is not larger than 1GB, it will be: `result_0.csv`.
    If larger than 1GB, it may be `result_0.csv, result_1.csv, ...`.
@@ -258,7 +258,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.bos_accesskey" = "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
        "broker.bos_secret_accesskey" = "yyyyyyyyyyyyyyyyyyyyyyyyy"
    );
-   ````
+   ```
 
 5. Export the query result of the select statement to the file `s3a://${bucket_name}/path/result.txt`. Specify the export format as csv.
    After the export is complete, an identity file is generated.
@@ -278,7 +278,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "max_file_size" = "1024MB",
        "success_file_name" = "SUCCESS"
    )
-   ````
+   ```
 
    If the final generated file is not larger than 1GB, it will be: `my_file_0.csv`.
    If larger than 1GB, it may be `my_file_0.csv, result_1.csv, ...`.
@@ -301,7 +301,7 @@ Parquet and ORC file formats have their own data types. The export function of D
         "s3.secret_key" = "xxx",
         "s3.region" = "bd"
    )
-   ````
+   ```
 
    The resulting file is prefixed with `my_file_{fragment_instance_id}_`.
 
@@ -320,7 +320,7 @@ Parquet and ORC file formats have their own data types. The export function of D
         "s3.secret_key" = "xxx",
         "s3.region" = "bd"
    )
-   ````
+   ```
 
 8. Use hdfs export to export simple query results to the file `hdfs://${host}:${fileSystem_port}/path/to/result.txt`. Specify the export format as CSV and the user name as work. Specify the column separator as `,` and the row separator as `\n`.
 
@@ -377,7 +377,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "max_file_size" = "1024MB",
        "success_file_name" = "SUCCESS"
    )
-   ````
+   ```
 
 ### keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-CANCEL-REPAIR.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-CANCEL-REPAIR.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN CANCEL REPAIR TABLE table_name[ PARTITION (p1,...)];
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
 
      ```sql
       ADMIN CANCEL REPAIR TABLE tbl PARTITION(p1);
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-CLEAN-TRASH.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-CLEAN-TRASH.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 ADMIN CLEAN TRASH [ON ("BackendHost1:BackendHeartBeatPort1", "BackendHost2:BackendHeartBeatPort2", ...)];
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-REPAIR-TABLE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-REPAIR-TABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN REPAIR TABLE table_name[ PARTITION (p1,...)]
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SET-CONFIG.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SET-CONFIG.md
@@ -40,7 +40,7 @@ grammar:
 ```sql
   ADMIN SET FRONTEND CONFIG ("key" = "value") [ALL];
   ADMIN SET ALL FRONTENDS CONFIG ("key" = "value");
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SET-REPLICA-STATUS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SET-REPLICA-STATUS.md
@@ -41,7 +41,7 @@ grammar:
 ```sql
 ADMIN SET REPLICA STATUS
         PROPERTIES ("key" = "value", ...);
-````
+```
 
  The following properties are currently supported:
 
@@ -63,20 +63,20 @@ If the specified replica does not exist, or the status is already bad, it will b
 
        ```sql
     ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "bad");
-       ````
+       ```
 
  2. Set the replica status of tablet 10003 on BE 10001 to drop.
 
        ```sql
     ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "drop");
-       ````
+       ```
 
 
  3. Set the replica status of tablet 10003 on BE 10001 to ok.
 
    ```sql
    ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "ok");
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-CONFIG.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-CONFIG.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
  ADMIN SHOW FRONTEND CONFIG [LIKE "pattern"];
-````
+```
 
 The columns in the results have the following meanings:
 
@@ -59,7 +59,7 @@ The columns in the results have the following meanings:
 
 2. Use the like predicate to search the configuration of the current Fe node
 
-   ````
+   ```
    mysql> ADMIN SHOW FRONTEND CONFIG LIKE '%check_java_version%';
    +--------------------+-------+---------+---------- -+------------+---------+
    | Key | Value | Type | IsMutable | MasterOnly | Comment |
@@ -67,7 +67,7 @@ The columns in the results have the following meanings:
    | check_java_version | true | boolean | false | false | |
    +--------------------+-------+---------+---------- -+------------+---------+
    1 row in set (0.01 sec)
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-REPLICA-DISTRIBUTION.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-REPLICA-DISTRIBUTION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN SHOW REPLICA DISTRIBUTION FROM [db_name.]tbl_name [PARTITION (p1, ...)];
-````
+```
 
 illustrate:
 
@@ -50,13 +50,13 @@ illustrate:
 
     ```sql
     ADMIN SHOW REPLICA DISTRIBUTION FROM tbl1;
-    ````
+    ```
 
   2. View the replica distribution of the partitions of the table
 
       ```sql
      ADMIN SHOW REPLICA DISTRIBUTION FROM db1.tbl1 PARTITION(p1, p2);
-      ````
+      ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-REPLICA-STATUS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-SHOW-REPLICA-STATUS.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
  ADMIN SHOW REPLICA STATUS FROM [db_name.]tbl_name [PARTITION (p1, ...)]
 [where_clause];
-````
+```
 
 illustrate
 
@@ -59,21 +59,21 @@ illustrate
 
    ```sql
    ADMIN SHOW REPLICA STATUS FROM db1.tbl1;
-   ````
+   ```
 
 2. View a copy of a table with a partition status of VERSION_ERROR
 
    ```sql
    ADMIN SHOW REPLICA STATUS FROM tbl1 PARTITION (p1, p2)
    WHERE STATUS = "VERSION_ERROR";
-   ````
+   ```
 
 3. View all unhealthy replicas of the table
 
    ```sql
    ADMIN SHOW REPLICA STATUS FROM tbl1
    WHERE STATUS != "OK";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/INSTALL-PLUGIN.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/INSTALL-PLUGIN.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 INSTALL PLUGIN FROM [source] [PROPERTIES ("key"="value", ...)]
-````
+```
 
 source supports three types:
 
@@ -52,19 +52,19 @@ source supports three types:
 
     ```sql
     INSTALL PLUGIN FROM "/home/users/doris/auditdemo.zip";
-    ````
+    ```
 
 2. Install the plugin in a local directory:
 
     ```sql
     INSTALL PLUGIN FROM "/home/users/doris/auditdemo/";
-    ````
+    ```
 
 3. Download and install a plugin:
 
     ```sql
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip";
-    ````
+    ```
 
     Note than an md5 file with the same name as the `.zip` file needs to be placed, such as `http://mywebsite.com/plugin.zip.md5` . 
     The content is the MD5 value of the .zip file.
@@ -73,7 +73,7 @@ source supports three types:
 
     ```sql
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip" PROPERTIES("md5sum" = "73877f6029216f4314d712086a146570");
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/KILL.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/KILL.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 KILL [CONNECTION] processlist_id
-````
+```
 
 In addition, you can also use processlist_id or query_id terminates the executing query command
 
@@ -48,7 +48,7 @@ grammar:
 
 ```sql
 KILL QUERY processlist_id | query_id
-````
+```
 
 
 ### Example

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/SET-VARIABLE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/SET-VARIABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SET variable_assignment [, variable_assignment] ...
-````
+```
 
 illustrate:
 
@@ -55,15 +55,15 @@ illustrate:
 
 1. Set the time zone to Dongba District
 
-   ````
+   ```
    SET time_zone = "Asia/Shanghai";
-   ````
+   ```
 
 2. Set the global execution memory size
 
-   ````
+   ```
    SET GLOBAL exec_mem_limit = 137438953472
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/UNINSTALL-PLUGIN.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Database-Administration-Statements/UNINSTALL-PLUGIN.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 UNINSTALL PLUGIN plugin_name;
-````
+```
 
   plugin_name can be viewed with the `SHOW PLUGINS;` command.
 
@@ -50,7 +50,7 @@ Only non-builtin plugins can be uninstalled.
 
     ```sql
     UNINSTALL PLUGIN auditdemo;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ALTER-TABLE-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ALTER-TABLE-MATERIALIZED-VIEW.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database: View jobs under the specified database. If not specified, the current database is used.
 - WHERE: You can filter the result column, currently only the following columns are supported:
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`: Job unique ID.
 
@@ -110,7 +110,7 @@ RollupIndexName: r1
 
    ```sql
    SHOW ALTER TABLE MATERIALIZED VIEW FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ALTER.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ALTER.md
@@ -36,7 +36,7 @@ This statement is used to display the execution of various modification tasks cu
 
 ```sql
 SHOW ALTER [CLUSTER | TABLE [COLUMN | ROLLUP] [FROM db_name]];
-````
+```
 
 TABLE COLUMN: show ALTER tasks that modify columns
                       Support syntax [WHERE TableName|CreateTime|FinishTime|State] [ORDER BY] [LIMIT]
@@ -50,25 +50,25 @@ TABLE COLUMN: show ALTER tasks that modify columns
 
    ```sql
     SHOW ALTER TABLE COLUMN;
-   ````
+   ```
 
 2. Display the task execution status of the last modified column of a table
 
    ```sql
    SHOW ALTER TABLE COLUMN WHERE TableName = "table1" ORDER BY CreateTime DESC LIMIT 1;
-   ````
+   ```
 
 3. Display the task execution of creating or deleting ROLLUP index for the specified db
 
    ```sql
    SHOW ALTER TABLE ROLLUP FROM example_db;
-   ````
+   ```
 
 4. Show tasks related to cluster operations (only for administrators! To be implemented...)
 
-   ````
+   ```
    SHOW ALTER CLUSTER;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
@@ -36,7 +36,7 @@ This statement is used to view the BE nodes in the cluster
 
 ```sql
  SHOW BACKENDS;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-BACKUP.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-BACKUP.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
  SHOW BACKUP [FROM db_name]
-````
+```
 
 illustrate:
 
@@ -71,7 +71,7 @@ illustrate:
 
    ```sql
     SHOW BACKUP FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-BROKER.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-BROKER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW BROKER;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-COLUMNS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-COLUMNS.md
@@ -46,7 +46,7 @@ SHOW [FULL] COLUMNS FROM tbl;
 
     ```sql
      SHOW FULL COLUMNS FROM tbl;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CONVERT-LIGHR-SCHEMA-CHANGE-PROCESS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CONVERT-LIGHR-SCHEMA-CHANGE-PROCESS.md
@@ -46,7 +46,7 @@ SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS [FROM db]
 
     ```sql
      SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS FROM test;
-    ````
+    ```
 
 2. View the converting process globally
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-DATABASE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-DATABASE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE DATABASE db_name;
-````
+```
 
 illustrate:
 
@@ -56,7 +56,7 @@ illustrate:
     | test | CREATE DATABASE `test` |
     +----------+----------------------------+
     1 row in set (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-FUNCTION.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-FUNCTION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE [GLOBAL] FUNCTION function_name(arg_type [, ...]) [FROM db_name]];
-````
+```
 
 illustrate:
 1. `global`: The show function is global 
@@ -54,12 +54,12 @@ illustrate:
 
     ```sql
     SHOW CREATE FUNCTION my_add(INT, INT)
-    ````
+    ```
 2. Show the creation statement of the specified global function
 
     ```sql
     SHOW CREATE GLOBAL FUNCTION my_add(INT, INT)
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-LOAD.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE LOAD for load_name;
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
 
     ```sql
     SHOW CREATE LOAD for test_load
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-REPOSITORY.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-REPOSITORY.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE REPOSITORY for repository_name;
-````
+```
 
 illustrate:
 -  `repository_name`: repository name
@@ -49,7 +49,7 @@ illustrate:
 
     ```sql
     SHOW CREATE REPOSITORY for test_repository
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-ROUTINE-LOAD.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW [ALL] CREATE ROUTINE LOAD for load_name;
-````
+```
 
 illustrate:
 
@@ -53,7 +53,7 @@ illustrate:
 
     ```sql
     SHOW CREATE ROUTINE LOAD for test_load
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-TABLE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-TABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [BRIEF] CREATE TABLE [DBNAME.]TABLE_NAME
-````
+```
 
 illustrate:
 
@@ -57,7 +57,7 @@ illustrate:
 
     ```sql
     SHOW CREATE TABLE demo.tb1
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DATA.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DATA.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATA [FROM [db_name.]table_name] [ORDER BY ...];
-````
+```
 
 illustrate:
 
@@ -60,9 +60,9 @@ illustrate:
 
    ```sql
    SHOW DATA;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-------------+--------------+
    | TableName | Size        | ReplicaCount |
    +-----------+-------------+--------------+
@@ -72,15 +72,15 @@ illustrate:
    | Quota     | 1024.000 GB | 1073741824   |
    | Left      | 1021.921 GB | 1073741815   |
    +-----------+-------------+--------------+
-   ````
+   ```
 
 2. Display the subdivided data volume, the number of replicas and the number of statistical rows of the specified table under the specified db
 
    ```sql
    SHOW DATA FROM example_db.test;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-----------+-----------+--------------+----------+
    | TableName | IndexName | Size      | ReplicaCount | RowCount |
    +-----------+-----------+-----------+--------------+----------+
@@ -89,15 +89,15 @@ illustrate:
    |           | test2     | 50.000MB  | 30           | 50000    |
    |           | Total     | 80.000    | 90           |          |
    +-----------+-----------+-----------+--------------+----------+
-   ````
+   ```
 
 3. It can be combined and sorted according to the amount of data, the number of copies, the number of statistical rows, etc.
 
    ```sql
    SHOW DATA ORDER BY ReplicaCount desc,Size asc;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-------------+--------------+
    | TableName | Size        | ReplicaCount |
    +-----------+-------------+--------------+
@@ -109,7 +109,7 @@ illustrate:
    | Quota     | 1024.000 GB | 1073741824   |
    | Left      | 1024.000 GB | 1073741734   |
    +-----------+-------------+--------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DATABASE-ID.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DATABASE-ID.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATABASE [database_id]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DATABASE [database_id]
 
     ```sql
     SHOW DATABASE 1001;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DATABASES.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DATABASES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATABASES [FROM catalog] [filter expr];
-````
+```
 
 illustrate:
 1. `SHOW DATABASES` will get all database names from current catalog.
@@ -51,45 +51,45 @@ illustrate:
 
    ```sql
    SHOW DATABASES;
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | test               |
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 2. Display all database names from the catalog named 'hms_catalog'.
 
    ```sql
    SHOW DATABASES from hms_catalog;
-   ````
+   ```
 
-   ````
+   ```
   +---------------+
   | Database      |
   +---------------+
   | default       |
   | tpch          |
   +---------------+
-   ````
+   ```
 
 3. Display the filtered database names from current catalog with the expr 'like'.
 
    ```sql
    SHOW DATABASES like 'infor%';
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DELETE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DELETE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DELETE [FROM db_name]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DELETE [FROM db_name]
 
       ```sql
       SHOW DELETE FROM database;
-      ````
+      ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DYNAMIC-PARTITION.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-DYNAMIC-PARTITION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DYNAMIC PARTITION TABLES [FROM db_name];
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DYNAMIC PARTITION TABLES [FROM db_name];
 
      ```sql
      SHOW DYNAMIC PARTITION TABLES FROM database;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ENCRYPT-KEY.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ENCRYPT-KEY.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW ENCRYPTKEYS [IN|FROM db] [LIKE 'key_pattern']
-````
+```
 
 parameter
 
@@ -65,7 +65,7 @@ parameter
     | example_db.my_key | ABCD123456789     |
     +-------------------+-------------------+
     1 row in set (0.00 sec)
- ````
+ ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-EXPORT.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-EXPORT.md
@@ -47,7 +47,7 @@ SHOW EXPORT
    ]
 [ORDER BY...]
 [LIMIT limit];
-````
+```
 
 illustrate:
       1. If db_name is not specified, the current default db is used
@@ -61,31 +61,31 @@ illustrate:
 
    ```sql
    SHOW EXPORT;
-   ````
+   ```
 
 2. Display the export tasks of the specified db, sorted by StartTime in descending order
 
    ```sql
     SHOW EXPORT FROM example_db ORDER BY StartTime DESC;
-   ````
+   ```
 
 3. Display the export tasks of the specified db, the state is "exporting", and sort by StartTime in descending order
 
    ```sql
    SHOW EXPORT FROM example_db WHERE STATE = "exporting" ORDER BY StartTime DESC;
-   ````
+   ```
 
 4. Display the export task of the specified db and specified job_id
 
    ```sql
      SHOW EXPORT FROM example_db WHERE ID = job_id;
-   ````
+   ```
 
 5. Display the specified db and specify the export task of the label
 
    ```sql
     SHOW EXPORT FROM example_db WHERE LABEL = "mylabel";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-FILE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-FILE.md
@@ -38,18 +38,18 @@ grammar:
 
 ```sql
 SHOW FILE [FROM database];
-````
+```
 
 illustrate:
 
-````text
+```text
 FileId: file ID, globally unique
 DbName: the name of the database to which it belongs
 Catalog: Custom Category
 FileName: file name
 FileSize: file size, in bytes
 MD5: MD5 of the file
-````
+```
 
 ### Example
 
@@ -57,7 +57,7 @@ MD5: MD5 of the file
 
      ```sql
      SHOW FILE FROM my_database;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-FRONTENDS-DISKS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-FRONTENDS-DISKS.md
@@ -38,7 +38,7 @@ This statement is used to view FE nodes's important paths' disk information, suc
 
 ```sql
 SHOW FRONTENDS DISKS;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-FRONTENDS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-FRONTENDS.md
@@ -38,7 +38,7 @@ This statement is used to view FE nodes
 
 ```sql
 SHOW FRONTENDS;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-FUNCTIONS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-FUNCTIONS.md
@@ -40,7 +40,7 @@ grammar
 
 ```sql
 SHOW [FULL] [BUILTIN] FUNCTIONS [IN|FROM db] [LIKE 'function_pattern']
-````
+```
 
 Parameters
 
@@ -53,7 +53,7 @@ grammar
 
 ```sql
 SHOW GLOBAL [FULL] FUNCTIONS [LIKE 'function_pattern']
-````
+```
 
 Parameters
 
@@ -65,7 +65,7 @@ Parameters
 
 ### Example
 
-````sql
+```sql
 mysql> show full functions in testDb\G
 **************************** 1. row ******************** ******
         Signature: my_add(INT,INT)
@@ -122,7 +122,7 @@ mysql> show global functions ;
 +---------------+
 2 rows in set (0.00 sec)    
     
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-GRANTS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-GRANTS.md
@@ -52,19 +52,19 @@ illustrate:
 
     ```sql
     SHOW ALL GRANTS;
-    ````
+    ```
 
 2. View the permissions of the specified user
 
     ```sql
     SHOW GRANTS FOR jack@'%';
-    ````
+    ```
 
 3. View the permissions of the current user
 
     ```sql
     SHOW GRANTS;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-INDEX.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-INDEX.md
@@ -36,19 +36,19 @@ SHOW INDEX
 
 grammar:
 
-````SQL
+```SQL
 SHOW INDEX[ES] FROM [db_name.]table_name [FROM database];
 or
 SHOW KEY[S] FROM [db_name.]table_name [FROM database];
-````
+```
 
 ### Example
 
   1. Display the lower index of the specified table_name
 
-     ````SQL
+     ```SQL
       SHOW INDEX FROM example_db.table_name;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-LAST-INSERT.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-LAST-INSERT.md
@@ -39,11 +39,11 @@ grammar:
 
 ```sql
 SHOW LAST INSERT
-````
+```
 
 Example of returned result:
 
-````
+```
      TransactionId: 64067
              Label: insert_ba8f33aea9544866-8ed77e2844d0cc9b
           Database: default_cluster:db1
@@ -51,7 +51,7 @@ Example of returned result:
 TransactionStatus: VISIBLE
         LoadedRows: 2
       FilteredRows: 0
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-LOAD-PROFILE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-LOAD-PROFILE.md
@@ -36,13 +36,13 @@ This statement is used to view the Profile information of the import operation. 
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Versions 0.15 and later perform the following settings:
 
 ```sql
 SET [GLOBAL] enable_profile=true;
-````
+```
 
 grammar:
 
@@ -56,7 +56,7 @@ show load profile "/[queryId]/[TaskId]"
 show load profile "/[queryId]/[TaskId]/[FragmentId]/"
 
 show load profile "/[queryId]/[TaskId]/[FragmentId]/[InstanceId]"
-````
+```
 
 This command will list all currently saved import profiles. Each line corresponds to one import. where the QueryId column is the ID of the import job. This ID can also be viewed through the SHOW LOAD statement. We can select the QueryId corresponding to the Profile we want to see to see the specific situation
 
@@ -102,7 +102,7 @@ WaitAndFetchResultTime: NULL
        FetchResultTime: 0ns
        WriteResultTime: 0ns
 WaitAndFetchResultTime: N/A
-   ````
+   ```
 
 2. View an overview of the subtasks with imported jobs:
 
@@ -113,7 +113,7 @@ WaitAndFetchResultTime: N/A
    +-----------------------------------+------------+
    | 980014623046410a-af5d36f23381017f | 3m14s      |
    +-----------------------------------+------------+
-   ````
+   ```
    
 3. View the plan tree of the specified subtask
 
@@ -173,7 +173,7 @@ WaitAndFetchResultTime: N/A
    | 980014623046410a-88e260f0c43031f4 | 10.81.85.89:9067 | 3m10s      |
    | 980014623046410a-88e260f0c43031f5 | 10.81.85.89:9067 | 3m14s      |
    +-----------------------------------+------------------+------------+
-   ````
+   ```
 
 4. Continue to view the detailed Profile of each operator on a specific Instance
 
@@ -221,7 +221,7 @@ WaitAndFetchResultTime: N/A
    │      - TotalReadThroughput: 30.39858627319336 MB/sec│
    │      - WaitScannerTime: 56s528ms                    │
    └-----------------------------------------------------┘
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-LOAD-WARNINGS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-LOAD-WARNINGS.md
@@ -44,7 +44,7 @@ SHOW LOAD WARNINGS
     [LABEL[="your_label"]]
     [LOAD_JOB_ID = ["job id"]]
 ]
-````
+```
 
 1) If db_name is not specified, the current default db is used
 1) If LABEL = is used, it matches the specified label exactly
@@ -56,7 +56,7 @@ SHOW LOAD WARNINGS
 
     ```sql
     SHOW LOAD WARNINGS FROM demo WHERE LABEL = "load_demo_20210112"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-LOAD.md
@@ -46,7 +46,7 @@ SHOW LOAD
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -68,7 +68,7 @@ illustrate:
 
    ```sql
    SHOW LOAD WARNINGS ON 'url'
-   ````
+   ```
 
 ### Example
 
@@ -76,38 +76,38 @@ illustrate:
 
    ```sql
    SHOW LOAD;
-   ````
+   ```
 
 2. Display the import tasks of the specified db, the label contains the string "2014_01_02", and display the oldest 10
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 3. Display the import tasks of the specified db, specify the label as "load_example_db_20140102" and sort by LoadStartTime in descending order
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL = "load_example_db_20140102" ORDER BY LoadStartTime DESC;
-   ````
+   ```
 
 4. Display the import task of the specified db, specify the label as "load_example_db_20140102", the state as "loading", and sort by LoadStartTime in descending order
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL = "load_example_db_20140102" AND STATE = "loading" ORDER BY LoadStartTime DESC;
-   ````
+   ```
 
 5. Display the import tasks of the specified db and sort them in descending order by LoadStartTime, and display 10 query results starting from offset 5
 
    ```sql
    SHOW LOAD FROM example_db ORDER BY LoadStartTime DESC limit 5,10;
    SHOW LOAD FROM example_db ORDER BY LoadStartTime DESC limit 10 offset 5;
-   ````
+   ```
 
 6. Small batch import is a command to check the import status
 
-   ````
+   ```
    curl --location-trusted -u {user}:{passwd} http://{hostname}:{port}/api/{database}/_load_info?label={labelname}
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-MIGRATIONS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-MIGRATIONS.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW MIGRATIONS
-````
+```
 
 ### Example
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-PARTITION-ID.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-PARTITION-ID.md
@@ -45,7 +45,7 @@ SHOW PARTITION [partition_id]
 
     ```sql
     SHOW PARTITION 10002;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-PARTITIONS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-PARTITIONS.md
@@ -36,9 +36,9 @@ SHOW PARTITIONS
 
 grammar:
 
-````SQL
+```SQL
   SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT];
-````
+```
 
 illustrate:
 
@@ -57,27 +57,27 @@ Will return all partitions' name. Support multilevel partition table
 
 1. Display all non-temporary partition information of the specified table under the specified db
 
-````SQL
+```SQL
   SHOW PARTITIONS FROM example_db.table_name;
-````
+```
 
 2. Display all temporary partition information of the specified table under the specified db
 
-    ````SQL
+    ```SQL
     SHOW TEMPORARY PARTITIONS FROM example_db.table_name;
-    ````
+    ```
 
 3. Display the information of the specified non-temporary partition of the specified table under the specified db
 
-    ````SQL
+    ```SQL
      SHOW PARTITIONS FROM example_db.table_name WHERE PartitionName = "p1";
-    ````
+    ```
 
 4. Display the latest non-temporary partition information of the specified table under the specified db
 
-    ````SQL
+    ```SQL
     SHOW PARTITIONS FROM example_db.table_name ORDER BY PartitionId DESC LIMIT 1;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-PLUGINS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-PLUGINS.md
@@ -36,9 +36,9 @@ This statement is used to display installed plugins
 
 grammar:
 
-````SQL
+```SQL
 SHOW PLUGINS
-````
+```
 
 This command will display all user-installed and system built-in plugins
 
@@ -46,9 +46,9 @@ This command will display all user-installed and system built-in plugins
 
 1. Show installed plugins:
 
-    ````SQL
+    ```SQL
     SHOW PLUGINS;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-PROC.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-PROC.md
@@ -49,7 +49,7 @@ After connecting to Doris through the MySQL client, you can execute the SHOW PRO
 
 The results of the show proc statement are presented in a two-dimensional table. And usually the first column of the result table is the next subdirectory of proc.
 
-````none
+```none
 mysql> show proc "/";
 +---------------------------+
 | name                      |
@@ -79,7 +79,7 @@ mysql> show proc "/";
 | trash                     |
 +---------------------------+
 23 rows in set (0.00 sec)
-````
+```
 
 illustrate:
 
@@ -122,7 +122,7 @@ illustrate:
    | 10124   | test_parquet_import  | 1        | NULL                | 1            | NORMAL | OLAP | NULL                     | 1            |
    +---------+----------------------+----------+---------------------+--------------+--------+------+--------------------------+--------------+
    4 rows in set (0.00 sec)
-   ````
+   ```
 
 2. Display information about the number of all database tables in the cluster.
 
@@ -135,11 +135,11 @@ illustrate:
    | Total | 1                    | 4        | 12           | 12       | 21        | 21         |
    +-------+----------------------+----------+--------------+----------+-----------+------------+
    2 rows in set (0.00 sec)
-   ````
+   ```
 
 3. The following command can view the existing Group information in the cluster.
 
-   ````
+   ```
    SHOW PROC '/colocation_group';
    
    +-------------+--------------+--------------+------------+----------------+----------+----------+
@@ -147,7 +147,7 @@ illustrate:
    +-------------+--------------+--------------+------------+----------------+----------+----------+
    | 10005.10008 | 10005_group1 | 10007, 10040 | 10         | 3              | int(11)  | true     |
    +-------------+--------------+--------------+------------+----------------+----------+----------+
-   ````
+   ```
 
    - GroupId: The cluster-wide unique identifier of a group, the first half is the db id, and the second half is the group id.
    - GroupName: The full name of the Group.
@@ -174,7 +174,7 @@ illustrate:
    | 6           | 10003, 10004, 10001 |
    | 7           | 10003, 10004, 10002 |
    +-------------+---------------------+
-   ````
+   ```
 
    - BucketIndex: The index of the bucket sequence.
    - BackendIds: The list of BE node IDs where the data shards in the bucket are located.
@@ -214,7 +214,7 @@ illustrate:
    | Total                   | 0         | 0        |
    +-------------------------+-----------+----------+
    26 rows in set (0.01 sec)
-   ````
+   ```
 
 5. Display the replica status of the entire cluster.
    ```sql

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-PROCESSLIST.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-PROCESSLIST.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [FULL] PROCESSLIST
-````
+```
 
 illustrate:
 
@@ -68,9 +68,9 @@ Other types can refer to [MySQL official website for explanation](https://dev.my
 
 1. View the threads running by the current user
 
-   ````SQL
+   ```SQL
    SHOW PROCESSLIST
-   ````
+   ```
    return
    ```
    MySQL [test]> show full processlist;

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-REPOSITORIES.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-REPOSITORIES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW REPOSITORIES;
-````
+```
 
 illustrate:
 
@@ -57,7 +57,7 @@ illustrate:
 
 ```sql
   SHOW REPOSITORIES;
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-RESOURCES.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-RESOURCES.md
@@ -45,7 +45,7 @@ SHOW RESOURCES
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -62,19 +62,19 @@ illustrate:
 
    ```sql
    SHOW RESOURCES;
-   ````
+   ```
 
 1. Display the specified Resource, the name contains the string "20140102", and display 10 attributes
 
    ```sql
    SHOW RESOURCES WHERE NAME LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 1. Display the specified Resource, specify the name as "20140102" and sort by KEY in descending order
 
    ```sql
    SHOW RESOURCES WHERE NAME = "20140102" ORDER BY `KEY` DESC;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-RESTORE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-RESTORE.md
@@ -36,9 +36,9 @@ This statement is used to view RESTORE tasks
 
 grammar:
 
-````SQL
+```SQL
 SHOW [BRIEF] RESTORE [FROM DB_NAME]
-````
+```
 
 illustrate:
         1. Only the most recent RESTORE task is saved in Doris.
@@ -80,7 +80,7 @@ illustrate:
 
    ```sql
    SHOW RESTORE FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ROLES.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ROLES.md
@@ -36,17 +36,17 @@ This statement is used to display all created role information, including role n
 
 grammar:
 
-````SQL
+```SQL
 SHOW ROLES
-````
+```
 
 ### Example
 
 1. View created roles
 
-    ````SQL
+    ```SQL
     SHOW ROLES
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
@@ -39,11 +39,11 @@ View the currently running subtasks of a specified Routine Load job.
 ```sql
 SHOW ROUTINE LOAD TASK
 WHERE JobName = "job_name";
-````
+```
 
 The returned results are as follows:
 
-````text
+```text
               TaskId: d67ce537f1be4b86-abf47530b79ab8e6
                TxnId: 4
            TxnStatus: UNKNOWN
@@ -53,7 +53,7 @@ The returned results are as follows:
              Timeout: 20
                 BeId: 10002
 DataSourceProperties: {"0":19}
-````
+```
 
 - `TaskId`: The unique ID of the subtask.
 - `TxnId`: The import transaction ID corresponding to the subtask.
@@ -71,7 +71,7 @@ DataSourceProperties: {"0":19}
 
    ```sql
    SHOW ROUTINE LOAD TASK WHERE JobName = "test1";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD.md
@@ -38,11 +38,11 @@ grammar:
 
 ```sql
 SHOW [ALL] ROUTINE LOAD [FOR jobName];
-````
+```
 
 Result description:
 
-````
+```
                   Id: job ID
                 Name: job name
           CreateTime: job creation time
@@ -63,7 +63,7 @@ DataSourceProperties: Data source configuration details
 ReasonOfStateChanged: The reason for the job state change
         ErrorLogUrls: The viewing address of the filtered unqualified data
             OtherMsg: other error messages
-````
+```
 
 * State
 
@@ -88,39 +88,39 @@ ReasonOfStateChanged: The reason for the job state change
 
    ```sql
    SHOW ALL ROUTINE LOAD FOR test1;
-   ````
+   ```
 
 2. Show the currently running routine import job named test1
 
    ```sql
    SHOW ROUTINE LOAD FOR test1;
-   ````
+   ```
 
 3. Display all routine import jobs (including stopped or canceled jobs) under example_db. The result is one or more lines.
 
    ```sql
    use example_db;
    SHOW ALL ROUTINE LOAD;
-   ````
+   ```
 
 4. Display all running routine import jobs under example_db
 
    ```sql
    use example_db;
    SHOW ROUTINE LOAD;
-   ````
+   ```
 
 5. Display the currently running routine import job named test1 under example_db
 
    ```sql
    SHOW ROUTINE LOAD FOR example_db.test1;
-   ````
+   ```
 
 6. Displays all routine import jobs named test1 under example_db (including stopped or canceled jobs). The result is one or more lines.
 
    ```sql
    SHOW ALL ROUTINE LOAD FOR example_db.test1;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-SMALL-FILES.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-SMALL-FILES.md
@@ -36,7 +36,7 @@ This statement is used to display files created by the CREATE FILE command withi
 
 ```sql
 SHOW FILE [FROM database];
-````
+```
 
 Return result description:
 
@@ -53,7 +53,7 @@ Return result description:
 
     ```sql
     SHOW FILE FROM my_database;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-SNAPSHOT.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-SNAPSHOT.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW SNAPSHOT ON `repo_name`
 [WHERE SNAPSHOT = "snapshot" [AND TIMESTAMP = "backup_timestamp"]];
-````
+```
 
 illustrate:
 
@@ -57,20 +57,20 @@ illustrate:
 
    ```sql
    SHOW SNAPSHOT ON example_repo;
-   ````
+   ```
 
 2. View only the backup named backup1 in the repository example_repo:
 
    ```sql
    SHOW SNAPSHOT ON example_repo WHERE SNAPSHOT = "backup1";
-   ````
+   ```
 
 3. View the details of the backup named backup1 in the warehouse example_repo with the time version "2018-05-05-15-34-26":
 
    ```sql
    SHOW SNAPSHOT ON example_repo
    WHERE SNAPSHOT = "backup1" AND TIMESTAMP = "2018-05-05-15-34-26";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-SQL-BLOCK-RULE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
-````
+```
 
 ### Example
 
@@ -53,7 +53,7 @@ SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
     | test_rule2 | NULL | NULL | 30 | 0 | 10000000000 | false | true |
     +------------+----------------------------+---------+- -------------+------------+-------------+--------+- -------+
     2 rows in set (0.01 sec)
-    ````
+    ```
     
 2. Make a rule name query
 
@@ -66,7 +66,7 @@ SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
     +------------+------+---------+---------------+---- -------+-------------+--------+--------+
     1 row in set (0.00 sec)
     
-    ````
+    ```
     
 
 ### Keywords

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-STATUS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-STATUS.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database: View jobs under the specified database. If not specified, the current database is used.
 - WHERE: You can filter the result column, currently only the following columns are supported:
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`: Job unique ID.
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-STREAM-LOAD.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-STREAM-LOAD.md
@@ -46,7 +46,7 @@ SHOW STREAM LOAD
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -65,32 +65,32 @@ illustrate:
 
    ```sql
      SHOW STREAM LOAD;
-   ````
+   ```
 
 2. Display the Stream Load task of the specified db, the label contains the string "2014_01_02", and display the oldest 10
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE LABEL LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 3. Display the Stream Load task of the specified db and specify the label as "load_example_db_20140102"
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE LABEL = "load_example_db_20140102";
-   ````
+   ```
 
 4. Display the Stream Load task of the specified db, specify the status as "success", and sort by StartTime in descending order
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE STATUS = "success" ORDER BY StartTime DESC;
-   ````
+   ```
 
 5. Display the import tasks of the specified db and sort them in descending order of StartTime, and display 10 query results starting from offset 5
 
    ```sql
    SHOW STREAM LOAD FROM example_db ORDER BY StartTime DESC limit 5,10;
    SHOW STREAM LOAD FROM example_db ORDER BY StartTime DESC limit 10 offset 5;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-SYNC-JOB.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-SYNC-JOB.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW SYNC JOB [FROM db_name]
-````
+```
 
 ### Example
 
@@ -48,13 +48,13 @@ SHOW SYNC JOB [FROM db_name]
 
     ```sql
     SHOW SYNC JOB;
-    ````
+    ```
 
 2. Display the status of all data synchronization jobs under the database `test_db`.
 
     ```sql
     SHOW SYNC JOB FROM `test_db`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLE-ID.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLE-ID.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TABLE [table_id]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW TABLE [table_id]
 
      ```sql
      SHOW TABLE 10001;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLE-STATUS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLE-STATUS.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW TABLE STATUS
 [FROM db] [LIKE "pattern"]
-````
+```
 
 illustrate:
 
@@ -51,13 +51,13 @@ illustrate:
 
      ```sql
      SHOW TABLE STATUS;
-     ````
+     ```
 
   2. View the information of the table whose name contains example under the specified database
 
      ```sql
      SHOW TABLE STATUS FROM db LIKE "%example%";
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLES.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [FULL] TABLES [LIKE]
-````
+```
 
 illustrate:
 
@@ -60,7 +60,7 @@ illustrate:
      | left_table                      |
      +---------------------------------+
      5 rows in set (0.00 sec)
-     ````
+     ```
 
 2. Fuzzy query by table name
 
@@ -73,7 +73,7 @@ illustrate:
     | cmy2           |
     +----------------+
     2 rows in set (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLET.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLET.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TABLET tablet_id
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW TABLET tablet_id
 
     ```sql
     SHOW TABLET 10000;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLETS.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TABLETS.md
@@ -42,7 +42,7 @@ SHOW TABLETS FROM [database.]table [PARTITIONS(p1,p2)]
 [WHERE where_condition]
 [ORDER BY col_name]
 [LIMIT [offset,] row_count]
-````
+```
 
 1. **Syntax Description:**
 
@@ -61,19 +61,19 @@ or compound them with operator `AND`.
 
     ```sql
     SHOW TABLETS FROM example_db.table_name;
-    ````
+    ```
 
 2. list all tablets of the specified partitions
 
     ```sql
     SHOW TABLETS FROM example_db.table_name PARTITIONS(p1, p2);
-    ````
+    ```
 
 3. list all DECOMMISSION tablets on the specified backend
 
     ```sql
     SHOW TABLETS FROM example_db.table_name WHERE state="DECOMMISSION" AND BackendId=11003;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TRANSACTION.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TRANSACTION.md
@@ -42,11 +42,11 @@ SHOW TRANSACTION
 WHERE
 [id=transaction_id]
 [label = label_name];
-````
+```
 
 Example of returned result:
 
-````
+```
      TransactionId: 4005
              Label: insert_8d807d5d-bcdd-46eb-be6d-3fa87aa4952d
        Coordinator: FE: 10.74.167.16
@@ -59,7 +59,7 @@ Example of returned result:
 ErrorReplicasCount: 0
         ListenerId: -1
          TimeoutMs: 300000
-````
+```
 
 * TransactionId: transaction id
 * Label: the label corresponding to the import task
@@ -84,19 +84,19 @@ ErrorReplicasCount: 0
 
    ```sql
    SHOW TRANSACTION WHERE ID=4005;
-   ````
+   ```
 
 2. In the specified db, view the transaction with id 4005:
 
    ```sql
    SHOW TRANSACTION FROM db WHERE ID=4005;
-   ````
+   ```
 
 3. View the transaction whose label is label_name:
 
    ```sql
    SHOW TRANSACTION WHERE LABEL = 'label_name';
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TRASH.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TRASH.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TRASH [ON BackendHost:BackendHeartBeatPort];
-````
+```
 
 illustrate:
 
@@ -51,13 +51,13 @@ illustrate:
 
    ```sql
     SHOW TRASH;
-   ````
+   ```
 
 2. View the space occupied by garbage data of '192.168.0.1:9050' (specific disk information will be displayed).
 
    ```sql
    SHOW TRASH ON "192.168.0.1:9050";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TYPECAST.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-TYPECAST.md
@@ -40,7 +40,7 @@ grammar
 
 ```sql
 SHOW TYPE_CAST [IN|FROM db]
-````
+```
 
  Parameters
 
@@ -48,7 +48,7 @@ SHOW TYPE_CAST [IN|FROM db]
 
 ### Example
 
-````sql
+```sql
 mysql> show type_cast in testDb\G
 **************************** 1. row ******************** ******
 Origin Type: TIMEV2
@@ -61,7 +61,7 @@ Origin Type: TIMEV2
   Cast Type: TIMEV2
 
 3 rows in set (0.00 sec)
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-VARIABLES.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-VARIABLES.md
@@ -36,10 +36,10 @@ This statement is used to display Doris system variables, which can be queried b
 
 grammar:
 
-````sql
+```sql
 SHOW [GLOBAL | SESSION] VARIABLES
      [LIKE 'pattern' | WHERE expr]
-````
+```
 
 illustrate:
 
@@ -54,19 +54,19 @@ illustrate:
 
     ```sql
     show variables like 'max_connections';
-    ````
+    ```
 
 2. Matching through the percent sign (%) wildcard can match multiple items
 
     ```sql
     show variables like '%connec%';
-    ````
+    ```
 
 3. Use the Where clause for matching queries
 
     ```sql
     show variables where variable_name = 'version';
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-VIEW.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-VIEW.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
   SHOW VIEW { FROM | IN } table [ FROM db ]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ grammar:
 
     ```sql
     SHOW VIEW FROM testTbl;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Utility-Statements/DESCRIBE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Utility-Statements/DESCRIBE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DESC[RIBE] [db_name.]table_name [ALL];
-````
+```
 
 illustrate:
 
@@ -50,13 +50,13 @@ illustrate:
 
     ```sql
     DESC table_name;
-    ````
+    ```
 
 2. Display the schema of all indexes of the table
 
     ```sql
     DESC db1.table_name ALL;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Utility-Statements/HELP.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Utility-Statements/HELP.md
@@ -36,9 +36,9 @@ The directory of help can be queried by changing the command
 
 grammar:
 
-```` sql
+``` sql
 HELP <item>
-````
+```
 
 All Doris commands can be listed with `help`
 
@@ -72,7 +72,7 @@ nowarning (\w) Don't show warnings after every statement.
 resetconnection(\x) Clean session context.
 
 For server side help, type 'help contents'
-````
+```
 
 Get the Doris SQL help contents via `help contents`
 
@@ -83,7 +83,7 @@ where <item> is one of the following
 categories:
    sql-functions
    sql-statements
-````
+```
 
 ### Example
 
@@ -91,19 +91,19 @@ categories:
 
    ```sql
    help contents
-   ````
+   ```
 
 2. The command to list all function directories of the Doris cluster
 
    ```sql
    help sql-functions
-   ````
+   ```
 
 3. List all functions under the date function
 
    ```sql
    help date-time-functions
-   ````
+   ```
 
 
 ### Keywords

--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Utility-Statements/USE.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Utility-Statements/USE.md
@@ -36,9 +36,9 @@ The USE command allows us to use the database
 
 grammar:
 
-````SQL
+```SQL
 USE <[CATALOG_NAME].DATABASE_NAME>
-````
+```
 
 illustrate:
 1. `USE CATALOG_NAME.DATABASE_NAME` will switch the current catalog into `CATALOG_NAME` and then change the current database into `DATABASE_NAME`
@@ -50,13 +50,13 @@ illustrate:
     ```sql
     mysql> use demo;
     Database changed
-    ````
+    ```
 2. If the demo database exists in catalog hms_catalog, try switching the catalog and accessing it:
 
     ```sql
     mysql> use hms_catalog.demo;
     Database changed
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.0/table-design/index/ngram-bloomfilter-index.md
+++ b/versioned_docs/version-2.0/table-design/index/ngram-bloomfilter-index.md
@@ -133,7 +133,7 @@ https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/amazon_
 
 **Import the data using stream load:**
 
-```bash
+```shell
 curl --location-trusted -u root: -T amazon_reviews_2010.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load
 curl --location-trusted -u root: -T amazon_reviews_2011.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load
 curl --location-trusted -u root: -T amazon_reviews_2012.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load

--- a/versioned_docs/version-2.1/admin-manual/auth/certificate.md
+++ b/versioned_docs/version-2.1/admin-manual/auth/certificate.md
@@ -39,7 +39,7 @@ In addition to the Doris default certificate file, you can also generate a custo
 
 1. Generate the CA, server-side, and client-side keys and certificates:
 
-```bash
+```shell
 # Generate the CA certificate
 openssl genrsa 2048 > ca-key.pem
 openssl req -new -x509 -nodes -days 3600 \
@@ -64,13 +64,13 @@ openssl x509 -req -in client-req.pem -days 3600 \
 
 2. Verify the created certificates:
 
-```bash
+```shell
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
 3. Combine your key and certificate in a PKCS#12 (P12) bundle. You can also specify a certificate format (PKCS12 by default). You can modify the conf/fe.conf configuration file and add parameter ssl_trust_store_type to specify the certificate format.
 
-```bash
+```shell
 # Package the CA key and certificate
 openssl pkcs12 -inkey ca-key.pem -in ca.pem -export -out ca_certificate.p12
 

--- a/versioned_docs/version-2.1/admin-manual/auth/ldap.md
+++ b/versioned_docs/version-2.1/admin-manual/auth/ldap.md
@@ -108,7 +108,7 @@ Client-side LDAP authentication requires the mysql client-side explicit authenti
 
 * Set the environment variable LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN to value 1.
   For example, in a linux or max environment you can use the command:
-  ```bash
+  ```shell
   echo "export LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN=1" >> ～/.bash_profile && source ～/.bash_profile
   ```
 
@@ -168,12 +168,12 @@ For example:
 Doris account exists: jack@'172.10.1.10', password: 123456  
 LDAP user node presence attribute: uid: jack user password: abcdef  
 The jack@'172.10.1.10' account can be logged into by logging into Doris using the following command:
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
 Login will fail with the following command:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 
@@ -181,7 +181,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 
 LDAP user node presence attribute: uid: jack User password: abcdef  
 Use the following command to create a temporary user and log in to jack@'%', the temporary user has basic privileges DatabasePrivs: Select_priv, Doris will delete the temporary user after the user logs out and logs in:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
@@ -189,7 +189,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 
 Doris account exists: jack@'172.10.1.10', password: 123456  
 Login to the account using the Doris password, successfully:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 

--- a/versioned_docs/version-2.1/admin-manual/cluster-management/load-balancing.md
+++ b/versioned_docs/version-2.1/admin-manual/cluster-management/load-balancing.md
@@ -487,7 +487,7 @@ IP: 172.31.7.119
 
 ### Install dependencies
 
-```bash
+```shell
 sudo apt-get install build-essential
 sudo apt-get install libpcre3 libpcre3-dev 
 sudo apt-get install zlib1g-dev
@@ -496,7 +496,7 @@ sudo apt-get install openssl libssl-dev
 
 ### Install Nginx
 
-```bash
+```shell
 sudo wget http://nginx.org/download/nginx-1.18.0.tar.gz
 sudo tar zxvf nginx-1.18.0.tar.gz
 cd nginx-1.18.0
@@ -508,13 +508,13 @@ sudo make && make install
 
 Here is a new configuration file
 
-```bash
+```shell
 vim /usr/local/nginx/conf/default.conf
 ```
 
 Then add the following in it
 
-```bash
+```shell
 events {  
 worker_connections 1024;  
 }  
@@ -538,7 +538,7 @@ stream {
 
 Start the specified configuration file
 
-```bash
+```shell
 cd /usr/local/nginx
 /usr/local/nginx/sbin/nginx -c conf.d/default.conf
 ```

--- a/versioned_docs/version-2.1/admin-manual/data-admin/ccr.md
+++ b/versioned_docs/version-2.1/admin-manual/data-admin/ccr.md
@@ -70,7 +70,7 @@ enable_feature_binlog=true
 
 ​Build CCR syncer
 
-```Bash
+```shell
 git clone https://github.com/selectdb/ccr-syncer
 cd ccr-syncer   
 bash build.sh <-j NUM_OF_THREAD> <--output SYNCER_OUTPUT_DIR>
@@ -81,7 +81,7 @@ cd SYNCER_OUTPUT_DIR# Contact the Doris community for a free CCR binary package
 Start and stop syncer
 
 
-```Bash
+```shell
 # Start
 cd bin && sh start_syncer.sh --daemon
    
@@ -91,7 +91,7 @@ sh stop_syncer.sh
 
 5. Enable binlog in the source cluster.
 
-```Bash
+```shell
 -- If you want to synchronize the entire database, you can execute the following script:
 vim shell/enable_db_binlog.sh
 Modify host, port, user, password, and db in the source cluster
@@ -103,7 +103,7 @@ ALTER TABLE enable_binlog SET ("binlog.enable" = "true");
 
 6. Launch a synchronization task to the syncer
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -129,7 +129,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Parameter description:
 
-```Bash
+```shell
 name: name of the CCR synchronization task, should be unique
 host, port: host and mysql(jdbc) port for the master FE for the corresponding cluster
 user, password: the credentials used by the syncer to initiate transactions, fetch data, etc.
@@ -271,7 +271,7 @@ Stop the syncer according to the process number in the pid file under the defaul
 
 The file structure can be seen under the output path after compilation:
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -306,7 +306,7 @@ Follow the default configurations.
 
 Specify the directory where the pid file is located. The above three stopping methods all depend on the directory where the pid file is located for execution.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --pid_dir /path/to/pids
 ```
 
@@ -318,7 +318,7 @@ The default value is `SYNCER_OUTPUT_DIR/bin`.
 
 Stop the syncer corresponding to host: port in the pid_dir path.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --host 127.0.0.1 --port 9190
 ```
 
@@ -328,7 +328,7 @@ The default value of host is 127.0.0.1, and the default value of port is empty. 
 
 Stop the syncer corresponding to the specified pid file name in the pid_dir path.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 ```
 
@@ -338,7 +338,7 @@ The file names should be wrapped in `" "` and separated with spaces.
 
 **Template for requests**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d {json_body} http://ccr_syncer_host:ccr_syncer_port/operator
 ```
 
@@ -362,7 +362,7 @@ or
 
 Create CCR tasks
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -398,7 +398,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 View the synchronization progress.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/get_lag
@@ -410,7 +410,7 @@ The job_name is the name specified when create_ccr.
 
 Pause synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/pause 
@@ -420,7 +420,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Resume synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/resume
@@ -430,7 +430,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Delete synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/delete
@@ -440,7 +440,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 View version information.
 
-```Bash
+```shell
 curl http://ccr_syncer_host:ccr_syncer_port/version
 
 # > return
@@ -451,7 +451,7 @@ curl http://ccr_syncer_host:ccr_syncer_port/version
 
 View job status.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/job_status
@@ -470,7 +470,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 No sync. Users can swap the source and target clusters.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/desync
@@ -480,7 +480,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 List all created tasks.
 
-```Bash
+```shell
 curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
 {"success":true,"jobs":["ccr_db_table_alias"]}
@@ -492,7 +492,7 @@ curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
 The file structure can be seen under the output path after compilation:
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -509,7 +509,7 @@ output_dir
 
 **Usage**
 
-```Bash
+```shell
 bash bin/enable_db_binlog.sh -h host -p port -u user -P password -d db
 ```
 
@@ -556,7 +556,7 @@ Minimum required version: V2.0.3
 
 BE-side configuration parameter
 
-```Bash
+```shell
 download_binlog_rate_limit_kbs=1024 # This configuration limits the size to 1MB. It applies to all binlogs, including local snapshots, in a single BE.
 ```
 

--- a/versioned_docs/version-2.1/admin-manual/log-management/fe-log.md
+++ b/versioned_docs/version-2.1/admin-manual/log-management/fe-log.md
@@ -131,7 +131,7 @@ The Debug level log of FE can be enabled by modifying the configuration file or 
 
    You can also modify the log level at runtime through the following API. No need to restart the FE node.
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?add_verbose=org.apache.doris.catalog.Catalog
    ```
 
@@ -154,7 +154,7 @@ The Debug level log of FE can be enabled by modifying the configuration file or 
 
    You can also close Debug log through the following API:
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?del_verbose=org.apache.doris.catalog.Catalog
    ```
 

--- a/versioned_docs/version-2.1/admin-manual/memory-management/memory-analysis/memory-log-analysis.md
+++ b/versioned_docs/version-2.1/admin-manual/memory-management/memory-analysis/memory-log-analysis.md
@@ -30,7 +30,11 @@ The process memory logs in `be/log/be.INFO` are mainly divided into two categori
 
 The process memory status of Doris BE will be printed in the `log/be.INFO` log every time the process memory increases or decreases by 256 MB. In addition, when the process memory is insufficient, the process memory status will also be printed along with other logs.
 
-``` os physical memory 375.81 GB. process memory used 4.09 GB(= 3.49 GB[vm/rss] - 410.44 MB[tc/jemalloc_cache] + 1 GB[reserved] + 0B[waiting_refresh]), limit 3.01 GB, soft limit 2.71 GB. sys available memory 134.41 GB(= 1 35.41 GB[proc/available] - 1 GB[reserved] - 0B[waiting_refresh]), low water mark 3.20 GB, warning water mark 6.40 GB. ```` 1. `os physical memory 375.81 GB` refers to the system physical memory 375.81 GB.
+```
+os physical memory 375.81 GB. process memory used 4.09 GB(= 3.49 GB[vm/rss] - 410.44 MB[tc/jemalloc_cache] + 1 GB[reserved] + 0B[waiting_refresh]), limit 3.01 GB, soft limit 2.71 GB. sys available memory 134.41 GB(= 1 35.41 GB[proc/available] - 1 GB[reserved] - 0B[waiting_refresh]), low water mark 3.20 GB, warning water mark 6.40 GB.
+```
+
+1. `os physical memory 375.81 GB` refers to the system physical memory 375.81 GB.
 
 2. `process memory used 4.09 GB (= 3.49 GB [vm/rss] - 410.44 MB [tc/jemalloc_cache] + 1 GB [reserved] + 0B [waiting_refresh])`
 - Currently we think that the BE process uses 4.09 GB of memory, and the actual physical memory used by the BE process `vm/rss` is 3.49 GB,

--- a/versioned_docs/version-2.1/data-operate/delete/batch-delete-manual.md
+++ b/versioned_docs/version-2.1/data-operate/delete/batch-delete-manual.md
@@ -252,7 +252,7 @@ mysql DESC test;
 
 4. When the table has the sequence column, delete all data with the same key as the imported data
 
-    ```bash
+    ```shell
     curl --location-trusted -u root: -H "column_separator:," -H "columns: name, gender, age" -H "function_column.sequence_col: age" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
     ```
 

--- a/versioned_docs/version-2.1/data-operate/import/load-atomicity.md
+++ b/versioned_docs/version-2.1/data-operate/import/load-atomicity.md
@@ -126,7 +126,7 @@ Empty set (0.019 sec)
 
 **1. Enable two-phase commit by setting `two_phase_commit:true` in the HTTP Header.**
 
-```Bash
+```shell
 curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt http://fe_host:http_port/api/{db}/{table}/_stream_load
 {
     "TxnId": 18036,
@@ -152,7 +152,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the Transaction ID:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18036" -H "txn_operation:commit" http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -162,7 +162,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the label:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:commit"  http://fe_host:http_port/api/{db}/{table}/_stream_load_2pc
   {
       "status": "Success",
@@ -174,7 +174,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the Transaction ID:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18037" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -184,7 +184,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the label:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",

--- a/versioned_docs/version-2.1/data-operate/import/load-data-convert.md
+++ b/versioned_docs/version-2.1/data-operate/import/load-data-convert.md
@@ -60,7 +60,7 @@ WITH BROKER bos
 
 ### STREAM LOAD
 
-```bash
+```shell
 curl
 --location-trusted
 -u user:passwd
@@ -96,7 +96,7 @@ Stream load does not support preceding filtering.
 
 Example:
 
-```bash
+```shell
 curl
 --location-trusted
 -u user:passwd

--- a/versioned_docs/version-2.1/data-operate/import/load-json-format.md
+++ b/versioned_docs/version-2.1/data-operate/import/load-json-format.md
@@ -46,21 +46,21 @@ Currently only the following three JSON formats are supported:
 
    JSON format with Array as root node. Each element in the Array represents a row of data to be imported, usually an Object. An example is as follows:
 
-   ````json
+   ```json
    [
        { "id": 123, "city" : "beijing"},
        { "id": 456, "city" : "shanghai"},
        ...
    ]
-   ````
+   ```
 
-   ````json
+   ```json
    [
        { "id": 123, "city" : { "name" : "beijing", "region" : "haidian"}},
        { "id": 456, "city" : { "name" : "beijing", "region" : "chaoyang"}},
        ...
    ]
-   ````
+   ```
 
    This method is typically used for Stream Load import methods to represent multiple rows of data in a batch of imported data.
 
@@ -69,13 +69,13 @@ Currently only the following three JSON formats are supported:
 2. A single row of data represented by Object
    JSON format with Object as root node. The entire Object represents a row of data to be imported. An example is as follows:
 
-   ````json
+   ```json
    { "id": 123, "city" : "beijing"}
-   ````
+   ```
    
-   ````json
+   ```json
    { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
-   ````
+   ```
    
    This method is usually used for the Routine Load import method, such as representing a message in Kafka, that is, a row of data.
 
@@ -83,11 +83,11 @@ Currently only the following three JSON formats are supported:
    
    A row of data represented by Object represents a row of data to be imported. The example is as follows:
    
-   ````json
+   ```json
    { "id": 123, "city" : "beijing"}
    { "id": 456, "city" : "shanghai"}
    ...
-   ````
+   ```
    
    This method is typically used for Stream Load import methods to represent multiple rows of data in a batch of imported data.
    
@@ -121,17 +121,17 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is as follows:
 
-  ````json
+  ```json
   { "id": 123, "city" : "beijing"}
-  ````
+  ```
 
   Then Doris will use `id`, `city` for matching, and get the final data `123` and `beijing`.
 
   If the JSON data is as follows:
 
-  ````json
+  ```json
   { "id": 123, "name" : "beijing"}
-  ````
+  ```
 
   Then use `id`, `city` for matching, and get the final data `123` and `null`.
 
@@ -139,13 +139,13 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   Specify a set of JSON Path in the form of a JSON data. Each element in the array represents a column to extract. An example is as follows:
 
-  ````json
+  ```json
   ["$.id", "$.name"]
-  ````
+  ```
 
-  ````json
+  ```json
   ["$.id.sub_id", "$.name[0]", "$.city[0]"]
-  ````
+  ```
 
   Doris will use the specified JSON Path for data matching and extraction.
 
@@ -155,21 +155,21 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
-  ````
+  ```
 
   JSON Path is `["$.city"]`. The matched elements are:
 
-  ````json
+  ```json
   { "name" : "beijing", "region" : "haidian" }
-  ````
+  ```
 
   The element will be converted to a string for subsequent import operations:
 
-  ````json
+  ```json
   "{'name':'beijing','region':'haidian'}"
-  ````
+  ```
 
 - match failed
 
@@ -177,41 +177,41 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "name" : "beijing"}
-  ````
+  ```
 
   JSON Path is `["$.id", "$.info"]`. The matched elements are `123` and `null`.
 
   Doris currently does not distinguish between null values represented in JSON data and null values produced when a match fails. Suppose the JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "name" : null }
-  ````
+  ```
 
   The same result would be obtained with the following two JSON Paths: `123` and `null`.
 
-  ````json
+  ```json
   ["$.id", "$.name"]
-  ````
+  ```
 
-  ````json
+  ```json
   ["$.id", "$.info"]
-  ````
+  ```
 
 - Exact match failed
 
   In order to prevent misoperation caused by some parameter setting errors. When Doris tries to match a row of data, if all columns fail to match, it considers this to be an error row. Suppose the Json data is:
 
-  ````json
+  ```json
   { "id": 123, "city" : "beijing" }
-  ````
+  ```
 
   If the JSON Path is written incorrectly as (or if the JSON Path is not specified, the columns in the table do not contain `id` and `city`):
 
-  ````json
+  ```json
   ["$.ad", "$.infa"]
-  ````
+  ```
 
   would cause the exact match to fail, and the line would be marked as an error line instead of yielding `null, null`.
 
@@ -223,65 +223,65 @@ In other words, it is equivalent to rearranging the columns of a JSON format dat
 
 Data content:
 
-````json
+```json
 {"k1": 1, "k2": 2}
-````
+```
 
 Table Structure:
 
-````
+```
 k2 int, k1 int
-````
+```
 
 Import statement 1 (take Stream Load as an example):
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -T example.json http:/ /127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 In import statement 1, only JSON Path is specified, and Columns is not specified. The role of JSON Path is to extract the JSON data in the order of the fields in the JSON Path, and then write it in the order of the table structure. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1   | k2   |
 +------+------+
 | 2    | 1    |
 +------+------+
-````
+```
 
 You can see that the actual k1 column imports the value of the "k2" column in the JSON data. This is because the field name in JSON is not equivalent to the field name in the table structure. We need to explicitly specify the mapping between the two.
 
 Import statement 2:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, k1 " -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Compared with the import statement 1, the Columns field is added here to describe the mapping relationship of the columns, in the order of `k2, k1`. That is, after extracting in the order of fields in JSON Path, specify the value of column k2 in the table for the first column, and the value of column k1 in the table for the second column. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1   |  k2  |
 +------+------+
 | 1    | 2    |
 +------+------+
-````
+```
 
 Of course, as with other imports, column transformations can be performed in Columns. An example is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, tmp_k1 , k1 = tmp_k1 * 100" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 The above example will import the value of k1 multiplied by 100. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1   | k2   |
 +------+------+
 | 100  | 2    |
 +------+------+
-````
+```
 
 Import statement 3:
 
@@ -294,7 +294,7 @@ k2 int, k1 int, k1_copy int
 
 If you want to assign a column field in JSON to several column fields in the table multiple times, you can specify the column multiple times in jsonPaths and specify the mapping order in sequence. An example is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\", \"$.k1\"]" -H "columns: k2,k1,k1_copy" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -325,7 +325,7 @@ k2 int, k1 int, k1_nested1 int, k1_nested2 int
 ```
 If you want to assign multi-level fields with the same name nested in json to different columns in the table, you can specify the column in jsonPaths and specify the mapping order in turn. An example are as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\",\"$.k3.k1\",\"$.k3.k1_nested.k1\" -H "columns: k2,k1,k1_nested1,k1_nested2" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -375,26 +375,26 @@ Doris supports extracting data specified in JSON through JSON root.
 
 Example data is as follows:
 
-````json
+```json
 [
     {"k1": 1, "k2": "a"},
     {"k1": 2},
     {"k1": 3, "k2": "c"}
 ]
-````
+```
 
 
 The table structure is: `k1 int null, k2 varchar(32) null default "x"`
 
 The import statement is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 The import results that users may expect are as follows, that is, for missing columns, fill in the default values.
 
-````text
+```text
 +------+------+
 | k1 | k2     |
 +------+------+
@@ -404,11 +404,11 @@ The import results that users may expect are as follows, that is, for missing co
 +------+------+
 |3     |c     |
 +------+------+
-````
+```
 
 But the actual import result is as follows, that is, for the missing column, NULL is added.
 
-````text
+```text
 +------+------+
 | k1 | k2     |
 +------+------+
@@ -418,13 +418,13 @@ But the actual import result is as follows, that is, for the missing column, NUL
 +------+------+
 |3     |c     |
 +------+------+
-````
+```
 
 This is because Doris doesn't know "the missing column is column k2 in the table" from the information in the import statement. If you want to import the above data according to the expected result, the import statement is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -H "jsonpaths: [\"$.k1\", \"$.k2\"]" - H "columns: k1, tmp_k2, k2 = ifnull(tmp_k2, 'x')" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 ## Application example
 
@@ -434,63 +434,63 @@ Because of the inseparability of the JSON format, when using Stream Load to impo
 
 Suppose the table structure is:
 
-````text
+```text
 id INT NOT NULL,
 city VARHCAR NULL,
 code INT NULL
-````
+```
 
 1. Import a single row of data 1
 
-   ````json
+   ```json
    {"id": 100, "city": "beijing", "code" : 1}
-   ````
+   ```
 
    - do not specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
 2. Import a single row of data 2
 
-   ````json
+   ```json
    {"id": 100, "content": {"city": "beijing", "code": 1}}
-   ````
+   ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\ "]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
 3. Import multiple rows of data as Array
 
-   ````json
+   ```json
    [
        {"id": 100, "city": "beijing", "code" : 1},
        {"id": 101, "city": "shanghai"},
@@ -505,24 +505,24 @@ code INT NULL
            "code" : 6
        }
    ]
-   ````
+   ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
      101 shanghai NULL
      102 tianjin 3
      103 chongqing 4
      104 ["zhejiang","guangzhou"] 5
      105 {"order1":["guangzhou"]} 6
-     ````
+     ```
 
 4. Import multi-line data as multi-line Object
 
@@ -535,7 +535,7 @@ code INT NULL
 
  	 StreamLoad import:
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 	   Import result:
@@ -549,20 +549,20 @@ curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: 
 
 The data is still the multi-line data in Example 3, and now it is necessary to add 1 to the `code` column in the imported data before importing.
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Import result:
 
-````text
+```text
 100 beijing 2
 101 shanghai NULL
 102 tianjin 4
 103 chongqing 5
 104 ["zhejiang","guangzhou"] 6
 105 {"order1":["guangzhou"]} 7
-````
+```
 
 6. Import Array by JSON
 Since the Rapidjson handles decimal and largeint numbers which will cause precision problems, 
@@ -576,7 +576,7 @@ we suggest you to use JSON string to import data to `array<decimal>` or `array<l
 {"k1": 40, "k2": ["10000000000000000000.1111111222222222"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_decimal.json http://localhost:8035/api/example_db/array_test_decimal/_stream_load
 ```
 
@@ -596,7 +596,7 @@ MySQL > select * from array_test_decimal;
 {"k1": 999, "k2": ["76959836937749932879763573681792701709", "26017042825937891692910431521038521227"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_largeint.json http://localhost:8035/api/example_db/array_test_largeint/_stream_load
 ```
 

--- a/versioned_docs/version-2.1/data-operate/import/load-strict-mode.md
+++ b/versioned_docs/version-2.1/data-operate/import/load-strict-mode.md
@@ -55,16 +55,16 @@ Different import methods set strict mode in different ways.
    (
        "strict_mode" = "true"
    )
-   ````
+   ```
 
 2. [STREAM LOAD](../../sql-manual/sql-statements/Data-Manipulation-Statements/Load/STREAM-LOAD)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "strict_mode: true" \
    -T 1.txt \
    http://host:port/api/example_db/my_table/_stream_load
-   ````
+   ```
 
 3. [ROUTINE LOAD](../../sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD)
 
@@ -79,7 +79,7 @@ Different import methods set strict mode in different ways.
        "kafka_broker_list" = "broker1:9092,broker2:9092,broker3:9092",
        "kafka_topic" = "my_topic"
    );
-   ````
+   ```
 
 4. [INSERT](../../sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/INSERT)
 
@@ -88,7 +88,7 @@ Different import methods set strict mode in different ways.
    ```sql
    SET enable_insert_strict = true;
    INSERT INTO my_table ...;
-   ````
+   ```
 
 ## The role of strict mode
 

--- a/versioned_docs/version-2.1/data-operate/import/stream-load-manual.md
+++ b/versioned_docs/version-2.1/data-operate/import/stream-load-manual.md
@@ -117,7 +117,7 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 
    The Stream Load job can be submitted using the `curl` command.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "column_separator:," \
@@ -200,7 +200,7 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 
    The Stream Load job can be submitted using the `curl` command.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:124" \
     -H "Expect:100-continue" \
@@ -261,7 +261,7 @@ Users cannot manually cancel a Stream Load operation. A Stream Load job will be 
 
 The syntax for Stream Load is as follows:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
   -H "Expect:100-continue" [-H ""...] \
   -T <file_path> \
@@ -400,7 +400,7 @@ When performing Stream Load using the TVF `http_stream`, the Rest API URL differ
 
 Using curl for Stream Load in http_stream Mode:
 
-```Bash
+```shell
 curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -XPUT http://fe_host:http_port/api/_http_stream
 ```
 
@@ -408,7 +408,7 @@ Adding a SQL parameter in the header to replace the previous parameters such as 
 
 Example of load SQL:
 
-```Bash
+```shell
 insert into db.table (col, ...) select stream_col, ... from http_stream("property1"="value1");
 ```
 
@@ -455,7 +455,7 @@ Load job can tolerate a certain amount of data with formatting errors. The toler
 
 You can use the following command to specify a `max_filter_ratio` tolerance of 0.4 for creating a Stream Load job:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "max_filter_ratio:0.4" \
@@ -485,7 +485,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 Loading data from local files into partitions p1 and p2 of the table, allowing a 20% error rate.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:123" \
     -H "Expect:100-continue" \
@@ -513,7 +513,7 @@ Stream Load is based on the HTTP protocol for importing, which supports using pr
 
 The following example demonstrates this usage through a bash command pipeline. The imported data is generated streamingly by the program rather than from a local file.
 
-```Bash
+```shell
 seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -537,7 +537,7 @@ curl --location-trusted -u root -T test.csv  -H "label:1" -H "format:csv_with_na
 
 In stream load, there are three import types: APPEND, DELETE, and MERGE. These can be adjusted by specifying the parameter `merge_type`. If you want to specify that all data with the same key as the imported data should be deleted, you can use the following command:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: DELETE" \
@@ -580,7 +580,7 @@ After importing, the original table data will be deleted, resulting in the follo
 
 By specifying `merge_type` as MERGE, the imported data can be merged into the table. The MERGE semantics need to be used in combination with the DELETE condition, which means that data satisfying the DELETE condition is processed according to the DELETE semantics, and the rest is added to the table according to the APPEND semantics. The following operation represents deleting the row with `siteid` of 1, and adding the rest of the data to the table:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: MERGE" \
@@ -772,7 +772,7 @@ JSON data type:
 
 Command:
 
-```Bash
+```shell
 curl --location-trusted -u root -T test.json -H "label:1" -H "format:json" -H 'columns: id, order_code, create_time=CURRENT_TIMESTAMP()' http://host:port/api/testDb/testTbl/_stream_load
 ```
 

--- a/versioned_docs/version-2.1/data-operate/update/unique-update-transaction.md
+++ b/versioned_docs/version-2.1/data-operate/update/unique-update-transaction.md
@@ -109,7 +109,7 @@ PROPERTIES (
 
 The syntax for stream load is to add the mapping of the hidden column `function_column.sequence_col` to the `source_sequence` in the header. Example:
 
-```Bash
+```shell
 curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -228,7 +228,7 @@ Load the following data:
 
 Here is an example using Stream Load:
 
-```Bash
+```shell
 curl --location-trusted -u root: -T testData http://host:port/api/test/test_table/_stream_load
 ```
 

--- a/versioned_docs/version-2.1/db-connect/database-connect.md
+++ b/versioned_docs/version-2.1/db-connect/database-connect.md
@@ -32,14 +32,14 @@ Download MySQL Client from the MySQL official website or use the pre-installed [
 
 Extract the downloaded MySQL client. In the `bin/` directory, find the `mysql` command-line tool. Execute the following command to connect to Doris:
 
-```Bash
+```shell
 # FE_IP represents the listening address of the FE node, while FE_QUERY_PORT represents the port of the MySQL protocol service of the FE. This corresponds to the query_port parameter in fe.conf and it defaults to 9030.
 mysql -h FE_IP -P FE_QUERY_PORT -u USER_NAME 
 ```
 
 After login, the following message will be displayed.
 
-```Bash
+```shell
 Welcome to the MySQL monitor.  Commands end with ; or \g.                               
 Your MySQL connection id is 236                                                         
 Server version: 5.7.99 Doris version doris-2.0.3-rc06-37d31a5                           

--- a/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/helm-chart-deploy.md
+++ b/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/helm-chart-deploy.md
@@ -32,15 +32,15 @@ Helm Chart makes it easy to deploy Doris clusters and skip difficult configurati
 
 This [Doris repository](https://artifacthub.io/packages/search?ts_query_web=doris&sort=relevance&page=1) have resources about RBAC , deployment ...etc for doris-operator running.
 1. Add the Doris repository
-```Bash
+```shell
 $ helm repo add doris-repo https://charts.selectdb.com
 ```
 2. Update the Chart to the latest version
-```Bash
+```shell
 $ helm repo update doris-repo
 ```
 3. Check the Helm Chart Repo is the latest version
-```Bash
+```shell
 $ helm search repo doris-repo
 NAME                          CHART VERSION    APP VERSION   DESCRIPTION
 doris-repo/doris-operator     1.3.1            1.3.1         Doris-operator for doris creat ...
@@ -51,17 +51,17 @@ doris-repo/doris              1.3.1            2.0.3         Apache Doris is an 
 
 ### 1. Install
 - Install [doris-operator](https://artifacthub.io/packages/helm/doris/doris-operator)，with default config  in a namespace named `doris`
-```Bash
+```shell
 $ helm install operator doris-repo/doris-operator
 ```
 - The repo defines the basic function for running doris-operator, Please use next command to deploy operator, when you have completed customization of [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values)
-```Bash
+```shell
 $ helm install -f values.yaml operator doris-repo/doris-operator 
 ```
 ### 2. Validate installation Status
 Check the deployment status of Pods through the `kubectl get pods` command.
 Observe that the Pod of doris-operator is in the Running state and all containers in the Pod are ready, that means, the deployment is successful.
-```Bash
+```shell
 $ kubectl get pod --namespace doris
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
@@ -71,11 +71,11 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 ### 1. Install
 - Use default config for deploying [doriscluster](https://artifacthub.io/packages/helm/doris/doris). This only deploys 3 FE and 3 BE components and using default `storageClass` for providing persistent volume.
-```Bash
+```shell
 $ helm install doriscluster doris-repo/doris
 ```
 - Custom Doris deploying, specify resources or different deployment type, please customize the resource configuration according to the annotations of each resource configuration in [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) and use next command for deploying.
-```Bash
+```shell
 $ helm install -f values.yaml doriscluster doris-repo/doris 
 ```
 ### 2. Validate installation Status
@@ -83,7 +83,7 @@ After executing the installation command, deployment and distribution, service d
 Check the deployment status of Pods through the `kubectl get pods` command.
 
 Observe that the Pod of `doriscluster` is in the `Running` state and all containers in the Pod are ready, that means, the deployment is successful.
-```Bash
+```shell
 $  kubectl get pod --namespace doris
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
@@ -98,11 +98,11 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 ### Uninstall doriscluster
 Please confirm the Doris is not used, when using next command to uninstall `doriscluster`.
-```bash
+```shell
 $ helm uninstall doriscluster
 ```
 ### Uninstall doris-operator
 Please confirm that Doris is not running in Kubernetes, use next command to uninstall `doris-operator`.
-```bash
+```shell
 $ helm uninstall operator
 ```

--- a/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/install-access-cluster.md
+++ b/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/install-access-cluster.md
@@ -35,13 +35,13 @@ Doris provides ClusterIP access mode by default on Kubernetes. No modification i
 
 After deploying the cluster, you can view the services exposed by Doris Operator through the following command:
 
-```bash
+```shell
 kubectl -n doris get svc
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                               AGE
 doriscluster-sample-be-internal   ClusterIP   None          <none>        9050/TCP                              9m
 doriscluster-sample-be-service    ClusterIP   10.1.68.128   <none>        9060/TCP,8040/TCP,9050/TCP,8060/TCP   9m
@@ -58,13 +58,13 @@ In the above results, FE and BE have two types of Services, with the suffixes in
 
 Use the following command to create a pod containing the mysql client in the current Kubernetes cluster:
 
-```bash
+```shell
 kubectl run mysql-client --image=mysql:5.7 -it --rm --restart=Never --namespace=doris -- /bin/bash
 ```
 
 In the container in the cluster, you can use the externally exposed service name with the suffix `service` to access the Doris cluster:
 
-```bash
+```shell
 ## Use service type pod name to access the Doris cluster
 mysql -uroot -P9030 -hdoriscluster-sample-fe-service
 ```
@@ -143,13 +143,13 @@ spec:
 
 After deploying the cluster, you can view the services exposed by Doris Operator through the following command:
 
-```bash
+```shell
 kubectl get service
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME TYPE CLUSTER-IP EXTERNAL-IP PORT(S) AGE
 kubernetes ClusterIP 10.152.183.1 <none> 443/TCP 169d
 doriscluster-sample-fe-internal ClusterIP None <none> 9030/TCP 2d
@@ -160,13 +160,13 @@ doriscluster-sample-be-service NodePort 10.152.183.244 <none> 9060:30940/TCP,804
 
 Doris's Query Port defaults to 9030, which is mapped to local port 31545 locally. When accessing the Doris cluster, you need to obtain the corresponding IP address, which can be viewed with the following command:
 
-```bash
+```shell
 kubectl get nodes -owide
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME   STATUS   ROLES           AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION          CONTAINER-RUNTIME
 r60    Ready    control-plane   14d   v1.28.2   192.168.88.60   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
 r61    Ready    <none>          14d   v1.28.2   192.168.88.61   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
@@ -176,7 +176,7 @@ r63    Ready    <none>          14d   v1.28.2   192.168.88.63   <none>        Ce
 
 In NodePort mode, you can access services in the Kubernetes cluster based on the host IP and port mapping of any node. In this example, you can use any node IP, 192.168.88.61, 192.168.88.62, 192.168.88.63, to access the Doris service. For example, in the following example, the node node 192.168.88.62 and the mapped query port port 31545 are used to access the cluster:
 
-```bash
+```shell
 mysql -h 192.168.88.62 -P 31545 -uroot
 ```
 
@@ -192,7 +192,7 @@ If you perform Stream Load inside Kubernetes, you can directly use the error add
 
 In the return result of the above example, you can directly obtain the return result through the curl command in the Pod in the same Kubernetes cluster:
 
-```bash
+```shell
 curl http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local:8040/api/_load_error_log?file=__shard_1/error_log_insert_stmt_af474190276a2e9c-49bb9d175b8e968e_af474190276a2e9c_49bb9d175b8e968e
 ```
 
@@ -243,7 +243,7 @@ Since the pod name returned by each stream load may be different, please delete 
 
 Follow the service in the above example, replace ${podName} in CR with doriscluster-sample-be-2, and replace ${ServiceType} with NodePort. Use the kubectl apply command to create the service service in the same namespace of the doris cluster.
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -251,13 +251,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 Use the following command to view the NodePort assigned by the above deployment Service:
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
 doriscluster-detail-error         NodePort    10.152.183.35    <none>        8040:31201/TCP     32s
 ```
@@ -266,13 +266,13 @@ The BE port accessed by `Stream Load` is 8040, and the host port (NodePort) corr
 
 Get the host address controlled by K8s:
 
-```bash
+```shell
 kubectl get node -owide
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME             STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION       CONTAINER-RUNTIME
 vm-10-8-centos   Ready    <none>   226d   v1.28.7   10.16.10.8    <none>        TencentOS Server 3.1 (Final)   5.4.119-19-0009.3    containerd://1.6.28
 vm-10-7-centos   Ready    <none>   19d    v1.28.7   10.16.10.7    <none>        TencentOS Server 3.1 (Final)   5.4.119-19.0009.25   containerd://1.6.28
@@ -298,7 +298,7 @@ http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluste
 
 The domain name address of the above address is `doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local`. Among the domain names used by pods deployed by `Doris Operator` on `Kubernetes`, the third level The domain name is the name of the pod. Replace {podName} in the above template with the real `pod` name, replace {serviceType} with `LoadBalancer`, and save the changes to the newly created `stream_load_get_error.yaml` file. Use the following command to deploy service:
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -306,13 +306,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 Use the following command to view the LoadBalaner address EXTERNAL-IP assigned by the above deployment Service. The following is a test instance in aws eks:
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                         TYPE          CLUSTER-IP       EXTERNAL-IP                                                              PORT(S)           AGE
 doriscluster-detail-error    LoadBalancer  172.20.183.136   ac4828493dgrftb884g67wg4tb68gyut-1137856348.us-east-1.elb.amazonaws.com  8040:32003/TCP    14s
 ```

--- a/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/install-config-cluster.md
+++ b/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/install-config-cluster.md
@@ -99,13 +99,13 @@ feSpec:
 
 Among them, the name of [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) needs to be specified in ${storageClassName}. You can use the following command to view the StorageClass supported in the current Kubernetes cluster:
 
-```bash
+```shell
 kubectl get sc
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                          PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
 openebs-hostpath              openebs.io/local               Delete          WaitForFirstConsumer   false                  212d
 openebs-device                openebs.io/local               Delete          WaitForFirstConsumer   false                  212d

--- a/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/install-doris-cluster.md
+++ b/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/install-doris-cluster.md
@@ -36,13 +36,13 @@ Deploying a cluster online requires the following steps:
 
 1. Create namespace:
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 2. Deploy Doris cluster
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -61,7 +61,7 @@ selectdb/doris.be-ubuntu:2.0.2
 
 Download the image locally and package it into a tar file
 
-```bash
+```shell
 ## download docker image
 docker pull selectdb/doris.fe-ubuntu:2.0.2
 docker pull selectdb/doris.be-ubuntu:2.0.2
@@ -73,7 +73,7 @@ docker save -o doris.be-ubuntu-v2.0.2.tar docker pull selectdb/doris.be-ubuntu:2
 
 Upload the image tar package to the server and execute the docker load command:
 
-```bash
+```shell
 ## load docker image
 docker load -i doris.fe-ubuntu-v2.0.2.tar
 docker load -i doris.be-ubuntu-v2.0.2.tar
@@ -81,13 +81,13 @@ docker load -i doris.be-ubuntu-v2.0.2.tar
 
 2. Create namespace:
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 3. Deploy Doris cluster
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -101,13 +101,13 @@ Before installation, you need to add a deployment warehouse. If it has been adde
 
 Install [doriscluster](https://artifacthub.io/packages/helm/doris/doris), using the default configuration this deployment only deploys 3 FE and 3 BE components, using the default `storageClass` to implement PV dynamic provisioning.
 
-```bash
+```shell
 helm install doriscluster doris-repo/doris
 ```
 
 If you need to customize resources and cluster shapes, please customize the resource configuration according to the annotations of each resource configuration in [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) and execute The following command:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-repo/doris
 ```
 
@@ -115,13 +115,13 @@ helm install -f values.yaml doriscluster doris-repo/doris
 
 You can check the pod deployment status through the `kubectl get pods` command. When the Pod of `doriscluster` is in `Running` state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -137,7 +137,7 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 Download `doris-{chart_version}.tgz` to install Doris Cluster chart. If you need to download the 2.0.6 version of the Doris cluster, you can use the following command:
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-2.0.6.tgz
 ```
 
@@ -145,13 +145,13 @@ wget https://charts.selectdb.com/doris-2.0.6.tgz
 
 Doris cluster can be installed through the `helm install` command.
 
-```bash
+```shell
 helm install doriscluster doris-1.4.0.tgz
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-1.4.0.tgz
 ```
 
@@ -159,13 +159,13 @@ helm install -f values.yaml doriscluster doris-1.4.0.tgz
 
 You can check the pod deployment status through the `kubectl get pods` command. When the Pod of `doriscluster` is in `Running` state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -181,13 +181,13 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 After the cluster deployment resources are delivered, you can check the cluster status by running the following command.
 
-```bash
+```shell
 kubectl get pods -n ${namespace}
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                       READY   STATUS    RESTARTS   AGE
 doriscluster-sample-fe-0   1/1     Running   0          20m
 doriscluster-sample-be-0   1/1     Running   0          19m
@@ -199,13 +199,13 @@ When the `STATUS` of all pods is in the `Running` state, and all containers in t
 
 Doris Operator will collect the status of cluster services and display them in the distributed resources. Doris Operator defines the abbreviation `dcr` for the `DorisCluster` type resource name, which can be replaced by the abbreviation when using the resource type to view the cluster status.
 
-```bash
+```shell
 kubectl get dcr
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                  FESTATUS    BESTATUS    CNSTATUS   BROKERSTATUS
 doriscluster-sample   available   available
 ```

--- a/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/install-env.md
+++ b/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/install-env.md
@@ -39,7 +39,7 @@ under the License.
 
 When deploying a Doris cluster on Kubernetes, it is recommended to turn off the firewall configuration:
 
-```bash
+```shell
 systemctl stop firewalld
 systemctl disable firewalld
 ```
@@ -56,7 +56,7 @@ When deploying Doris, it is recommended to turn off the swap partition.
 
 The swap partition can be permanently shut down with the following command.
 
-```bash
+```shell
 echo "vm.swappiness = 0">> /etc/sysctl.conf
 swapoff -a && swapon -a
 sysctl -p
@@ -64,7 +64,7 @@ sysctl -p
 
 ### Set the maximum number of open file handles in the system
 
-```bash
+```shell
 vi /etc/security/limits.conf 
 * soft nofile 65536
 * hard nofile 65536
@@ -74,7 +74,7 @@ vi /etc/security/limits.conf
 
 Modify the virtual memory area to at least 2000000
 
-```bash
+```shell
 sysctl -w vm.max_map_count=2000000
 ```
 
@@ -82,7 +82,7 @@ sysctl -w vm.max_map_count=2000000
 
 When deploying Doris, it is recommended to turn off transparent huge pages.
 
-```bash
+```shell
 echo never > /sys/kernel/mm/transparent_hugepage/enabled
 echo never > /sys/kernel/mm/transparent_hugepage/defrag
 ```

--- a/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/install-operator.md
+++ b/versioned_docs/version-2.1/install/cluster-deployment/k8s-deploy/install-operator.md
@@ -29,32 +29,32 @@ Doris Operator extends Kubernetes with Custom Resource Definition (CRD). The CRD
 
 Doris Cluster CRD can be deployed in a Kubernetes environment with the following command:
 
-```bash
+```shell
 kubectl create -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 ```
 
 If there is no external network, download the CRD file to your local computer first:
 
-```bash
+```shell
 wget https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 kubectl create -f ./doris.selectdb.com_dorisclusters.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 customresourcedefinition.apiextensions.k8s.io/dorisclusters.doris.selectdb.com created
 ```
 
 After the Doris Cluster CRD is created, you can view the created CRD with the following command.
 
-```bash
+```shell
 kubectl get crd | grep doris
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 ```
 
@@ -66,13 +66,13 @@ You can directly pull the Doris Operator template in the warehouse for quick dep
 
 Doris Operator can be deployed in a Kubernetes cluster using the following command:
 
-```bash
+```shell
 kubectl apply -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/operator/operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -91,13 +91,13 @@ The minimum requirements for deploying operator services are specified in the op
 
 After modifying the operator.yaml file, you can deploy the Doris Operator service using the following command:
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -113,13 +113,13 @@ deployment.apps/doris-operator created
 
 If the server is not connected to the external network, you need to download the corresponding operator image file first. Doris Operator uses the following images:
 
-```bash
+```shell
 selectdb/doris.k8s-operator:latest
 ```
 
 Run the following command on a server that can connect to the external network to download the image:
 
-```bash
+```shell
 ## download doris operator image
 docker pull selectdb/doris.k8s-operator:latest
 ## save the doris operator image as a tar package
@@ -128,7 +128,7 @@ docker save -o doris.k8s-operator-latest.tar selectdb/doris.k8s-operator:latest
 
 Place the packaged tar file into all Kubernetes nodes and run the following command to upload the image:
 
-```bash
+```shell
 docker load -i doris.k8s-operator-latest.tar
 ```
 
@@ -138,7 +138,7 @@ After downloading the operator.yaml file, you can modify the template according 
 
 Doris Operator is a stateless Deployment in the Kubernetes cluster. Items such as `limits`, `replica`, `label`, `namespace` and other items can be modified according to needs. If you need to specify a certain version of the doirs operator image, you can make the following modifications to the operator.yaml file after uploading the image:
 
-```bash
+```shell
 ...
 containers:
   - command:
@@ -158,13 +158,13 @@ containers:
 
 After modifying the Doris Operator template, you can use the apply command to deploy the Operator:
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -184,13 +184,13 @@ Helm Chart is an encapsulation of a series of YAML files that describe Kubernete
 
 Add the remote repository through the `repo add` command
 
-```bash
+```shell
 helm repo add doris-repo https://charts.selectdb.com
 ```
 
 Update the latest version of the chart through the `repo update` command
 
-```bash
+```shell
 helm repo update doris-repo
 ```
 
@@ -198,25 +198,25 @@ helm repo update doris-repo
 
 Doris Operator can be installed in the doris namespace using the default configuration through the `helm install` command.
 
-```bash
+```shell
 helm install operator doris-repo/doris-operator
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-repo/doris-operator
 ```
 
 Check the deployment status of Pods through the `kubectl get pods` command. When the Doris Operator's Pod is in the Running state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -229,7 +229,7 @@ If the server cannot connect to the external network, you need to download the c
 
 Download `doris-operator-{chart_version}.tgz` to install Doris Operator chart. If you need to download version 1.4.0 of Doris Operator, you can use the following command:
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 ```
 
@@ -237,25 +237,25 @@ wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 
 Doris Operator can be installed through the `helm install` command.
 
-```bash
+```shell
 helm install operator doris-operator-1.4.0.tgz
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-operator-1.4.0.tgz
 ```
 
 Check the deployment status of Pods through the `kubectl get pods` command. When the Doris Operator's Pod is in the Running state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -264,13 +264,13 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 After deploying the Operator service, you can check the service status through the following command.
 
-```bash
+```shell
 kubectl get pod -n doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-6f47594455-p5tp7   1/1     Running   0          11s
 ```

--- a/versioned_docs/version-2.1/install/cluster-deployment/run-docker-cluster.md
+++ b/versioned_docs/version-2.1/install/cluster-deployment/run-docker-cluster.md
@@ -81,7 +81,7 @@ Download the [official binary package](https://doris.apache.org/zh-CN/download/)
 
 3. Write Dockerfile
 
-```Bash
+```shell
 # Choose a base image
 FROM openjdk:8u342-jdk
 

--- a/versioned_docs/version-2.1/install/cluster-deployment/standard-deployment.md
+++ b/versioned_docs/version-2.1/install/cluster-deployment/standard-deployment.md
@@ -286,7 +286,7 @@ This is a CIDR representation that specifies the IP used by the FE. In environme
 
 Start FE process by executing the following command
 
-```Bash
+```shell
 bin/start_fe.sh --daemon
 ```
 
@@ -349,7 +349,7 @@ ALTER SYSTEM ADD OBSERVER "<fe_ip_address>:<fe_edit_log_port>"
 
 Execute the following command to start FE Follower node and synchronize metadata automatically.
 
-```Bash
+```shell
 bin/start_fe.sh --helper <helper_fe_ip>:<fe_edit_log_port> --daemon
 ```
 
@@ -568,7 +568,7 @@ As a distributed database, Doris generally has many BE nodes. Doris adds BE node
 
 You can use the following command to check if the FE has started successfully.
 
-```Bash
+```shell
 # Retry the following command, if it returns "msg":"success"，the FE has started successfully.
 server1:apache-doris/fe doris$ curl http://127.0.0.1:8030/api/bootstrap
 {"msg":"success","code":0,"data":{"replayedJournalId":0,"queryPort":0,"rpcPort":0,"version":""},"count":0}

--- a/versioned_docs/version-2.1/install/source-install/compilation-mac.md
+++ b/versioned_docs/version-2.1/install/source-install/compilation-mac.md
@@ -92,7 +92,7 @@ cd output/fe/bin
 
 Download the pre-compiled third-party libraries from [Apache Doris Third Party Prebuilt](https://github.com/apache/doris-thirdparty/releases/tag/automation). Refer to the command below: 
 
-```Bash
+```shell
 cd thirdparty
 rm -rf installed
 

--- a/versioned_docs/version-2.1/install/source-install/compilation-with-docker.md
+++ b/versioned_docs/version-2.1/install/source-install/compilation-with-docker.md
@@ -32,7 +32,7 @@ This guide is about how to compile Doris using the official compilation image pr
 
 In CentOS, execute the following command: 
 
-```Bash
+```shell
 yum install docker
 ```
 
@@ -51,7 +51,7 @@ For different versions of Doris, you need to download different build images. Th
 
 Take Doris 2.0 as an example, download and check the correponding Docker image.
 
-```Bash
+```shell
 # Choose docker.io/apache/doris:build-env-for-2.0
 $ docker pull apache/doris:build-env-for-2.0
 
@@ -69,7 +69,7 @@ apache/doris    build-env-for-2.0    f29cf1979dba    3 days ago    3.3GB
 - For information about changes in the compilation image, please see [ChangeLog](https://github.com/apache/doris/blob/master/thirdparty/CHANGELOG.md).
 - The Docker compilation image includes both JDK 8 and JDK 17. You can check the default JDK version by running `java -version`, and switch between versions using the following commands. For versions earlier than 2.1 (inclusive), please use JDK 8. For versions later than 3.0 (inclusive) or the master branch, please use JDK 17.
 
-```Bash
+```shell
 # Switch to JDK 8
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0
 export PATH=$JAVA_HOME/bin/:$PATH

--- a/versioned_docs/version-2.1/install/source-install/compilation-with-ldb-toolchain.md
+++ b/versioned_docs/version-2.1/install/source-install/compilation-with-ldb-toolchain.md
@@ -118,7 +118,7 @@ The first step of compiling Doris source code is to first download third-party l
 
 1. **Enter the Doris source code directory and execute the following command to check if the compilation machine supports the AVX2 instruction set.**
 
-```Bash
+```shell
 $ cat /proc/cpuinfo | grep avx2
 ```
 

--- a/versioned_docs/version-2.1/lakehouse/database/es.md
+++ b/versioned_docs/version-2.1/lakehouse/database/es.md
@@ -122,7 +122,7 @@ For example, suppose there is an index `doc` containing the following data struc
 The array fields of this structure can be defined by using the following command to add the field property definition 
 to the `_meta.doris` property of the target index mapping.
 
-```bash
+```shell
 # ES 7.x and above
 curl -X PUT "localhost:9200/doc/_mapping?pretty" -H 'Content-Type:application/json' -d '
 {

--- a/versioned_docs/version-2.1/practical-guide/log-storage-analysis.md
+++ b/versioned_docs/version-2.1/practical-guide/log-storage-analysis.md
@@ -398,7 +398,7 @@ output {
 
 3. Run Logstash according to the command below, collect logs, and output to Apache Doris.
 
-```Bash  
+```shell  
 ./bin/logstash -f logstash_demo.conf
 ```
 
@@ -465,7 +465,7 @@ headers:
 
 3. Run Filebeat according to the command below, collect logs, and output to Apache Doris.
 
-    ```Bash  
+    ```shell  
     chmod +x filebeat-doris-1.0.0  
     ./filebeat-doris-1.0.0 -c filebeat_demo.yml
     ```
@@ -509,7 +509,7 @@ For more information about Kafka, see [Routine Load](../data-operate/import/rout
 
 In addition to integrating common log collectors, you can also customize programs to import log data into Apache Doris using the Stream Load HTTP API. Refer to the following code:
 
-```Bash  
+```shell  
 curl   
 --location-trusted   
 -u username:password   

--- a/versioned_docs/version-2.1/query/query-analysis/import-analysis.md
+++ b/versioned_docs/version-2.1/query/query-analysis/import-analysis.md
@@ -45,7 +45,7 @@ The execution process of a [Broker Load](../../data-operate/import/broker-load-m
 ┌────────────────┐
 │BrokerScanNode│
 └────────────────┘
-````
+```
 
 BrokerScanNode is mainly responsible for reading the source data and sending it to OlapTableSink, and OlapTableSink is responsible for sending data to the corresponding node according to the partition and bucketing rules, and the corresponding node is responsible for the actual data writing.
 
@@ -59,7 +59,7 @@ The user can open the session variable `is_report_success` with the following co
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Then submit a Broker Load import request and wait until the import execution completes. Doris will generate a Profile for this import. Profile contains the execution details of importing each subtask and Instance, which helps us analyze import bottlenecks.
 
@@ -105,7 +105,7 @@ WaitAndFetchResultTime: NULL
        FetchResultTime: 0ns
        WriteResultTime: 0ns
 WaitAndFetchResultTime: N/A
-````
+```
 
 This command will list all currently saved import profiles. Each line corresponds to one import. where the QueryId column is the ID of the import job. This ID can also be viewed through the SHOW LOAD statement. We can select the QueryId corresponding to the Profile we want to see to see the specific situation.
 
@@ -124,7 +124,7 @@ This command will list all currently saved import profiles. Each line correspond
    +-----------------------------------+------------+
    | 980014623046410a-af5d36f23381017f | 3m14s      |
    +-----------------------------------+------------+
-   ````
+   ```
 
 As shown in the figure above, it means that the import job `980014623046410a-af5d36f23381017f` has a total of one subtask, in which ActiveTime indicates the execution time of the longest instance in this subtask.
 
@@ -144,7 +144,7 @@ As shown in the figure above, it means that the import job `980014623046410a-af5
    | 980014623046410a-88e260f0c43031f4 | 10.81.85.89:9067 | 3m10s      |
    | 980014623046410a-88e260f0c43031f5 | 10.81.85.89:9067 | 3m14s      |
    +-----------------------------------+------------------+------------+
-   ````
+   ```
 
 This shows the time-consuming of four instances of the subtask 980014623046410a-af5d36f23381017f, and also shows the execution node where the instance is located.
 
@@ -195,7 +195,7 @@ This shows the time-consuming of four instances of the subtask 980014623046410a-
    │ - TotalReadThroughput: 30.39858627319336 MB/sec│
    │ - WaitScannerTime: 56s528ms │
    └------------------------------------------------- ----┘
-   ````
+   ```
 
 The figure above shows the specific profiles of each operator of Instance 980014623046410a-af5d36f23381017f in subtask 980014623046410a-88e260f0c43031f5.
 

--- a/versioned_docs/version-2.1/query/query-analysis/query-analytics.md
+++ b/versioned_docs/version-2.1/query/query-analysis/query-analytics.md
@@ -37,7 +37,7 @@ For example, if the user specifies a Join operator, the query planner needs to d
 
 Doris' query planning process is to first convert an SQL statement into a single-machine execution plan tree.
 
-````text
+```text
      ┌────┐
      │Sort│
      └────┘
@@ -53,11 +53,11 @@ Doris' query planning process is to first convert an SQL statement into a single
 ┌──────┐ ┌──────┐
 │Scan-1│ │Scan-2│
 └──────┘ └──────┘
-````
+```
 
 After that, the query planner will convert the single-machine query plan into a distributed query plan according to the specific operator execution mode and the specific distribution of data. The distributed query plan is composed of multiple fragments, each fragment is responsible for a part of the query plan, and the data is transmitted between the fragments through the ExchangeNode operator.
 
-````text
+```text
         ┌────┐
         │Sort│
         │F1 │
@@ -87,7 +87,7 @@ After that, the query planner will convert the single-machine query plan into a 
             │Scan-2│
             │F2 │
             └──────┘
-````
+```
 
 As shown above, we divided the stand-alone plan into two Fragments: F1 and F2. Data is transmitted between two Fragments through an ExchangeNode.
 
@@ -472,7 +472,7 @@ The user can open the session variable `is_report_success` with the following co
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Then execute the query, and Doris will generate a Profile of the query. Profile contains the specific execution of a query for each node, which helps us analyze query bottlenecks.
 
@@ -490,7 +490,7 @@ mysql> show query profile "/"\G
    EndTime: 2021-04-08 11:30:50
  TotalTime: 9ms
 QueryState: EOF
-````
+```
 
 This command will list all currently saved profiles. Each row corresponds to a query. We can select the QueryId corresponding to the Profile we want to see to see the specific situation.
 
@@ -669,7 +669,7 @@ This shows the execution nodes and time consumption of all three Instances on Fr
    │ - RowsReturnedRate: 0 │
    │ - SendersBlockedTotalTimer(*): 0ns │
    └────────────────────────────────────────────────────┘
-   ````
+   ```
 
    The above figure shows the specific profiles of each operator of Instance c257c52f93e149ee-ace8ac14e8c9ff03 in Fragment 1.
 

--- a/versioned_docs/version-2.1/query/query-variables/variables.md
+++ b/versioned_docs/version-2.1/query/query-variables/variables.md
@@ -587,19 +587,19 @@ Note that the comment must start with /*+ and can only follow the SELECT.
 
 	Default password expiration time. The default value is 0, which means no expiration. The unit is days. This parameter is only enabled if the user's password expiration property has a value of DEFAULT. like:
 
-   ````
+   ```
    CREATE USER user1 IDENTIFIED BY "12345" PASSWORD_EXPIRE DEFAULT;
    ALTER USER user1 PASSWORD_EXPIRE DEFAULT;
-   ````
+   ```
 
 * `password_history`
 
 	The default number of historical passwords. The default value is 0, which means no limit. This parameter is enabled only when the user's password history attribute is the DEFAULT value. like:
 
-   ````
+   ```
    CREATE USER user1 IDENTIFIED BY "12345" PASSWORD_HISTORY DEFAULT;
    ALTER USER user1 PASSWORD_HISTORY DEFAULT;
-   ````
+   ```
 
 * `validate_password_policy`
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/CREATE-ROLE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/CREATE-ROLE.md
@@ -36,7 +36,7 @@ The statement user creates a role
 
 ```sql
   CREATE ROLE role_name [comment];
-````
+```
 
 This statement creates an unprivileged role, which can be subsequently granted with the GRANT command.
 
@@ -46,7 +46,7 @@ This statement creates an unprivileged role, which can be subsequently granted w
 
     ```sql
     CREATE ROLE role1;
-    ````
+    ```
 
 2. Create a role with comment
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
@@ -32,7 +32,7 @@ The statement user removes a role
 
 ```sql
   DROP ROLE [IF EXISTS] role1;
-````
+```
 
 Deleting a role does not affect the permissions of users who previously belonged to the role. It is only equivalent to decoupling the role from the user. The permissions that the user has obtained from the role will not change
 
@@ -42,7 +42,7 @@ Deleting a role does not affect the permissions of users who previously belonged
 
 ```sql
 DROP ROLE role1;
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/DROP-USER.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/DROP-USER.md
@@ -41,7 +41,7 @@ Delete a user
     
          user@'host'
          user@['domain']
-````
+```
 
   Delete the specified user identitiy.
 
@@ -51,7 +51,7 @@ Delete a user
 
     ```sql
     DROP USER 'jack'@'192.%'
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
@@ -47,7 +47,7 @@ GRANT privilege_list ON priv_level TO user_identity [ROLE role_name]
 GRANT privilege_list ON RESOURCE resource_name TO user_identity [ROLE role_name]
 
 GRANT role_list TO user_identity
-````
+```
 
 GRANT privilege_list ON WORKLOAD GROUP workload_group_name TO user_identity [ROLE role_name]
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/LDAP.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/LDAP.md
@@ -36,7 +36,7 @@ SET LDAP_ADMIN_PASSWORD
 
 ```sql
   SET LDAP_ADMIN_PASSWORD = PASSWORD('plain password')
-````
+```
 
   The SET LDAP_ADMIN_PASSWORD command is used to set the LDAP administrator password. When using LDAP authentication, doris needs to use the administrator account and password to query the LDAP service for login user information.
 
@@ -46,7 +46,7 @@ SET LDAP_ADMIN_PASSWORD
 
 ```sql
 SET LDAP_ADMIN_PASSWORD = PASSWORD('123456')
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/REVOKE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/REVOKE.md
@@ -47,7 +47,7 @@ REVOKE privilege_list ON db_name[.tbl_name] FROM user_identity [ROLE role_name]
 REVOKE privilege_list ON RESOURCE resource_name FROM user_identity [ROLE role_name]
 
 REVOKE role_list FROM user_identity
-````
+```
 
 user_identity:
 
@@ -63,13 +63,13 @@ role_list is the list of roles to be revoked, separated by commas. The specified
 
     ```sql
     REVOKE SELECT_PRIV ON db1.* FROM 'jack'@'192.%';
-    ````
+    ```
 
 2. Revoke user jack resource spark_resource permission
 
     ```sql
     REVOKE USAGE_PRIV ON RESOURCE 'spark_resource' FROM 'jack'@'192.%';
-    ````
+    ```
 3. Revoke the roles role1 and role2 previously granted to jack
 
     ```sql

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/SET-PASSWORD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/SET-PASSWORD.md
@@ -37,7 +37,7 @@ The SET PASSWORD command can be used to modify a user's login password. If the [
 ```sql
 SET PASSWORD [FOR user_identity] =
     [PASSWORD('plain password')]|['hashed password']
-````
+```
 
 Note that the user_identity here must exactly match the user_identity specified when creating a user with CREATE USER, otherwise an error will be reported that the user does not exist. If user_identity is not specified, the current user is 'username'@'ip', which may not match any user_identity. Current users can be viewed through SHOW GRANTS.
 
@@ -51,14 +51,14 @@ To modify the passwords of other users, administrator privileges are required.
    ```sql
    SET PASSWORD = PASSWORD('123456')
    SET PASSWORD = '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9'
-   ````
+   ```
 
 2. Modify the specified user password
 
    ```sql
    SET PASSWORD FOR 'jack'@'192.%' = PASSWORD('123456')
    SET PASSWORD FOR 'jack'@['domain'] = '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9'
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/SET-PROPERTY.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Account-Management-Statements/SET-PROPERTY.md
@@ -36,7 +36,7 @@ Set user attributes, including resources assigned to users, importing clusters, 
 
 ```sql
 SET PROPERTY [FOR 'user'] 'key' = 'value' [, 'key' = 'value']
-````
+```
 
 The user attribute set here is for user, not user_identity. That is, if two users 'jack'@'%' and 'jack'@'192.%' are created through the CREATE USER statement, the SET PROPERTY statement can only be used for the user jack, not 'jack'@'% ' or 'jack'@'192.%'
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 -- Add nodes (add this method if you do not use the multi-tenancy function)
    ALTER SYSTEM ADD BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
  illustrate:
 
@@ -53,7 +53,7 @@ grammar:
 
     ```sql
     ALTER SYSTEM ADD BACKEND "host:port";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BROKER.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BROKER.md
@@ -39,7 +39,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host2:broker_ipc_port2",...;
-````
+```
 
 ### Example
 
@@ -47,7 +47,7 @@ ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host
 
     ```sql
      ALTER SYSTEM ADD BROKER "host1:port", "host2:port";
-    ````
+    ```
 2. When fe enable fqdn([fqdn](../../../admin-manual/cluster-management/fqdn.md)),add one Broker
 
    ```sql

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-FOLLOWER.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-FOLLOWER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD FOLLOWER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM ADD FOLLOWER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-OBSERVER.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-OBSERVER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD OBSERVER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM ADD OBSERVER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DECOMMISSION-BACKEND.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DECOMMISSION-BACKEND.md
@@ -40,13 +40,13 @@ grammar:
 
 ```sql
 ALTER SYSTEM DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM DECOMMISSION BACKEND "id1","id2"...;
-````
+```
 
   illustrate:
 
@@ -61,11 +61,11 @@ ALTER SYSTEM DECOMMISSION BACKEND "id1","id2"...;
 
     ```sql
     ALTER SYSTEM DECOMMISSION BACKEND "host1:port", "host2:port";
-    ````
+    ```
 
     ```sql
     ALTER SYSTEM DECOMMISSION BACKEND "id1", "id2";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BACKEND.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BACKEND.md
@@ -40,12 +40,12 @@ grammar:
 
 ```sql
 ALTER SYSTEM DROP BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...]
-````
+```
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM DROP BACKEND "id1","id2"...;
-````
+```
 
 illustrate:
 
@@ -59,11 +59,11 @@ illustrate:
 
     ```sql
     ALTER SYSTEM DROP BACKEND "host1:port", "host2:port";
-    ````
+    ```
 
     ```sql
     ALTER SYSTEM DROP BACKEND "ids1", "ids2";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BROKER.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BROKER.md
@@ -42,7 +42,7 @@ grammar:
 ALTER SYSTEM DROP ALL BROKER broker_name
 -- Delete a Broker node
 ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
-````
+```
 
 ### Example
 
@@ -50,13 +50,13 @@ ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
 
     ```sql
     ALTER SYSTEM DROP ALL BROKER broker_name
-    ````
+    ```
 
 2. Delete a Broker node
 
     ```sql
     ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-OBSERVER.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-OBSERVER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM DROP OBSERVER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM DROP OBSERVER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
@@ -41,13 +41,13 @@ grammar:
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
-````
+```
 
   illustrate:
 
@@ -69,32 +69,32 @@ Note:
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("tag.location" = "group_a");
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a");
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-    ````
+    ```
 
 2. Modify the query disable property of BE
 
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("disable_query" = "true");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_query" = "true");
-    ````
+    ```
 
 3. Modify the import disable property of BE
 
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("disable_load" = "true");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_load" = "true");
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/CANCEL-ALTER-SYSTEM.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Cluster-Management-Statements/CANCEL-ALTER-SYSTEM.md
@@ -40,13 +40,13 @@ grammar:
 
 ```sql
 CANCEL DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 CANCEL DECOMMISSION BACKEND "id1","id2","id3...";
-````
+```
 
 ### Example
 
@@ -54,7 +54,7 @@ CANCEL DECOMMISSION BACKEND "id1","id2","id3...";
 
       ```sql
       CANCEL DECOMMISSION BACKEND "host1:port", "host2:port";
-      ````
+      ```
 
  2. Cancel the offline operation of the node with backend_id 1:
     

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-SQL-BLOCK-RULE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 ALTER SQL_BLOCK_RULE rule_name
 [PROPERTIES ("key"="value", ...)];
-````
+```
 
 illustrate:
 
@@ -52,18 +52,18 @@ illustrate:
 
 ```sql
 ALTER SQL_BLOCK_RULE test_rule PROPERTIES("sql"="select \\* from test_table","enable"="true")
-````
+```
 
 2. If a rule sets partition_num, then sql or sqlHash cannot be modified
 
 ```sql
 ALTER SQL_BLOCK_RULE test_rule2 PROPERTIES("partition_num" = "10","tablet_num"="300","enable"="true")
-````
+```
 
 ### Keywords
 
-````text
+```text
 ALTER,SQL_BLOCK_RULE
-````
+```
 
 ### Best Practice

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
@@ -161,7 +161,7 @@ ALTER TABLE example_db.mysql_table SET ("replication_num" = "2");
 ALTER TABLE example_db.mysql_table SET ("default.replication_num" = "2");
 ALTER TABLE example_db.mysql_table SET ("replication_allocation" = "tag.location.default: 1");
 ALTER TABLE example_db.mysql_table SET ("default.replication_allocation" = "tag.location.default: 1");
-````
+```
 
 Note:
 1. The property with the default prefix indicates the default replica distribution for the modified table. This modification does not modify the current actual replica distribution of the table, but only affects the replica distribution of newly created partitions on the partitioned table.

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-DATABASE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-DATABASE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 CREATE DATABASE [IF NOT EXISTS] db_name
     [PROPERTIES ("key"="value", ...)];
-````
+```
 
 `PROPERTIES` Additional information about the database, which can be defaulted.
 
@@ -57,7 +57,7 @@ CREATE DATABASE [IF NOT EXISTS] db_name
 
    ```sql
    CREATE DATABASE db_test;
-   ````
+   ```
 
 2. Create a new database with default replica distribution:
 
@@ -66,13 +66,13 @@ CREATE DATABASE [IF NOT EXISTS] db_name
    PROPERTIES (
        "replication_allocation" = "tag.location.group_1:3"
    );
-   ````
+   ```
 
 ### Keywords
 
-````text
+```text
 CREATE, DATABASE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-ENCRYPT-KEY.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-ENCRYPT-KEY.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 CREATE ENCRYPTKEY key_name AS "key_string"
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ If `key_name` contains the database name, then the custom key will be created in
 
    ```sql
    CREATE ENCRYPTKEY my_key AS "ABCD123456789";
-   ````
+   ```
 
 2. Use a custom key
 
@@ -76,7 +76,7 @@ If `key_name` contains the database name, then the custom key will be created in
    | Doris is Great |
    +------------------------------------------------- -------------------+
    1 row in set (0.01 sec)
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FILE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FILE.md
@@ -46,7 +46,7 @@ grammar:
 ```sql
 CREATE FILE "file_name" [IN database]
 PROPERTIES("key"="value", ...)
-````
+```
 
 illustrate:
 
@@ -68,7 +68,7 @@ illustrate:
        "url" = "https://test.bj.bcebos.com/kafka-key/ca.pem",
        "catalog" = "kafka"
    );
-   ````
+   ```
 
 2. Create a file client.key, classified as my_catalog
 
@@ -81,13 +81,13 @@ illustrate:
        "catalog" = "my_catalog",
        "md5" = "b5bb901bf10f99205b39a46ac3557dd9"
    );
-   ````
+   ```
 
 ### Keywords
 
-````text
+```text
 CREATE, FILE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
@@ -45,7 +45,7 @@ CREATE [GLOBAL] [AGGREGATE] [ALIAS] FUNCTION function_name
     [INTERMEDIATE inter_type]
     [WITH PARAMETER(param [,...]) AS origin_function]
     [PROPERTIES ("key" = "value" [, ...]) ]
-````
+```
 
 Parameter Description:
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-INDEX.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-INDEX.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 CREATE INDEX [IF NOT EXISTS] index_name ON table_name (column [, ...],) [USING INVERTED] [COMMENT 'balabala'];
-````
+```
 Notice:
 - INVERTED indexes are only created on a single column
 
@@ -47,14 +47,14 @@ Notice:
 
     ```sql
     CREATE INDEX [IF NOT EXISTS] index_name ON table1 (siteid) USING INVERTED COMMENT 'balabala';
-    ````
+    ```
 
 
 ### Keywords
 
-````text
+```text
 CREATE, INDEX
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-MATERIALIZED-VIEW.md
@@ -41,7 +41,7 @@ grammar:
 ```sql
 CREATE MATERIALIZED VIEW < MV name > as < query >
 [PROPERTIES ("key" = "value")]
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ illustrate:
   FROM [Base view name]
   GROUP BY column_name[, column_name ...]
   ORDER BY column_name[, column_name ...]
-  ````
+  ```
 
   The syntax is the same as the query syntax.
 
@@ -73,16 +73,16 @@ illustrate:
 
   Declare some configuration of the materialized view, optional.
 
-  ````text
+  ```text
   PROPERTIES ("key" = "value", "key" = "value" ...)
-  ````
+  ```
 
   The following configurations can be declared here:
 
-  ````text
+  ```text
    short_key: The number of sorting columns.
    timeout: The timeout for materialized view construction.
-  ````
+  ```
 
 ### Example
 
@@ -98,7 +98,7 @@ mysql> desc duplicate_table;
 | k3 | BIGINT | Yes | true | N/A | |
 | k4 | BIGINT | Yes | true | N/A | |
 +-------+--------+------+------+---------+-------+
-````
+```
 ```sql
 create table duplicate_table(
 	k1 int null,
@@ -117,49 +117,49 @@ attention：If the materialized view contains partitioned and distributed column
    ```sql
    create materialized view k2_k1 as
    select k2, k1 from duplicate_table;
-   ````
+   ```
 
    The schema of the materialized view is as follows, the materialized view contains only two columns k1, k2 without any aggregation
 
-   ````text
+   ```text
    +-------+-------+--------+------+------+ ---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------+ ---------+-------+
    | k2_k1 | k2 | INT | Yes | true | N/A | |
    | | k1 | INT | Yes | true | N/A | |
    +-------+-------+--------+------+------+ ---------+-------+
-   ````
+   ```
 
 2. Create a materialized view with k2 as the sort column
 
    ```sql
    create materialized view k2_order as
    select k2, k1 from duplicate_table order by k2;
-   ````
+   ```
 
    The schema of the materialized view is shown in the figure below. The materialized view contains only two columns k2, k1, where k2 is the sorting column without any aggregation.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
    | k2_order | k2 | INT | Yes | true | N/A | |
    | | k1 | INT | Yes | false | N/A | NONE |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 3. Create a materialized view with k1, k2 grouping and k3 column aggregated by SUM
 
    ```sql
    create materialized view k1_k2_sumk3 as
    select k1, k2, sum(k3) from duplicate_table group by k1, k2;
-   ````
+   ```
 
    The schema of the materialized view is shown in the figure below. The materialized view contains two columns k1, k2, sum(k3) where k1, k2 are the grouping columns, and sum(k3) is the sum value of the k3 column grouped by k1, k2.
 
    Since the materialized view does not declare a sorting column, and the materialized view has aggregated data, the system defaults to supplement the grouping columns k1 and k2 as sorting columns.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
@@ -167,18 +167,18 @@ attention：If the materialized view contains partitioned and distributed column
    | | k2 | INT | Yes | true | N/A | |
    | | k3 | BIGINT | Yes | false | N/A | SUM |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 4. Create a materialized view that removes duplicate rows
 
    ```sql
    create materialized view deduplicate as
    select k1, k2, k3, k4 from duplicate_table group by k1, k2, k3, k4;
-   ````
+   ```
 
    The materialized view schema is as shown below. The materialized view contains columns k1, k2, k3, and k4, and there are no duplicate rows.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
@@ -187,13 +187,13 @@ attention：If the materialized view contains partitioned and distributed column
    | | k3 | BIGINT | Yes | true | N/A | |
    | | k4 | BIGINT | Yes | true | N/A | |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 5. Create a non-aggregate materialized view that does not declare a sort column
 
    The schema of all_type_table is as follows
 
-   ````
+   ```
    +-------+--------------+------+-------+---------+- ------+
    | Field | Type | Null | Key | Default | Extra |
    +-------+--------------+------+-------+---------+- ------+
@@ -205,14 +205,14 @@ attention：If the materialized view contains partitioned and distributed column
    | k6 | DOUBLE | Yes | false | N/A | NONE |
    | k7 | VARCHAR(20) | Yes | false | N/A | NONE |
    +-------+--------------+------+-------+---------+- ------+
-   ````
+   ```
 
    The materialized view contains k3, k4, k5, k6, k7 columns, and does not declare a sort column, the creation statement is as follows:
 
    ```sql
    create materialized view mv_1 as
    select k3, k4, k5, k6, k7 from all_type_table;
-   ````
+   ```
 
    The default added sorting column of the system is k3, k4, k5 three columns. The sum of the bytes of these three column types is 4(INT) + 8(BIGINT) + 16(DECIMAL) = 28 < 36. So the addition is that these three columns are used as sorting columns. The schema of the materialized view is as follows, you can see that the key field of the k3, k4, k5 columns is true, that is, the sorting column. The key field of the k6, k7 columns is false, which is a non-sorted column.
 
@@ -226,7 +226,7 @@ attention：If the materialized view contains partitioned and distributed column
    | | k6 | DOUBLE | Yes | false | N/A | NONE |
    | | k7 | VARCHAR(20) | Yes | false | N/A | NONE |
    +----------------+-------+--------------+------+-- -----+---------+-------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-RESOURCE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-RESOURCE.md
@@ -40,7 +40,7 @@ grammar:
 ```sql
 CREATE [EXTERNAL] RESOURCE "resource_name"
 PROPERTIES ("key"="value", ...);
-````
+```
 
 illustrate:
 
@@ -69,7 +69,7 @@ illustrate:
      "broker.username" = "user0",
      "broker.password" = "password0"
    );
-   ````
+   ```
 
    Spark related parameters are as follows:
    - spark.master: Required, currently supports yarn, spark://host:port.
@@ -100,7 +100,7 @@ illustrate:
    "odbc_type" = "oracle",
    "driver" = "Oracle 19 ODBC driver"
    );
-   ````
+   ```
 
    The relevant parameters of ODBC are as follows:
    - hosts: IP address of the external database

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-SQL-BLOCK-RULE.md
@@ -45,7 +45,7 @@ grammar:
 ```sql
 CREATE SQL_BLOCK_RULE rule_name
 [PROPERTIES ("key"="value", ...)];
-````
+```
 
 Parameter Description:
 
@@ -68,7 +68,7 @@ Parameter Description:
     "global"="false",
     "enable"="true"
     );
-    ````
+    ```
 
     >Notes:
     >
@@ -79,7 +79,7 @@ Parameter Description:
     ```sql
     select * from order_analysis;
     ERROR 1064 (HY000): errCode = 2, detailMessage = sql match regex sql block rule: order_analysis_rule
-    ````
+    ```
 
 
 2. Create test_rule2, limit the maximum number of scanned partitions to 30, and limit the maximum scan base to 10 billion rows. The example is as follows:
@@ -92,7 +92,7 @@ Parameter Description:
     "global" = "false",
     "enable" = "true"
     );
-   ````
+   ```
 3. Create SQL BLOCK RULE with special chars
 
     ```sql
@@ -150,9 +150,9 @@ Here are some commonly used regular expressions:
 
 ### Keywords
 
-````text
+```text
 CREATE, SQL_BLCOK_RULE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE-LIKE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE-LIKE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 CREATE [EXTERNAL] TABLE [IF NOT EXISTS] [database.]table_name LIKE [database.]table_name [WITH ROLLUP (r1,r2,r3,...)]
-````
+```
 
 illustrate: 
 
@@ -53,43 +53,43 @@ illustrate:
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1
-    ````
+    ```
 
 2. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1
-    ````
+    ```
 
 3. Create an empty table with the same table structure as table1 under the test1 library, the table name is table2, and copy the two rollups of r1 and r2 of table1 at the same time
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1 WITH ROLLUP (r1,r2)
-    ````
+    ```
 
 4. Create an empty table with the same table structure as table1 under the test1 library, the table name is table2, and copy all the rollups of table1 at the same time
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1 WITH ROLLUP
-    ````
+    ```
 
 5. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2, and copy the two rollups of r1 and r2 of table1 at the same time
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1 WITH ROLLUP (r1,r2)
-    ````
+    ```
 
 6. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2, and copy all the rollups of table1 at the same time
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1 WITH ROLLUP
-    ````
+    ```
 
 7. Create an empty table under the test1 library with the same table structure as the MySQL outer table1, the table name is table2
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-VIEW.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-VIEW.md
@@ -40,7 +40,7 @@ CREATE VIEW [IF NOT EXISTS]
  [db_name.]view_name
  (column1[ COMMENT "col comment"][, column2, ...])
 AS query_stmt
-````
+```
 
 
 illustrate:
@@ -57,7 +57,7 @@ illustrate:
     AS
     SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table
     WHERE k1 = 20160112 GROUP BY k1,k2,k3;
-    ````
+    ```
     
 2. Create a view with a comment
 
@@ -73,7 +73,7 @@ illustrate:
     AS
     SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table
     WHERE k1 = 20160112 GROUP BY k1,k2,k3;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-DATABASE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-DATABASE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP DATABASE [IF EXISTS] db_name [FORCE];
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
    
      ```sql
      DROP DATABASE db_test;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-ENCRYPT-KEY.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-ENCRYPT-KEY.md
@@ -36,7 +36,7 @@ grammar:
 
 ```sql
 DROP ENCRYPTKEY key_name
-````
+```
 
 Parameter Description:
 
@@ -52,7 +52,7 @@ Executing this command requires the user to have `ADMIN` privileges.
 
     ```sql
     DROP ENCRYPTKEY my_key;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FILE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FILE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 DROP FILE "file_name" [FROM database]
 [properties]
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ illustrate:
 
      ```sql
      DROP FILE "ca.pem" properties("catalog" = "kafka");
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 DROP [GLOBAL] FUNCTION function_name
      (arg_type [, ...])
-````
+```
 
 Parameter Description:
 
@@ -52,12 +52,12 @@ Parameter Description:
 
     ```sql
     DROP FUNCTION my_add(INT, INT)
-    ````
+    ```
 2. Delete a global function
 
     ```sql
     DROP GLOBAL FUNCTION my_add(INT, INT)
-    ````   
+    ```   
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-INDEX.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-INDEX.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP INDEX [IF EXISTS] index_name ON [db_name.]table_name;
-````
+```
 
 ### Example
 
@@ -45,7 +45,7 @@ DROP INDEX [IF EXISTS] index_name ON [db_name.]table_name;
 
     ```sql
     DROP INDEX [IF NOT EXISTS] index_name ON table1 ;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-MATERIALIZED-VIEW.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DROP MATERIALIZED VIEW [IF EXISTS] mv_name ON table_name;
-````
+```
 
 
 1. IF EXISTS:
@@ -70,17 +70,17 @@ mysql> desc all_type_table all;
 | k1_sumk2 | k1 | TINYINT | Yes | true | N/A | |
 | | k2 | SMALLINT | Yes | false | N/A | SUM |
 +----------------+-------+----------+------+------ -+---------+-------+
-````
+```
 
 1. Drop the materialized view named k1_sumk2 of the table all_type_table
 
    ```sql
    drop materialized view k1_sumk2 on all_type_table;
-   ````
+   ```
 
    The table structure after the materialized view is deleted
 
-   ````text
+   ```text
    +----------------+-------+----------+------+------ -+---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +----------------+-------+----------+------+------ -+---------+-------+
@@ -92,14 +92,14 @@ mysql> desc all_type_table all;
    | | k6 | FLOAT | Yes | false | N/A | NONE |
    | | k7 | DOUBLE | Yes | false | N/A | NONE |
    +----------------+-------+----------+------+------ -+---------+-------+
-   ````
+   ```
 
 2. Drop a non-existent materialized view in the table all_type_table
 
    ```sql
    drop materialized view k1_k2 on all_type_table;
    ERROR 1064 (HY000): errCode = 2, detailMessage = Materialized view [k1_k2] does not exist in table [all_type_table]
-   ````
+   ```
 
    The delete request reports an error directly
 
@@ -108,7 +108,7 @@ mysql> desc all_type_table all;
    ```sql
    drop materialized view if exists k1_k2 on all_type_table;
    Query OK, 0 rows affected (0.00 sec)
-   ````
+   ```
 
     If it exists, delete it, if it does not exist, no error is reported.
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-RESOURCE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-RESOURCE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP RESOURCE 'resource_name'
-````
+```
 
 Note: ODBC/S3 resources in use cannot be deleted.
 
@@ -47,7 +47,7 @@ Note: ODBC/S3 resources in use cannot be deleted.
    
      ```sql
      DROP RESOURCE 'spark0';
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-SQL-BLOCK-RULE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DROP SQL_BLOCK_RULE test_rule1,...
-````
+```
 
 ### Example
 
@@ -47,12 +47,12 @@ DROP SQL_BLOCK_RULE test_rule1,...
     ```sql
     mysql> DROP SQL_BLOCK_RULE test_rule1,test_rule2;
     Query OK, 0 rows affected (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 
-````text
+```text
 DROP, SQL_BLOCK_RULE
-````
+```
 
 ### Best Practice

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-TABLE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-TABLE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP TABLE [IF EXISTS] [db_name.]table_name [FORCE];
-````
+```
 
 
 illustrate:
@@ -51,13 +51,13 @@ illustrate:
    
      ```sql
      DROP TABLE my_table;
-     ````
+     ```
     
 2. If it exists, delete the table of the specified database
    
      ```sql
      DROP TABLE IF EXISTS example_db.my_table;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/TRUNCATE-TABLE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Drop/TRUNCATE-TABLE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 TRUNCATE TABLE [db.]tbl[ PARTITION(p1, p2, ...)];
-````
+```
 
 illustrate:
 
@@ -54,13 +54,13 @@ illustrate:
 
      ```sql
      TRUNCATE TABLE example_db.tbl;
-     ````
+     ```
 
 2. Empty p1 and p2 partitions of table tbl
 
      ```sql
      TRUNCATE TABLE tbl PARTITION(p1, p2);
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/ALTER-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/ALTER-ROUTINE-LOAD.md
@@ -43,7 +43,7 @@ ALTER ROUTINE LOAD FOR [db.]job_name
 [job_properties]
 FROM data_source
 [data_source_properties]
-````
+```
 
 1. `[db.]job_name`
 
@@ -103,7 +103,7 @@ FROM data_source
    (
        "desired_concurrent_number" = "1"
    );
-   ````
+   ```
 
 2. Modify `desired_concurrent_number` to 10, modify the offset of the partition, and modify the group id.
 
@@ -119,7 +119,7 @@ FROM data_source
        "kafka_offsets" = "100, 200, 100",
        "property.group.id" = "new_group"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/BROKER-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/BROKER-LOAD.md
@@ -76,7 +76,7 @@ WITH BROKER broker_name
   [DELETE ON expr]
   [ORDER BY source_sequence]
   [PROPERTIES ("key1"="value1", ...)]
-  ````
+  ```
 
   - `[MERGE|APPEND|DELETE]`
 
@@ -159,13 +159,13 @@ WITH BROKER broker_name
 
   Specifies the information required by the broker. This information is usually used by the broker to be able to access remote storage systems. Such as BOS or HDFS. See the [Broker](../../../../advanced/broker.md) documentation for specific information.
 
-  ````text
+  ```text
   (
       "key1" = "val1",
       "key2" = "val2",
       ...
   )
-  ````
+  ```
 
 - `load_properties`
 
@@ -236,7 +236,7 @@ This feature is supported since the Apache Doris 1.2.3 version
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    Import the file `file.txt`, separated by commas, into the table `my_table`.
 
@@ -264,7 +264,7 @@ This feature is supported since the Apache Doris 1.2.3 version
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    Import two batches of files `file-10*` and `file-20*` using wildcard matching. Imported into two tables `my_table1` and `my_table2` respectively. Where `my_table1` specifies to import into partition `p1`, and will import the values of the second and third columns in the source file +1.
 
@@ -288,7 +288,7 @@ This feature is supported since the Apache Doris 1.2.3 version
        "dfs.namenode.rpc-address.my_ha.my_namenode2" = "nn2_host:rpc_port",
        "dfs.client.failover.proxy.provider.my_ha" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
    );
-   ````
+   ```
 
    Specify the delimiter as Hive's default delimiter `\\x01`, and use the wildcard * to specify all files in all directories under the `data` directory. Use simple authentication while configuring namenode HA.
 
@@ -307,7 +307,7 @@ This feature is supported since the Apache Doris 1.2.3 version
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
 5. Import the data and extract the partition field in the file path
 
@@ -325,18 +325,18 @@ This feature is supported since the Apache Doris 1.2.3 version
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    The columns in the `my_table` table are `k1, k2, k3, city, utc_date`.
 
    The `hdfs://hdfs_host:hdfs_port/user/doris/data/input/dir/city=beijing` directory includes the following files:
 
-   ````text
+   ```text
    hdfs://hdfs_host:hdfs_port/input/city=beijing/utc_date=2020-10-01/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=beijing/utc_date=2020-10-02/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=tianji/utc_date=2020-10-03/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=tianji/utc_date=2020-10-04/0000.csv
-   ````
+   ```
 
    The file only contains three columns of `k1, k2, k3`, and the two columns of `city, utc_date` will be extracted from the file path.
 
@@ -359,7 +359,7 @@ This feature is supported since the Apache Doris 1.2.3 version
        "username"="user",
        "password"="pass"
    );
-   ````
+   ```
 
    Only in the original data, k1 = 1, and after transformation, rows with k1 > k2 will be imported.
 
@@ -382,22 +382,22 @@ This feature is supported since the Apache Doris 1.2.3 version
        "username"="user",
        "password"="pass"
    );
-   ````
+   ```
 
    There are the following files in the path:
 
-   ````text
+   ```text
    /user/data/data_time=2020-02-17 00%3A00%3A00/test.txt
    /user/data/data_time=2020-02-18 00%3A00%3A00/test.txt
-   ````
+   ```
 
    The table structure is:
 
-   ````text
+   ```text
    data_time DATETIME,
    k2 INT,
    k3 INT
-   ````
+   ```
 
 8. Import a batch of data from HDFS, specify the timeout and filter ratio. Broker with clear text my_hdfs_broker. Simple authentication. And delete the columns in the original data that match the columns with v2 greater than 100 in the imported data, and other columns are imported normally
 
@@ -419,7 +419,7 @@ This feature is supported since the Apache Doris 1.2.3 version
         "timeout" = "3600",
         "max_filter_ratio" = "0.1"
     );
-    ````
+    ```
 
    Import using the MERGE method. `my_table` must be a table with Unique Key. When the value of the v2 column in the imported data is greater than 100, the row is considered a delete row.
 
@@ -441,7 +441,7 @@ This feature is supported since the Apache Doris 1.2.3 version
         "hadoop.username"="user",
         "password"="pass"
     )
-    ````
+    ```
 
    `my_table` must be an Unique Key model table with Sequence Col specified. The data will be ordered according to the value of the `source_sequence` column in the source data.
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CANCEL-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CANCEL-LOAD.md
@@ -50,7 +50,7 @@ Notice: Cancel by State is supported since 1.2.0.
     CANCEL LOAD
     FROM example_db
     WHERE LABEL = "example_db_test_load_label";
-    ````
+    ```
 
 2. Cancel all import jobs containing example* on the database example*db.
 
@@ -58,7 +58,7 @@ Notice: Cancel by State is supported since 1.2.0.
     CANCEL LOAD
     FROM example_db
     WHERE LABEL like "example_";
-    ````
+    ```
 
 
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md
@@ -74,7 +74,7 @@ FROM data_source [data_source_properties]
 
   Used to describe imported data. The composition is as follows:
 
-  ````SQL
+  ```SQL
   [column_separator],
   [columns_mapping],
   [preceding_filter],
@@ -82,7 +82,7 @@ FROM data_source [data_source_properties]
   [partitions],
   [DELETE ON],
   [ORDER BY]
-  ````
+  ```
 
   - `column_separator`
 
@@ -138,12 +138,12 @@ FROM data_source [data_source_properties]
 
   Common parameters for specifying routine import jobs.
 
-  ````text
+  ```text
   PROPERTIES (
       "key1" = "val1",
       "key2" = "val2"
   )
-  ````
+  ```
 
   Currently we support the following parameters:
 
@@ -165,11 +165,11 @@ FROM data_source [data_source_properties]
 
      These three parameters are used to control the execution time and processing volume of a subtask. When either one reaches the threshold, the task ends.
 
-     ````text
+     ```text
      "max_batch_interval" = "20",
      "max_batch_rows" = "300000",
      "max_batch_size" = "209715200"
-     ````
+     ```
 
   3. `max_error_number`
 
@@ -270,13 +270,13 @@ FROM data_source [data_source_properties]
 
   The type of data source. Currently supports:
 
-  ````text
+  ```text
   FROM KAFKA
   (
       "key1" = "val1",
       "key2" = "val2"
   )
-  ````
+  ```
 
   `data_source_properties` supports the following data source properties:
 
@@ -304,15 +304,15 @@ FROM data_source [data_source_properties]
 
      If not specified, all partitions under topic will be subscribed from `OFFSET_END` by default.
 
-     ````text
+     ```text
      "kafka_partitions" = "0,1,2,3",
      "kafka_offsets" = "101,0,OFFSET_BEGINNING,OFFSET_END"
-     ````
+     ```
 
-     ````text
+     ```text
      "kafka_partitions" = "0,1,2,3",
      "kafka_offsets" = "2021-05-22 11:00:00,2021-05-22 11:00:00,2021-05-22 11:00:00"
-     ````
+     ```
 
      Note that the time format cannot be mixed with the OFFSET format.
 
@@ -326,20 +326,20 @@ FROM data_source [data_source_properties]
 
      For more supported custom parameters, please refer to the configuration items on the client side in the official CONFIGURATION document of librdkafka. Such as:
 
-     ````text
+     ```text
      "property.client.id" = "12345",
      "property.ssl.ca.location" = "FILE:ca.pem"
-     ````
+     ```
 
      1. When connecting to Kafka using SSL, you need to specify the following parameters:
 
-        ````text
+        ```text
         "property.security.protocol" = "ssl",
         "property.ssl.ca.location" = "FILE:ca.pem",
         "property.ssl.certificate.location" = "FILE:client.pem",
         "property.ssl.key.location" = "FILE:client.key",
         "property.ssl.key.password" = "abcdefg"
-        ````
+        ```
 
         in:
 
@@ -347,11 +347,11 @@ FROM data_source [data_source_properties]
 
         If client authentication is enabled on the Kafka server side, thenAlso set:
 
-        ````text
+        ```text
         "property.ssl.certificate.location"
         "property.ssl.key.location"
         "property.ssl.key.password"
-        ````
+        ```
 
         They are used to specify the client's public key, private key, and password for the private key, respectively.
 
@@ -363,9 +363,9 @@ FROM data_source [data_source_properties]
 
         Example:
 
-        ````text
+        ```text
         "property.kafka_default_offsets" = "OFFSET_BEGINNING"
-        ````
+        ```
 - comment 
 
   Comment for the routine load job.
@@ -400,7 +400,7 @@ This feature is supported since the Apache Doris 1.2.3 version
        "property.client.id" = "xxx",
        "property.kafka_default_offsets" = "OFFSET_BEGINNING"
    );
-   ````
+   ```
 
 2. Create a Kafka routine dynamic multiple tables import task named "test1" for the "example_db". Specify the column delimiter, group.id, and client.id, and automatically consume all partitions, subscribing from the position with data (OFFSET_BEGINNING).
 
@@ -450,7 +450,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 4. Import data from the Kafka cluster through SSL authentication. Also set the client.id parameter. The import task is in non-strict mode and the time zone is Africa/Abidjan
 
@@ -480,7 +480,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "property.ssl.key.password" = "abcdefg",
        "property.client.id" = "my_client_id"
    );
-   ````
+   ```
 
 5. Import data in Json format. By default, the field name in Json is used as the column name mapping. Specify to import three partitions 0, 1, and 2, and the starting offsets are all 0
 
@@ -505,7 +505,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2",
        "kafka_offsets" = "0,0,0"
    );
-   ````
+   ```
 
 6. Import Json data, extract fields through Jsonpaths, and specify the root node of the Json document
 
@@ -533,7 +533,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2",
        "kafka_offsets" = "0,0,0"
    );
-   ````
+   ```
 
 7. Create a Kafka routine import task named test1 for example_tbl of example_db. And use conditional filtering.
 
@@ -560,7 +560,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 8. Import data to Unique with sequence column Key model table
 
@@ -584,7 +584,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 9. Consume from a specified point in time
 
@@ -604,7 +604,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_topic" = "my_topic",
        "kafka_default_offsets" = "2021-05-21 10:00:00"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-SYNC-JOB.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-SYNC-JOB.md
@@ -48,7 +48,7 @@ CREATE SYNC [db.]job_name
  ...
  )
 binlog_desc
-````
+```
 
 1. `job_name`
 
@@ -63,7 +63,7 @@ binlog_desc
    ```sql
    FROM mysql_db.src_tbl INTO des_tbl
    [columns_mapping]
-   ````
+   ```
    
    1. `mysql_db.src_tbl`
    
@@ -81,7 +81,7 @@ binlog_desc
    
       Example:
    
-      ````
+      ```
       Suppose the target table column is (k1, k2, v1),
       
       Change the order of columns k1 and k2
@@ -89,7 +89,7 @@ binlog_desc
       
       Ignore the fourth column of the source data
       (k2, k1, v1, dummy_column)
-      ````
+      ```
    
 3. `binlog_desc`
 
@@ -103,7 +103,7 @@ binlog_desc
        "key1" = "value1",
        "key2" = "value2"
    )
-   ````
+   ```
 
    1. The properties corresponding to the Canal data source, prefixed with `canal.`
 
@@ -119,7 +119,7 @@ binlog_desc
 
 1. Simply create a data synchronization job named `job1` for `test_tbl` of `test_db`, connect to the local Canal server, corresponding to the Mysql source table `mysql_db1.tbl1`.
 
-   ````SQL
+   ```SQL
    CREATE SYNC `test_db`.`job1`
    (
    FROM `mysql_db1`.`tbl1` INTO `test_tbl`
@@ -133,11 +133,11 @@ binlog_desc
    "canal.username" = "",
    "canal.password" = ""
    );
-   ````
+   ```
 
 2. Create a data synchronization job named `job1` for multiple tables of `test_db`, corresponding to multiple Mysql source tables one-to-one, and explicitly specify the column mapping.
 
-   ````SQL
+   ```SQL
    CREATE SYNC `test_db`.`job1`
    (
    FROM `mysql_db`.`t1` INTO `test1` (k1, k2, v1) ,
@@ -152,7 +152,7 @@ binlog_desc
    "canal.username" = "username",
    "canal.password" = "password"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/MULTI-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/MULTI-LOAD.md
@@ -34,7 +34,7 @@ MULTI LOAD
 
 Users submit multiple import jobs through the HTTP protocol. Multi Load can ensure the atomic effect of multiple import jobs
 
-````
+```
 Syntax:
     curl --location-trusted -u user:passwd -XPOST http://host:port/api/{db}/_multi_start?label=xxx
     curl --location-trusted -u user:passwd -T data.file http://host:port/api/{db}/{table1}/_load?label=xxx\&sub_label=yyy
@@ -91,11 +91,11 @@ NOTE:
 
     3. Supports the use of curl to import data into Doris in a way similar to streaming, but only after the streaming ends Doris
     The real import behavior will occur, and the amount of data in this way cannot be too large.
-````
+```
 
 ### Example
 
-````
+```
 1. Import the data in the local file 'testData1' into the table 'testTbl1' in the database 'testDb', and
 Import the data of 'testData2' into table 'testTbl2' in 'testDb' (user is in defalut_cluster)
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_start?label=123
@@ -112,7 +112,7 @@ Import the data of 'testData2' into table 'testTbl2' in 'testDb' (user is in def
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_start?label=123
     curl --location-trusted -u root -T testData1 http://host:port/api/testDb/testTbl1/_load?label=123\&sub_label=1
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_desc?label=123
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ Used to pause a Routine Load job. A suspended job can be rerun with the RESUME c
 
 ```sql
 PAUSE [ALL] ROUTINE LOAD FOR job_name
-````
+```
 
 ### Example
 
@@ -44,13 +44,13 @@ PAUSE [ALL] ROUTINE LOAD FOR job_name
 
     ```sql
     PAUSE ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 2. Pause all routine import jobs.
 
     ```sql
     PAUSE ALL ROUTINE LOAD;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-SYNC-JOB.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 PAUSE SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ PAUSE SYNC JOB [db.]job_name
 
     ```sql
     PAUSE SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ Used to restart a suspended Routine Load job. The restarted job will continue to
 
 ```sql
 RESUME [ALL] ROUTINE LOAD FOR job_name
-````
+```
 
 ### Example
 
@@ -44,13 +44,13 @@ RESUME [ALL] ROUTINE LOAD FOR job_name
 
     ```sql
     RESUME ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 2. Restart all routine import jobs.
 
     ```sql
     RESUME ALL ROUTINE LOAD;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-SYNC-JOB.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 RESUME SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ RESUME SYNC JOB [db.]job_name
 
     ```sql
     RESUME SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ User stops a Routine Load job. A stopped job cannot be rerun.
 
 ```sql
 STOP ROUTINE LOAD FOR job_name;
-````
+```
 
 ### Example
 
@@ -44,7 +44,7 @@ STOP ROUTINE LOAD FOR job_name;
 
     ```sql
     STOP ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-SYNC-JOB.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 STOP SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ STOP SYNC JOB [db.]job_name
 
     ```sql
     STOP SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STREAM-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STREAM-LOAD.md
@@ -34,9 +34,9 @@ STREAM LOAD
 
 stream-load: load data to table in streaming
 
-````
+```
 curl --location-trusted -u user:passwd [-H ""...] -T data.file -XPUT http://fe_host:http_port/api/{db}/{table}/_stream_load
-````
+```
 
 This statement is used to import data into the specified table. The difference from ordinary Load is that this import method is synchronous import.
 
@@ -117,12 +117,12 @@ This feature is supported since the Apache Doris 1.2.3 version
 
 14. strip_outer_array: Boolean type, true indicates that the json data starts with an array object and flattens the array object, the default value is false. E.g:
 
-     ````
+     ```
       [
        {"k1" : 1, "v1" : 2},
        {"k1" : 3, "v1" : 4}
       ]
-    ````
+    ```
     When strip_outer_array is true, the final import into doris will generate two rows of data.
 
 
@@ -172,56 +172,56 @@ This feature is supported since the Apache Doris 1.2.3 version
 
 1. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', and use Label for deduplication. Specify a timeout of 100 seconds
 
-   ````
+   ```
        curl --location-trusted -u root -H "label:123" -H "timeout:100" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 2. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', use Label for deduplication, and only import data whose k1 is equal to 20180601
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "where: k1=20180601" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 3. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', allowing a 20% error rate (the user is in the defalut_cluster)
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 4. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', allow a 20% error rate, and specify the column name of the file (the user is in the defalut_cluster)
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -H "columns: k2, k1, v1" -T testData http://host:port/api/testDb/testTbl /_stream_load
-   ````
+   ```
 
 5. Import the data in the local file 'testData' into the p1, p2 partitions of the table 'testTbl' in the database 'testDb', allowing a 20% error rate.
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -H "partitions: p1, p2" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 6. Import using streaming (user is in defalut_cluster)
 
-    ````
+    ```
     seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/ _stream_load
-    ````
+    ```
 
 7. Import a table containing HLL columns, which can be columns in the table or columns in the data to generate HLL columns, or use hll_empty to supplement columns that are not in the data
 
-   ````
+   ```
    curl --location-trusted -u root -H "columns: k1, k2, v1=hll_hash(k1), v2=hll_empty()" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 8. Import data for strict mode filtering and set the time zone to Africa/Abidjan
 
-   ````
+   ```
    curl --location-trusted -u root -H "strict_mode: true" -H "timezone: Africa/Abidjan" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 9. Import a table with a BITMAP column, which can be a column in the table or a column in the data to generate a BITMAP column, or use bitmap_empty to fill an empty Bitmap
-   ````
+   ```
     curl --location-trusted -u root -H "columns: k1, k2, v1=to_bitmap(k1), v2=bitmap_empty()" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 10. Simple mode, import json data
     Table Structure:
@@ -232,39 +232,39 @@ This feature is supported since the Apache Doris 1.2.3 version
     `price` double NULL COMMENT ""
     ```
     json data format:
-    ````
+    ```
     {"category":"C++","author":"avc","title":"C++ primer","price":895}
-    ````
+    ```
     
     Import command:
     
-    ````
+    ```
     curl --location-trusted -u root -H "label:123" -H "format: json" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
     In order to improve throughput, it supports importing multiple pieces of json data at one time, each line is a json object, and \n is used as a newline by default. You need to set read_json_by_line to true. The json data format is as follows:
 
-    ````
+    ```
     {"category":"C++","author":"avc","title":"C++ primer","price":89.5}
     {"category":"Java","author":"avc","title":"Effective Java","price":95}
     {"category":"Linux","author":"avc","title":"Linux kernel","price":195}
-    ````
+    ```
     
 11. Match pattern, import json data
     json data format:
 
-    ````
+    ```
     [
     {"category":"xuxb111","author":"1avc","title":"SayingsoftheCentury","price":895},{"category":"xuxb222","author":"2avc"," title":"SayingsoftheCentury","price":895},
     {"category":"xuxb333","author":"3avc","title":"SayingsoftheCentury","price":895}
     ]
-    ````
+    ```
 
     Precise import by specifying jsonpath, such as importing only three attributes of category, author, and price
 
-    ````
+    ```
     curl --location-trusted -u root -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\" $.price\",\"$.author\"]" -H "strip_outer_array: true" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
 
     illustrate:
         1) If the json data starts with an array, and each object in the array is a record, you need to set strip_outer_array to true, which means flatten the array.
@@ -273,7 +273,7 @@ This feature is supported since the Apache Doris 1.2.3 version
 12. User specified json root node
     json data format:
 
-    ````
+    ```
     {
      "RECORDS":[
     {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
@@ -281,31 +281,31 @@ This feature is supported since the Apache Doris 1.2.3 version
     {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
     ]
     }
-    ````
+    ```
 
     Precise import by specifying jsonpath, such as importing only three attributes of category, author, and price
     
-    ````
+    ```
     curl --location-trusted -u root -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\" $.price\",\"$.author\"]" -H "strip_outer_array: true" -H "json_root: $.RECORDS" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
 13. Delete the data with the same import key as this batch
 
-    ````
+    ```
     curl --location-trusted -u root -H "merge_type: DELETE" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
 
 14. Delete the columns in this batch of data that match the data whose flag is listed as true, and append other rows normally
     
-    ````
+    ```
     curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv, flag" -H "merge_type: MERGE" -H "delete: flag=1" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
 15. Import data into UNIQUE_KEYS table with sequence column
     
-    ````
+    ```
     curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/ _stream_load
-    ````
+    ```
 
 16. csv file line header filter import
 
@@ -353,7 +353,7 @@ This feature is supported since the Apache Doris 1.2.3 version
 
    Stream Load is a synchronous import process. The successful execution of the statement means that the data is imported successfully. The imported execution result will be returned synchronously through the HTTP return value. And display it in Json format. An example is as follows:
 
-   ````json
+   ```json
    {
        "TxnId": 17,
        "Label": "707717c0-271a-44c5-be0b-4e71bfeacaa5",
@@ -371,7 +371,7 @@ This feature is supported since the Apache Doris 1.2.3 version
        "WriteDataTimeMs": 3,
        "CommitAndPublishTimeMs": 18
    }
-   ````
+   ```
 
    The following main explanations are given for the Stream load import result parameters:
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/CANCEL-EXPORT.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/CANCEL-EXPORT.md
@@ -52,7 +52,7 @@ WHERE [LABEL = "export_label" | LABEL like "label_pattern" | STATE = "PENDING/IN
     CANCEL EXPORT
     FROM example_db
     WHERE LABEL = "example_db_test_export_label" and STATE = "EXPORTING";
-    ````
+    ```
 
 2. Cancel all export jobs containing example* on the database example*db.
 
@@ -60,7 +60,7 @@ WHERE [LABEL = "export_label" | LABEL like "label_pattern" | STATE = "PENDING/IN
     CANCEL EXPORT
     FROM example_db
     WHERE LABEL like "%example%";
-    ````
+    ```
 
 3. Cancel all export jobs which state are "PENDING"
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/DELETE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/DELETE.md
@@ -91,21 +91,21 @@ This feature is supported since the Apache Doris 1.2 version
    ```sql
    DELETE FROM my_table PARTITION p1
        WHERE k1 = 3;
-   ````
+   ```
 
 2. Delete the data rows where the value of column k1 is greater than or equal to 3 and the value of column k2 is "abc" in my_table partition p1
 
    ```sql
    DELETE FROM my_table PARTITION p1
    WHERE k1 >= 3 AND k2 = "abc";
-   ````
+   ```
 
 3. Delete the data rows where the value of column k1 is greater than or equal to 3 and the value of column k2 is "abc" in my_table partition p1, p2
 
    ```sql
    DELETE FROM my_table PARTITIONS (p1, p2)
    WHERE k1 >= 3 AND k2 = "abc";
-   ````
+   ```
 
 4. use the result of `t2` join `t3` to romve rows from `t1`,delete table only support unique key model
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/EXPORT.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/EXPORT.md
@@ -72,7 +72,7 @@ The bottom layer of the `Export` statement actually executes the `select...outfi
 
   ```sql
   [PROPERTIES ("key"="value", ...)]
-  ````
+  ```
 
   The following parameters can be specified:
 
@@ -116,7 +116,7 @@ The bottom layer of the `Export` statement actually executes the `select...outfi
         hadoop.security.authentication: specify the authentication method as kerberos
         kerberos_principal: specifies the principal of kerberos
         kerberos_keytab: specifies the path to the keytab file of kerberos. The file must be the absolute path to the file on the server where the broker process is located. and can be accessed by the Broker process
-  ````
+  ```
 
 - `WITH HDFS`
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/INSERT.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/INSERT.md
@@ -41,7 +41,7 @@ INSERT INTO table_name
     [ (column [, ...]) ]
     [ [ hint [, ...] ] ]
     { VALUES ( { expression | DEFAULT } [, ...] ) [, ...] | query }
-````
+```
 
  Parameters
 
@@ -83,7 +83,7 @@ INSERT INTO test VALUES (1, 2);
 INSERT INTO test (c1, c2) VALUES (1, 2);
 INSERT INTO test (c1, c2) VALUES (1, DEFAULT);
 INSERT INTO test (c1) VALUES (1);
-````
+```
 
 The first and second statements have the same effect. When no target column is specified, the column order in the table is used as the default target column.
 The third and fourth statements express the same meaning, use the default value of the `c2` column to complete the data import.
@@ -95,7 +95,7 @@ INSERT INTO test VALUES (1, 2), (3, 2 + 2);
 INSERT INTO test (c1, c2) VALUES (1, 2), (3, 2 * 2);
 INSERT INTO test (c1) VALUES (1), (3);
 INSERT INTO test (c1, c2) VALUES (1, DEFAULT), (3, DEFAULT);
-````
+```
 
 The first and second statements have the same effect, import two pieces of data into the `test` table at one time
 The effect of the third and fourth statements is known, and the default value of the `c2` column is used to import two pieces of data into the `test` table
@@ -105,14 +105,14 @@ The effect of the third and fourth statements is known, and the default value of
 ```sql
 INSERT INTO test SELECT * FROM test2;
 INSERT INTO test (c1, c2) SELECT * from test2;
-````
+```
 
 4. Import a query result into the `test` table, specifying the partition and label
 
 ```sql
 INSERT INTO test PARTITION(p1, p2) WITH LABEL `label1` SELECT * FROM test2;
 INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
-````
+```
 
 
 ### Keywords
@@ -158,17 +158,17 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
          mysql> insert into tbl1 select * from tbl2;
          Query OK, 2 rows affected, 2 warnings (0.31 sec)
          {'label':'insert_f0747f0e-7a35-46e2-affa-13a235f4020d', 'status':'committed', 'txnId':'4005'}
-         ````
+         ```
 
          `Query OK` indicates successful execution. `4 rows affected` means that a total of 4 rows of data were imported. `2 warnings` indicates the number of lines to be filtered.
 
          Also returns a json string:
 
-         ````json
+         ```json
          {'label':'my_label1', 'status':'visible', 'txnId':'4005'}
          {'label':'insert_f0747f0e-7a35-46e2-affa-13a235f4020d', 'status':'committed', 'txnId':'4005'}
          {'label':'my_label1', 'status':'visible', 'txnId':'4005', 'err':'some other error'}
-         ````
+         ```
 
          `label` is a user-specified label or an automatically generated label. Label is the ID of this Insert Into import job. Each import job has a unique Label within a single database.
 
@@ -182,7 +182,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
          ```sql
          show load where label="xxx";
-         ````
+         ```
 
          The URL in the returned result can be used to query the wrong data. For details, see the summary of **Viewing Error Lines** later.
 
@@ -192,7 +192,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
          ```sql
          show transaction where id=4005;
-         ````
+         ```
 
          If the `TransactionStatus` column in the returned result is `visible`, the representation data is visible.
 
@@ -209,7 +209,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
       ```sql
       show load warnings on "url";
-      ````
+      ```
 
       You can view the specific error line.
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/SELECT.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/SELECT.md
@@ -326,7 +326,7 @@ Recursive CTE is currently not supported.
      
      SELECT college, region, seed FROM tournament
        ORDER BY 2, 3;
-     ````
+     ```
 
    - If ORDER BY appears in a subquery and also applies to the outer query, the outermost ORDER BY takes precedence.
 
@@ -334,7 +334,7 @@ Recursive CTE is currently not supported.
 
      ```sql
      SELECT a, COUNT(b) FROM test_table GROUP BY a ORDER BY NULL;
-     ````
+     ```
 
      
 
@@ -348,7 +348,7 @@ Recursive CTE is currently not supported.
 
      ```sql
      SELECT COUNT(col1) AS col2 FROM t GROUP BY col2 HAVING col2 = 2;
-     ````
+     ```
 
    - Remember not to use HAVING where WHERE should be used. HAVING is paired with GROUP BY.
 
@@ -357,7 +357,7 @@ Recursive CTE is currently not supported.
      ```sql
      SELECT user, MAX(salary) FROM users
        GROUP BY user HAVING MAX(salary) > 10;
-     ````
+     ```
 
    - The LIMIT clause can be used to constrain the number of rows returned by a SELECT statement. LIMIT can have one or two arguments, both of which must be non-negative integers.
 
@@ -367,7 +367,7 @@ Recursive CTE is currently not supported.
      /*Then if you want to retrieve all rows after a certain offset is set, you can set a very large constant for the second parameter. The following query fetches all data from row 96 onwards */
      SELECT * FROM tbl LIMIT 95,18446744073709551615;
      /*If LIMIT has only one parameter, the parameter specifies the number of rows that should be retrieved, and the offset defaults to 0, that is, starting from the first row*/
-     ````
+     ```
 
    - SELECT...INTO allows query results to be written to a file
 
@@ -408,7 +408,7 @@ Recursive CTE is currently not supported.
        | 21 |
        +-------------+
        4 rows in set (0.01 sec)
-       ````
+       ```
    
 6. JOIN
    

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/OUTFILE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Data-Manipulation-Statements/OUTFILE.md
@@ -198,7 +198,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "line_delimiter" = "\n",
        "max_file_size" = "100MB"
    );
-   ````
+   ```
 
    If the final generated file is not larger than 100MB, it will be: `result_0.csv`.
    If larger than 100MB, it may be `result_0.csv, result_1.csv, ...`.
@@ -216,7 +216,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.kerberos_principal" = "doris@YOUR.COM",
        "broker.kerberos_keytab" = "/home/doris/my.keytab"
    );
-   ````
+   ```
 
 3. Export the query result of the CTE statement to the file `hdfs://path/to/result.txt`. The default export format is CSV. Use `my_broker` and set hdfs high availability information. Use the default row and column separators.
 
@@ -239,7 +239,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.dfs.namenode.rpc-address.my_ha.my_namenode2" = "nn2_host:rpc_port",
        "broker.dfs.client.failover.proxy.provider.my_ha" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
    );
-   ````
+   ```
 
    If the final generated file is not larger than 1GB, it will be: `result_0.csv`.
    If larger than 1GB, it may be `result_0.csv, result_1.csv, ...`.
@@ -258,7 +258,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.bos_accesskey" = "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
        "broker.bos_secret_accesskey" = "yyyyyyyyyyyyyyyyyyyyyyyyy"
    );
-   ````
+   ```
 
 5. Export the query result of the select statement to the file `s3a://${bucket_name}/path/result.txt`. Specify the export format as csv.
    After the export is complete, an identity file is generated.
@@ -278,7 +278,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "max_file_size" = "1024MB",
        "success_file_name" = "SUCCESS"
    )
-   ````
+   ```
 
    If the final generated file is not larger than 1GB, it will be: `my_file_0.csv`.
    If larger than 1GB, it may be `my_file_0.csv, result_1.csv, ...`.
@@ -301,7 +301,7 @@ Parquet and ORC file formats have their own data types. The export function of D
         "s3.secret_key" = "xxx",
         "s3.region" = "bd"
    )
-   ````
+   ```
 
    The resulting file is prefixed with `my_file_{fragment_instance_id}_`.
 
@@ -320,7 +320,7 @@ Parquet and ORC file formats have their own data types. The export function of D
         "s3.secret_key" = "xxx",
         "s3.region" = "bd"
    )
-   ````
+   ```
 
 8. Use hdfs export to export simple query results to the file `hdfs://${host}:${fileSystem_port}/path/to/result.txt`. Specify the export format as CSV and the user name as work. Specify the column separator as `,` and the row separator as `\n`.
 
@@ -377,7 +377,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "max_file_size" = "1024MB",
        "success_file_name" = "SUCCESS"
    )
-   ````
+   ```
 
 ### keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CANCEL-REPAIR.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CANCEL-REPAIR.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN CANCEL REPAIR TABLE table_name[ PARTITION (p1,...)];
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
 
      ```sql
       ADMIN CANCEL REPAIR TABLE tbl PARTITION(p1);
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CLEAN-TRASH.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CLEAN-TRASH.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 ADMIN CLEAN TRASH [ON ("BackendHost1:BackendHeartBeatPort1", "BackendHost2:BackendHeartBeatPort2", ...)];
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-REPAIR-TABLE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-REPAIR-TABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN REPAIR TABLE table_name[ PARTITION (p1,...)]
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-SET-REPLICA-STATUS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-SET-REPLICA-STATUS.md
@@ -41,7 +41,7 @@ grammar:
 ```sql
 ADMIN SET REPLICA STATUS
         PROPERTIES ("key" = "value", ...);
-````
+```
 
  The following properties are currently supported:
 
@@ -63,20 +63,20 @@ If the specified replica does not exist, or the status is already bad, it will b
 
        ```sql
     ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "bad");
-       ````
+       ```
 
  2. Set the replica status of tablet 10003 on BE 10001 to drop.
 
        ```sql
     ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "drop");
-       ````
+       ```
 
 
  3. Set the replica status of tablet 10003 on BE 10001 to ok.
 
    ```sql
    ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "ok");
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/INSTALL-PLUGIN.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/INSTALL-PLUGIN.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 INSTALL PLUGIN FROM [source] [PROPERTIES ("key"="value", ...)]
-````
+```
 
 source supports three types:
 
@@ -52,19 +52,19 @@ source supports three types:
 
     ```sql
     INSTALL PLUGIN FROM "/home/users/doris/auditdemo.zip";
-    ````
+    ```
 
 2. Install the plugin in a local directory:
 
     ```sql
     INSTALL PLUGIN FROM "/home/users/doris/auditdemo/";
-    ````
+    ```
 
 3. Download and install a plugin:
 
     ```sql
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip";
-    ````
+    ```
 
     Note than an md5 file with the same name as the `.zip` file needs to be placed, such as `http://mywebsite.com/plugin.zip.md5` . 
     The content is the MD5 value of the .zip file.
@@ -73,7 +73,7 @@ source supports three types:
 
     ```sql
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip" PROPERTIES("md5sum" = "73877f6029216f4314d712086a146570");
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/KILL.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/KILL.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 KILL [CONNECTION] processlist_id
-````
+```
 
 In addition, you can also use processlist_id or query_id terminates the executing query command
 
@@ -48,7 +48,7 @@ grammar:
 
 ```sql
 KILL QUERY processlist_id | query_id
-````
+```
 
 
 ### Example

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/SET-VARIABLE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/SET-VARIABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SET variable_assignment [, variable_assignment] ...
-````
+```
 
 illustrate:
 
@@ -55,15 +55,15 @@ illustrate:
 
 1. Set the time zone to Dongba District
 
-   ````
+   ```
    SET time_zone = "Asia/Shanghai";
-   ````
+   ```
 
 2. Set the global execution memory size
 
-   ````
+   ```
    SET GLOBAL exec_mem_limit = 137438953472
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/SHOW-CONFIG.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/SHOW-CONFIG.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW FRONTEND CONFIG [LIKE "pattern"];
-````
+```
 
 The columns in the results have the following meanings:
 
@@ -59,7 +59,7 @@ The columns in the results have the following meanings:
 
 2. Use the like predicate to search the configuration of the current Fe node
 
-   ````
+   ```
    mysql> SHOW FRONTEND CONFIG LIKE '%check_java_version%';
    +--------------------+-------+---------+---------- -+------------+---------+
    | Key | Value | Type | IsMutable | MasterOnly | Comment |
@@ -67,7 +67,7 @@ The columns in the results have the following meanings:
    | check_java_version | true | boolean | false | false | |
    +--------------------+-------+---------+---------- -+------------+---------+
    1 row in set (0.01 sec)
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-DISTRIBUTION.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-DISTRIBUTION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW REPLICA DISTRIBUTION FROM [db_name.]tbl_name [PARTITION (p1, ...)];
-````
+```
 
 illustrate:
 
@@ -50,13 +50,13 @@ illustrate:
 
     ```sql
     SHOW REPLICA DISTRIBUTION FROM tbl1;
-    ````
+    ```
 
   2. View the replica distribution of the partitions of the table
 
       ```sql
      SHOW REPLICA DISTRIBUTION FROM db1.tbl1 PARTITION(p1, p2);
-      ````
+      ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-STATUS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-STATUS.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW REPLICA STATUS FROM [db_name.]tbl_name [PARTITION (p1, ...)]
 [where_clause];
-````
+```
 
 illustrate
 
@@ -59,21 +59,21 @@ illustrate
 
    ```sql
    SHOW REPLICA STATUS FROM db1.tbl1;
-   ````
+   ```
 
 2. View a copy of a table with a partition status of VERSION_ERROR
 
    ```sql
    SHOW REPLICA STATUS FROM tbl1 PARTITION (p1, p2)
    WHERE STATUS = "VERSION_ERROR";
-   ````
+   ```
 
 3. View all unhealthy replicas of the table
 
    ```sql
    SHOW REPLICA STATUS FROM tbl1
    WHERE STATUS != "OK";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/UNINSTALL-PLUGIN.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/UNINSTALL-PLUGIN.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 UNINSTALL PLUGIN plugin_name;
-````
+```
 
   plugin_name can be viewed with the `SHOW PLUGINS;` command.
 
@@ -50,7 +50,7 @@ Only non-builtin plugins can be uninstalled.
 
     ```sql
     UNINSTALL PLUGIN auditdemo;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/UNSET-VARIABLE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Database-Administration-Statements/UNSET-VARIABLE.md
@@ -42,7 +42,7 @@ grammar:
 
 ```sql
 UNSET [SESSION|GLOBAL] VARIABLE (variable_name | ALL)
-````
+```
 
 illustrate:
 
@@ -57,15 +57,15 @@ illustrate:
 
 1. Restore value of the time zone
 
-   ````
+   ```
    UNSET VARIABLE time_zone;
-   ````
+   ```
 
 2. Restore the global execution memory size
 
-   ````
+   ```
    UNSET GLOBAL VARIABLE exec_mem_limit;
-   ````
+   ```
 3. Restore all variables globally
 
    ```

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ALTER-TABLE-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ALTER-TABLE-MATERIALIZED-VIEW.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database: View jobs under the specified database. If not specified, the current database is used.
 - WHERE: You can filter the result column, currently only the following columns are supported:
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`: Job unique ID.
 
@@ -110,7 +110,7 @@ RollupIndexName: r1
 
    ```sql
    SHOW ALTER TABLE MATERIALIZED VIEW FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ALTER.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ALTER.md
@@ -36,7 +36,7 @@ This statement is used to display the execution of various modification tasks cu
 
 ```sql
 SHOW ALTER [CLUSTER | TABLE [COLUMN | ROLLUP] [FROM db_name]];
-````
+```
 
 TABLE COLUMN: show ALTER tasks that modify columns
                       Support syntax [WHERE TableName|CreateTime|FinishTime|State] [ORDER BY] [LIMIT]
@@ -50,25 +50,25 @@ TABLE COLUMN: show ALTER tasks that modify columns
 
    ```sql
     SHOW ALTER TABLE COLUMN;
-   ````
+   ```
 
 2. Display the task execution status of the last modified column of a table
 
    ```sql
    SHOW ALTER TABLE COLUMN WHERE TableName = "table1" ORDER BY CreateTime DESC LIMIT 1;
-   ````
+   ```
 
 3. Display the task execution of creating or deleting ROLLUP index for the specified db
 
    ```sql
    SHOW ALTER TABLE ROLLUP FROM example_db;
-   ````
+   ```
 
 4. Show tasks related to cluster operations (only for administrators! To be implemented...)
 
-   ````
+   ```
    SHOW ALTER CLUSTER;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-BACKENDS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-BACKENDS.md
@@ -36,7 +36,7 @@ This statement is used to view the BE nodes in the cluster
 
 ```sql
  SHOW BACKENDS;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-BACKUP.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-BACKUP.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
  SHOW BACKUP [FROM db_name]
     [WHERE SnapshotName ( LIKE | = ) 'snapshot name']
-````
+```
 
 illustrate:
 
@@ -72,7 +72,7 @@ illustrate:
 
    ```sql
     SHOW BACKUP FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-BROKER.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-BROKER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW BROKER;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-COLUMNS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-COLUMNS.md
@@ -46,7 +46,7 @@ SHOW [FULL] COLUMNS FROM tbl;
 
     ```sql
      SHOW FULL COLUMNS FROM tbl;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
@@ -46,7 +46,7 @@ SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS [FROM db]
 
     ```sql
      SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS FROM test;
-    ````
+    ```
 
 2. View the converting process globally
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-DATABASE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-DATABASE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE DATABASE db_name;
-````
+```
 
 illustrate:
 
@@ -57,7 +57,7 @@ illustrate:
     | test | CREATE DATABASE `test` |
     +----------+----------------------------+
     1 row in set (0.00 sec)
-    ````
+    ```
 
 2. view a database named `hdfs_text` from a hms catalog
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-FUNCTION.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-FUNCTION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE [GLOBAL] FUNCTION function_name(arg_type [, ...]) [FROM db_name]];
-````
+```
 
 illustrate:
 1. `global`: The show function is global 
@@ -54,12 +54,12 @@ illustrate:
 
     ```sql
     SHOW CREATE FUNCTION my_add(INT, INT)
-    ````
+    ```
 2. Show the creation statement of the specified global function
 
     ```sql
     SHOW CREATE GLOBAL FUNCTION my_add(INT, INT)
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-LOAD.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE LOAD for load_name;
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
 
     ```sql
     SHOW CREATE LOAD for test_load
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-REPOSITORY.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-REPOSITORY.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE REPOSITORY for repository_name;
-````
+```
 
 illustrate:
 -  `repository_name`: repository name
@@ -49,7 +49,7 @@ illustrate:
 
     ```sql
     SHOW CREATE REPOSITORY for test_repository
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-ROUTINE-LOAD.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW [ALL] CREATE ROUTINE LOAD for load_name;
-````
+```
 
 illustrate:
 
@@ -53,7 +53,7 @@ illustrate:
 
     ```sql
     SHOW CREATE ROUTINE LOAD for test_load
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-TABLE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-TABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [BRIEF] CREATE TABLE [DBNAME.]TABLE_NAME
-````
+```
 
 illustrate:
 
@@ -57,7 +57,7 @@ illustrate:
 
     ```sql
     SHOW CREATE TABLE demo.tb1
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DATA.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DATA.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATA [FROM [db_name.]table_name] [ORDER BY ...];
-````
+```
 
 illustrate:
 
@@ -82,9 +82,9 @@ illustrate:
    ```sql
    USE db1;
    SHOW DATA;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-------------+--------------+
    | TableName | Size        | ReplicaCount |
    +-----------+-------------+--------------+
@@ -94,15 +94,15 @@ illustrate:
    | Quota     | 1024.000 GB | 1073741824   |
    | Left      | 1021.921 GB | 1073741815   |
    +-----------+-------------+--------------+
-   ````
+   ```
 
 3. Display the subdivided data volume, the number of replicas and the number of statistical rows of the specified table under the specified db
 
    ```sql
    SHOW DATA FROM example_db.test;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-----------+-----------+--------------+----------+
    | TableName | IndexName | Size      | ReplicaCount | RowCount |
    +-----------+-----------+-----------+--------------+----------+
@@ -111,15 +111,15 @@ illustrate:
    |           | test2     | 50.000MB  | 30           | 50000    |
    |           | Total     | 80.000    | 90           |          |
    +-----------+-----------+-----------+--------------+----------+
-   ````
+   ```
 
 4. It can be combined and sorted according to the amount of data, the number of copies, the number of statistical rows, etc.
 
    ```sql
    SHOW DATA ORDER BY ReplicaCount desc,Size asc;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-------------+--------------+
    | TableName | Size        | ReplicaCount |
    +-----------+-------------+--------------+
@@ -131,7 +131,7 @@ illustrate:
    | Quota     | 1024.000 GB | 1073741824   |
    | Left      | 1024.000 GB | 1073741734   |
    +-----------+-------------+--------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DATABASE-ID.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DATABASE-ID.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATABASE [database_id]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DATABASE [database_id]
 
     ```sql
     SHOW DATABASE 1001;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATABASES [FROM catalog] [filter expr];
-````
+```
 
 illustrate:
 1. `SHOW DATABASES` will get all database names from current catalog.
@@ -51,45 +51,45 @@ illustrate:
 
    ```sql
    SHOW DATABASES;
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | test               |
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 2. Display all database names from the catalog named 'hms_catalog'.
 
    ```sql
    SHOW DATABASES from hms_catalog;
-   ````
+   ```
 
-   ````
+   ```
   +---------------+
   | Database      |
   +---------------+
   | default       |
   | tpch          |
   +---------------+
-   ````
+   ```
 
 3. Display the filtered database names from current catalog with the expr 'like'.
 
    ```sql
    SHOW DATABASES like 'infor%';
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DELETE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DELETE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DELETE [FROM db_name]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DELETE [FROM db_name]
 
       ```sql
       SHOW DELETE FROM database;
-      ````
+      ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DYNAMIC-PARTITION.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-DYNAMIC-PARTITION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DYNAMIC PARTITION TABLES [FROM db_name];
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DYNAMIC PARTITION TABLES [FROM db_name];
 
      ```sql
      SHOW DYNAMIC PARTITION TABLES FROM database;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ENCRYPT-KEY.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ENCRYPT-KEY.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW ENCRYPTKEYS [IN|FROM db] [LIKE 'key_pattern']
-````
+```
 
 parameter
 
@@ -65,7 +65,7 @@ parameter
     | example_db.my_key | ABCD123456789     |
     +-------------------+-------------------+
     1 row in set (0.00 sec)
- ````
+ ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-EXPORT.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-EXPORT.md
@@ -47,7 +47,7 @@ SHOW EXPORT
    ]
 [ORDER BY...]
 [LIMIT limit];
-````
+```
 
 illustrate:
       1. If db_name is not specified, the current default db is used
@@ -61,31 +61,31 @@ illustrate:
 
    ```sql
    SHOW EXPORT;
-   ````
+   ```
 
 2. Display the export tasks of the specified db, sorted by StartTime in descending order
 
    ```sql
     SHOW EXPORT FROM example_db ORDER BY StartTime DESC;
-   ````
+   ```
 
 3. Display the export tasks of the specified db, the state is "exporting", and sort by StartTime in descending order
 
    ```sql
    SHOW EXPORT FROM example_db WHERE STATE = "exporting" ORDER BY StartTime DESC;
-   ````
+   ```
 
 4. Display the export task of the specified db and specified job_id
 
    ```sql
      SHOW EXPORT FROM example_db WHERE ID = job_id;
-   ````
+   ```
 
 5. Display the specified db and specify the export task of the label
 
    ```sql
     SHOW EXPORT FROM example_db WHERE LABEL = "mylabel";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-FILE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-FILE.md
@@ -38,18 +38,18 @@ grammar:
 
 ```sql
 SHOW FILE [FROM database];
-````
+```
 
 illustrate:
 
-````text
+```text
 FileId: file ID, globally unique
 DbName: the name of the database to which it belongs
 Catalog: Custom Category
 FileName: file name
 FileSize: file size, in bytes
 MD5: MD5 of the file
-````
+```
 
 ### Example
 
@@ -57,7 +57,7 @@ MD5: MD5 of the file
 
      ```sql
      SHOW FILE FROM my_database;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS-DISKS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS-DISKS.md
@@ -38,7 +38,7 @@ This statement is used to view FE nodes's important paths' disk information, suc
 
 ```sql
 SHOW FRONTENDS DISKS;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS.md
@@ -38,7 +38,7 @@ This statement is used to view FE nodes
 
 ```sql
 SHOW FRONTENDS;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-FUNCTIONS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-FUNCTIONS.md
@@ -40,7 +40,7 @@ grammar
 
 ```sql
 SHOW [FULL] [BUILTIN] FUNCTIONS [IN|FROM db] [LIKE 'function_pattern']
-````
+```
 
 Parameters
 
@@ -53,7 +53,7 @@ grammar
 
 ```sql
 SHOW GLOBAL [FULL] FUNCTIONS [LIKE 'function_pattern']
-````
+```
 
 Parameters
 
@@ -65,7 +65,7 @@ Parameters
 
 ### Example
 
-````sql
+```sql
 mysql> show full functions in testDb\G
 **************************** 1. row ******************** ******
         Signature: my_add(INT,INT)
@@ -122,7 +122,7 @@ mysql> show global functions ;
 +---------------+
 2 rows in set (0.00 sec)    
     
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-GRANTS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-GRANTS.md
@@ -52,19 +52,19 @@ illustrate:
 
     ```sql
     SHOW ALL GRANTS;
-    ````
+    ```
 
 2. View the permissions of the specified user
 
     ```sql
     SHOW GRANTS FOR jack@'%';
-    ````
+    ```
 
 3. View the permissions of the current user
 
     ```sql
     SHOW GRANTS;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-INDEX.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-INDEX.md
@@ -36,19 +36,19 @@ SHOW INDEX
 
 grammar:
 
-````SQL
+```SQL
 SHOW INDEX[ES] FROM [db_name.]table_name [FROM database];
 or
 SHOW KEY[S] FROM [db_name.]table_name [FROM database];
-````
+```
 
 ### Example
 
   1. Display the lower index of the specified table_name
 
-     ````SQL
+     ```SQL
       SHOW INDEX FROM example_db.table_name;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-LAST-INSERT.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-LAST-INSERT.md
@@ -39,11 +39,11 @@ grammar:
 
 ```sql
 SHOW LAST INSERT
-````
+```
 
 Example of returned result:
 
-````
+```
      TransactionId: 64067
              Label: insert_ba8f33aea9544866-8ed77e2844d0cc9b
           Database: default_cluster:db1
@@ -51,7 +51,7 @@ Example of returned result:
 TransactionStatus: VISIBLE
         LoadedRows: 2
       FilteredRows: 0
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-PROFILE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-PROFILE.md
@@ -60,7 +60,7 @@ show load profile "/[queryId]/[TaskId]"
 show load profile "/[queryId]/[TaskId]/[FragmentId]/"
 
 show load profile "/[queryId]/[TaskId]/[FragmentId]/[InstanceId]"
-````
+```
 
 This command will list all currently saved import profiles. Each line corresponds to one import. where the QueryId column is the ID of the import job. This ID can also be viewed through the SHOW LOAD statement. We can select the QueryId corresponding to the Profile we want to see to see the specific situation
 
@@ -117,7 +117,7 @@ WaitAndFetchResultTime: N/A
    +-----------------------------------+------------+
    | 980014623046410a-af5d36f23381017f | 3m14s      |
    +-----------------------------------+------------+
-   ````
+   ```
    
 3. View the plan tree of the specified subtask
 
@@ -177,7 +177,7 @@ WaitAndFetchResultTime: N/A
    | 980014623046410a-88e260f0c43031f4 | 10.81.85.89:9067 | 3m10s      |
    | 980014623046410a-88e260f0c43031f5 | 10.81.85.89:9067 | 3m14s      |
    +-----------------------------------+------------------+------------+
-   ````
+   ```
 
 4. Continue to view the detailed Profile of each operator on a specific Instance
 
@@ -225,7 +225,7 @@ WaitAndFetchResultTime: N/A
    │      - TotalReadThroughput: 30.39858627319336 MB/sec│
    │      - WaitScannerTime: 56s528ms                    │
    └-----------------------------------------------------┘
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-WARNINGS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-WARNINGS.md
@@ -44,7 +44,7 @@ SHOW LOAD WARNINGS
     [LABEL[="your_label"]]
     [LOAD_JOB_ID = ["job id"]]
 ]
-````
+```
 
 1) If db_name is not specified, the current default db is used
 1) If LABEL = is used, it matches the specified label exactly
@@ -56,7 +56,7 @@ SHOW LOAD WARNINGS
 
     ```sql
     SHOW LOAD WARNINGS FROM demo WHERE LABEL = "load_demo_20210112"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-LOAD.md
@@ -46,7 +46,7 @@ SHOW LOAD
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -68,7 +68,7 @@ illustrate:
 
    ```sql
    SHOW LOAD WARNINGS ON 'url'
-   ````
+   ```
 
 ### Example
 
@@ -76,38 +76,38 @@ illustrate:
 
    ```sql
    SHOW LOAD;
-   ````
+   ```
 
 2. Display the import tasks of the specified db, the label contains the string "2014_01_02", and display the oldest 10
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 3. Display the import tasks of the specified db, specify the label as "load_example_db_20140102" and sort by LoadStartTime in descending order
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL = "load_example_db_20140102" ORDER BY LoadStartTime DESC;
-   ````
+   ```
 
 4. Display the import task of the specified db, specify the label as "load_example_db_20140102", the state as "loading", and sort by LoadStartTime in descending order
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL = "load_example_db_20140102" AND STATE = "loading" ORDER BY LoadStartTime DESC;
-   ````
+   ```
 
 5. Display the import tasks of the specified db and sort them in descending order by LoadStartTime, and display 10 query results starting from offset 5
 
    ```sql
    SHOW LOAD FROM example_db ORDER BY LoadStartTime DESC limit 5,10;
    SHOW LOAD FROM example_db ORDER BY LoadStartTime DESC limit 10 offset 5;
-   ````
+   ```
 
 6. Small batch import is a command to check the import status
 
-   ````
+   ```
    curl --location-trusted -u {user}:{passwd} http://{hostname}:{port}/api/{database}/_load_info?label={labelname}
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-PARTITION-ID.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-PARTITION-ID.md
@@ -45,7 +45,7 @@ SHOW PARTITION [partition_id]
 
     ```sql
     SHOW PARTITION 10002;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-PARTITIONS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-PARTITIONS.md
@@ -36,9 +36,9 @@ SHOW PARTITIONS
 
 grammar:
 
-````SQL
+```SQL
   SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT];
-````
+```
 
 illustrate:
 
@@ -56,27 +56,27 @@ Will return all partitions' name. Support multilevel partition table
 
 1. Display all non-temporary partition information of the specified table under the specified db
 
-````SQL
+```SQL
   SHOW PARTITIONS FROM example_db.table_name;
-````
+```
 
 2. Display all temporary partition information of the specified table under the specified db
 
-    ````SQL
+    ```SQL
     SHOW TEMPORARY PARTITIONS FROM example_db.table_name;
-    ````
+    ```
 
 3. Display the information of the specified non-temporary partition of the specified table under the specified db
 
-    ````SQL
+    ```SQL
      SHOW PARTITIONS FROM example_db.table_name WHERE PartitionName = "p1";
-    ````
+    ```
 
 4. Display the latest non-temporary partition information of the specified table under the specified db
 
-    ````SQL
+    ```SQL
     SHOW PARTITIONS FROM example_db.table_name ORDER BY PartitionId DESC LIMIT 1;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-PLUGINS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-PLUGINS.md
@@ -36,9 +36,9 @@ This statement is used to display installed plugins
 
 grammar:
 
-````SQL
+```SQL
 SHOW PLUGINS
-````
+```
 
 This command will display all user-installed and system built-in plugins
 
@@ -46,9 +46,9 @@ This command will display all user-installed and system built-in plugins
 
 1. Show installed plugins:
 
-    ````SQL
+    ```SQL
     SHOW PLUGINS;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-PROC.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-PROC.md
@@ -49,7 +49,7 @@ After connecting to Doris through the MySQL client, you can execute the SHOW PRO
 
 The results of the show proc statement are presented in a two-dimensional table. And usually the first column of the result table is the next subdirectory of proc.
 
-````none
+```none
 mysql> show proc "/";
 +---------------------------+
 | name                      |
@@ -80,7 +80,7 @@ mysql> show proc "/";
 | trash                     |
 +---------------------------+
 23 rows in set (0.00 sec)
-````
+```
 
 illustrate:
 
@@ -124,7 +124,7 @@ illustrate:
    | 10124   | test_parquet_import  | 1        | NULL                | 1            | NORMAL | OLAP | NULL                     | 1            |
    +---------+----------------------+----------+---------------------+--------------+--------+------+--------------------------+--------------+
    4 rows in set (0.00 sec)
-   ````
+   ```
 
 2. Display information about the number of all database tables in the cluster.
 
@@ -137,11 +137,11 @@ illustrate:
    | Total | 1                    | 4        | 12           | 12       | 21        | 21         |
    +-------+----------------------+----------+--------------+----------+-----------+------------+
    2 rows in set (0.00 sec)
-   ````
+   ```
 
 3. The following command can view the existing Group information in the cluster.
 
-   ````
+   ```
    SHOW PROC '/colocation_group';
    
    +-------------+--------------+--------------+------------+----------------+----------+----------+
@@ -149,7 +149,7 @@ illustrate:
    +-------------+--------------+--------------+------------+----------------+----------+----------+
    | 10005.10008 | 10005_group1 | 10007, 10040 | 10         | 3              | int(11)  | true     |
    +-------------+--------------+--------------+------------+----------------+----------+----------+
-   ````
+   ```
 
    - GroupId: The cluster-wide unique identifier of a group, the first half is the db id, and the second half is the group id.
    - GroupName: The full name of the Group.
@@ -176,7 +176,7 @@ illustrate:
    | 6           | 10003, 10004, 10001 |
    | 7           | 10003, 10004, 10002 |
    +-------------+---------------------+
-   ````
+   ```
 
    - BucketIndex: The index of the bucket sequence.
    - BackendIds: The list of BE node IDs where the data shards in the bucket are located.
@@ -216,7 +216,7 @@ illustrate:
    | Total                   | 0         | 0        |
    +-------------------------+-----------+----------+
    26 rows in set (0.01 sec)
-   ````
+   ```
 
 5. Display the replica status of the entire cluster.
    ```sql

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-PROCESSLIST.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-PROCESSLIST.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW [FULL] PROCESSLIST
-````
+```
 
 illustrate:
 
@@ -70,9 +70,9 @@ Other types can refer to [MySQL official website for explanation](https://dev.my
 
 1. View the threads running by the current user
 
-   ````SQL
+   ```SQL
    SHOW PROCESSLIST
-   ````
+   ```
    return
    ```
    MySQL [test]> show full processlist;

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-REPOSITORIES.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-REPOSITORIES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW REPOSITORIES;
-````
+```
 
 illustrate:
 
@@ -57,7 +57,7 @@ illustrate:
 
 ```sql
   SHOW REPOSITORIES;
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-RESOURCES.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-RESOURCES.md
@@ -45,7 +45,7 @@ SHOW RESOURCES
 ] | [LIKE "pattern"]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-RESTORE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-RESTORE.md
@@ -36,9 +36,9 @@ This statement is used to view RESTORE tasks
 
 grammar:
 
-````SQL
+```SQL
 SHOW [BRIEF] RESTORE [FROM DB_NAME]
-````
+```
 
 illustrate:
         1. Only the most recent RESTORE task is saved in Doris.
@@ -80,7 +80,7 @@ illustrate:
 
    ```sql
    SHOW RESTORE FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ROLES.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ROLES.md
@@ -36,17 +36,17 @@ This statement is used to display all created role information, including role n
 
 grammar:
 
-````SQL
+```SQL
 SHOW ROLES
-````
+```
 
 ### Example
 
 1. View created roles
 
-    ````SQL
+    ```SQL
     SHOW ROLES
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
@@ -39,11 +39,11 @@ View the currently running subtasks of a specified Routine Load job.
 ```sql
 SHOW ROUTINE LOAD TASK
 WHERE JobName = "job_name";
-````
+```
 
 The returned results are as follows:
 
-````text
+```text
               TaskId: d67ce537f1be4b86-abf47530b79ab8e6
                TxnId: 4
            TxnStatus: UNKNOWN
@@ -53,7 +53,7 @@ The returned results are as follows:
              Timeout: 20
                 BeId: 10002
 DataSourceProperties: {"0":19}
-````
+```
 
 - `TaskId`: The unique ID of the subtask.
 - `TxnId`: The import transaction ID corresponding to the subtask.
@@ -71,7 +71,7 @@ DataSourceProperties: {"0":19}
 
    ```sql
    SHOW ROUTINE LOAD TASK WHERE JobName = "test1";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD.md
@@ -38,11 +38,11 @@ grammar:
 
 ```sql
 SHOW [ALL] ROUTINE LOAD [FOR jobName];
-````
+```
 
 Result description:
 
-````
+```
                   Id: job ID
                 Name: job name
           CreateTime: job creation time
@@ -63,7 +63,7 @@ DataSourceProperties: Data source configuration details
 ReasonOfStateChanged: The reason for the job state change
         ErrorLogUrls: The viewing address of the filtered unqualified data
             OtherMsg: other error messages
-````
+```
 
 * State
 
@@ -88,39 +88,39 @@ ReasonOfStateChanged: The reason for the job state change
 
    ```sql
    SHOW ALL ROUTINE LOAD FOR test1;
-   ````
+   ```
 
 2. Show the currently running routine import job named test1
 
    ```sql
    SHOW ROUTINE LOAD FOR test1;
-   ````
+   ```
 
 3. Display all routine import jobs (including stopped or canceled jobs) under example_db. The result is one or more lines.
 
    ```sql
    use example_db;
    SHOW ALL ROUTINE LOAD;
-   ````
+   ```
 
 4. Display all running routine import jobs under example_db
 
    ```sql
    use example_db;
    SHOW ROUTINE LOAD;
-   ````
+   ```
 
 5. Display the currently running routine import job named test1 under example_db
 
    ```sql
    SHOW ROUTINE LOAD FOR example_db.test1;
-   ````
+   ```
 
 6. Displays all routine import jobs named test1 under example_db (including stopped or canceled jobs). The result is one or more lines.
 
    ```sql
    SHOW ALL ROUTINE LOAD FOR example_db.test1;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-SMALL-FILES.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-SMALL-FILES.md
@@ -36,7 +36,7 @@ This statement is used to display files created by the CREATE FILE command withi
 
 ```sql
 SHOW FILE [FROM database];
-````
+```
 
 Return result description:
 
@@ -53,7 +53,7 @@ Return result description:
 
     ```sql
     SHOW FILE FROM my_database;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-SNAPSHOT.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-SNAPSHOT.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW SNAPSHOT ON `repo_name`
 [WHERE SNAPSHOT = "snapshot" [AND TIMESTAMP = "backup_timestamp"]];
-````
+```
 
 illustrate:
 
@@ -57,20 +57,20 @@ illustrate:
 
    ```sql
    SHOW SNAPSHOT ON example_repo;
-   ````
+   ```
 
 2. View only the backup named backup1 in the repository example_repo:
 
    ```sql
    SHOW SNAPSHOT ON example_repo WHERE SNAPSHOT = "backup1";
-   ````
+   ```
 
 3. View the details of the backup named backup1 in the warehouse example_repo with the time version "2018-05-05-15-34-26":
 
    ```sql
    SHOW SNAPSHOT ON example_repo
    WHERE SNAPSHOT = "backup1" AND TIMESTAMP = "2018-05-05-15-34-26";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-SQL-BLOCK-RULE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
-````
+```
 
 ### Example
 
@@ -53,7 +53,7 @@ SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
     | test_rule2 | NULL | NULL | 30 | 0 | 10000000000 | false | true |
     +------------+----------------------------+---------+- -------------+------------+-------------+--------+- -------+
     2 rows in set (0.01 sec)
-    ````
+    ```
     
 2. Make a rule name query
 
@@ -66,7 +66,7 @@ SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
     +------------+------+---------+---------------+---- -------+-------------+--------+--------+
     1 row in set (0.00 sec)
     
-    ````
+    ```
     
 
 ### Keywords

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database: View jobs under the specified database. If not specified, the current database is used.
 - WHERE: You can filter the result column, currently only the following columns are supported:
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`: Job unique ID.
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-STREAM-LOAD.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-STREAM-LOAD.md
@@ -46,7 +46,7 @@ SHOW STREAM LOAD
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -65,32 +65,32 @@ illustrate:
 
    ```sql
      SHOW STREAM LOAD;
-   ````
+   ```
 
 2. Display the Stream Load task of the specified db, the label contains the string "2014_01_02", and display the oldest 10
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE LABEL LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 3. Display the Stream Load task of the specified db and specify the label as "load_example_db_20140102"
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE LABEL = "load_example_db_20140102";
-   ````
+   ```
 
 4. Display the Stream Load task of the specified db, specify the status as "success", and sort by StartTime in descending order
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE STATUS = "success" ORDER BY StartTime DESC;
-   ````
+   ```
 
 5. Display the import tasks of the specified db and sort them in descending order of StartTime, and display 10 query results starting from offset 5
 
    ```sql
    SHOW STREAM LOAD FROM example_db ORDER BY StartTime DESC limit 5,10;
    SHOW STREAM LOAD FROM example_db ORDER BY StartTime DESC limit 10 offset 5;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-SYNC-JOB.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-SYNC-JOB.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW SYNC JOB [FROM db_name]
-````
+```
 
 ### Example
 
@@ -48,13 +48,13 @@ SHOW SYNC JOB [FROM db_name]
 
     ```sql
     SHOW SYNC JOB;
-    ````
+    ```
 
 2. Display the status of all data synchronization jobs under the database `test_db`.
 
     ```sql
     SHOW SYNC JOB FROM `test_db`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-ID.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-ID.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TABLE [table_id]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW TABLE [table_id]
 
      ```sql
      SHOW TABLE 10001;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-STATUS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-STATUS.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW TABLE STATUS
 [FROM db] [LIKE "pattern"]
-````
+```
 
 illustrate:
 
@@ -51,13 +51,13 @@ illustrate:
 
      ```sql
      SHOW TABLE STATUS;
-     ````
+     ```
 
   2. View the information of the table whose name contains example under the specified database
 
      ```sql
      SHOW TABLE STATUS FROM db LIKE "%example%";
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLES.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [FULL] TABLES [LIKE]
-````
+```
 
 illustrate:
 
@@ -60,7 +60,7 @@ illustrate:
      | left_table                      |
      +---------------------------------+
      5 rows in set (0.00 sec)
-     ````
+     ```
 
 2. Fuzzy query by table name
 
@@ -73,7 +73,7 @@ illustrate:
     | cmy2           |
     +----------------+
     2 rows in set (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLET.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLET.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TABLET tablet_id
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW TABLET tablet_id
 
     ```sql
     SHOW TABLET 10000;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
@@ -42,7 +42,7 @@ SHOW TABLETS FROM [database.]table [PARTITIONS(p1,p2)]
 [WHERE where_condition]
 [ORDER BY col_name]
 [LIMIT [offset,] row_count]
-````
+```
 
 1. **Syntax Description:**
 
@@ -61,19 +61,19 @@ or compound them with operator `AND`.
 
     ```sql
     SHOW TABLETS FROM example_db.table_name;
-    ````
+    ```
 
 2. list all tablets of the specified partitions
 
     ```sql
     SHOW TABLETS FROM example_db.table_name PARTITIONS(p1, p2);
-    ````
+    ```
 
 3. list all DECOMMISSION tablets on the specified backend
 
     ```sql
     SHOW TABLETS FROM example_db.table_name WHERE state="DECOMMISSION" AND BackendId=11003;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TRANSACTION.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TRANSACTION.md
@@ -42,11 +42,11 @@ SHOW TRANSACTION
 WHERE
 [id=transaction_id]
 [label = label_name];
-````
+```
 
 Example of returned result:
 
-````
+```
      TransactionId: 4005
              Label: insert_8d807d5d-bcdd-46eb-be6d-3fa87aa4952d
        Coordinator: FE: 10.74.167.16
@@ -59,7 +59,7 @@ Example of returned result:
 ErrorReplicasCount: 0
         ListenerId: -1
          TimeoutMs: 300000
-````
+```
 
 * TransactionId: transaction id
 * Label: the label corresponding to the import task
@@ -84,19 +84,19 @@ ErrorReplicasCount: 0
 
    ```sql
    SHOW TRANSACTION WHERE ID=4005;
-   ````
+   ```
 
 2. In the specified db, view the transaction with id 4005:
 
    ```sql
    SHOW TRANSACTION FROM db WHERE ID=4005;
-   ````
+   ```
 
 3. View the transaction whose label is label_name:
 
    ```sql
    SHOW TRANSACTION WHERE LABEL = 'label_name';
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TRASH.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TRASH.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TRASH [ON BackendHost:BackendHeartBeatPort];
-````
+```
 
 illustrate:
 
@@ -51,13 +51,13 @@ illustrate:
 
    ```sql
     SHOW TRASH;
-   ````
+   ```
 
 2. View the space occupied by garbage data of '192.168.0.1:9050' (specific disk information will be displayed).
 
    ```sql
    SHOW TRASH ON "192.168.0.1:9050";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
@@ -40,7 +40,7 @@ grammar
 
 ```sql
 SHOW TYPE_CAST [IN|FROM db]
-````
+```
 
  Parameters
 
@@ -48,7 +48,7 @@ SHOW TYPE_CAST [IN|FROM db]
 
 ### Example
 
-````sql
+```sql
 mysql> show type_cast in testDb\G
 **************************** 1. row ******************** ******
 Origin Type: TIMEV2
@@ -61,7 +61,7 @@ Origin Type: TIMEV2
   Cast Type: TIMEV2
 
 3 rows in set (0.00 sec)
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-VARIABLES.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-VARIABLES.md
@@ -36,10 +36,10 @@ This statement is used to display Doris system variables, which can be queried b
 
 grammar:
 
-````sql
+```sql
 SHOW [GLOBAL | SESSION] VARIABLES
      [LIKE 'pattern' | WHERE expr]
-````
+```
 
 illustrate:
 
@@ -54,19 +54,19 @@ illustrate:
 
     ```sql
     show variables like 'max_connections';
-    ````
+    ```
 
 2. Matching through the percent sign (%) wildcard can match multiple items
 
     ```sql
     show variables like '%connec%';
-    ````
+    ```
 
 3. Use the Where clause for matching queries
 
     ```sql
     show variables where variable_name = 'version';
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-VIEW.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Show-Statements/SHOW-VIEW.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
   SHOW VIEW { FROM | IN } table [ FROM db ]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ grammar:
 
     ```sql
     SHOW VIEW FROM testTbl;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Utility-Statements/DESCRIBE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Utility-Statements/DESCRIBE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DESC[RIBE] [db_name.]table_name [ALL];
-````
+```
 
 illustrate:
 
@@ -50,13 +50,13 @@ illustrate:
 
     ```sql
     DESC table_name;
-    ````
+    ```
 
 2. Display the schema of all indexes of the table
 
     ```sql
     DESC db1.table_name ALL;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Utility-Statements/HELP.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Utility-Statements/HELP.md
@@ -36,9 +36,9 @@ The directory of help can be queried by changing the command
 
 grammar:
 
-```` sql
+``` sql
 HELP <item>
-````
+```
 
 All Doris commands can be listed with `help`
 
@@ -72,7 +72,7 @@ nowarning (\w) Don't show warnings after every statement.
 resetconnection(\x) Clean session context.
 
 For server side help, type 'help contents'
-````
+```
 
 Get the Doris SQL help contents via `help contents`
 
@@ -83,7 +83,7 @@ where <item> is one of the following
 categories:
    sql-functions
    sql-statements
-````
+```
 
 ### Example
 
@@ -91,19 +91,19 @@ categories:
 
    ```sql
    help contents
-   ````
+   ```
 
 2. The command to list all function directories of the Doris cluster
 
    ```sql
    help sql-functions
-   ````
+   ```
 
 3. List all functions under the date function
 
    ```sql
    help date-time-functions
-   ````
+   ```
 
 
 ### Keywords

--- a/versioned_docs/version-2.1/sql-manual/sql-statements/Utility-Statements/USE.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/Utility-Statements/USE.md
@@ -36,9 +36,9 @@ The USE command allows us to use the database
 
 grammar:
 
-````SQL
+```SQL
 USE <[CATALOG_NAME].DATABASE_NAME>
-````
+```
 
 illustrate:
 1. `USE CATALOG_NAME.DATABASE_NAME` will switch the current catalog into `CATALOG_NAME` and then change the current database into `DATABASE_NAME`
@@ -50,13 +50,13 @@ illustrate:
     ```sql
     mysql> use demo;
     Database changed
-    ````
+    ```
 2. If the demo database exists in catalog hms_catalog, try switching the catalog and accessing it:
 
     ```sql
     mysql> use hms_catalog.demo;
     Database changed
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-2.1/table-design/index/ngram-bloomfilter-index.md
+++ b/versioned_docs/version-2.1/table-design/index/ngram-bloomfilter-index.md
@@ -133,7 +133,7 @@ https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/amazon_
 
 **Import the data using stream load:**
 
-```bash
+```shell
 curl --location-trusted -u root: -T amazon_reviews_2010.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load
 curl --location-trusted -u root: -T amazon_reviews_2011.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load
 curl --location-trusted -u root: -T amazon_reviews_2012.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load

--- a/versioned_docs/version-3.0/admin-manual/auth/certificate.md
+++ b/versioned_docs/version-3.0/admin-manual/auth/certificate.md
@@ -39,7 +39,7 @@ In addition to the Doris default certificate file, you can also generate a custo
 
 1. Generate the CA, server-side, and client-side keys and certificates:
 
-```bash
+```shell
 # Generate the CA certificate
 openssl genrsa 2048 > ca-key.pem
 openssl req -new -x509 -nodes -days 3600 \
@@ -64,13 +64,13 @@ openssl x509 -req -in client-req.pem -days 3600 \
 
 2. Verify the created certificates:
 
-```bash
+```shell
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
 3. Combine your key and certificate in a PKCS#12 (P12) bundle. You can also specify a certificate format (PKCS12 by default). You can modify the conf/fe.conf configuration file and add parameter ssl_trust_store_type to specify the certificate format.
 
-```bash
+```shell
 # Package the CA key and certificate
 openssl pkcs12 -inkey ca-key.pem -in ca.pem -export -out ca_certificate.p12
 

--- a/versioned_docs/version-3.0/admin-manual/auth/ldap.md
+++ b/versioned_docs/version-3.0/admin-manual/auth/ldap.md
@@ -108,7 +108,7 @@ Client-side LDAP authentication requires the mysql client-side explicit authenti
 
 * Set the environment variable LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN to value 1.
   For example, in a linux or max environment you can use the command:
-  ```bash
+  ```shell
   echo "export LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN=1" >> ～/.bash_profile && source ～/.bash_profile
   ```
 
@@ -168,12 +168,12 @@ For example:
 Doris account exists: jack@'172.10.1.10', password: 123456  
 LDAP user node presence attribute: uid: jack user password: abcdef  
 The jack@'172.10.1.10' account can be logged into by logging into Doris using the following command:
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
 Login will fail with the following command:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 
@@ -181,7 +181,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 
 LDAP user node presence attribute: uid: jack User password: abcdef  
 Use the following command to create a temporary user and log in to jack@'%', the temporary user has basic privileges DatabasePrivs: Select_priv, Doris will delete the temporary user after the user logs out and logs in:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 ```
 
@@ -189,7 +189,7 @@ mysql -hDoris_HOST -PDoris_PORT -ujack -p abcdef
 
 Doris account exists: jack@'172.10.1.10', password: 123456  
 Login to the account using the Doris password, successfully:  
-```bash
+```shell
 mysql -hDoris_HOST -PDoris_PORT -ujack -p 123456
 ```
 

--- a/versioned_docs/version-3.0/admin-manual/cluster-management/load-balancing.md
+++ b/versioned_docs/version-3.0/admin-manual/cluster-management/load-balancing.md
@@ -486,7 +486,7 @@ IP: 172.31.7.119
 
 ### Install dependencies
 
-```bash
+```shell
 sudo apt-get install build-essential
 sudo apt-get install libpcre3 libpcre3-dev 
 sudo apt-get install zlib1g-dev
@@ -495,7 +495,7 @@ sudo apt-get install openssl libssl-dev
 
 ### Install Nginx
 
-```bash
+```shell
 sudo wget http://nginx.org/download/nginx-1.18.0.tar.gz
 sudo tar zxvf nginx-1.18.0.tar.gz
 cd nginx-1.18.0
@@ -507,13 +507,13 @@ sudo make && make install
 
 Here is a new configuration file
 
-```bash
+```shell
 vim /usr/local/nginx/conf/default.conf
 ```
 
 Then add the following in it
 
-```bash
+```shell
 events {  
 worker_connections 1024;  
 }  
@@ -537,7 +537,7 @@ stream {
 
 Start the specified configuration file
 
-```bash
+```shell
 cd /usr/local/nginx
 /usr/local/nginx/sbin/nginx -c conf.d/default.conf
 ```

--- a/versioned_docs/version-3.0/admin-manual/data-admin/ccr.md
+++ b/versioned_docs/version-3.0/admin-manual/data-admin/ccr.md
@@ -70,7 +70,7 @@ enable_feature_binlog=true
 
 ​Build CCR syncer
 
-```Bash
+```shell
 git clone https://github.com/selectdb/ccr-syncer
 cd ccr-syncer   
 bash build.sh <-j NUM_OF_THREAD> <--output SYNCER_OUTPUT_DIR>
@@ -81,7 +81,7 @@ cd SYNCER_OUTPUT_DIR# Contact the Doris community for a free CCR binary package
 Start and stop syncer
 
 
-```Bash
+```shell
 # Start
 cd bin && sh start_syncer.sh --daemon
    
@@ -91,7 +91,7 @@ sh stop_syncer.sh
 
 5. Enable binlog in the source cluster.
 
-```Bash
+```shell
 -- If you want to synchronize the entire database, you can execute the following script:
 vim shell/enable_db_binlog.sh
 Modify host, port, user, password, and db in the source cluster
@@ -103,7 +103,7 @@ ALTER TABLE enable_binlog SET ("binlog.enable" = "true");
 
 6. Launch a synchronization task to the syncer
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -129,7 +129,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Parameter description:
 
-```Bash
+```shell
 name: name of the CCR synchronization task, should be unique
 host, port: host and mysql(jdbc) port for the master FE for the corresponding cluster
 user, password: the credentials used by the syncer to initiate transactions, fetch data, etc.
@@ -271,7 +271,7 @@ Stop the syncer according to the process number in the pid file under the defaul
 
 The file structure can be seen under the output path after compilation:
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -306,7 +306,7 @@ Follow the default configurations.
 
 Specify the directory where the pid file is located. The above three stopping methods all depend on the directory where the pid file is located for execution.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --pid_dir /path/to/pids
 ```
 
@@ -318,7 +318,7 @@ The default value is `SYNCER_OUTPUT_DIR/bin`.
 
 Stop the syncer corresponding to host: port in the pid_dir path.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --host 127.0.0.1 --port 9190
 ```
 
@@ -328,7 +328,7 @@ The default value of host is 127.0.0.1, and the default value of port is empty. 
 
 Stop the syncer corresponding to the specified pid file name in the pid_dir path.
 
-```Bash
+```shell
 bash bin/stop_syncer.sh --files "127.0.0.1_9190.pid 127.0.0.1_9191.pid"
 ```
 
@@ -338,7 +338,7 @@ The file names should be wrapped in `" "` and separated with spaces.
 
 **Template for requests**
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d {json_body} http://ccr_syncer_host:ccr_syncer_port/operator
 ```
 
@@ -362,7 +362,7 @@ or
 
 Create CCR tasks
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "ccr_test",
     "src": {
@@ -398,7 +398,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 View the synchronization progress.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/get_lag
@@ -410,7 +410,7 @@ The job_name is the name specified when create_ccr.
 
 Pause synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/pause 
@@ -420,7 +420,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Resume synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/resume
@@ -430,7 +430,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 Delete synchronization task.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/delete
@@ -440,7 +440,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 View version information.
 
-```Bash
+```shell
 curl http://ccr_syncer_host:ccr_syncer_port/version
 
 # > return
@@ -451,7 +451,7 @@ curl http://ccr_syncer_host:ccr_syncer_port/version
 
 View job status.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/job_status
@@ -470,7 +470,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 No sync. Users can swap the source and target clusters.
 
-```Bash
+```shell
 curl -X POST -H "Content-Type: application/json" -d '{
     "name": "job_name"
 }' http://ccr_syncer_host:ccr_syncer_port/desync
@@ -480,7 +480,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 
 List all created tasks.
 
-```Bash
+```shell
 curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
 {"success":true,"jobs":["ccr_db_table_alias"]}
@@ -492,7 +492,7 @@ curl http://ccr_syncer_host:ccr_syncer_port/list_jobs
 
 The file structure can be seen under the output path after compilation:
 
-```Bash
+```shell
 output_dir
     bin
         ccr_syncer
@@ -509,7 +509,7 @@ output_dir
 
 **Usage**
 
-```Bash
+```shell
 bash bin/enable_db_binlog.sh -h host -p port -u user -P password -d db
 ```
 
@@ -556,7 +556,7 @@ Minimum required version: V2.0.3
 
 BE-side configuration parameter
 
-```Bash
+```shell
 download_binlog_rate_limit_kbs=1024 # This configuration limits the size to 1MB. It applies to all binlogs, including local snapshots, in a single BE.
 ```
 

--- a/versioned_docs/version-3.0/admin-manual/log-management/fe-log.md
+++ b/versioned_docs/version-3.0/admin-manual/log-management/fe-log.md
@@ -131,7 +131,7 @@ The Debug level log of FE can be enabled by modifying the configuration file or 
 
    You can also modify the log level at runtime through the following API. No need to restart the FE node.
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?add_verbose=org.apache.doris.catalog.Catalog
    ```
 
@@ -154,7 +154,7 @@ The Debug level log of FE can be enabled by modifying the configuration file or 
 
    You can also close Debug log through the following API:
 
-   ```bash
+   ```shell
    curl -X POST -uuser:passwd fe_host:http_port/rest/v1/log?del_verbose=org.apache.doris.catalog.Catalog
    ```
 

--- a/versioned_docs/version-3.0/admin-manual/memory-management/memory-analysis/memory-log-analysis.md
+++ b/versioned_docs/version-3.0/admin-manual/memory-management/memory-analysis/memory-log-analysis.md
@@ -30,7 +30,11 @@ The process memory logs in `be/log/be.INFO` are mainly divided into two categori
 
 The process memory status of Doris BE will be printed in the `log/be.INFO` log every time the process memory increases or decreases by 256 MB. In addition, when the process memory is insufficient, the process memory status will also be printed along with other logs.
 
-``` os physical memory 375.81 GB. process memory used 4.09 GB(= 3.49 GB[vm/rss] - 410.44 MB[tc/jemalloc_cache] + 1 GB[reserved] + 0B[waiting_refresh]), limit 3.01 GB, soft limit 2.71 GB. sys available memory 134.41 GB(= 1 35.41 GB[proc/available] - 1 GB[reserved] - 0B[waiting_refresh]), low water mark 3.20 GB, warning water mark 6.40 GB. ```` 1. `os physical memory 375.81 GB` refers to the system physical memory 375.81 GB.
+```
+os physical memory 375.81 GB. process memory used 4.09 GB(= 3.49 GB[vm/rss] - 410.44 MB[tc/jemalloc_cache] + 1 GB[reserved] + 0B[waiting_refresh]), limit 3.01 GB, soft limit 2.71 GB. sys available memory 134.41 GB(= 1 35.41 GB[proc/available] - 1 GB[reserved] - 0B[waiting_refresh]), low water mark 3.20 GB, warning water mark 6.40 GB.
+```
+
+1. `os physical memory 375.81 GB` refers to the system physical memory 375.81 GB.
 
 2. `process memory used 4.09 GB (= 3.49 GB [vm/rss] - 410.44 MB [tc/jemalloc_cache] + 1 GB [reserved] + 0B [waiting_refresh])`
 - Currently we think that the BE process uses 4.09 GB of memory, and the actual physical memory used by the BE process `vm/rss` is 3.49 GB,

--- a/versioned_docs/version-3.0/compute-storage-decoupled/before-deployment.md
+++ b/versioned_docs/version-3.0/compute-storage-decoupled/before-deployment.md
@@ -171,7 +171,7 @@ Adjust the FoundationDB configurations based on different hardware specification
 
 This is an example `foundationdb.conf` configuration file for a machine with 8 CPU cores, 32 GB of memory, and a 500 GB SSD data disk. Ensure that the `datadir` and `logdir` paths are set correctly. The data disk is typically mounted at `/mnt`:
 
-```Bash
+```shell
 # foundationdb.conf
 ##
 ## Configuration file for FoundationDB server processes
@@ -257,7 +257,7 @@ On the primary machine, update the `ip` in the `/etc/foundationdb/fdb.cluster` f
 
 Then, restart the FoundationDB service to apply the changes:
 
-```Bash
+```shell
 # for service
 user@host$ sudo service foundationdb restart
 
@@ -306,7 +306,7 @@ Replace `/etc/foundationdb/foundationdb.conf` and `/etc/foundationdb/fdb.cluster
 
 Then, restart FoundationDB service on the local machine.
 
-```Bash
+```shell
 # for service
 user@host$ sudo service foundationdb restart
 
@@ -395,7 +395,7 @@ All nodes must have OpenJDK 17 installed. You can download the installation pack
 
 Then, simply extract the downloaded OpenJDK package directly to the installation path:
 
-```Bash
+```shell
 tar xf openjdk-17.0.1_linux-x64_bin.tar.gz  -C /opt/
 
 # Before starting Meta Service or Recycler

--- a/versioned_docs/version-3.0/compute-storage-decoupled/compilation-and-deployment.md
+++ b/versioned_docs/version-3.0/compute-storage-decoupled/compilation-and-deployment.md
@@ -30,13 +30,13 @@ Compilation in the compute-storage decoupled mode is similar to that in the comp
 
 Similar to the compute-storage coupled mode, you can use the built-in `build.sh` script to compile Doris in the compute-storage decoupled mode. Add the `--cloud` parameter for compilation of the new Meta Service module (The binary name for it is `doris_cloud`). 
 
-```Bash
+```shell
 sh build.sh --fe --be --cloud 
 ```
 
 Unlike the compute-storage coupled mode, you will find an `ms` directory in the `output` directory after compiling in the compute-storage decoupled mode.
 
-```Bash
+```shell
 output
 ├── be
 ├── fe
@@ -61,7 +61,7 @@ The version information of `doris_cloud` can be checked in two ways. If one meth
 - `bin/start.sh --version`
 - `lib/doris_cloud --version`
 
-```Bash
+```shell
 $ lib/doris_cloud --version
 version:{doris_cloud-0.0.0-debug} code_version:{commit=b9c1d057f07dd874ad32501ff43701247179adcb time=2024-03-24 20:44:50 +0800} build_info:{initiator=gavinchou@VM-10-7-centos build_at=2024-03-24 20:44:50 +0800 build_on=NAME="TencentOS Server" VERSION="3.1 (Final)" }
 ```
@@ -85,7 +85,7 @@ The `brpc_listen_port = 5000` above is the default port for Meta Service. `fdb_c
 
 **Example**
 
-```Bash
+```shell
 cat /etc/foundationdb/fdb.cluster
 
 DO NOT EDIT!
@@ -108,7 +108,7 @@ The `brpc_listen_port = 5100` above is the default port for Recycler. `fdb_clust
 
 **Example**
 
-```Bash
+```shell
 cat /etc/foundationdb/fdb.cluster
 
 DO NOT EDIT!

--- a/versioned_docs/version-3.0/compute-storage-decoupled/creating-cluster.md
+++ b/versioned_docs/version-3.0/compute-storage-decoupled/creating-cluster.md
@@ -81,7 +81,7 @@ To create a Doris cluster in the compute-storage decoupled mode using HDFS as th
 
 **Example**
 
-```Bash
+```shell
 curl -s "127.0.0.1:5000/MetaService/http/create_instance?token=greedisgood9999" -d \
 '{
   "instance_id": "sample_instance_id",
@@ -356,7 +356,7 @@ Users/Roles with the `USAGE_PRIV` privilege for a specific storage vault can per
 
 **Example**
 
-```Bash
+```shell
 grant usage_priv on storage vault my_storage_vault to user1
 ```
 
@@ -375,7 +375,7 @@ Only the Admin user has the privilege to execute the `REVOKE` statement, which i
 
 **Example**
 
-```Bash
+```shell
 revoke usage_priv on storage vault my_storage_vault from user1
 ```
 
@@ -404,7 +404,7 @@ The parameter list for the `add_cluster` interface is as follows:
 
 This is an example of adding one FE:
 
-```Bash
+```shell
 # Add FE
 curl '127.0.0.1:5000/MetaService/http/add_cluster?token=greedisgood9999' -d '{
     "instance_id":"sample_instance_id",
@@ -467,7 +467,7 @@ Users can adjust the number of compute clusters and the number of nodes within e
 
 This is an example of adding a compute cluster that consists of 1 BE node.
 
-```Bash
+```shell
 # 172.19.0.11
 # Add BE
 curl '127.0.0.1:5000/MetaService/http/add_cluster?token=greedisgood9999' -d '{

--- a/versioned_docs/version-3.0/compute-storage-decoupled/file-cache.md
+++ b/versioned_docs/version-3.0/compute-storage-decoupled/file-cache.md
@@ -66,7 +66,7 @@ To apply the TTL strategy for a table, set the TTL strategy in the PROPERTIES of
 
 - `file_cache_ttl_seconds`: The expected time (measured in seconds) for newly imported data to be retained in the cache.
 
-```Bash
+```shell
 CREATE TABLE IF NOT EXISTS customer (
   C_CUSTKEY     INTEGER NOT NULL,
   C_NAME        VARCHAR(25) NOT NULL,
@@ -208,7 +208,7 @@ A user has a total data volume of over 3TB, but the available cache capacity is 
 
 Under the LRU strategy, if a large table is queried and accessed, its data will replace that of the small table in the cache, causing performance fluctuations. To solve this, the user adopts a TTL strategy, setting the TTL time of the dimension table and fact table to 1 year and 1 day, respectively. 
 
-```Bash
+```shell
 ALTER TABLE dimension_table set ("file_cache_ttl_seconds"="31536000");
 
 ALTER TABLE fact_table set ("file_cache_ttl_seconds"="86400");

--- a/versioned_docs/version-3.0/compute-storage-decoupled/managing-compute-cluster.md
+++ b/versioned_docs/version-3.0/compute-storage-decoupled/managing-compute-cluster.md
@@ -339,7 +339,7 @@ In a compute-storage decoupled architecture, the user can specify the database a
 USE { [catalog_name.]database_name[@cluster_name] | @cluster_name }
 ```
 
-If the name of the database or compute cluster contains a reserved keyword, the respective name needs to be enclosed within backticks ```` to denote it as a quoted identifier.
+If the name of the database or compute cluster contains a reserved keyword, the respective name needs to be enclosed within backticks \``` to denote it as a quoted identifier.
 
 **Example**
 

--- a/versioned_docs/version-3.0/compute-storage-decoupled/meta-service-api.md
+++ b/versioned_docs/version-3.0/compute-storage-decoupled/meta-service-api.md
@@ -60,7 +60,7 @@ This API is used to create an instance, which supports one or more storage vault
 
 - Syntax for a `create_instance` request using HDFS as the storage vault
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token> HTTP/1.1
 Content-Length: <ContentLength>
 Content-Type: text/plain
@@ -140,7 +140,7 @@ Content-Type: text/plain
 
 - Syntax for a `create_instance` request using object storage as the storage vault
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token HTTP/1.1
 Content-Length: <ContentLength>
 Content-Type: text/plain
@@ -183,7 +183,7 @@ Content-Type: text/plain
 
 - Example of a `create_instance` request using object storage as the storage vault
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=greedisgood9999 HTTP/1.1
 Content-Length: 441
 Content-Type: text/plain
@@ -248,7 +248,7 @@ This API is used to create an instance, which only supports one storage vault (m
 
 - Syntax
 
-```Bash
+```shell
 PUT /MetaService/http/create_instance?token=<token HTTP/1.1
 Content-Length: <ContentLength
 Content-Type: text/plain

--- a/versioned_docs/version-3.0/data-operate/delete/batch-delete-manual.md
+++ b/versioned_docs/version-3.0/data-operate/delete/batch-delete-manual.md
@@ -252,7 +252,7 @@ mysql DESC test;
 
 4. When the table has the sequence column, delete all data with the same key as the imported data
 
-    ```bash
+    ```shell
     curl --location-trusted -u root: -H "column_separator:," -H "columns: name, gender, age" -H "function_column.sequence_col: age" -H "merge_type: DELETE"  -T ~/table1_data http://127.0.0.1:8130/api/test/table1/_stream_load
     ```
 

--- a/versioned_docs/version-3.0/data-operate/import/load-atomicity.md
+++ b/versioned_docs/version-3.0/data-operate/import/load-atomicity.md
@@ -126,7 +126,7 @@ Empty set (0.019 sec)
 
 **1. Enable two-phase commit by setting `two_phase_commit:true` in the HTTP Header.**
 
-```Bash
+```shell
 curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt http://fe_host:http_port/api/{db}/{table}/_stream_load
 {
     "TxnId": 18036,
@@ -152,7 +152,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the Transaction ID:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18036" -H "txn_operation:commit" http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -162,7 +162,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the label:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:commit"  http://fe_host:http_port/api/{db}/{table}/_stream_load_2pc
   {
       "status": "Success",
@@ -174,7 +174,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the Transaction ID:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "txn_id:18037" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",
@@ -184,7 +184,7 @@ curl --location-trusted -u user:passwd -H "two_phase_commit:true" -T test.txt ht
 
 - Specify the transaction using the label:
 
-  ```Bash
+  ```shell
   curl -X PUT --location-trusted -u user:passwd -H "label:55c8ffc9-1c40-4d51-b75e-f2265b3602ef" -H "txn_operation:abort"  http://fe_host:http_port/api/{db}/{table}/stream_load2pc
   {
       "status": "Success",

--- a/versioned_docs/version-3.0/data-operate/import/load-data-convert.md
+++ b/versioned_docs/version-3.0/data-operate/import/load-data-convert.md
@@ -60,7 +60,7 @@ WITH BROKER bos
 
 ### STREAM LOAD
 
-```bash
+```shell
 curl
 --location-trusted
 -u user:passwd
@@ -96,7 +96,7 @@ Stream load does not support preceding filtering.
 
 Example:
 
-```bash
+```shell
 curl
 --location-trusted
 -u user:passwd

--- a/versioned_docs/version-3.0/data-operate/import/load-json-format.md
+++ b/versioned_docs/version-3.0/data-operate/import/load-json-format.md
@@ -45,21 +45,21 @@ Currently only the following three JSON formats are supported:
 
    JSON format with Array as root node. Each element in the Array represents a row of data to be imported, usually an Object. An example is as follows:
 
-   ````json
+   ```json
    [
        { "id": 123, "city" : "beijing"},
        { "id": 456, "city" : "shanghai"},
        ...
    ]
-   ````
+   ```
 
-   ````json
+   ```json
    [
        { "id": 123, "city" : { "name" : "beijing", "region" : "haidian"}},
        { "id": 456, "city" : { "name" : "beijing", "region" : "chaoyang"}},
        ...
    ]
-   ````
+   ```
 
    This method is typically used for Stream Load import methods to represent multiple rows of data in a batch of imported data.
 
@@ -68,13 +68,13 @@ Currently only the following three JSON formats are supported:
 2. A single row of data represented by Object
    JSON format with Object as root node. The entire Object represents a row of data to be imported. An example is as follows:
 
-   ````json
+   ```json
    { "id": 123, "city" : "beijing"}
-   ````
+   ```
    
-   ````json
+   ```json
    { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
-   ````
+   ```
    
    This method is usually used for the Routine Load import method, such as representing a message in Kafka, that is, a row of data.
 
@@ -82,11 +82,11 @@ Currently only the following three JSON formats are supported:
    
    A row of data represented by Object represents a row of data to be imported. The example is as follows:
    
-   ````json
+   ```json
    { "id": 123, "city" : "beijing"}
    { "id": 456, "city" : "shanghai"}
    ...
-   ````
+   ```
    
    This method is typically used for Stream Load import methods to represent multiple rows of data in a batch of imported data.
    
@@ -120,17 +120,17 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is as follows:
 
-  ````json
+  ```json
   { "id": 123, "city" : "beijing"}
-  ````
+  ```
 
   Then Doris will use `id`, `city` for matching, and get the final data `123` and `beijing`.
 
   If the JSON data is as follows:
 
-  ````json
+  ```json
   { "id": 123, "name" : "beijing"}
-  ````
+  ```
 
   Then use `id`, `city` for matching, and get the final data `123` and `null`.
 
@@ -138,13 +138,13 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   Specify a set of JSON Path in the form of a JSON data. Each element in the array represents a column to extract. An example is as follows:
 
-  ````json
+  ```json
   ["$.id", "$.name"]
-  ````
+  ```
 
-  ````json
+  ```json
   ["$.id.sub_id", "$.name[0]", "$.city[0]"]
-  ````
+  ```
 
   Doris will use the specified JSON Path for data matching and extraction.
 
@@ -154,21 +154,21 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "city" : { "name" : "beijing", "region" : "haidian" }}
-  ````
+  ```
 
   JSON Path is `["$.city"]`. The matched elements are:
 
-  ````json
+  ```json
   { "name" : "beijing", "region" : "haidian" }
-  ````
+  ```
 
   The element will be converted to a string for subsequent import operations:
 
-  ````json
+  ```json
   "{'name':'beijing','region':'haidian'}"
-  ````
+  ```
 
 - match failed
 
@@ -176,41 +176,41 @@ Doris supports extracting data specified in JSON through JSON Path.
 
   The JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "name" : "beijing"}
-  ````
+  ```
 
   JSON Path is `["$.id", "$.info"]`. The matched elements are `123` and `null`.
 
   Doris currently does not distinguish between null values represented in JSON data and null values produced when a match fails. Suppose the JSON data is:
 
-  ````json
+  ```json
   { "id": 123, "name" : null }
-  ````
+  ```
 
   The same result would be obtained with the following two JSON Paths: `123` and `null`.
 
-  ````json
+  ```json
   ["$.id", "$.name"]
-  ````
+  ```
 
-  ````json
+  ```json
   ["$.id", "$.info"]
-  ````
+  ```
 
 - Exact match failed
 
   In order to prevent misoperation caused by some parameter setting errors. When Doris tries to match a row of data, if all columns fail to match, it considers this to be an error row. Suppose the Json data is:
 
-  ````json
+  ```json
   { "id": 123, "city" : "beijing" }
-  ````
+  ```
 
   If the JSON Path is written incorrectly as (or if the JSON Path is not specified, the columns in the table do not contain `id` and `city`):
 
-  ````json
+  ```json
   ["$.ad", "$.infa"]
-  ````
+  ```
 
   would cause the exact match to fail, and the line would be marked as an error line instead of yielding `null, null`.
 
@@ -222,65 +222,65 @@ In other words, it is equivalent to rearranging the columns of a JSON format dat
 
 Data content:
 
-````json
+```json
 {"k1": 1, "k2": 2}
-````
+```
 
 Table Structure:
 
-````
+```
 k2 int, k1 int
-````
+```
 
 Import statement 1 (take Stream Load as an example):
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -T example.json http:/ /127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 In import statement 1, only JSON Path is specified, and Columns is not specified. The role of JSON Path is to extract the JSON data in the order of the fields in the JSON Path, and then write it in the order of the table structure. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1   | k2   |
 +------+------+
 | 2    | 1    |
 +------+------+
-````
+```
 
 You can see that the actual k1 column imports the value of the "k2" column in the JSON data. This is because the field name in JSON is not equivalent to the field name in the table structure. We need to explicitly specify the mapping between the two.
 
 Import statement 2:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, k1 " -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Compared with the import statement 1, the Columns field is added here to describe the mapping relationship of the columns, in the order of `k2, k1`. That is, after extracting in the order of fields in JSON Path, specify the value of column k2 in the table for the first column, and the value of column k1 in the table for the second column. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1   |  k2  |
 +------+------+
 | 1    | 2    |
 +------+------+
-````
+```
 
 Of course, as with other imports, column transformations can be performed in Columns. An example is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\"]" -H "columns: k2, tmp_k1 , k1 = tmp_k1 * 100" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 The above example will import the value of k1 multiplied by 100. The final imported data results are as follows:
 
-````text
+```text
 +------+------+
 | k1   | k2   |
 +------+------+
 | 100  | 2    |
 +------+------+
-````
+```
 
 Import statement 3:
 
@@ -293,7 +293,7 @@ k2 int, k1 int, k1_copy int
 
 If you want to assign a column field in JSON to several column fields in the table multiple times, you can specify the column multiple times in jsonPaths and specify the mapping order in sequence. An example is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\", \"$.k1\"]" -H "columns: k2,k1,k1_copy" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -324,7 +324,7 @@ k2 int, k1 int, k1_nested1 int, k1_nested2 int
 ```
 If you want to assign multi-level fields with the same name nested in json to different columns in the table, you can specify the column in jsonPaths and specify the mapping order in turn. An example are as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "jsonpaths: [\"$.k2\", \"$.k1\",\"$.k3.k1\",\"$.k3.k1_nested.k1\" -H "columns: k2,k1,k1_nested1,k1_nested2" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
 ```
 
@@ -374,26 +374,26 @@ Doris supports extracting data specified in JSON through JSON root.
 
 Example data is as follows:
 
-````json
+```json
 [
     {"k1": 1, "k2": "a"},
     {"k1": 2},
     {"k1": 3, "k2": "c"}
 ]
-````
+```
 
 
 The table structure is: `k1 int null, k2 varchar(32) null default "x"`
 
 The import statement is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 The import results that users may expect are as follows, that is, for missing columns, fill in the default values.
 
-````text
+```text
 +------+------+
 | k1 | k2     |
 +------+------+
@@ -403,11 +403,11 @@ The import results that users may expect are as follows, that is, for missing co
 +------+------+
 |3     |c     |
 +------+------+
-````
+```
 
 But the actual import result is as follows, that is, for the missing column, NULL is added.
 
-````text
+```text
 +------+------+
 | k1 | k2     |
 +------+------+
@@ -417,13 +417,13 @@ But the actual import result is as follows, that is, for the missing column, NUL
 +------+------+
 |3     |c     |
 +------+------+
-````
+```
 
 This is because Doris doesn't know "the missing column is column k2 in the table" from the information in the import statement. If you want to import the above data according to the expected result, the import statement is as follows:
 
-```bash
+```shell
 curl -v --location-trusted -u root: -H "format: json" -H "strip_outer_array: true" -H "jsonpaths: [\"$.k1\", \"$.k2\"]" - H "columns: k1, tmp_k2, k2 = ifnull(tmp_k2, 'x')" -T example.json http://127.0.0.1:8030/api/db1/tbl1/_stream_load
-````
+```
 
 ## Application example
 
@@ -433,63 +433,63 @@ Because of the inseparability of the JSON format, when using Stream Load to impo
 
 Suppose the table structure is:
 
-````text
+```text
 id INT NOT NULL,
 city VARHCAR NULL,
 code INT NULL
-````
+```
 
 1. Import a single row of data 1
 
-   ````json
+   ```json
    {"id": 100, "city": "beijing", "code" : 1}
-   ````
+   ```
 
    - do not specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
 2. Import a single row of data 2
 
-   ````json
+   ```json
    {"id": 100, "content": {"city": "beijing", "code": 1}}
-   ````
+   ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.content.city\",\"$.content.code\ "]" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
-     ````
+     ```
 
 3. Import multiple rows of data as Array
 
-   ````json
+   ```json
    [
        {"id": 100, "city": "beijing", "code" : 1},
        {"id": 101, "city": "shanghai"},
@@ -504,24 +504,24 @@ code INT NULL
            "code" : 6
        }
    ]
-   ````
+   ```
 
    - Specify JSON Path
 
-     ```bash
+     ```shell
      curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - H "strip_outer_array: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-     ````
+     ```
 
      Import result:
 
-     ````text
+     ```text
      100 beijing 1
      101 shanghai NULL
      102 tianjin 3
      103 chongqing 4
      104 ["zhejiang","guangzhou"] 5
      105 {"order1":["guangzhou"]} 6
-     ````
+     ```
 
 4. Import multi-line data as multi-line Object
 
@@ -534,7 +534,7 @@ code INT NULL
 
  	 StreamLoad import:
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: true" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
 ```
 	   Import result:
@@ -548,20 +548,20 @@ curl --location-trusted -u user:passwd -H "format: json" -H "read_json_by_line: 
 
 The data is still the multi-line data in Example 3, and now it is necessary to add 1 to the `code` column in the imported data before importing.
 
-```bash
+```shell
 curl --location-trusted -u user:passwd -H "format: json" -H "jsonpaths: [\"$.id\",\"$.city\",\"$.code\"]" - H "strip_outer_array: true" -H "columns: id, city, tmpc, code=tmpc+1" -T data.json http://localhost:8030/api/db1/tbl1/_stream_load
-````
+```
 
 Import result:
 
-````text
+```text
 100 beijing 2
 101 shanghai NULL
 102 tianjin 4
 103 chongqing 5
 104 ["zhejiang","guangzhou"] 6
 105 {"order1":["guangzhou"]} 7
-````
+```
 
 6. Import Array by JSON
 Since the Rapidjson handles decimal and largeint numbers which will cause precision problems, 
@@ -575,7 +575,7 @@ we suggest you to use JSON string to import data to `array<decimal>` or `array<l
 {"k1": 40, "k2": ["10000000000000000000.1111111222222222"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_decimal.json http://localhost:8035/api/example_db/array_test_decimal/_stream_load
 ```
 
@@ -595,7 +595,7 @@ MySQL > select * from array_test_decimal;
 {"k1": 999, "k2": ["76959836937749932879763573681792701709", "26017042825937891692910431521038521227"]}
 ```
 
-```bash
+```shell
 curl --location-trusted -u root:  -H "max_filter_ratio:0.01" -H "format:json" -H "timeout:300" -T test_largeint.json http://localhost:8035/api/example_db/array_test_largeint/_stream_load
 ```
 

--- a/versioned_docs/version-3.0/data-operate/import/load-strict-mode.md
+++ b/versioned_docs/version-3.0/data-operate/import/load-strict-mode.md
@@ -54,16 +54,16 @@ Different import methods set strict mode in different ways.
    (
        "strict_mode" = "true"
    )
-   ````
+   ```
 
 2. [STREAM LOAD](../../sql-manual/sql-statements/Data-Manipulation-Statements/Load/STREAM-LOAD)
 
-   ```bash
+   ```shell
    curl --location-trusted -u user:passwd \
    -H "strict_mode: true" \
    -T 1.txt \
    http://host:port/api/example_db/my_table/_stream_load
-   ````
+   ```
 
 3. [ROUTINE LOAD](../../sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD)
 
@@ -78,7 +78,7 @@ Different import methods set strict mode in different ways.
        "kafka_broker_list" = "broker1:9092,broker2:9092,broker3:9092",
        "kafka_topic" = "my_topic"
    );
-   ````
+   ```
 
 4. [INSERT](../../sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/INSERT)
 
@@ -87,7 +87,7 @@ Different import methods set strict mode in different ways.
    ```sql
    SET enable_insert_strict = true;
    INSERT INTO my_table ...;
-   ````
+   ```
 
 ## The role of strict mode
 

--- a/versioned_docs/version-3.0/data-operate/import/stream-load-manual.md
+++ b/versioned_docs/version-3.0/data-operate/import/stream-load-manual.md
@@ -117,7 +117,7 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 
    The Stream Load job can be submitted using the `curl` command.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "column_separator:," \
@@ -200,7 +200,7 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 
    The Stream Load job can be submitted using the `curl` command.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:124" \
     -H "Expect:100-continue" \
@@ -261,7 +261,7 @@ Users cannot manually cancel a Stream Load operation. A Stream Load job will be 
 
 The syntax for Stream Load is as follows:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
   -H "Expect:100-continue" [-H ""...] \
   -T <file_path> \
@@ -400,7 +400,7 @@ When performing Stream Load using the TVF `http_stream`, the Rest API URL differ
 
 Using curl for Stream Load in http_stream Mode:
 
-```Bash
+```shell
 curl --location-trusted -u user:passwd [-H "sql: ${load_sql}"...] -T data.file -XPUT http://fe_host:http_port/api/_http_stream
 ```
 
@@ -408,7 +408,7 @@ Adding a SQL parameter in the header to replace the previous parameters such as 
 
 Example of load SQL:
 
-```Bash
+```shell
 insert into db.table (col, ...) select stream_col, ... from http_stream("property1"="value1");
 ```
 
@@ -455,7 +455,7 @@ Load job can tolerate a certain amount of data with formatting errors. The toler
 
 You can use the following command to specify a `max_filter_ratio` tolerance of 0.4 for creating a Stream Load job:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "max_filter_ratio:0.4" \
@@ -485,7 +485,7 @@ curl --location-trusted -u <doris_user>:<doris_password> \
 
 Loading data from local files into partitions p1 and p2 of the table, allowing a 20% error rate.
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "label:123" \
     -H "Expect:100-continue" \
@@ -513,7 +513,7 @@ Stream Load is based on the HTTP protocol for importing, which supports using pr
 
 The following example demonstrates this usage through a bash command pipeline. The imported data is generated streamingly by the program rather than from a local file.
 
-```Bash
+```shell
 seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -537,7 +537,7 @@ curl --location-trusted -u root -T test.csv  -H "label:1" -H "format:csv_with_na
 
 In stream load, there are three import types: APPEND, DELETE, and MERGE. These can be adjusted by specifying the parameter `merge_type`. If you want to specify that all data with the same key as the imported data should be deleted, you can use the following command:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: DELETE" \
@@ -580,7 +580,7 @@ After importing, the original table data will be deleted, resulting in the follo
 
 By specifying `merge_type` as MERGE, the imported data can be merged into the table. The MERGE semantics need to be used in combination with the DELETE condition, which means that data satisfying the DELETE condition is processed according to the DELETE semantics, and the rest is added to the table according to the APPEND semantics. The following operation represents deleting the row with `siteid` of 1, and adding the rest of the data to the table:
 
-```Bash
+```shell
 curl --location-trusted -u <doris_user>:<doris_password> \
     -H "Expect:100-continue" \
     -H "merge_type: MERGE" \
@@ -772,7 +772,7 @@ JSON data type:
 
 Command:
 
-```Bash
+```shell
 curl --location-trusted -u root -T test.json -H "label:1" -H "format:json" -H 'columns: id, order_code, create_time=CURRENT_TIMESTAMP()' http://host:port/api/testDb/testTbl/_stream_load
 ```
 

--- a/versioned_docs/version-3.0/data-operate/update/unique-update-transaction.md
+++ b/versioned_docs/version-3.0/data-operate/update/unique-update-transaction.md
@@ -109,7 +109,7 @@ PROPERTIES (
 
 The syntax for stream load is to add the mapping of the hidden column `function_column.sequence_col` to the `source_sequence` in the header. Example:
 
-```Bash
+```shell
 curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/_stream_load
 ```
 
@@ -228,7 +228,7 @@ Load the following data:
 
 Here is an example using Stream Load:
 
-```Bash
+```shell
 curl --location-trusted -u root: -T testData http://host:port/api/test/test_table/_stream_load
 ```
 

--- a/versioned_docs/version-3.0/db-connect/database-connect.md
+++ b/versioned_docs/version-3.0/db-connect/database-connect.md
@@ -32,14 +32,14 @@ Download MySQL Client from the MySQL official website or use the pre-installed [
 
 Extract the downloaded MySQL client. In the `bin/` directory, find the `mysql` command-line tool. Execute the following command to connect to Doris:
 
-```Bash
+```shell
 # FE_IP represents the listening address of the FE node, while FE_QUERY_PORT represents the port of the MySQL protocol service of the FE. This corresponds to the query_port parameter in fe.conf and it defaults to 9030.
 mysql -h FE_IP -P FE_QUERY_PORT -u USER_NAME 
 ```
 
 After login, the following message will be displayed.
 
-```Bash
+```shell
 Welcome to the MySQL monitor.  Commands end with ; or \g.                               
 Your MySQL connection id is 236                                                         
 Server version: 5.7.99 Doris version doris-2.0.3-rc06-37d31a5                           

--- a/versioned_docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-access-cluster.md
+++ b/versioned_docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-access-cluster.md
@@ -35,13 +35,13 @@ Doris provides ClusterIP access mode by default on Kubernetes. No modification i
 
 After deploying the cluster, you can view the services exposed by Doris Operator through the following command:
 
-```bash
+```shell
 kubectl -n doris get svc
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                               AGE
 doriscluster-sample-be-internal   ClusterIP   None          <none>        9050/TCP                              9m
 doriscluster-sample-be-service    ClusterIP   10.1.68.128   <none>        9060/TCP,8040/TCP,9050/TCP,8060/TCP   9m
@@ -58,13 +58,13 @@ In the above results, FE and BE have two types of Services, with the suffixes in
 
 Use the following command to create a pod containing the mysql client in the current Kubernetes cluster:
 
-```bash
+```shell
 kubectl run mysql-client --image=mysql:5.7 -it --rm --restart=Never --namespace=doris -- /bin/bash
 ```
 
 In the container in the cluster, you can use the externally exposed service name with the suffix `service` to access the Doris cluster:
 
-```bash
+```shell
 ## Use service type pod name to access the Doris cluster
 mysql -uroot -P9030 -hdoriscluster-sample-fe-service
 ```
@@ -143,13 +143,13 @@ spec:
 
 After deploying the cluster, you can view the services exposed by Doris Operator through the following command:
 
-```bash
+```shell
 kubectl get service
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME TYPE CLUSTER-IP EXTERNAL-IP PORT(S) AGE
 kubernetes ClusterIP 10.152.183.1 <none> 443/TCP 169d
 doriscluster-sample-fe-internal ClusterIP None <none> 9030/TCP 2d
@@ -160,13 +160,13 @@ doriscluster-sample-be-service NodePort 10.152.183.244 <none> 9060:30940/TCP,804
 
 Doris's Query Port defaults to 9030, which is mapped to local port 31545 locally. When accessing the Doris cluster, you need to obtain the corresponding IP address, which can be viewed with the following command:
 
-```bash
+```shell
 kubectl get nodes -owide
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME   STATUS   ROLES           AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION          CONTAINER-RUNTIME
 r60    Ready    control-plane   14d   v1.28.2   192.168.88.60   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
 r61    Ready    <none>          14d   v1.28.2   192.168.88.61   <none>        CentOS Stream 8   4.18.0-294.el8.x86_64   containerd://1.6.22
@@ -176,7 +176,7 @@ r63    Ready    <none>          14d   v1.28.2   192.168.88.63   <none>        Ce
 
 In NodePort mode, you can access services in the Kubernetes cluster based on the host IP and port mapping of any node. In this example, you can use any node IP, 192.168.88.61, 192.168.88.62, 192.168.88.63, to access the Doris service. For example, in the following example, the node node 192.168.88.62 and the mapped query port port 31545 are used to access the cluster:
 
-```bash
+```shell
 mysql -h 192.168.88.62 -P 31545 -uroot
 ```
 
@@ -192,7 +192,7 @@ If you perform Stream Load inside Kubernetes, you can directly use the error add
 
 In the return result of the above example, you can directly obtain the return result through the curl command in the Pod in the same Kubernetes cluster:
 
-```bash
+```shell
 curl http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local:8040/api/_load_error_log?file=__shard_1/error_log_insert_stmt_af474190276a2e9c-49bb9d175b8e968e_af474190276a2e9c_49bb9d175b8e968e
 ```
 
@@ -243,7 +243,7 @@ Since the pod name returned by each stream load may be different, please delete 
 
 Follow the service in the above example, replace ${podName} in CR with doriscluster-sample-be-2, and replace ${ServiceType} with NodePort. Use the kubectl apply command to create the service service in the same namespace of the doris cluster.
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -251,13 +251,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 Use the following command to view the NodePort assigned by the above deployment Service:
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
 doriscluster-detail-error         NodePort    10.152.183.35    <none>        8040:31201/TCP     32s
 ```
@@ -266,13 +266,13 @@ The BE port accessed by `Stream Load` is 8040, and the host port (NodePort) corr
 
 Get the host address controlled by K8s:
 
-```bash
+```shell
 kubectl get node -owide
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME             STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION       CONTAINER-RUNTIME
 vm-10-8-centos   Ready    <none>   226d   v1.28.7   10.16.10.8    <none>        TencentOS Server 3.1 (Final)   5.4.119-19-0009.3    containerd://1.6.28
 vm-10-7-centos   Ready    <none>   19d    v1.28.7   10.16.10.7    <none>        TencentOS Server 3.1 (Final)   5.4.119-19.0009.25   containerd://1.6.28
@@ -298,7 +298,7 @@ http://doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluste
 
 The domain name address of the above address is `doriscluster-sample-be-2.doriscluster-sample-be-internal.doris.svc.cluster.local`. Among the domain names used by pods deployed by `Doris Operator` on `Kubernetes`, the third level The domain name is the name of the pod. Replace {podName} in the above template with the real `pod` name, replace {serviceType} with `LoadBalancer`, and save the changes to the newly created `stream_load_get_error.yaml` file. Use the following command to deploy service:
 
-```bash
+```shell
 kubectl -n {namespace} apply -f strem_load_get_error.yaml
 ```
 
@@ -306,13 +306,13 @@ kubectl -n {namespace} apply -f strem_load_get_error.yaml
 
 Use the following command to view the LoadBalaner address EXTERNAL-IP assigned by the above deployment Service. The following is a test instance in aws eks:
 
-```bash
+```shell
 kubectl get service -n doris doriscluster-detail-error
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                         TYPE          CLUSTER-IP       EXTERNAL-IP                                                              PORT(S)           AGE
 doriscluster-detail-error    LoadBalancer  172.20.183.136   ac4828493dgrftb884g67wg4tb68gyut-1137856348.us-east-1.elb.amazonaws.com  8040:32003/TCP    14s
 ```

--- a/versioned_docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-config-cluster.md
+++ b/versioned_docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-config-cluster.md
@@ -99,13 +99,13 @@ feSpec:
 
 Among them, the name of [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) needs to be specified in ${storageClassName}. You can use the following command to view the StorageClass supported in the current Kubernetes cluster:
 
-```bash
+```shell
 kubectl get sc
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                          PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
 openebs-hostpath              openebs.io/local               Delete          WaitForFirstConsumer   false                  212d
 openebs-device                openebs.io/local               Delete          WaitForFirstConsumer   false                  212d

--- a/versioned_docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-doris-cluster.md
+++ b/versioned_docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-doris-cluster.md
@@ -36,13 +36,13 @@ Deploying a cluster online requires the following steps:
 
 1. Create namespace:
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 2. Deploy Doris cluster
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -61,7 +61,7 @@ selectdb/doris.be-ubuntu:2.0.2
 
 Download the image locally and package it into a tar file
 
-```bash
+```shell
 ## download docker image
 docker pull selectdb/doris.fe-ubuntu:2.0.2
 docker pull selectdb/doris.be-ubuntu:2.0.2
@@ -73,7 +73,7 @@ docker save -o doris.be-ubuntu-v2.0.2.tar docker pull selectdb/doris.be-ubuntu:2
 
 Upload the image tar package to the server and execute the docker load command:
 
-```bash
+```shell
 ## load docker image
 docker load -i doris.fe-ubuntu-v2.0.2.tar
 docker load -i doris.be-ubuntu-v2.0.2.tar
@@ -81,13 +81,13 @@ docker load -i doris.be-ubuntu-v2.0.2.tar
 
 2. Create namespace:
 
-```bash
+```shell
 kubectl create namespace ${namespace}
 ```
 
 3. Deploy Doris cluster
 
-```bash
+```shell
 kubectl apply -f ./${cluster_sample}.yaml -n ${namespace}
 ```
 
@@ -101,13 +101,13 @@ Before installation, you need to add a deployment warehouse. If it has been adde
 
 Install [doriscluster](https://artifacthub.io/packages/helm/doris/doris), using the default configuration this deployment only deploys 3 FE and 3 BE components, using the default `storageClass` to implement PV dynamic provisioning.
 
-```bash
+```shell
 helm install doriscluster doris-repo/doris
 ```
 
 If you need to customize resources and cluster shapes, please customize the resource configuration according to the annotations of each resource configuration in [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values) and execute The following command:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-repo/doris
 ```
 
@@ -115,13 +115,13 @@ helm install -f values.yaml doriscluster doris-repo/doris
 
 You can check the pod deployment status through the `kubectl get pods` command. When the Pod of `doriscluster` is in `Running` state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -137,7 +137,7 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 Download `doris-{chart_version}.tgz` to install Doris Cluster chart. If you need to download the 2.0.6 version of the Doris cluster, you can use the following command:
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-2.0.6.tgz
 ```
 
@@ -145,13 +145,13 @@ wget https://charts.selectdb.com/doris-2.0.6.tgz
 
 Doris cluster can be installed through the `helm install` command.
 
-```bash
+```shell
 helm install doriscluster doris-1.4.0.tgz
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml doriscluster doris-1.4.0.tgz
 ```
 
@@ -159,13 +159,13 @@ helm install -f values.yaml doriscluster doris-1.4.0.tgz
 
 You can check the pod deployment status through the `kubectl get pods` command. When the Pod of `doriscluster` is in `Running` state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                     READY   STATUS    RESTARTS   AGE
 doriscluster-helm-fe-0   1/1     Running   0          1m39s
 doriscluster-helm-fe-1   1/1     Running   0          1m39s
@@ -181,13 +181,13 @@ doriscluster-helm-be-2   1/1     Running   0          16s
 
 After the cluster deployment resources are delivered, you can check the cluster status by running the following command.
 
-```bash
+```shell
 kubectl get pods -n ${namespace}
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                       READY   STATUS    RESTARTS   AGE
 doriscluster-sample-fe-0   1/1     Running   0          20m
 doriscluster-sample-be-0   1/1     Running   0          19m
@@ -199,13 +199,13 @@ When the `STATUS` of all pods is in the `Running` state, and all containers in t
 
 Doris Operator will collect the status of cluster services and display them in the distributed resources. Doris Operator defines the abbreviation `dcr` for the `DorisCluster` type resource name, which can be replaced by the abbreviation when using the resource type to view the cluster status.
 
-```bash
+```shell
 kubectl get dcr
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                  FESTATUS    BESTATUS    CNSTATUS   BROKERSTATUS
 doriscluster-sample   available   available
 ```

--- a/versioned_docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-operator.md
+++ b/versioned_docs/version-3.0/install/cluster-deployment/k8s-deploy/compute-storage-coupled/install-operator.md
@@ -29,32 +29,32 @@ Doris Operator extends Kubernetes with Custom Resource Definition (CRD). The CRD
 
 Doris Cluster CRD can be deployed in a Kubernetes environment with the following command:
 
-```bash
+```shell
 kubectl create -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 ```
 
 If there is no external network, download the CRD file to your local computer first:
 
-```bash
+```shell
 wget https://raw.githubusercontent.com/selectdb/doris-operator/master/config/crd/bases/doris.selectdb.com_dorisclusters.yaml
 kubectl create -f ./doris.selectdb.com_dorisclusters.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 customresourcedefinition.apiextensions.k8s.io/dorisclusters.doris.selectdb.com created
 ```
 
 After the Doris Cluster CRD is created, you can view the created CRD with the following command.
 
-```bash
+```shell
 kubectl get crd | grep doris
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 dorisclusters.doris.selectdb.com                      2024-02-22T16:23:13Z
 ```
 
@@ -66,13 +66,13 @@ You can directly pull the Doris Operator template in the warehouse for quick dep
 
 Doris Operator can be deployed in a Kubernetes cluster using the following command:
 
-```bash
+```shell
 kubectl apply -f https://raw.githubusercontent.com/selectdb/doris-operator/master/config/operator/operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -91,13 +91,13 @@ The minimum requirements for deploying operator services are specified in the op
 
 After modifying the operator.yaml file, you can deploy the Doris Operator service using the following command:
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -113,13 +113,13 @@ deployment.apps/doris-operator created
 
 If the server is not connected to the external network, you need to download the corresponding operator image file first. Doris Operator uses the following images:
 
-```bash
+```shell
 selectdb/doris.k8s-operator:latest
 ```
 
 Run the following command on a server that can connect to the external network to download the image:
 
-```bash
+```shell
 ## download doris operator image
 docker pull selectdb/doris.k8s-operator:latest
 ## save the doris operator image as a tar package
@@ -128,7 +128,7 @@ docker save -o doris.k8s-operator-latest.tar selectdb/doris.k8s-operator:latest
 
 Place the packaged tar file into all Kubernetes nodes and run the following command to upload the image:
 
-```bash
+```shell
 docker load -i doris.k8s-operator-latest.tar
 ```
 
@@ -138,7 +138,7 @@ After downloading the operator.yaml file, you can modify the template according 
 
 Doris Operator is a stateless Deployment in the Kubernetes cluster. Items such as `limits`, `replica`, `label`, `namespace` and other items can be modified according to needs. If you need to specify a certain version of the doirs operator image, you can make the following modifications to the operator.yaml file after uploading the image:
 
-```bash
+```shell
 ...
 containers:
   - command:
@@ -158,13 +158,13 @@ containers:
 
 After modifying the Doris Operator template, you can use the apply command to deploy the Operator:
 
-```bash
+```shell
 kubectl apply -f ./operator.yaml
 ```
 
 The following is the expected output:
 
-```bash
+```shell
 namespace/doris created
 role.rbac.authorization.k8s.io/leader-election-role created
 rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding created
@@ -184,13 +184,13 @@ Helm Chart is an encapsulation of a series of YAML files that describe Kubernete
 
 Add the remote repository through the `repo add` command
 
-```bash
+```shell
 helm repo add doris-repo https://charts.selectdb.com
 ```
 
 Update the latest version of the chart through the `repo update` command
 
-```bash
+```shell
 helm repo update doris-repo
 ```
 
@@ -198,25 +198,25 @@ helm repo update doris-repo
 
 Doris Operator can be installed in the doris namespace using the default configuration through the `helm install` command.
 
-```bash
+```shell
 helm install operator doris-repo/doris-operator
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-repo/doris-operator
 ```
 
 Check the deployment status of Pods through the `kubectl get pods` command. When the Doris Operator's Pod is in the Running state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -229,7 +229,7 @@ If the server cannot connect to the external network, you need to download the c
 
 Download `doris-operator-{chart_version}.tgz` to install Doris Operator chart. If you need to download version 1.4.0 of Doris Operator, you can use the following command:
 
-```bash
+```shell
 wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 ```
 
@@ -237,25 +237,25 @@ wget https://charts.selectdb.com/doris-operator-1.4.0.tgz
 
 Doris Operator can be installed through the `helm install` command.
 
-```bash
+```shell
 helm install operator doris-operator-1.4.0.tgz
 ```
 
 If you need to customize the assembly [values.yaml](https://artifacthub.io/packages/helm/doris/doris-operator?modal=values), you can refer to the following command:
 
-```bash
+```shell
 helm install -f values.yaml operator doris-operator-1.4.0.tgz
 ```
 
 Check the deployment status of Pods through the `kubectl get pods` command. When the Doris Operator's Pod is in the Running state and all containers in the Pod are ready, the deployment is successful.
 
-```bash
+```shell
 kubectl get pod --namespace doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 ```
@@ -264,13 +264,13 @@ doris-operator-866bd449bb-zl5mr   1/1     Running   0          18m
 
 After deploying the Operator service, you can check the service status through the following command.
 
-```bash
+```shell
 kubectl get pod -n doris
 ```
 
 The return result is as follows:
 
-```bash
+```shell
 NAME                              READY   STATUS    RESTARTS   AGE
 doris-operator-6f47594455-p5tp7   1/1     Running   0          11s
 ```

--- a/versioned_docs/version-3.0/install/cluster-deployment/k8s-deploy/install-env.md
+++ b/versioned_docs/version-3.0/install/cluster-deployment/k8s-deploy/install-env.md
@@ -39,7 +39,7 @@ under the License.
 
 When deploying a Doris cluster on Kubernetes, it is recommended to turn off the firewall configuration:
 
-```bash
+```shell
 systemctl stop firewalld
 systemctl disable firewalld
 ```
@@ -56,7 +56,7 @@ When deploying Doris, it is recommended to turn off the swap partition.
 
 The swap partition can be permanently shut down with the following command.
 
-```bash
+```shell
 echo "vm.swappiness = 0">> /etc/sysctl.conf
 swapoff -a && swapon -a
 sysctl -p
@@ -64,7 +64,7 @@ sysctl -p
 
 ### Set the maximum number of open file handles in the system
 
-```bash
+```shell
 vi /etc/security/limits.conf 
 * soft nofile 65536
 * hard nofile 65536
@@ -74,7 +74,7 @@ vi /etc/security/limits.conf
 
 Modify the virtual memory area to at least 2000000
 
-```bash
+```shell
 sysctl -w vm.max_map_count=2000000
 ```
 
@@ -82,7 +82,7 @@ sysctl -w vm.max_map_count=2000000
 
 When deploying Doris, it is recommended to turn off transparent huge pages.
 
-```bash
+```shell
 echo never > /sys/kernel/mm/transparent_hugepage/enabled
 echo never > /sys/kernel/mm/transparent_hugepage/defrag
 ```

--- a/versioned_docs/version-3.0/install/cluster-deployment/run-docker-cluster.md
+++ b/versioned_docs/version-3.0/install/cluster-deployment/run-docker-cluster.md
@@ -81,7 +81,7 @@ Download the [official binary package](https://doris.apache.org/zh-CN/download/)
 
 3. Write Dockerfile
 
-```Bash
+```shell
 # Choose a base image
 FROM openjdk:8u342-jdk
 

--- a/versioned_docs/version-3.0/install/cluster-deployment/standard-deployment.md
+++ b/versioned_docs/version-3.0/install/cluster-deployment/standard-deployment.md
@@ -296,7 +296,7 @@ This is a CIDR representation that specifies the IP used by the FE. In environme
 
 Start FE process by executing the following command
 
-```Bash
+```shell
 bin/start_fe.sh --daemon
 ```
 
@@ -359,7 +359,7 @@ ALTER SYSTEM ADD OBSERVER "<fe_ip_address>:<fe_edit_log_port>"
 
 Execute the following command to start FE Follower node and synchronize metadata automatically.
 
-```Bash
+```shell
 bin/start_fe.sh --helper <helper_fe_ip>:<fe_edit_log_port> --daemon
 ```
 
@@ -578,7 +578,7 @@ As a distributed database, Doris generally has many BE nodes. Doris adds BE node
 
 You can use the following command to check if the FE has started successfully.
 
-```Bash
+```shell
 # Retry the following command, if it returns "msg":"success"，the FE has started successfully.
 server1:apache-doris/fe doris$ curl http://127.0.0.1:8030/api/bootstrap
 {"msg":"success","code":0,"data":{"replayedJournalId":0,"queryPort":0,"rpcPort":0,"version":""},"count":0}

--- a/versioned_docs/version-3.0/install/source-install/compilation-mac.md
+++ b/versioned_docs/version-3.0/install/source-install/compilation-mac.md
@@ -98,7 +98,7 @@ cd output/fe/bin
 
 Download the pre-compiled third-party libraries from [Apache Doris Third Party Prebuilt](https://github.com/apache/doris-thirdparty/releases/tag/automation). Refer to the command below: 
 
-```Bash
+```shell
 cd thirdparty
 rm -rf installed
 

--- a/versioned_docs/version-3.0/install/source-install/compilation-with-docker.md
+++ b/versioned_docs/version-3.0/install/source-install/compilation-with-docker.md
@@ -38,7 +38,7 @@ Currently, this is not supported in the compute-storage decoupled mode.
 
 In CentOS, execute the following command: 
 
-```Bash
+```shell
 yum install docker
 ```
 
@@ -57,7 +57,7 @@ For different versions of Doris, you need to download different build images. Th
 
 Take Doris 2.0 as an example, download and check the correponding Docker image.
 
-```Bash
+```shell
 # Choose docker.io/apache/doris:build-env-for-2.0
 $ docker pull apache/doris:build-env-for-2.0
 
@@ -75,7 +75,7 @@ apache/doris    build-env-for-2.0    f29cf1979dba    3 days ago    3.3GB
 - For information about changes in the compilation image, please see [ChangeLog](https://github.com/apache/doris/blob/master/thirdparty/CHANGELOG.md).
 - The Docker compilation image includes both JDK 8 and JDK 17. You can check the default JDK version by running `java -version`, and switch between versions using the following commands. For versions earlier than 2.1 (inclusive), please use JDK 8. For versions later than 3.0 (inclusive) or the master branch, please use JDK 17.
 
-```Bash
+```shell
 # Switch to JDK 8
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0
 export PATH=$JAVA_HOME/bin/:$PATH

--- a/versioned_docs/version-3.0/install/source-install/compilation-with-ldb-toolchain.md
+++ b/versioned_docs/version-3.0/install/source-install/compilation-with-ldb-toolchain.md
@@ -118,7 +118,7 @@ The first step of compiling Doris source code is to first download third-party l
 
 1. **Enter the Doris source code directory and execute the following command to check if the compilation machine supports the AVX2 instruction set.**
 
-```Bash
+```shell
 $ cat /proc/cpuinfo | grep avx2
 ```
 

--- a/versioned_docs/version-3.0/lakehouse/database/es.md
+++ b/versioned_docs/version-3.0/lakehouse/database/es.md
@@ -120,7 +120,7 @@ For example, suppose there is an index `doc` containing the following data struc
 The array fields of this structure can be defined by using the following command to add the field property definition 
 to the `_meta.doris` property of the target index mapping.
 
-```bash
+```shell
 # ES 7.x and above
 curl -X PUT "localhost:9200/doc/_mapping?pretty" -H 'Content-Type:application/json' -d '
 {

--- a/versioned_docs/version-3.0/practical-guide/log-storage-analysis.md
+++ b/versioned_docs/version-3.0/practical-guide/log-storage-analysis.md
@@ -398,7 +398,7 @@ output {
 
 3. Run Logstash according to the command below, collect logs, and output to Apache Doris.
 
-```Bash  
+```shell
 ./bin/logstash -f logstash_demo.conf
 ```
 
@@ -465,7 +465,7 @@ headers:
 
 3. Run Filebeat according to the command below, collect logs, and output to Apache Doris.
 
-    ```Bash  
+    ```shell  
     chmod +x filebeat-doris-1.0.0  
     ./filebeat-doris-1.0.0 -c filebeat_demo.yml
     ```
@@ -509,7 +509,7 @@ For more information about Kafka, see [Routine Load](../data-operate/import/rout
 
 In addition to integrating common log collectors, you can also customize programs to import log data into Apache Doris using the Stream Load HTTP API. Refer to the following code:
 
-```Bash  
+```shell  
 curl   
 --location-trusted   
 -u username:password   

--- a/versioned_docs/version-3.0/query/query-analysis/import-analysis.md
+++ b/versioned_docs/version-3.0/query/query-analysis/import-analysis.md
@@ -45,7 +45,7 @@ The execution process of a [Broker Load](../../data-operate/import/broker-load-m
 ┌────────────────┐
 │BrokerScanNode│
 └────────────────┘
-````
+```
 
 BrokerScanNode is mainly responsible for reading the source data and sending it to OlapTableSink, and OlapTableSink is responsible for sending data to the corresponding node according to the partition and bucketing rules, and the corresponding node is responsible for the actual data writing.
 
@@ -59,7 +59,7 @@ The user can open the session variable `is_report_success` with the following co
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Then submit a Broker Load import request and wait until the import execution completes. Doris will generate a Profile for this import. Profile contains the execution details of importing each subtask and Instance, which helps us analyze import bottlenecks.
 
@@ -105,7 +105,7 @@ WaitAndFetchResultTime: NULL
        FetchResultTime: 0ns
        WriteResultTime: 0ns
 WaitAndFetchResultTime: N/A
-````
+```
 
 This command will list all currently saved import profiles. Each line corresponds to one import. where the QueryId column is the ID of the import job. This ID can also be viewed through the SHOW LOAD statement. We can select the QueryId corresponding to the Profile we want to see to see the specific situation.
 
@@ -124,7 +124,7 @@ This command will list all currently saved import profiles. Each line correspond
    +-----------------------------------+------------+
    | 980014623046410a-af5d36f23381017f | 3m14s      |
    +-----------------------------------+------------+
-   ````
+   ```
 
 As shown in the figure above, it means that the import job `980014623046410a-af5d36f23381017f` has a total of one subtask, in which ActiveTime indicates the execution time of the longest instance in this subtask.
 
@@ -144,7 +144,7 @@ As shown in the figure above, it means that the import job `980014623046410a-af5
    | 980014623046410a-88e260f0c43031f4 | 10.81.85.89:9067 | 3m10s      |
    | 980014623046410a-88e260f0c43031f5 | 10.81.85.89:9067 | 3m14s      |
    +-----------------------------------+------------------+------------+
-   ````
+   ```
 
 This shows the time-consuming of four instances of the subtask 980014623046410a-af5d36f23381017f, and also shows the execution node where the instance is located.
 
@@ -195,7 +195,7 @@ This shows the time-consuming of four instances of the subtask 980014623046410a-
    │ - TotalReadThroughput: 30.39858627319336 MB/sec│
    │ - WaitScannerTime: 56s528ms │
    └------------------------------------------------- ----┘
-   ````
+   ```
 
 The figure above shows the specific profiles of each operator of Instance 980014623046410a-af5d36f23381017f in subtask 980014623046410a-88e260f0c43031f5.
 

--- a/versioned_docs/version-3.0/query/query-analysis/query-analytics.md
+++ b/versioned_docs/version-3.0/query/query-analysis/query-analytics.md
@@ -37,7 +37,7 @@ For example, if the user specifies a Join operator, the query planner needs to d
 
 Doris' query planning process is to first convert an SQL statement into a single-machine execution plan tree.
 
-````text
+```text
      ┌────┐
      │Sort│
      └────┘
@@ -53,11 +53,11 @@ Doris' query planning process is to first convert an SQL statement into a single
 ┌──────┐ ┌──────┐
 │Scan-1│ │Scan-2│
 └──────┘ └──────┘
-````
+```
 
 After that, the query planner will convert the single-machine query plan into a distributed query plan according to the specific operator execution mode and the specific distribution of data. The distributed query plan is composed of multiple fragments, each fragment is responsible for a part of the query plan, and the data is transmitted between the fragments through the ExchangeNode operator.
 
-````text
+```text
         ┌────┐
         │Sort│
         │F1 │
@@ -87,7 +87,7 @@ After that, the query planner will convert the single-machine query plan into a 
             │Scan-2│
             │F2 │
             └──────┘
-````
+```
 
 As shown above, we divided the stand-alone plan into two Fragments: F1 and F2. Data is transmitted between two Fragments through an ExchangeNode.
 
@@ -472,7 +472,7 @@ The user can open the session variable `is_report_success` with the following co
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Then execute the query, and Doris will generate a Profile of the query. Profile contains the specific execution of a query for each node, which helps us analyze query bottlenecks.
 
@@ -490,7 +490,7 @@ mysql> show query profile "/"\G
    EndTime: 2021-04-08 11:30:50
  TotalTime: 9ms
 QueryState: EOF
-````
+```
 
 This command will list all currently saved profiles. Each row corresponds to a query. We can select the QueryId corresponding to the Profile we want to see to see the specific situation.
 
@@ -669,7 +669,7 @@ This shows the execution nodes and time consumption of all three Instances on Fr
    │ - RowsReturnedRate: 0 │
    │ - SendersBlockedTotalTimer(*): 0ns │
    └────────────────────────────────────────────────────┘
-   ````
+   ```
 
    The above figure shows the specific profiles of each operator of Instance c257c52f93e149ee-ace8ac14e8c9ff03 in Fragment 1.
 

--- a/versioned_docs/version-3.0/query/query-variables/variables.md
+++ b/versioned_docs/version-3.0/query/query-variables/variables.md
@@ -587,19 +587,19 @@ Note that the comment must start with /*+ and can only follow the SELECT.
 
 	Default password expiration time. The default value is 0, which means no expiration. The unit is days. This parameter is only enabled if the user's password expiration property has a value of DEFAULT. like:
 
-   ````
+   ```
    CREATE USER user1 IDENTIFIED BY "12345" PASSWORD_EXPIRE DEFAULT;
    ALTER USER user1 PASSWORD_EXPIRE DEFAULT;
-   ````
+   ```
 
 * `password_history`
 
 	The default number of historical passwords. The default value is 0, which means no limit. This parameter is enabled only when the user's password history attribute is the DEFAULT value. like:
 
-   ````
+   ```
    CREATE USER user1 IDENTIFIED BY "12345" PASSWORD_HISTORY DEFAULT;
    ALTER USER user1 PASSWORD_HISTORY DEFAULT;
-   ````
+   ```
 
 * `validate_password_policy`
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/CREATE-ROLE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/CREATE-ROLE.md
@@ -36,7 +36,7 @@ The statement user creates a role
 
 ```sql
   CREATE ROLE role_name [comment];
-````
+```
 
 This statement creates an unprivileged role, which can be subsequently granted with the GRANT command.
 
@@ -46,7 +46,7 @@ This statement creates an unprivileged role, which can be subsequently granted w
 
     ```sql
     CREATE ROLE role1;
-    ````
+    ```
 
 2. Create a role with comment
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/DROP-ROLE.md
@@ -32,7 +32,7 @@ The statement user removes a role
 
 ```sql
   DROP ROLE [IF EXISTS] role1;
-````
+```
 
 Deleting a role does not affect the permissions of users who previously belonged to the role. It is only equivalent to decoupling the role from the user. The permissions that the user has obtained from the role will not change
 
@@ -42,7 +42,7 @@ Deleting a role does not affect the permissions of users who previously belonged
 
 ```sql
 DROP ROLE role1;
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/DROP-USER.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/DROP-USER.md
@@ -41,7 +41,7 @@ Delete a user
     
          user@'host'
          user@['domain']
-````
+```
 
   Delete the specified user identitiy.
 
@@ -51,7 +51,7 @@ Delete a user
 
     ```sql
     DROP USER 'jack'@'192.%'
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/GRANT.md
@@ -47,7 +47,7 @@ GRANT privilege_list ON priv_level TO user_identity [ROLE role_name]
 GRANT privilege_list ON RESOURCE resource_name TO user_identity [ROLE role_name]
 
 GRANT role_list TO user_identity
-````
+```
 
 GRANT privilege_list ON WORKLOAD GROUP workload_group_name TO user_identity [ROLE role_name]
 
@@ -105,67 +105,67 @@ role_list is the list of roles to be assigned, separated by commas,the specified
 
    ```sql
    GRANT SELECT_PRIV ON *.*.* TO 'jack'@'%';
-   ````
+   ```
 
 2. Grant permissions to the specified database table to the user
 
    ```sql
    GRANT SELECT_PRIV,ALTER_PRIV,LOAD_PRIV ON ctl1.db1.tbl1 TO 'jack'@'192.8.%';
-   ````
+   ```
 
 3. Grant permissions to the specified database table to the role
 
    ```sql
    GRANT LOAD_PRIV ON ctl1.db1.* TO ROLE 'my_role';
-   ````
+   ```
 
 4. Grant access to all resources to users
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE * TO 'jack'@'%';
-   ````
+   ```
 
 5. Grant the user permission to use the specified resource
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE 'spark_resource' TO 'jack'@'%';
-   ````
+   ```
 
 6. Grant access to specified resources to roles
 
    ```sql
    GRANT USAGE_PRIV ON RESOURCE 'spark_resource' TO ROLE 'my_role';
-   ````
+   ```
 
 7. Grant the specified role to a user
 
     ```sql
     GRANT 'role1','role2' TO 'jack'@'%';
-    ````
+    ```
 
 8. Grant the specified workload group 'g1' to user jack
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO 'jack'@'%'.
-    ````
+    ```
 
 9. match all workload groups granted to user jack
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP '%' TO 'jack'@'%'.
-    ````
+    ```
 
 10. grant the workload group 'g1' to the role my_role
 
     ```sql
     GRANT USAGE_PRIV ON WORKLOAD GROUP 'g1' TO ROLE 'my_role'.
-    ````
+    ```
 
 11. Allow jack to view the creation statement of view1 under db1
 
     ```sql
     GRANT SHOW_VIEW_PRIV ON db1.view1 TO 'jack'@'%';
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/LDAP.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/LDAP.md
@@ -36,7 +36,7 @@ SET LDAP_ADMIN_PASSWORD
 
 ```sql
   SET LDAP_ADMIN_PASSWORD = PASSWORD('plain password')
-````
+```
 
   The SET LDAP_ADMIN_PASSWORD command is used to set the LDAP administrator password. When using LDAP authentication, doris needs to use the administrator account and password to query the LDAP service for login user information.
 
@@ -46,7 +46,7 @@ SET LDAP_ADMIN_PASSWORD
 
 ```sql
 SET LDAP_ADMIN_PASSWORD = PASSWORD('123456')
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/REVOKE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/REVOKE.md
@@ -47,7 +47,7 @@ REVOKE privilege_list ON db_name[.tbl_name] FROM user_identity [ROLE role_name]
 REVOKE privilege_list ON RESOURCE resource_name FROM user_identity [ROLE role_name]
 
 REVOKE role_list FROM user_identity
-````
+```
 
 user_identity:
 
@@ -63,13 +63,13 @@ role_list is the list of roles to be revoked, separated by commas. The specified
 
     ```sql
     REVOKE SELECT_PRIV ON db1.* FROM 'jack'@'192.%';
-    ````
+    ```
 
 2. Revoke user jack resource spark_resource permission
 
     ```sql
     REVOKE USAGE_PRIV ON RESOURCE 'spark_resource' FROM 'jack'@'192.%';
-    ````
+    ```
 3. Revoke the roles role1 and role2 previously granted to jack
 
     ```sql

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/SET-PASSWORD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/SET-PASSWORD.md
@@ -37,7 +37,7 @@ The SET PASSWORD command can be used to modify a user's login password. If the [
 ```sql
 SET PASSWORD [FOR user_identity] =
     [PASSWORD('plain password')]|['hashed password']
-````
+```
 
 Note that the user_identity here must exactly match the user_identity specified when creating a user with CREATE USER, otherwise an error will be reported that the user does not exist. If user_identity is not specified, the current user is 'username'@'ip', which may not match any user_identity. Current users can be viewed through SHOW GRANTS.
 
@@ -51,14 +51,14 @@ To modify the passwords of other users, administrator privileges are required.
    ```sql
    SET PASSWORD = PASSWORD('123456')
    SET PASSWORD = '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9'
-   ````
+   ```
 
 2. Modify the specified user password
 
    ```sql
    SET PASSWORD FOR 'jack'@'192.%' = PASSWORD('123456')
    SET PASSWORD FOR 'jack'@['domain'] = '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9'
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/SET-PROPERTY.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Account-Management-Statements/SET-PROPERTY.md
@@ -72,7 +72,7 @@ Super user privileges:
 
    ```sql
    SET PROPERTY FOR 'jack' 'max_query_instances' = '3000';
-   ````
+   ```
 
 3. Modify the sql block rule of user jack
 
@@ -84,7 +84,7 @@ Super user privileges:
 
     ```sql
     SET PROPERTY FOR 'jack' 'cpu_resource_limit' = '2';
-    ````
+    ```
 
 5. Modify the user's resource tag permissions
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BACKEND.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 -- Add nodes (add this method if you do not use the multi-tenancy function)
    ALTER SYSTEM ADD BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
  illustrate:
 
@@ -53,7 +53,7 @@ grammar:
 
     ```sql
     ALTER SYSTEM ADD BACKEND "host:port";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BROKER.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-BROKER.md
@@ -39,7 +39,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host2:broker_ipc_port2",...;
-````
+```
 
 ### Example
 
@@ -47,7 +47,7 @@ ALTER SYSTEM ADD BROKER broker_name "broker_host1:broker_ipc_port1","broker_host
 
     ```sql
      ALTER SYSTEM ADD BROKER "host1:port", "host2:port";
-    ````
+    ```
 2. When fe enable fqdn([fqdn](../../../admin-manual/cluster-management/fqdn.md)),add one Broker
 
    ```sql

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-FOLLOWER.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-FOLLOWER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD FOLLOWER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM ADD FOLLOWER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-OBSERVER.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-ADD-OBSERVER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM ADD OBSERVER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM ADD OBSERVER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DECOMMISSION-BACKEND.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DECOMMISSION-BACKEND.md
@@ -40,13 +40,13 @@ grammar:
 
 ```sql
 ALTER SYSTEM DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM DECOMMISSION BACKEND "id1","id2"...;
-````
+```
 
   illustrate:
 
@@ -61,11 +61,11 @@ ALTER SYSTEM DECOMMISSION BACKEND "id1","id2"...;
 
     ```sql
     ALTER SYSTEM DECOMMISSION BACKEND "host1:port", "host2:port";
-    ````
+    ```
 
     ```sql
     ALTER SYSTEM DECOMMISSION BACKEND "id1", "id2";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BACKEND.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BACKEND.md
@@ -40,12 +40,12 @@ grammar:
 
 ```sql
 ALTER SYSTEM DROP BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...]
-````
+```
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM DROP BACKEND "id1","id2"...;
-````
+```
 
 illustrate:
 
@@ -59,11 +59,11 @@ illustrate:
 
     ```sql
     ALTER SYSTEM DROP BACKEND "host1:port", "host2:port";
-    ````
+    ```
 
     ```sql
     ALTER SYSTEM DROP BACKEND "ids1", "ids2";
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BROKER.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-BROKER.md
@@ -42,7 +42,7 @@ grammar:
 ALTER SYSTEM DROP ALL BROKER broker_name
 -- Delete a Broker node
 ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
-````
+```
 
 ### Example
 
@@ -50,13 +50,13 @@ ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
 
     ```sql
     ALTER SYSTEM DROP ALL BROKER broker_name
-    ````
+    ```
 
 2. Delete a Broker node
 
     ```sql
     ALTER SYSTEM DROP BROKER broker_name "host:port"[,"host:port"...];
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-OBSERVER.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-DROP-OBSERVER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ALTER SYSTEM DROP OBSERVER "follower_host:edit_log_port"
-````
+```
 
 illustrate:
 
@@ -51,7 +51,7 @@ illustrate:
 
     ```sql
     ALTER SYSTEM DROP OBSERVER "host_ip:9010"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/ALTER-SYSTEM-MODIFY-BACKEND.md
@@ -41,13 +41,13 @@ grammar:
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "host:heartbeat_port" SET ("key" = "value"[, ...]);
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 ALTER SYSTEM MODIFY BACKEND "id1" SET ("key" = "value"[, ...]);
-````
+```
 
   illustrate:
 
@@ -69,32 +69,32 @@ Note:
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("tag.location" = "group_a");
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a");
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("tag.location" = "group_a", "tag.compute" = "c1");
-    ````
+    ```
 
 2. Modify the query disable property of BE
 
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("disable_query" = "true");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_query" = "true");
-    ````
+    ```
 
 3. Modify the import disable property of BE
 
     ```sql
     ALTER SYSTEM MODIFY BACKEND "host1:heartbeat_port" SET ("disable_load" = "true");
-    ````
+    ```
    
     ```sql
     ALTER SYSTEM MODIFY BACKEND "id1" SET ("disable_load" = "true");
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/CANCEL-ALTER-SYSTEM.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Cluster-Management-Statements/CANCEL-ALTER-SYSTEM.md
@@ -40,13 +40,13 @@ grammar:
 
 ```sql
 CANCEL DECOMMISSION BACKEND "host:heartbeat_port"[,"host:heartbeat_port"...];
-````
+```
 
 - Find backend through backend_id
 
 ```sql
 CANCEL DECOMMISSION BACKEND "id1","id2","id3...";
-````
+```
 
 ### Example
 
@@ -54,7 +54,7 @@ CANCEL DECOMMISSION BACKEND "id1","id2","id3...";
 
       ```sql
       CANCEL DECOMMISSION BACKEND "host1:port", "host2:port";
-      ````
+      ```
 
  2. Cancel the offline operation of the node with backend_id 1:
     

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-SQL-BLOCK-RULE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 ALTER SQL_BLOCK_RULE rule_name
 [PROPERTIES ("key"="value", ...)];
-````
+```
 
 illustrate:
 
@@ -52,18 +52,18 @@ illustrate:
 
 ```sql
 ALTER SQL_BLOCK_RULE test_rule PROPERTIES("sql"="select \\* from test_table","enable"="true")
-````
+```
 
 2. If a rule sets partition_num, then sql or sqlHash cannot be modified
 
 ```sql
 ALTER SQL_BLOCK_RULE test_rule2 PROPERTIES("partition_num" = "10","tablet_num"="300","enable"="true")
-````
+```
 
 ### Keywords
 
-````text
+```text
 ALTER,SQL_BLOCK_RULE
-````
+```
 
 ### Best Practice

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
@@ -161,7 +161,7 @@ ALTER TABLE example_db.mysql_table SET ("replication_num" = "2");
 ALTER TABLE example_db.mysql_table SET ("default.replication_num" = "2");
 ALTER TABLE example_db.mysql_table SET ("replication_allocation" = "tag.location.default: 1");
 ALTER TABLE example_db.mysql_table SET ("default.replication_allocation" = "tag.location.default: 1");
-````
+```
 
 Note:
 1. The property with the default prefix indicates the default replica distribution for the modified table. This modification does not modify the current actual replica distribution of the table, but only affects the replica distribution of newly created partitions on the partitioned table.

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-DATABASE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-DATABASE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 CREATE DATABASE [IF NOT EXISTS] db_name
     [PROPERTIES ("key"="value", ...)];
-````
+```
 
 `PROPERTIES` Additional information about the database, which can be defaulted.
 
@@ -57,7 +57,7 @@ CREATE DATABASE [IF NOT EXISTS] db_name
 
    ```sql
    CREATE DATABASE db_test;
-   ````
+   ```
 
 2. Create a new database with default replica distribution:
 
@@ -66,13 +66,13 @@ CREATE DATABASE [IF NOT EXISTS] db_name
    PROPERTIES (
        "replication_allocation" = "tag.location.group_1:3"
    );
-   ````
+   ```
 
 ### Keywords
 
-````text
+```text
 CREATE, DATABASE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-ENCRYPT-KEY.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-ENCRYPT-KEY.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 CREATE ENCRYPTKEY key_name AS "key_string"
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ If `key_name` contains the database name, then the custom key will be created in
 
    ```sql
    CREATE ENCRYPTKEY my_key AS "ABCD123456789";
-   ````
+   ```
 
 2. Use a custom key
 
@@ -76,7 +76,7 @@ If `key_name` contains the database name, then the custom key will be created in
    | Doris is Great |
    +------------------------------------------------- -------------------+
    1 row in set (0.01 sec)
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FILE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FILE.md
@@ -46,7 +46,7 @@ grammar:
 ```sql
 CREATE FILE "file_name" [IN database]
 PROPERTIES("key"="value", ...)
-````
+```
 
 illustrate:
 
@@ -68,7 +68,7 @@ illustrate:
        "url" = "https://test.bj.bcebos.com/kafka-key/ca.pem",
        "catalog" = "kafka"
    );
-   ````
+   ```
 
 2. Create a file client.key, classified as my_catalog
 
@@ -81,13 +81,13 @@ illustrate:
        "catalog" = "my_catalog",
        "md5" = "b5bb901bf10f99205b39a46ac3557dd9"
    );
-   ````
+   ```
 
 ### Keywords
 
-````text
+```text
 CREATE, FILE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-FUNCTION.md
@@ -45,7 +45,7 @@ CREATE [GLOBAL] [AGGREGATE] [ALIAS] FUNCTION function_name
     [INTERMEDIATE inter_type]
     [WITH PARAMETER(param [,...]) AS origin_function]
     [PROPERTIES ("key" = "value" [, ...]) ]
-````
+```
 
 Parameter Description:
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-INDEX.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-INDEX.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 CREATE INDEX [IF NOT EXISTS] index_name ON table_name (column [, ...],) [USING INVERTED] [COMMENT 'balabala'];
-````
+```
 Notice:
 - INVERTED indexes are only created on a single column
 
@@ -47,14 +47,14 @@ Notice:
 
     ```sql
     CREATE INDEX [IF NOT EXISTS] index_name ON table1 (siteid) USING INVERTED COMMENT 'balabala';
-    ````
+    ```
 
 
 ### Keywords
 
-````text
+```text
 CREATE, INDEX
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-MATERIALIZED-VIEW.md
@@ -41,7 +41,7 @@ grammar:
 ```sql
 CREATE MATERIALIZED VIEW < MV name > as < query >
 [PROPERTIES ("key" = "value")]
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ illustrate:
   FROM [Base view name]
   GROUP BY column_name[, column_name ...]
   ORDER BY column_name[, column_name ...]
-  ````
+  ```
 
   The syntax is the same as the query syntax.
 
@@ -73,16 +73,16 @@ illustrate:
 
   Declare some configuration of the materialized view, optional.
 
-  ````text
+  ```text
   PROPERTIES ("key" = "value", "key" = "value" ...)
-  ````
+  ```
 
   The following configurations can be declared here:
 
-  ````text
+  ```text
    short_key: The number of sorting columns.
    timeout: The timeout for materialized view construction.
-  ````
+  ```
 
 ### Example
 
@@ -98,7 +98,7 @@ mysql> desc duplicate_table;
 | k3 | BIGINT | Yes | true | N/A | |
 | k4 | BIGINT | Yes | true | N/A | |
 +-------+--------+------+------+---------+-------+
-````
+```
 ```sql
 create table duplicate_table(
 	k1 int null,
@@ -117,49 +117,49 @@ attention：If the materialized view contains partitioned and distributed column
    ```sql
    create materialized view k2_k1 as
    select k2, k1 from duplicate_table;
-   ````
+   ```
 
    The schema of the materialized view is as follows, the materialized view contains only two columns k1, k2 without any aggregation
 
-   ````text
+   ```text
    +-------+-------+--------+------+------+ ---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------+ ---------+-------+
    | k2_k1 | k2 | INT | Yes | true | N/A | |
    | | k1 | INT | Yes | true | N/A | |
    +-------+-------+--------+------+------+ ---------+-------+
-   ````
+   ```
 
 2. Create a materialized view with k2 as the sort column
 
    ```sql
    create materialized view k2_order as
    select k2, k1 from duplicate_table order by k2;
-   ````
+   ```
 
    The schema of the materialized view is shown in the figure below. The materialized view contains only two columns k2, k1, where k2 is the sorting column without any aggregation.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
    | k2_order | k2 | INT | Yes | true | N/A | |
    | | k1 | INT | Yes | false | N/A | NONE |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 3. Create a materialized view with k1, k2 grouping and k3 column aggregated by SUM
 
    ```sql
    create materialized view k1_k2_sumk3 as
    select k1, k2, sum(k3) from duplicate_table group by k1, k2;
-   ````
+   ```
 
    The schema of the materialized view is shown in the figure below. The materialized view contains two columns k1, k2, sum(k3) where k1, k2 are the grouping columns, and sum(k3) is the sum value of the k3 column grouped by k1, k2.
 
    Since the materialized view does not declare a sorting column, and the materialized view has aggregated data, the system defaults to supplement the grouping columns k1 and k2 as sorting columns.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
@@ -167,18 +167,18 @@ attention：If the materialized view contains partitioned and distributed column
    | | k2 | INT | Yes | true | N/A | |
    | | k3 | BIGINT | Yes | false | N/A | SUM |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 4. Create a materialized view that removes duplicate rows
 
    ```sql
    create materialized view deduplicate as
    select k1, k2, k3, k4 from duplicate_table group by k1, k2, k3, k4;
-   ````
+   ```
 
    The materialized view schema is as shown below. The materialized view contains columns k1, k2, k3, and k4, and there are no duplicate rows.
 
-   ````text
+   ```text
    +-------+-------+--------+------+------- +---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +-------+-------+--------+------+------- +---------+-------+
@@ -187,13 +187,13 @@ attention：If the materialized view contains partitioned and distributed column
    | | k3 | BIGINT | Yes | true | N/A | |
    | | k4 | BIGINT | Yes | true | N/A | |
    +-------+-------+--------+------+------- +---------+-------+
-   ````
+   ```
 
 5. Create a non-aggregate materialized view that does not declare a sort column
 
    The schema of all_type_table is as follows
 
-   ````
+   ```
    +-------+--------------+------+-------+---------+- ------+
    | Field | Type | Null | Key | Default | Extra |
    +-------+--------------+------+-------+---------+- ------+
@@ -205,14 +205,14 @@ attention：If the materialized view contains partitioned and distributed column
    | k6 | DOUBLE | Yes | false | N/A | NONE |
    | k7 | VARCHAR(20) | Yes | false | N/A | NONE |
    +-------+--------------+------+-------+---------+- ------+
-   ````
+   ```
 
    The materialized view contains k3, k4, k5, k6, k7 columns, and does not declare a sort column, the creation statement is as follows:
 
    ```sql
    create materialized view mv_1 as
    select k3, k4, k5, k6, k7 from all_type_table;
-   ````
+   ```
 
    The default added sorting column of the system is k3, k4, k5 three columns. The sum of the bytes of these three column types is 4(INT) + 8(BIGINT) + 16(DECIMAL) = 28 < 36. So the addition is that these three columns are used as sorting columns. The schema of the materialized view is as follows, you can see that the key field of the k3, k4, k5 columns is true, that is, the sorting column. The key field of the k6, k7 columns is false, which is a non-sorted column.
 
@@ -226,7 +226,7 @@ attention：If the materialized view contains partitioned and distributed column
    | | k6 | DOUBLE | Yes | false | N/A | NONE |
    | | k7 | VARCHAR(20) | Yes | false | N/A | NONE |
    +----------------+-------+--------------+------+-- -----+---------+-------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-RESOURCE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-RESOURCE.md
@@ -40,7 +40,7 @@ grammar:
 ```sql
 CREATE [EXTERNAL] RESOURCE "resource_name"
 PROPERTIES ("key"="value", ...);
-````
+```
 
 illustrate:
 
@@ -69,7 +69,7 @@ illustrate:
      "broker.username" = "user0",
      "broker.password" = "password0"
    );
-   ````
+   ```
 
    Spark related parameters are as follows:
    - spark.master: Required, currently supports yarn, spark://host:port.
@@ -100,7 +100,7 @@ illustrate:
    "odbc_type" = "oracle",
    "driver" = "Oracle 19 ODBC driver"
    );
-   ````
+   ```
 
    The relevant parameters of ODBC are as follows:
    - hosts: IP address of the external database

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-SQL-BLOCK-RULE.md
@@ -45,7 +45,7 @@ grammar:
 ```sql
 CREATE SQL_BLOCK_RULE rule_name
 [PROPERTIES ("key"="value", ...)];
-````
+```
 
 Parameter Description:
 
@@ -68,7 +68,7 @@ Parameter Description:
     "global"="false",
     "enable"="true"
     );
-    ````
+    ```
 
     >Notes:
     >
@@ -79,7 +79,7 @@ Parameter Description:
     ```sql
     select * from order_analysis;
     ERROR 1064 (HY000): errCode = 2, detailMessage = sql match regex sql block rule: order_analysis_rule
-    ````
+    ```
 
 
 2. Create test_rule2, limit the maximum number of scanned partitions to 30, and limit the maximum scan base to 10 billion rows. The example is as follows:
@@ -92,7 +92,7 @@ Parameter Description:
     "global" = "false",
     "enable" = "true"
     );
-   ````
+   ```
 3. Create SQL BLOCK RULE with special chars
 
     ```sql
@@ -150,9 +150,9 @@ Here are some commonly used regular expressions:
 
 ### Keywords
 
-````text
+```text
 CREATE, SQL_BLCOK_RULE
-````
+```
 
 ### Best Practice
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE-LIKE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE-LIKE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 CREATE [EXTERNAL] TABLE [IF NOT EXISTS] [database.]table_name LIKE [database.]table_name [WITH ROLLUP (r1,r2,r3,...)]
-````
+```
 
 illustrate: 
 
@@ -53,43 +53,43 @@ illustrate:
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1
-    ````
+    ```
 
 2. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1
-    ````
+    ```
 
 3. Create an empty table with the same table structure as table1 under the test1 library, the table name is table2, and copy the two rollups of r1 and r2 of table1 at the same time
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1 WITH ROLLUP (r1,r2)
-    ````
+    ```
 
 4. Create an empty table with the same table structure as table1 under the test1 library, the table name is table2, and copy all the rollups of table1 at the same time
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1 WITH ROLLUP
-    ````
+    ```
 
 5. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2, and copy the two rollups of r1 and r2 of table1 at the same time
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1 WITH ROLLUP (r1,r2)
-    ````
+    ```
 
 6. Create an empty table with the same table structure as test1.table1 under the test2 library, the table name is table2, and copy all the rollups of table1 at the same time
 
     ```sql
     CREATE TABLE test2.table2 LIKE test1.table1 WITH ROLLUP
-    ````
+    ```
 
 7. Create an empty table under the test1 library with the same table structure as the MySQL outer table1, the table name is table2
 
     ```sql
     CREATE TABLE test1.table2 LIKE test1.table1
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-VIEW.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-VIEW.md
@@ -40,7 +40,7 @@ CREATE VIEW [IF NOT EXISTS]
  [db_name.]view_name
  (column1[ COMMENT "col comment"][, column2, ...])
 AS query_stmt
-````
+```
 
 
 illustrate:
@@ -57,7 +57,7 @@ illustrate:
     AS
     SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table
     WHERE k1 = 20160112 GROUP BY k1,k2,k3;
-    ````
+    ```
     
 2. Create a view with a comment
 
@@ -73,7 +73,7 @@ illustrate:
     AS
     SELECT c1 as k1, k2, k3, SUM(v1) FROM example_table
     WHERE k1 = 20160112 GROUP BY k1,k2,k3;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-DATABASE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-DATABASE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP DATABASE [IF EXISTS] db_name [FORCE];
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
    
      ```sql
      DROP DATABASE db_test;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-ENCRYPT-KEY.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-ENCRYPT-KEY.md
@@ -36,7 +36,7 @@ grammar:
 
 ```sql
 DROP ENCRYPTKEY key_name
-````
+```
 
 Parameter Description:
 
@@ -52,7 +52,7 @@ Executing this command requires the user to have `ADMIN` privileges.
 
     ```sql
     DROP ENCRYPTKEY my_key;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FILE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FILE.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 DROP FILE "file_name" [FROM database]
 [properties]
-````
+```
 
 illustrate:
 
@@ -54,7 +54,7 @@ illustrate:
 
      ```sql
      DROP FILE "ca.pem" properties("catalog" = "kafka");
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-FUNCTION.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 DROP [GLOBAL] FUNCTION function_name
      (arg_type [, ...])
-````
+```
 
 Parameter Description:
 
@@ -52,12 +52,12 @@ Parameter Description:
 
     ```sql
     DROP FUNCTION my_add(INT, INT)
-    ````
+    ```
 2. Delete a global function
 
     ```sql
     DROP GLOBAL FUNCTION my_add(INT, INT)
-    ````   
+    ```   
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-INDEX.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-INDEX.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP INDEX [IF EXISTS] index_name ON [db_name.]table_name;
-````
+```
 
 ### Example
 
@@ -45,7 +45,7 @@ DROP INDEX [IF EXISTS] index_name ON [db_name.]table_name;
 
     ```sql
     DROP INDEX [IF NOT EXISTS] index_name ON table1 ;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-MATERIALIZED-VIEW.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DROP MATERIALIZED VIEW [IF EXISTS] mv_name ON table_name;
-````
+```
 
 
 1. IF EXISTS:
@@ -70,17 +70,17 @@ mysql> desc all_type_table all;
 | k1_sumk2 | k1 | TINYINT | Yes | true | N/A | |
 | | k2 | SMALLINT | Yes | false | N/A | SUM |
 +----------------+-------+----------+------+------ -+---------+-------+
-````
+```
 
 1. Drop the materialized view named k1_sumk2 of the table all_type_table
 
    ```sql
    drop materialized view k1_sumk2 on all_type_table;
-   ````
+   ```
 
    The table structure after the materialized view is deleted
 
-   ````text
+   ```text
    +----------------+-------+----------+------+------ -+---------+-------+
    | IndexName | Field | Type | Null | Key | Default | Extra |
    +----------------+-------+----------+------+------ -+---------+-------+
@@ -92,14 +92,14 @@ mysql> desc all_type_table all;
    | | k6 | FLOAT | Yes | false | N/A | NONE |
    | | k7 | DOUBLE | Yes | false | N/A | NONE |
    +----------------+-------+----------+------+------ -+---------+-------+
-   ````
+   ```
 
 2. Drop a non-existent materialized view in the table all_type_table
 
    ```sql
    drop materialized view k1_k2 on all_type_table;
    ERROR 1064 (HY000): errCode = 2, detailMessage = Materialized view [k1_k2] does not exist in table [all_type_table]
-   ````
+   ```
 
    The delete request reports an error directly
 
@@ -108,7 +108,7 @@ mysql> desc all_type_table all;
    ```sql
    drop materialized view if exists k1_k2 on all_type_table;
    Query OK, 0 rows affected (0.00 sec)
-   ````
+   ```
 
     If it exists, delete it, if it does not exist, no error is reported.
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-RESOURCE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-RESOURCE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP RESOURCE 'resource_name'
-````
+```
 
 Note: ODBC/S3 resources in use cannot be deleted.
 
@@ -47,7 +47,7 @@ Note: ODBC/S3 resources in use cannot be deleted.
    
      ```sql
      DROP RESOURCE 'spark0';
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-SQL-BLOCK-RULE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DROP SQL_BLOCK_RULE test_rule1,...
-````
+```
 
 ### Example
 
@@ -47,12 +47,12 @@ DROP SQL_BLOCK_RULE test_rule1,...
     ```sql
     mysql> DROP SQL_BLOCK_RULE test_rule1,test_rule2;
     Query OK, 0 rows affected (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 
-````text
+```text
 DROP, SQL_BLOCK_RULE
-````
+```
 
 ### Best Practice

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-TABLE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/DROP-TABLE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 DROP TABLE [IF EXISTS] [db_name.]table_name [FORCE];
-````
+```
 
 
 illustrate:
@@ -51,13 +51,13 @@ illustrate:
    
      ```sql
      DROP TABLE my_table;
-     ````
+     ```
     
 2. If it exists, delete the table of the specified database
    
      ```sql
      DROP TABLE IF EXISTS example_db.my_table;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/TRUNCATE-TABLE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Definition-Statements/Drop/TRUNCATE-TABLE.md
@@ -37,7 +37,7 @@ grammar:
 
 ```sql
 TRUNCATE TABLE [db.]tbl[ PARTITION(p1, p2, ...)];
-````
+```
 
 illustrate:
 
@@ -54,13 +54,13 @@ illustrate:
 
      ```sql
      TRUNCATE TABLE example_db.tbl;
-     ````
+     ```
 
 2. Empty p1 and p2 partitions of table tbl
 
      ```sql
      TRUNCATE TABLE tbl PARTITION(p1, p2);
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/ALTER-ROUTINE-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/ALTER-ROUTINE-LOAD.md
@@ -43,7 +43,7 @@ ALTER ROUTINE LOAD FOR [db.]job_name
 [job_properties]
 FROM data_source
 [data_source_properties]
-````
+```
 
 1. `[db.]job_name`
 
@@ -103,7 +103,7 @@ FROM data_source
    (
        "desired_concurrent_number" = "1"
    );
-   ````
+   ```
 
 2. Modify `desired_concurrent_number` to 10, modify the offset of the partition, and modify the group id.
 
@@ -119,7 +119,7 @@ FROM data_source
        "kafka_offsets" = "100, 200, 100",
        "property.group.id" = "new_group"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/BROKER-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/BROKER-LOAD.md
@@ -76,7 +76,7 @@ WITH BROKER broker_name
   [DELETE ON expr]
   [ORDER BY source_sequence]
   [PROPERTIES ("key1"="value1", ...)]
-  ````
+  ```
 
   - `[MERGE|APPEND|DELETE]`
 
@@ -159,13 +159,13 @@ WITH BROKER broker_name
 
   Specifies the information required by the broker. This information is usually used by the broker to be able to access remote storage systems. Such as BOS or HDFS. See the [Broker](../../../../advanced/broker.md) documentation for specific information.
 
-  ````text
+  ```text
   (
       "key1" = "val1",
       "key2" = "val2",
       ...
   )
-  ````
+  ```
 
 - `load_properties`
 
@@ -232,7 +232,7 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    Import the file `file.txt`, separated by commas, into the table `my_table`.
 
@@ -260,7 +260,7 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    Import two batches of files `file-10*` and `file-20*` using wildcard matching. Imported into two tables `my_table1` and `my_table2` respectively. Where `my_table1` specifies to import into partition `p1`, and will import the values of the second and third columns in the source file +1.
 
@@ -283,7 +283,7 @@ WITH BROKER broker_name
        "dfs.namenode.rpc-address.my_ha.my_namenode2" = "nn2_host:rpc_port",
        "dfs.client.failover.proxy.provider.my_ha" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
    );
-   ````
+   ```
 
    Specify the delimiter as Hive's default delimiter `\\x01`, and use the wildcard * to specify all files in all directories under the `data` directory. Use simple authentication while configuring namenode HA.
 
@@ -302,7 +302,7 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
 5. Import the data and extract the partition field in the file path
 
@@ -320,18 +320,18 @@ WITH BROKER broker_name
        "username"="hdfs_user",
        "password"="hdfs_password"
    );
-   ````
+   ```
 
    The columns in the `my_table` table are `k1, k2, k3, city, utc_date`.
 
    The `hdfs://hdfs_host:hdfs_port/user/doris/data/input/dir/city=beijing` directory includes the following files:
 
-   ````text
+   ```text
    hdfs://hdfs_host:hdfs_port/input/city=beijing/utc_date=2020-10-01/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=beijing/utc_date=2020-10-02/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=tianji/utc_date=2020-10-03/0000.csv
    hdfs://hdfs_host:hdfs_port/input/city=tianji/utc_date=2020-10-04/0000.csv
-   ````
+   ```
 
    The file only contains three columns of `k1, k2, k3`, and the two columns of `city, utc_date` will be extracted from the file path.
 
@@ -354,7 +354,7 @@ WITH BROKER broker_name
        "username"="user",
        "password"="pass"
    );
-   ````
+   ```
 
    Only in the original data, k1 = 1, and after transformation, rows with k1 > k2 will be imported.
 
@@ -377,22 +377,22 @@ WITH BROKER broker_name
        "username"="user",
        "password"="pass"
    );
-   ````
+   ```
 
    There are the following files in the path:
 
-   ````text
+   ```text
    /user/data/data_time=2020-02-17 00%3A00%3A00/test.txt
    /user/data/data_time=2020-02-18 00%3A00%3A00/test.txt
-   ````
+   ```
 
    The table structure is:
 
-   ````text
+   ```text
    data_time DATETIME,
    k2 INT,
    k3 INT
-   ````
+   ```
 
 8. Import a batch of data from HDFS, specify the timeout and filter ratio. Broker with clear text my_hdfs_broker. Simple authentication. And delete the columns in the original data that match the columns with v2 greater than 100 in the imported data, and other columns are imported normally
 
@@ -414,7 +414,7 @@ WITH BROKER broker_name
         "timeout" = "3600",
         "max_filter_ratio" = "0.1"
     );
-    ````
+    ```
 
    Import using the MERGE method. `my_table` must be a table with Unique Key. When the value of the v2 column in the imported data is greater than 100, the row is considered a delete row.
 
@@ -436,7 +436,7 @@ WITH BROKER broker_name
         "hadoop.username"="user",
         "password"="pass"
     )
-    ````
+    ```
 
    `my_table` must be an Unique Key model table with Sequence Col specified. The data will be ordered according to the value of the `source_sequence` column in the source data.
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CANCEL-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CANCEL-LOAD.md
@@ -50,7 +50,7 @@ Notice: Cancel by State is supported since 1.2.0.
     CANCEL LOAD
     FROM example_db
     WHERE LABEL = "example_db_test_load_label";
-    ````
+    ```
 
 2. Cancel all import jobs containing example* on the database example*db.
 
@@ -58,7 +58,7 @@ Notice: Cancel by State is supported since 1.2.0.
     CANCEL LOAD
     FROM example_db
     WHERE LABEL like "example_";
-    ````
+    ```
 
 3. Cancel all import jobs which state are "LOADING"
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-ROUTINE-LOAD.md
@@ -74,7 +74,7 @@ FROM data_source [data_source_properties]
 
   Used to describe imported data. The composition is as follows:
 
-  ````SQL
+  ```SQL
   [column_separator],
   [columns_mapping],
   [preceding_filter],
@@ -82,7 +82,7 @@ FROM data_source [data_source_properties]
   [partitions],
   [DELETE ON],
   [ORDER BY]
-  ````
+  ```
 
   - `column_separator`
 
@@ -138,12 +138,12 @@ FROM data_source [data_source_properties]
 
   Common parameters for specifying routine import jobs.
 
-  ````text
+  ```text
   PROPERTIES (
       "key1" = "val1",
       "key2" = "val2"
   )
-  ````
+  ```
 
   Currently we support the following parameters:
 
@@ -165,11 +165,11 @@ FROM data_source [data_source_properties]
 
      These three parameters are used to control the execution time and processing volume of a subtask. When either one reaches the threshold, the task ends.
 
-     ````text
+     ```text
      "max_batch_interval" = "20",
      "max_batch_rows" = "300000",
      "max_batch_size" = "209715200"
-     ````
+     ```
 
   3. `max_error_number`
 
@@ -270,13 +270,13 @@ FROM data_source [data_source_properties]
 
   The type of data source. Currently supports:
 
-  ````text
+  ```text
   FROM KAFKA
   (
       "key1" = "val1",
       "key2" = "val2"
   )
-  ````
+  ```
 
   `data_source_properties` supports the following data source properties:
 
@@ -304,15 +304,15 @@ FROM data_source [data_source_properties]
 
      If not specified, all partitions under topic will be subscribed from `OFFSET_END` by default.
 
-     ````text
+     ```text
      "kafka_partitions" = "0,1,2,3",
      "kafka_offsets" = "101,0,OFFSET_BEGINNING,OFFSET_END"
-     ````
+     ```
 
-     ````text
+     ```text
      "kafka_partitions" = "0,1,2,3",
      "kafka_offsets" = "2021-05-22 11:00:00,2021-05-22 11:00:00,2021-05-22 11:00:00"
-     ````
+     ```
 
      Note that the time format cannot be mixed with the OFFSET format.
 
@@ -326,20 +326,20 @@ FROM data_source [data_source_properties]
 
      For more supported custom parameters, please refer to the configuration items on the client side in the official CONFIGURATION document of librdkafka. Such as:
 
-     ````text
+     ```text
      "property.client.id" = "12345",
      "property.ssl.ca.location" = "FILE:ca.pem"
-     ````
+     ```
 
      1. When connecting to Kafka using SSL, you need to specify the following parameters:
 
-        ````text
+        ```text
         "property.security.protocol" = "ssl",
         "property.ssl.ca.location" = "FILE:ca.pem",
         "property.ssl.certificate.location" = "FILE:client.pem",
         "property.ssl.key.location" = "FILE:client.key",
         "property.ssl.key.password" = "abcdefg"
-        ````
+        ```
 
         in:
 
@@ -347,11 +347,11 @@ FROM data_source [data_source_properties]
 
         If client authentication is enabled on the Kafka server side, thenAlso set:
 
-        ````text
+        ```text
         "property.ssl.certificate.location"
         "property.ssl.key.location"
         "property.ssl.key.password"
-        ````
+        ```
 
         They are used to specify the client's public key, private key, and password for the private key, respectively.
 
@@ -363,9 +363,9 @@ FROM data_source [data_source_properties]
 
         Example:
 
-        ````text
+        ```text
         "property.kafka_default_offsets" = "OFFSET_BEGINNING"
-        ````
+        ```
 - comment
   Comment for the routine load job.
 ### Example
@@ -394,7 +394,7 @@ FROM data_source [data_source_properties]
        "property.client.id" = "xxx",
        "property.kafka_default_offsets" = "OFFSET_BEGINNING"
    );
-   ````
+   ```
 
 2. Create a Kafka routine dynamic multiple tables import task named "test1" for the "example_db". Specify the column delimiter, group.id, and client.id, and automatically consume all partitions, subscribing from the position with data (OFFSET_BEGINNING).
 
@@ -444,7 +444,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 4. Import data from the Kafka cluster through SSL authentication. Also set the client.id parameter. The import task is in non-strict mode and the time zone is Africa/Abidjan
 
@@ -474,7 +474,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "property.ssl.key.password" = "abcdefg",
        "property.client.id" = "my_client_id"
    );
-   ````
+   ```
 
 5. Import data in Json format. By default, the field name in Json is used as the column name mapping. Specify to import three partitions 0, 1, and 2, and the starting offsets are all 0
 
@@ -499,7 +499,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2",
        "kafka_offsets" = "0,0,0"
    );
-   ````
+   ```
 
 6. Import Json data, extract fields through Jsonpaths, and specify the root node of the Json document
 
@@ -527,7 +527,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2",
        "kafka_offsets" = "0,0,0"
    );
-   ````
+   ```
 
 7. Create a Kafka routine import task named test1 for example_tbl of example_db. And use conditional filtering.
 
@@ -554,7 +554,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 8. Import data to Unique with sequence column Key model table
 
@@ -578,7 +578,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_partitions" = "0,1,2,3",
        "kafka_offsets" = "101,0,0,200"
    );
-   ````
+   ```
 
 9. Consume from a specified point in time
 
@@ -598,7 +598,7 @@ Assuming that we need to import data from Kafka into tables "test1" and "test2" 
        "kafka_topic" = "my_topic",
        "kafka_default_offsets" = "2021-05-21 10:00:00"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-SYNC-JOB.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/CREATE-SYNC-JOB.md
@@ -48,7 +48,7 @@ CREATE SYNC [db.]job_name
  ...
  )
 binlog_desc
-````
+```
 
 1. `job_name`
 
@@ -63,7 +63,7 @@ binlog_desc
    ```sql
    FROM mysql_db.src_tbl INTO des_tbl
    [columns_mapping]
-   ````
+   ```
    
    1. `mysql_db.src_tbl`
    
@@ -81,7 +81,7 @@ binlog_desc
    
       Example:
    
-      ````
+      ```
       Suppose the target table column is (k1, k2, v1),
       
       Change the order of columns k1 and k2
@@ -89,7 +89,7 @@ binlog_desc
       
       Ignore the fourth column of the source data
       (k2, k1, v1, dummy_column)
-      ````
+      ```
    
 3. `binlog_desc`
 
@@ -103,7 +103,7 @@ binlog_desc
        "key1" = "value1",
        "key2" = "value2"
    )
-   ````
+   ```
 
    1. The properties corresponding to the Canal data source, prefixed with `canal.`
 
@@ -119,7 +119,7 @@ binlog_desc
 
 1. Simply create a data synchronization job named `job1` for `test_tbl` of `test_db`, connect to the local Canal server, corresponding to the Mysql source table `mysql_db1.tbl1`.
 
-   ````SQL
+   ```SQL
    CREATE SYNC `test_db`.`job1`
    (
    FROM `mysql_db1`.`tbl1` INTO `test_tbl`
@@ -133,11 +133,11 @@ binlog_desc
    "canal.username" = "",
    "canal.password" = ""
    );
-   ````
+   ```
 
 2. Create a data synchronization job named `job1` for multiple tables of `test_db`, corresponding to multiple Mysql source tables one-to-one, and explicitly specify the column mapping.
 
-   ````SQL
+   ```SQL
    CREATE SYNC `test_db`.`job1`
    (
    FROM `mysql_db`.`t1` INTO `test1` (k1, k2, v1) ,
@@ -152,7 +152,7 @@ binlog_desc
    "canal.username" = "username",
    "canal.password" = "password"
    );
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/MULTI-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/MULTI-LOAD.md
@@ -34,7 +34,7 @@ MULTI LOAD
 
 Users submit multiple import jobs through the HTTP protocol. Multi Load can ensure the atomic effect of multiple import jobs
 
-````
+```
 Syntax:
     curl --location-trusted -u user:passwd -XPOST http://host:port/api/{db}/_multi_start?label=xxx
     curl --location-trusted -u user:passwd -T data.file http://host:port/api/{db}/{table1}/_load?label=xxx\&sub_label=yyy
@@ -91,11 +91,11 @@ NOTE:
 
     3. Supports the use of curl to import data into Doris in a way similar to streaming, but only after the streaming ends Doris
     The real import behavior will occur, and the amount of data in this way cannot be too large.
-````
+```
 
 ### Example
 
-````
+```
 1. Import the data in the local file 'testData1' into the table 'testTbl1' in the database 'testDb', and
 Import the data of 'testData2' into table 'testTbl2' in 'testDb' (user is in defalut_cluster)
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_start?label=123
@@ -112,7 +112,7 @@ Import the data of 'testData2' into table 'testTbl2' in 'testDb' (user is in def
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_start?label=123
     curl --location-trusted -u root -T testData1 http://host:port/api/testDb/testTbl1/_load?label=123\&sub_label=1
     curl --location-trusted -u root -XPOST http://host:port/api/testDb/_multi_desc?label=123
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ Used to pause a Routine Load job. A suspended job can be rerun with the RESUME c
 
 ```sql
 PAUSE [ALL] ROUTINE LOAD FOR job_name
-````
+```
 
 ### Example
 
@@ -44,13 +44,13 @@ PAUSE [ALL] ROUTINE LOAD FOR job_name
 
     ```sql
     PAUSE ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 2. Pause all routine import jobs.
 
     ```sql
     PAUSE ALL ROUTINE LOAD;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-SYNC-JOB.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/PAUSE-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 PAUSE SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ PAUSE SYNC JOB [db.]job_name
 
     ```sql
     PAUSE SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-ROUTINE-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ Used to restart a suspended Routine Load job. The restarted job will continue to
 
 ```sql
 RESUME [ALL] ROUTINE LOAD FOR job_name
-````
+```
 
 ### Example
 
@@ -44,13 +44,13 @@ RESUME [ALL] ROUTINE LOAD FOR job_name
 
     ```sql
     RESUME ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 2. Restart all routine import jobs.
 
     ```sql
     RESUME ALL ROUTINE LOAD;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-SYNC-JOB.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/RESUME-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 RESUME SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ RESUME SYNC JOB [db.]job_name
 
     ```sql
     RESUME SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-ROUTINE-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-ROUTINE-LOAD.md
@@ -36,7 +36,7 @@ User stops a Routine Load job. A stopped job cannot be rerun.
 
 ```sql
 STOP ROUTINE LOAD FOR job_name;
-````
+```
 
 ### Example
 
@@ -44,7 +44,7 @@ STOP ROUTINE LOAD FOR job_name;
 
     ```sql
     STOP ROUTINE LOAD FOR test1;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-SYNC-JOB.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STOP-SYNC-JOB.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 STOP SYNC JOB [db.]job_name
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ STOP SYNC JOB [db.]job_name
 
     ```sql
     STOP SYNC JOB `job_name`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STREAM-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Load/STREAM-LOAD.md
@@ -34,9 +34,9 @@ STREAM LOAD
 
 stream-load: load data to table in streaming
 
-````
+```
 curl --location-trusted -u user:passwd [-H ""...] -T data.file -XPUT http://fe_host:http_port/api/{db}/{table}/_stream_load
-````
+```
 
 This statement is used to import data into the specified table. The difference from ordinary Load is that this import method is synchronous import.
 
@@ -105,20 +105,20 @@ Parameter introduction:
 
     Simple mode: The simple mode is not set the jsonpaths parameter. In this mode, the json data is required to be an object type, for example:
 
-       ````
+       ```
     {"k1":1, "k2":2, "k3":"hello"}, where k1, k2, k3 are column names.
-       ````
+       ```
 
     Matching mode: It is relatively complex for json data and needs to match the corresponding value through the jsonpaths parameter.
 
 14. strip_outer_array: Boolean type, true indicates that the json data starts with an array object and flattens the array object, the default value is false. E.g:
 
-     ````
+     ```
       [
        {"k1" : 1, "v1" : 2},
        {"k1" : 3, "v1" : 4}
       ]
-    ````
+    ```
     When strip_outer_array is true, the final import into doris will generate two rows of data.
 
 
@@ -164,56 +164,56 @@ separated by commas.
 
 1. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', and use Label for deduplication. Specify a timeout of 100 seconds
 
-   ````
+   ```
        curl --location-trusted -u root -H "label:123" -H "timeout:100" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 2. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', use Label for deduplication, and only import data whose k1 is equal to 20180601
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "where: k1=20180601" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 3. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', allowing a 20% error rate (the user is in the defalut_cluster)
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 4. Import the data in the local file 'testData' into the table 'testTbl' in the database 'testDb', allow a 20% error rate, and specify the column name of the file (the user is in the defalut_cluster)
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -H "columns: k2, k1, v1" -T testData http://host:port/api/testDb/testTbl /_stream_load
-   ````
+   ```
 
 5. Import the data in the local file 'testData' into the p1, p2 partitions of the table 'testTbl' in the database 'testDb', allowing a 20% error rate.
 
-   ````
+   ```
    curl --location-trusted -u root -H "label:123" -H "max_filter_ratio:0.2" -H "partitions: p1, p2" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 6. Import using streaming (user is in defalut_cluster)
 
-    ````
+    ```
     seq 1 10 | awk '{OFS="\t"}{print $1, $1 * 10}' | curl --location-trusted -u root -T - http://host:port/api/testDb/testTbl/ _stream_load
-    ````
+    ```
 
 7. Import a table containing HLL columns, which can be columns in the table or columns in the data to generate HLL columns, or use hll_empty to supplement columns that are not in the data
 
-   ````
+   ```
    curl --location-trusted -u root -H "columns: k1, k2, v1=hll_hash(k1), v2=hll_empty()" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 8. Import data for strict mode filtering and set the time zone to Africa/Abidjan
 
-   ````
+   ```
    curl --location-trusted -u root -H "strict_mode: true" -H "timezone: Africa/Abidjan" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 9. Import a table with a BITMAP column, which can be a column in the table or a column in the data to generate a BITMAP column, or use bitmap_empty to fill an empty Bitmap
-   ````
+   ```
     curl --location-trusted -u root -H "columns: k1, k2, v1=to_bitmap(k1), v2=bitmap_empty()" -T testData http://host:port/api/testDb/testTbl/_stream_load
-   ````
+   ```
 
 10. Simple mode, import json data
     Table Structure:
@@ -224,39 +224,39 @@ separated by commas.
     `price` double NULL COMMENT ""
     ```
     json data format:
-    ````
+    ```
     {"category":"C++","author":"avc","title":"C++ primer","price":895}
-    ````
+    ```
     
     Import command:
     
-    ````
+    ```
     curl --location-trusted -u root -H "label:123" -H "format: json" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
     In order to improve throughput, it supports importing multiple pieces of json data at one time, each line is a json object, and \n is used as a newline by default. You need to set read_json_by_line to true. The json data format is as follows:
 
-    ````
+    ```
     {"category":"C++","author":"avc","title":"C++ primer","price":89.5}
     {"category":"Java","author":"avc","title":"Effective Java","price":95}
     {"category":"Linux","author":"avc","title":"Linux kernel","price":195}
-    ````
+    ```
     
 11. Match pattern, import json data
     json data format:
 
-    ````
+    ```
     [
     {"category":"xuxb111","author":"1avc","title":"SayingsoftheCentury","price":895},{"category":"xuxb222","author":"2avc"," title":"SayingsoftheCentury","price":895},
     {"category":"xuxb333","author":"3avc","title":"SayingsoftheCentury","price":895}
     ]
-    ````
+    ```
 
     Precise import by specifying jsonpath, such as importing only three attributes of category, author, and price
 
-    ````
+    ```
     curl --location-trusted -u root -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\" $.price\",\"$.author\"]" -H "strip_outer_array: true" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
 
     illustrate:
         1) If the json data starts with an array, and each object in the array is a record, you need to set strip_outer_array to true, which means flatten the array.
@@ -265,7 +265,7 @@ separated by commas.
 12. User specified json root node
     json data format:
 
-    ````
+    ```
     {
      "RECORDS":[
     {"category":"11","title":"SayingsoftheCentury","price":895,"timestamp":1589191587},
@@ -273,31 +273,31 @@ separated by commas.
     {"category":"33","author":"3avc","title":"SayingsoftheCentury","timestamp":1589191387}
     ]
     }
-    ````
+    ```
 
     Precise import by specifying jsonpath, such as importing only three attributes of category, author, and price
     
-    ````
+    ```
     curl --location-trusted -u root -H "columns: category, price, author" -H "label:123" -H "format: json" -H "jsonpaths: [\"$.category\",\" $.price\",\"$.author\"]" -H "strip_outer_array: true" -H "json_root: $.RECORDS" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
 13. Delete the data with the same import key as this batch
 
-    ````
+    ```
     curl --location-trusted -u root -H "merge_type: DELETE" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
 
 14. Delete the columns in this batch of data that match the data whose flag is listed as true, and append other rows normally
     
-    ````
+    ```
     curl --location-trusted -u root: -H "column_separator:," -H "columns: siteid, citycode, username, pv, flag" -H "merge_type: MERGE" -H "delete: flag=1" -T testData http://host:port/api/testDb/testTbl/_stream_load
-    ````
+    ```
     
 15. Import data into UNIQUE_KEYS table with sequence column
     
-    ````
+    ```
     curl --location-trusted -u root -H "columns: k1,k2,source_sequence,v1,v2" -H "function_column.sequence_col: source_sequence" -T testData http://host:port/api/testDb/testTbl/ _stream_load
-    ````
+    ```
 
 16. csv file line header filter import
 
@@ -345,7 +345,7 @@ separated by commas.
 
    Stream Load is a synchronous import process. The successful execution of the statement means that the data is imported successfully. The imported execution result will be returned synchronously through the HTTP return value. And display it in Json format. An example is as follows:
 
-   ````json
+   ```json
    {
        "TxnId": 17,
        "Label": "707717c0-271a-44c5-be0b-4e71bfeacaa5",
@@ -363,7 +363,7 @@ separated by commas.
        "WriteDataTimeMs": 3,
        "CommitAndPublishTimeMs": 18
    }
-   ````
+   ```
 
    The following main explanations are given for the Stream load import result parameters:
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/CANCEL-EXPORT.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/CANCEL-EXPORT.md
@@ -48,7 +48,7 @@ WHERE [LABEL = "export_label" | LABEL like "label_pattern" | STATE = "PENDING/IN
     CANCEL EXPORT
     FROM example_db
     WHERE LABEL = "example_db_test_export_label" and STATE = "EXPORTING";
-    ````
+    ```
 
 2. Cancel all export jobs containing example* on the database example*db.
 
@@ -56,7 +56,7 @@ WHERE [LABEL = "export_label" | LABEL like "label_pattern" | STATE = "PENDING/IN
     CANCEL EXPORT
     FROM example_db
     WHERE LABEL like "%example%";
-    ````
+    ```
 
 3. Cancel all export jobs which state are "PENDING"
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/DELETE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/DELETE.md
@@ -86,21 +86,21 @@ DELETE FROM table_name
    ```sql
    DELETE FROM my_table PARTITION p1
        WHERE k1 = 3;
-   ````
+   ```
 
 2. Delete the data rows where the value of column k1 is greater than or equal to 3 and the value of column k2 is "abc" in my_table partition p1
 
    ```sql
    DELETE FROM my_table PARTITION p1
    WHERE k1 >= 3 AND k2 = "abc";
-   ````
+   ```
 
 3. Delete the data rows where the value of column k1 is greater than or equal to 3 and the value of column k2 is "abc" in my_table partition p1, p2
 
    ```sql
    DELETE FROM my_table PARTITIONS (p1, p2)
    WHERE k1 >= 3 AND k2 = "abc";
-   ````
+   ```
 
 4. use the result of `t2` join `t3` to romve rows from `t1`,delete table only support unique key model
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/EXPORT.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/EXPORT.md
@@ -72,7 +72,7 @@ The bottom layer of the `Export` statement actually executes the `select...outfi
 
   ```sql
   [PROPERTIES ("key"="value", ...)]
-  ````
+  ```
 
   The following parameters can be specified:
 
@@ -116,7 +116,7 @@ The bottom layer of the `Export` statement actually executes the `select...outfi
         hadoop.security.authentication: specify the authentication method as kerberos
         kerberos_principal: specifies the principal of kerberos
         kerberos_keytab: specifies the path to the keytab file of kerberos. The file must be the absolute path to the file on the server where the broker process is located. and can be accessed by the Broker process
-  ````
+  ```
 
 - `WITH HDFS`
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/INSERT.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/INSERT.md
@@ -41,7 +41,7 @@ INSERT INTO table_name
     [ (column [, ...]) ]
     [ [ hint [, ...] ] ]
     { VALUES ( { expression | DEFAULT } [, ...] ) [, ...] | query }
-````
+```
 
  Parameters
 
@@ -83,7 +83,7 @@ INSERT INTO test VALUES (1, 2);
 INSERT INTO test (c1, c2) VALUES (1, 2);
 INSERT INTO test (c1, c2) VALUES (1, DEFAULT);
 INSERT INTO test (c1) VALUES (1);
-````
+```
 
 The first and second statements have the same effect. When no target column is specified, the column order in the table is used as the default target column.
 The third and fourth statements express the same meaning, use the default value of the `c2` column to complete the data import.
@@ -95,7 +95,7 @@ INSERT INTO test VALUES (1, 2), (3, 2 + 2);
 INSERT INTO test (c1, c2) VALUES (1, 2), (3, 2 * 2);
 INSERT INTO test (c1) VALUES (1), (3);
 INSERT INTO test (c1, c2) VALUES (1, DEFAULT), (3, DEFAULT);
-````
+```
 
 The first and second statements have the same effect, import two pieces of data into the `test` table at one time
 The effect of the third and fourth statements is known, and the default value of the `c2` column is used to import two pieces of data into the `test` table
@@ -105,14 +105,14 @@ The effect of the third and fourth statements is known, and the default value of
 ```sql
 INSERT INTO test SELECT * FROM test2;
 INSERT INTO test (c1, c2) SELECT * from test2;
-````
+```
 
 4. Import a query result into the `test` table, specifying the partition and label
 
 ```sql
 INSERT INTO test PARTITION(p1, p2) WITH LABEL `label1` SELECT * FROM test2;
 INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
-````
+```
 
 
 ### Keywords
@@ -158,17 +158,17 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
          mysql> insert into tbl1 select * from tbl2;
          Query OK, 2 rows affected, 2 warnings (0.31 sec)
          {'label':'insert_f0747f0e-7a35-46e2-affa-13a235f4020d', 'status':'committed', 'txnId':'4005'}
-         ````
+         ```
 
          `Query OK` indicates successful execution. `4 rows affected` means that a total of 4 rows of data were imported. `2 warnings` indicates the number of lines to be filtered.
 
          Also returns a json string:
 
-         ````json
+         ```json
          {'label':'my_label1', 'status':'visible', 'txnId':'4005'}
          {'label':'insert_f0747f0e-7a35-46e2-affa-13a235f4020d', 'status':'committed', 'txnId':'4005'}
          {'label':'my_label1', 'status':'visible', 'txnId':'4005', 'err':'some other error'}
-         ````
+         ```
 
          `label` is a user-specified label or an automatically generated label. Label is the ID of this Insert Into import job. Each import job has a unique Label within a single database.
 
@@ -182,7 +182,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
          ```sql
          show load where label="xxx";
-         ````
+         ```
 
          The URL in the returned result can be used to query the wrong data. For details, see the summary of **Viewing Error Lines** later.
 
@@ -192,7 +192,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
          ```sql
          show transaction where id=4005;
-         ````
+         ```
 
          If the `TransactionStatus` column in the returned result is `visible`, the representation data is visible.
 
@@ -209,7 +209,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
       ```sql
       show load warnings on "url";
-      ````
+      ```
 
       You can view the specific error line.
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/SELECT.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/Manipulation/SELECT.md
@@ -323,7 +323,7 @@ Recursive CTE is currently not supported.
      
      SELECT college, region, seed FROM tournament
        ORDER BY 2, 3;
-     ````
+     ```
 
    - If ORDER BY appears in a subquery and also applies to the outer query, the outermost ORDER BY takes precedence.
 
@@ -331,7 +331,7 @@ Recursive CTE is currently not supported.
 
      ```sql
      SELECT a, COUNT(b) FROM test_table GROUP BY a ORDER BY NULL;
-     ````
+     ```
 
      
 
@@ -345,7 +345,7 @@ Recursive CTE is currently not supported.
 
      ```sql
      SELECT COUNT(col1) AS col2 FROM t GROUP BY col2 HAVING col2 = 2;
-     ````
+     ```
 
    - Remember not to use HAVING where WHERE should be used. HAVING is paired with GROUP BY.
 
@@ -354,7 +354,7 @@ Recursive CTE is currently not supported.
      ```sql
      SELECT user, MAX(salary) FROM users
        GROUP BY user HAVING MAX(salary) > 10;
-     ````
+     ```
 
    - The LIMIT clause can be used to constrain the number of rows returned by a SELECT statement. LIMIT can have one or two arguments, both of which must be non-negative integers.
 
@@ -364,7 +364,7 @@ Recursive CTE is currently not supported.
      /*Then if you want to retrieve all rows after a certain offset is set, you can set a very large constant for the second parameter. The following query fetches all data from row 96 onwards */
      SELECT * FROM tbl LIMIT 95,18446744073709551615;
      /*If LIMIT has only one parameter, the parameter specifies the number of rows that should be retrieved, and the offset defaults to 0, that is, starting from the first row*/
-     ````
+     ```
 
    - SELECT...INTO allows query results to be written to a file
 
@@ -405,7 +405,7 @@ Recursive CTE is currently not supported.
        | 21 |
        +-------------+
        4 rows in set (0.01 sec)
-       ````
+       ```
    
 6. JOIN
    

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/OUTFILE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Data-Manipulation-Statements/OUTFILE.md
@@ -199,7 +199,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "line_delimiter" = "\n",
        "max_file_size" = "100MB"
    );
-   ````
+   ```
 
    If the final generated file is not larger than 100MB, it will be: `result_0.csv`.
    If larger than 100MB, it may be `result_0.csv, result_1.csv, ...`.
@@ -217,7 +217,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.kerberos_principal" = "doris@YOUR.COM",
        "broker.kerberos_keytab" = "/home/doris/my.keytab"
    );
-   ````
+   ```
 
 3. Export the query result of the CTE statement to the file `hdfs://path/to/result.txt`. The default export format is CSV. Use `my_broker` and set hdfs high availability information. Use the default row and column separators.
 
@@ -240,7 +240,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.dfs.namenode.rpc-address.my_ha.my_namenode2" = "nn2_host:rpc_port",
        "broker.dfs.client.failover.proxy.provider.my_ha" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
    );
-   ````
+   ```
 
    If the final generated file is not larger than 1GB, it will be: `result_0.csv`.
    If larger than 1GB, it may be `result_0.csv, result_1.csv, ...`.
@@ -259,7 +259,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "broker.bos_accesskey" = "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
        "broker.bos_secret_accesskey" = "yyyyyyyyyyyyyyyyyyyyyyyyy"
    );
-   ````
+   ```
 
 5. Export the query result of the select statement to the file `s3a://${bucket_name}/path/result.txt`. Specify the export format as csv.
    After the export is complete, an identity file is generated.
@@ -279,7 +279,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "max_file_size" = "1024MB",
        "success_file_name" = "SUCCESS"
    )
-   ````
+   ```
 
    If the final generated file is not larger than 1GB, it will be: `my_file_0.csv`.
    If larger than 1GB, it may be `my_file_0.csv, result_1.csv, ...`.
@@ -302,7 +302,7 @@ Parquet and ORC file formats have their own data types. The export function of D
         "s3.secret_key" = "xxx",
         "s3.region" = "bd"
    )
-   ````
+   ```
 
    The resulting file is prefixed with `my_file_{fragment_instance_id}_`.
 
@@ -321,7 +321,7 @@ Parquet and ORC file formats have their own data types. The export function of D
         "s3.secret_key" = "xxx",
         "s3.region" = "bd"
    )
-   ````
+   ```
 
 8. Use hdfs export to export simple query results to the file `hdfs://${host}:${fileSystem_port}/path/to/result.txt`. Specify the export format as CSV and the user name as work. Specify the column separator as `,` and the row separator as `\n`.
 
@@ -378,7 +378,7 @@ Parquet and ORC file formats have their own data types. The export function of D
        "max_file_size" = "1024MB",
        "success_file_name" = "SUCCESS"
    )
-   ````
+   ```
 
 ### keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CANCEL-REPAIR.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CANCEL-REPAIR.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN CANCEL REPAIR TABLE table_name[ PARTITION (p1,...)];
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
 
      ```sql
       ADMIN CANCEL REPAIR TABLE tbl PARTITION(p1);
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CLEAN-TRASH.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-CLEAN-TRASH.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 ADMIN CLEAN TRASH [ON ("BackendHost1:BackendHeartBeatPort1", "BackendHost2:BackendHeartBeatPort2", ...)];
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-REPAIR-TABLE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-REPAIR-TABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 ADMIN REPAIR TABLE table_name[ PARTITION (p1,...)]
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-SET-REPLICA-STATUS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/ADMIN-SET-REPLICA-STATUS.md
@@ -41,7 +41,7 @@ grammar:
 ```sql
 ADMIN SET REPLICA STATUS
         PROPERTIES ("key" = "value", ...);
-````
+```
 
  The following properties are currently supported:
 
@@ -63,20 +63,20 @@ If the specified replica does not exist, or the status is already bad, it will b
 
        ```sql
     ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "bad");
-       ````
+       ```
 
  2. Set the replica status of tablet 10003 on BE 10001 to drop.
 
        ```sql
     ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "drop");
-       ````
+       ```
 
 
  3. Set the replica status of tablet 10003 on BE 10001 to ok.
 
    ```sql
    ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "10003", "backend_id" = "10001", "status" = "ok");
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/INSTALL-PLUGIN.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/INSTALL-PLUGIN.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 INSTALL PLUGIN FROM [source] [PROPERTIES ("key"="value", ...)]
-````
+```
 
 source supports three types:
 
@@ -52,19 +52,19 @@ source supports three types:
 
     ```sql
     INSTALL PLUGIN FROM "/home/users/doris/auditdemo.zip";
-    ````
+    ```
 
 2. Install the plugin in a local directory:
 
     ```sql
     INSTALL PLUGIN FROM "/home/users/doris/auditdemo/";
-    ````
+    ```
 
 3. Download and install a plugin:
 
     ```sql
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip";
-    ````
+    ```
 
     Note than an md5 file with the same name as the `.zip` file needs to be placed, such as `http://mywebsite.com/plugin.zip.md5` . 
     The content is the MD5 value of the .zip file.
@@ -73,7 +73,7 @@ source supports three types:
 
     ```sql
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip" PROPERTIES("md5sum" = "73877f6029216f4314d712086a146570");
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/KILL.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/KILL.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 KILL [CONNECTION] processlist_id
-````
+```
 
 In addition, you can also use processlist_id or query_id terminates the executing query command
 
@@ -48,7 +48,7 @@ grammar:
 
 ```sql
 KILL QUERY processlist_id | query_id
-````
+```
 
 
 ### Example

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/SET-VARIABLE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/SET-VARIABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SET variable_assignment [, variable_assignment] ...
-````
+```
 
 illustrate:
 
@@ -55,15 +55,15 @@ illustrate:
 
 1. Set the time zone to Dongba District
 
-   ````
+   ```
    SET time_zone = "Asia/Shanghai";
-   ````
+   ```
 
 2. Set the global execution memory size
 
-   ````
+   ```
    SET GLOBAL exec_mem_limit = 137438953472
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/SHOW-CONFIG.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/SHOW-CONFIG.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW FRONTEND CONFIG [LIKE "pattern"];
-````
+```
 
 The columns in the results have the following meanings:
 
@@ -59,7 +59,7 @@ The columns in the results have the following meanings:
 
 2. Use the like predicate to search the configuration of the current Fe node
 
-   ````
+   ```
    mysql> SHOW FRONTEND CONFIG LIKE '%check_java_version%';
    +--------------------+-------+---------+---------- -+------------+---------+
    | Key | Value | Type | IsMutable | MasterOnly | Comment |
@@ -67,7 +67,7 @@ The columns in the results have the following meanings:
    | check_java_version | true | boolean | false | false | |
    +--------------------+-------+---------+---------- -+------------+---------+
    1 row in set (0.01 sec)
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-DISTRIBUTION.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-DISTRIBUTION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW REPLICA DISTRIBUTION FROM [db_name.]tbl_name [PARTITION (p1, ...)];
-````
+```
 
 illustrate:
 
@@ -50,13 +50,13 @@ illustrate:
 
     ```sql
     SHOW REPLICA DISTRIBUTION FROM tbl1;
-    ````
+    ```
 
   2. View the replica distribution of the partitions of the table
 
       ```sql
      SHOW REPLICA DISTRIBUTION FROM db1.tbl1 PARTITION(p1, p2);
-      ````
+      ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-STATUS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/SHOW-REPLICA-STATUS.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW REPLICA STATUS FROM [db_name.]tbl_name [PARTITION (p1, ...)]
 [where_clause];
-````
+```
 
 illustrate
 
@@ -59,21 +59,21 @@ illustrate
 
    ```sql
    SHOW REPLICA STATUS FROM db1.tbl1;
-   ````
+   ```
 
 2. View a copy of a table with a partition status of VERSION_ERROR
 
    ```sql
    SHOW REPLICA STATUS FROM tbl1 PARTITION (p1, p2)
    WHERE STATUS = "VERSION_ERROR";
-   ````
+   ```
 
 3. View all unhealthy replicas of the table
 
    ```sql
    SHOW REPLICA STATUS FROM tbl1
    WHERE STATUS != "OK";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/UNINSTALL-PLUGIN.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/UNINSTALL-PLUGIN.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 UNINSTALL PLUGIN plugin_name;
-````
+```
 
   plugin_name can be viewed with the `SHOW PLUGINS;` command.
 
@@ -50,7 +50,7 @@ Only non-builtin plugins can be uninstalled.
 
     ```sql
     UNINSTALL PLUGIN auditdemo;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/UNSET-VARIABLE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Database-Administration-Statements/UNSET-VARIABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 UNSET [SESSION|GLOBAL] VARIABLE (variable_name | ALL)
-````
+```
 
 illustrate:
 
@@ -53,15 +53,15 @@ illustrate:
 
 1. Restore value of the time zone
 
-   ````
+   ```
    UNSET VARIABLE time_zone;
-   ````
+   ```
 
 2. Restore the global execution memory size
 
-   ````
+   ```
    UNSET GLOBAL VARIABLE exec_mem_limit;
-   ````
+   ```
 3. Restore all variables globally
 
    ```

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ALTER-TABLE-MATERIALIZED-VIEW.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ALTER-TABLE-MATERIALIZED-VIEW.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database: View jobs under the specified database. If not specified, the current database is used.
 - WHERE: You can filter the result column, currently only the following columns are supported:
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`: Job unique ID.
 
@@ -110,7 +110,7 @@ RollupIndexName: r1
 
    ```sql
    SHOW ALTER TABLE MATERIALIZED VIEW FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ALTER.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ALTER.md
@@ -36,7 +36,7 @@ This statement is used to display the execution of various modification tasks cu
 
 ```sql
 SHOW ALTER [CLUSTER | TABLE [COLUMN | ROLLUP] [FROM db_name]];
-````
+```
 
 TABLE COLUMN: show ALTER tasks that modify columns
                       Support syntax [WHERE TableName|CreateTime|FinishTime|State] [ORDER BY] [LIMIT]
@@ -50,25 +50,25 @@ TABLE COLUMN: show ALTER tasks that modify columns
 
    ```sql
     SHOW ALTER TABLE COLUMN;
-   ````
+   ```
 
 2. Display the task execution status of the last modified column of a table
 
    ```sql
    SHOW ALTER TABLE COLUMN WHERE TableName = "table1" ORDER BY CreateTime DESC LIMIT 1;
-   ````
+   ```
 
 3. Display the task execution of creating or deleting ROLLUP index for the specified db
 
    ```sql
    SHOW ALTER TABLE ROLLUP FROM example_db;
-   ````
+   ```
 
 4. Show tasks related to cluster operations (only for administrators! To be implemented...)
 
-   ````
+   ```
    SHOW ALTER CLUSTER;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-BACKENDS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-BACKENDS.md
@@ -36,7 +36,7 @@ This statement is used to view the BE nodes in the cluster
 
 ```sql
  SHOW BACKENDS;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-BACKUP.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-BACKUP.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
  SHOW BACKUP [FROM db_name]
     [WHERE SnapshotName ( LIKE | = ) 'snapshot name']
-````
+```
 
 illustrate:
 
@@ -72,7 +72,7 @@ illustrate:
 
    ```sql
     SHOW BACKUP FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-BROKER.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-BROKER.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW BROKER;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-COLUMNS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-COLUMNS.md
@@ -46,7 +46,7 @@ SHOW [FULL] COLUMNS FROM tbl;
 
     ```sql
      SHOW FULL COLUMNS FROM tbl;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CONVERT-LIGHT-SCHEMA-CHANGE-PROCESS.md
@@ -46,7 +46,7 @@ SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS [FROM db]
 
     ```sql
      SHOW CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS FROM test;
-    ````
+    ```
 
 2. View the converting process globally
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-DATABASE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-DATABASE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE DATABASE db_name;
-````
+```
 
 illustrate:
 
@@ -57,7 +57,7 @@ illustrate:
     | test | CREATE DATABASE `test` |
     +----------+----------------------------+
     1 row in set (0.00 sec)
-    ````
+    ```
 
 2. view a database named `hdfs_text` from a hms catalog
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-FUNCTION.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-FUNCTION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE [GLOBAL] FUNCTION function_name(arg_type [, ...]) [FROM db_name]];
-````
+```
 
 illustrate:
 1. `global`: The show function is global 
@@ -54,12 +54,12 @@ illustrate:
 
     ```sql
     SHOW CREATE FUNCTION my_add(INT, INT)
-    ````
+    ```
 2. Show the creation statement of the specified global function
 
     ```sql
     SHOW CREATE GLOBAL FUNCTION my_add(INT, INT)
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-LOAD.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE LOAD for load_name;
-````
+```
 
 illustrate:
 
@@ -50,7 +50,7 @@ illustrate:
 
     ```sql
     SHOW CREATE LOAD for test_load
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-REPOSITORY.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-REPOSITORY.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW CREATE REPOSITORY for repository_name;
-````
+```
 
 illustrate:
 -  `repository_name`: repository name
@@ -49,7 +49,7 @@ illustrate:
 
     ```sql
     SHOW CREATE REPOSITORY for test_repository
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-ROUTINE-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-ROUTINE-LOAD.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW [ALL] CREATE ROUTINE LOAD for load_name;
-````
+```
 
 illustrate:
 
@@ -53,7 +53,7 @@ illustrate:
 
     ```sql
     SHOW CREATE ROUTINE LOAD for test_load
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-TABLE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-CREATE-TABLE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [BRIEF] CREATE TABLE [DBNAME.]TABLE_NAME
-````
+```
 
 illustrate:
 
@@ -53,7 +53,7 @@ illustrate:
 
     ```sql
     SHOW CREATE TABLE demo.tb1
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DATA.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DATA.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATA [FROM [db_name.]table_name] [ORDER BY ...];
-````
+```
 
 illustrate:
 
@@ -82,9 +82,9 @@ illustrate:
    ```sql
    USE db1;
    SHOW DATA;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-------------+--------------+
    | TableName | Size        | ReplicaCount |
    +-----------+-------------+--------------+
@@ -94,15 +94,15 @@ illustrate:
    | Quota     | 1024.000 GB | 1073741824   |
    | Left      | 1021.921 GB | 1073741815   |
    +-----------+-------------+--------------+
-   ````
+   ```
 
 3. Display the subdivided data volume, the number of replicas and the number of statistical rows of the specified table under the specified db
 
    ```sql
    SHOW DATA FROM example_db.test;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-----------+-----------+--------------+----------+
    | TableName | IndexName | Size      | ReplicaCount | RowCount |
    +-----------+-----------+-----------+--------------+----------+
@@ -111,15 +111,15 @@ illustrate:
    |           | test2     | 50.000MB  | 30           | 50000    |
    |           | Total     | 80.000    | 90           |          |
    +-----------+-----------+-----------+--------------+----------+
-   ````
+   ```
 
 4. It can be combined and sorted according to the amount of data, the number of copies, the number of statistical rows, etc.
 
    ```sql
    SHOW DATA ORDER BY ReplicaCount desc,Size asc;
-   ````
+   ```
 
-   ````
+   ```
    +-----------+-------------+--------------+
    | TableName | Size        | ReplicaCount |
    +-----------+-------------+--------------+
@@ -131,7 +131,7 @@ illustrate:
    | Quota     | 1024.000 GB | 1073741824   |
    | Left      | 1024.000 GB | 1073741734   |
    +-----------+-------------+--------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DATABASE-ID.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DATABASE-ID.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATABASE [database_id]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DATABASE [database_id]
 
     ```sql
     SHOW DATABASE 1001;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DATABASES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DATABASES [FROM catalog] [filter expr];
-````
+```
 
 illustrate:
 1. `SHOW DATABASES` will get all database names from current catalog.
@@ -51,45 +51,45 @@ illustrate:
 
    ```sql
    SHOW DATABASES;
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | test               |
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 2. Display all database names from the catalog named 'hms_catalog'.
 
    ```sql
    SHOW DATABASES from hms_catalog;
-   ````
+   ```
 
-   ````
+   ```
   +---------------+
   | Database      |
   +---------------+
   | default       |
   | tpch          |
   +---------------+
-   ````
+   ```
 
 3. Display the filtered database names from current catalog with the expr 'like'.
 
    ```sql
    SHOW DATABASES like 'infor%';
-   ````
+   ```
 
-   ````
+   ```
   +--------------------+
   | Database           |
   +--------------------+
   | information_schema |
   +--------------------+
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DELETE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DELETE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DELETE [FROM db_name]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DELETE [FROM db_name]
 
       ```sql
       SHOW DELETE FROM database;
-      ````
+      ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DYNAMIC-PARTITION.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-DYNAMIC-PARTITION.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW DYNAMIC PARTITION TABLES [FROM db_name];
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW DYNAMIC PARTITION TABLES [FROM db_name];
 
      ```sql
      SHOW DYNAMIC PARTITION TABLES FROM database;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ENCRYPT-KEY.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ENCRYPT-KEY.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW ENCRYPTKEYS [IN|FROM db] [LIKE 'key_pattern']
-````
+```
 
 parameter
 
@@ -65,7 +65,7 @@ parameter
     | example_db.my_key | ABCD123456789     |
     +-------------------+-------------------+
     1 row in set (0.00 sec)
- ````
+ ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-EXPORT.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-EXPORT.md
@@ -47,7 +47,7 @@ SHOW EXPORT
    ]
 [ORDER BY...]
 [LIMIT limit];
-````
+```
 
 illustrate:
       1. If db_name is not specified, the current default db is used
@@ -61,31 +61,31 @@ illustrate:
 
    ```sql
    SHOW EXPORT;
-   ````
+   ```
 
 2. Display the export tasks of the specified db, sorted by StartTime in descending order
 
    ```sql
     SHOW EXPORT FROM example_db ORDER BY StartTime DESC;
-   ````
+   ```
 
 3. Display the export tasks of the specified db, the state is "exporting", and sort by StartTime in descending order
 
    ```sql
    SHOW EXPORT FROM example_db WHERE STATE = "exporting" ORDER BY StartTime DESC;
-   ````
+   ```
 
 4. Display the export task of the specified db and specified job_id
 
    ```sql
      SHOW EXPORT FROM example_db WHERE ID = job_id;
-   ````
+   ```
 
 5. Display the specified db and specify the export task of the label
 
    ```sql
     SHOW EXPORT FROM example_db WHERE LABEL = "mylabel";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-FILE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-FILE.md
@@ -38,18 +38,18 @@ grammar:
 
 ```sql
 SHOW FILE [FROM database];
-````
+```
 
 illustrate:
 
-````text
+```text
 FileId: file ID, globally unique
 DbName: the name of the database to which it belongs
 Catalog: Custom Category
 FileName: file name
 FileSize: file size, in bytes
 MD5: MD5 of the file
-````
+```
 
 ### Example
 
@@ -57,7 +57,7 @@ MD5: MD5 of the file
 
      ```sql
      SHOW FILE FROM my_database;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS-DISKS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS-DISKS.md
@@ -38,7 +38,7 @@ This statement is used to view FE nodes's important paths' disk information, suc
 
 ```sql
 SHOW FRONTENDS DISKS;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-FRONTENDS.md
@@ -38,7 +38,7 @@ This statement is used to view FE nodes
 
 ```sql
 SHOW FRONTENDS;
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-FUNCTIONS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-FUNCTIONS.md
@@ -40,7 +40,7 @@ grammar
 
 ```sql
 SHOW [FULL] [BUILTIN] FUNCTIONS [IN|FROM db] [LIKE 'function_pattern']
-````
+```
 
 Parameters
 
@@ -53,7 +53,7 @@ grammar
 
 ```sql
 SHOW GLOBAL [FULL] FUNCTIONS [LIKE 'function_pattern']
-````
+```
 
 Parameters
 
@@ -65,7 +65,7 @@ Parameters
 
 ### Example
 
-````sql
+```sql
 mysql> show full functions in testDb\G
 **************************** 1. row ******************** ******
         Signature: my_add(INT,INT)
@@ -122,7 +122,7 @@ mysql> show global functions ;
 +---------------+
 2 rows in set (0.00 sec)    
     
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-GRANTS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-GRANTS.md
@@ -52,19 +52,19 @@ illustrate:
 
     ```sql
     SHOW ALL GRANTS;
-    ````
+    ```
 
 2. View the permissions of the specified user
 
     ```sql
     SHOW GRANTS FOR jack@'%';
-    ````
+    ```
 
 3. View the permissions of the current user
 
     ```sql
     SHOW GRANTS;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-INDEX.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-INDEX.md
@@ -36,19 +36,19 @@ SHOW INDEX
 
 grammar:
 
-````SQL
+```SQL
 SHOW INDEX[ES] FROM [db_name.]table_name [FROM database];
 or
 SHOW KEY[S] FROM [db_name.]table_name [FROM database];
-````
+```
 
 ### Example
 
   1. Display the lower index of the specified table_name
 
-     ````SQL
+     ```SQL
       SHOW INDEX FROM example_db.table_name;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-LAST-INSERT.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-LAST-INSERT.md
@@ -39,11 +39,11 @@ grammar:
 
 ```sql
 SHOW LAST INSERT
-````
+```
 
 Example of returned result:
 
-````
+```
      TransactionId: 64067
              Label: insert_ba8f33aea9544866-8ed77e2844d0cc9b
           Database: default_cluster:db1
@@ -51,7 +51,7 @@ Example of returned result:
 TransactionStatus: VISIBLE
         LoadedRows: 2
       FilteredRows: 0
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-PROFILE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-PROFILE.md
@@ -40,13 +40,13 @@ This statement is used to view the Profile information of the import operation. 
 
 ```sql
 SET is_report_success=true;
-````
+```
 
 Versions 0.15 and later perform the following settings:
 
 ```sql
 SET [GLOBAL] enable_profile=true;
-````
+```
 
 grammar:
 
@@ -60,7 +60,7 @@ show load profile "/[queryId]/[TaskId]"
 show load profile "/[queryId]/[TaskId]/[FragmentId]/"
 
 show load profile "/[queryId]/[TaskId]/[FragmentId]/[InstanceId]"
-````
+```
 
 This command will list all currently saved import profiles. Each line corresponds to one import. where the QueryId column is the ID of the import job. This ID can also be viewed through the SHOW LOAD statement. We can select the QueryId corresponding to the Profile we want to see to see the specific situation
 
@@ -106,7 +106,7 @@ WaitAndFetchResultTime: NULL
        FetchResultTime: 0ns
        WriteResultTime: 0ns
 WaitAndFetchResultTime: N/A
-   ````
+   ```
 
 2. View an overview of the subtasks with imported jobs:
 
@@ -117,7 +117,7 @@ WaitAndFetchResultTime: N/A
    +-----------------------------------+------------+
    | 980014623046410a-af5d36f23381017f | 3m14s      |
    +-----------------------------------+------------+
-   ````
+   ```
    
 3. View the plan tree of the specified subtask
 
@@ -177,7 +177,7 @@ WaitAndFetchResultTime: N/A
    | 980014623046410a-88e260f0c43031f4 | 10.81.85.89:9067 | 3m10s      |
    | 980014623046410a-88e260f0c43031f5 | 10.81.85.89:9067 | 3m14s      |
    +-----------------------------------+------------------+------------+
-   ````
+   ```
 
 4. Continue to view the detailed Profile of each operator on a specific Instance
 
@@ -225,7 +225,7 @@ WaitAndFetchResultTime: N/A
    │      - TotalReadThroughput: 30.39858627319336 MB/sec│
    │      - WaitScannerTime: 56s528ms                    │
    └-----------------------------------------------------┘
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-WARNINGS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-LOAD-WARNINGS.md
@@ -44,7 +44,7 @@ SHOW LOAD WARNINGS
     [LABEL[="your_label"]]
     [LOAD_JOB_ID = ["job id"]]
 ]
-````
+```
 
 1) If db_name is not specified, the current default db is used
 1) If LABEL = is used, it matches the specified label exactly
@@ -56,7 +56,7 @@ SHOW LOAD WARNINGS
 
     ```sql
     SHOW LOAD WARNINGS FROM demo WHERE LABEL = "load_demo_20210112"
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-LOAD.md
@@ -46,7 +46,7 @@ SHOW LOAD
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -68,7 +68,7 @@ illustrate:
 
    ```sql
    SHOW LOAD WARNINGS ON 'url'
-   ````
+   ```
 
 ### Example
 
@@ -76,38 +76,38 @@ illustrate:
 
    ```sql
    SHOW LOAD;
-   ````
+   ```
 
 2. Display the import tasks of the specified db, the label contains the string "2014_01_02", and display the oldest 10
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 3. Display the import tasks of the specified db, specify the label as "load_example_db_20140102" and sort by LoadStartTime in descending order
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL = "load_example_db_20140102" ORDER BY LoadStartTime DESC;
-   ````
+   ```
 
 4. Display the import task of the specified db, specify the label as "load_example_db_20140102", the state as "loading", and sort by LoadStartTime in descending order
 
    ```sql
    SHOW LOAD FROM example_db WHERE LABEL = "load_example_db_20140102" AND STATE = "loading" ORDER BY LoadStartTime DESC;
-   ````
+   ```
 
 5. Display the import tasks of the specified db and sort them in descending order by LoadStartTime, and display 10 query results starting from offset 5
 
    ```sql
    SHOW LOAD FROM example_db ORDER BY LoadStartTime DESC limit 5,10;
    SHOW LOAD FROM example_db ORDER BY LoadStartTime DESC limit 10 offset 5;
-   ````
+   ```
 
 6. Small batch import is a command to check the import status
 
-   ````
+   ```
    curl --location-trusted -u {user}:{passwd} http://{hostname}:{port}/api/{database}/_load_info?label={labelname}
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-PARTITION-ID.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-PARTITION-ID.md
@@ -45,7 +45,7 @@ SHOW PARTITION [partition_id]
 
     ```sql
     SHOW PARTITION 10002;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-PARTITIONS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-PARTITIONS.md
@@ -36,9 +36,9 @@ SHOW PARTITIONS
 
 grammar:
 
-````SQL
+```SQL
   SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT];
-````
+```
 
 illustrate:
 
@@ -54,27 +54,27 @@ Will return all partitions' name. Support multilevel partition table
 
 1. Display all non-temporary partition information of the specified table under the specified db
 
-````SQL
+```SQL
   SHOW PARTITIONS FROM example_db.table_name;
-````
+```
 
 2. Display all temporary partition information of the specified table under the specified db
 
-    ````SQL
+    ```SQL
     SHOW TEMPORARY PARTITIONS FROM example_db.table_name;
-    ````
+    ```
 
 3. Display the information of the specified non-temporary partition of the specified table under the specified db
 
-    ````SQL
+    ```SQL
      SHOW PARTITIONS FROM example_db.table_name WHERE PartitionName = "p1";
-    ````
+    ```
 
 4. Display the latest non-temporary partition information of the specified table under the specified db
 
-    ````SQL
+    ```SQL
     SHOW PARTITIONS FROM example_db.table_name ORDER BY PartitionId DESC LIMIT 1;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-PLUGINS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-PLUGINS.md
@@ -36,9 +36,9 @@ This statement is used to display installed plugins
 
 grammar:
 
-````SQL
+```SQL
 SHOW PLUGINS
-````
+```
 
 This command will display all user-installed and system built-in plugins
 
@@ -46,9 +46,9 @@ This command will display all user-installed and system built-in plugins
 
 1. Show installed plugins:
 
-    ````SQL
+    ```SQL
     SHOW PLUGINS;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-PROC.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-PROC.md
@@ -49,7 +49,7 @@ After connecting to Doris through the MySQL client, you can execute the SHOW PRO
 
 The results of the show proc statement are presented in a two-dimensional table. And usually the first column of the result table is the next subdirectory of proc.
 
-````none
+```none
 mysql> show proc "/";
 +---------------------------+
 | name                      |
@@ -80,7 +80,7 @@ mysql> show proc "/";
 | trash                     |
 +---------------------------+
 23 rows in set (0.00 sec)
-````
+```
 
 illustrate:
 
@@ -124,7 +124,7 @@ illustrate:
    | 10124   | test_parquet_import  | 1        | NULL                | 1            | NORMAL | OLAP | NULL                     | 1            |
    +---------+----------------------+----------+---------------------+--------------+--------+------+--------------------------+--------------+
    4 rows in set (0.00 sec)
-   ````
+   ```
 
 2. Display information about the number of all database tables in the cluster.
 
@@ -137,11 +137,11 @@ illustrate:
    | Total | 1                    | 4        | 12           | 12       | 21        | 21         |
    +-------+----------------------+----------+--------------+----------+-----------+------------+
    2 rows in set (0.00 sec)
-   ````
+   ```
 
 3. The following command can view the existing Group information in the cluster.
 
-   ````
+   ```
    SHOW PROC '/colocation_group';
    
    +-------------+--------------+--------------+------------+----------------+----------+----------+
@@ -149,7 +149,7 @@ illustrate:
    +-------------+--------------+--------------+------------+----------------+----------+----------+
    | 10005.10008 | 10005_group1 | 10007, 10040 | 10         | 3              | int(11)  | true     |
    +-------------+--------------+--------------+------------+----------------+----------+----------+
-   ````
+   ```
 
    - GroupId: The cluster-wide unique identifier of a group, the first half is the db id, and the second half is the group id.
    - GroupName: The full name of the Group.
@@ -176,7 +176,7 @@ illustrate:
    | 6           | 10003, 10004, 10001 |
    | 7           | 10003, 10004, 10002 |
    +-------------+---------------------+
-   ````
+   ```
 
    - BucketIndex: The index of the bucket sequence.
    - BackendIds: The list of BE node IDs where the data shards in the bucket are located.
@@ -216,7 +216,7 @@ illustrate:
    | Total                   | 0         | 0        |
    +-------------------------+-----------+----------+
    26 rows in set (0.01 sec)
-   ````
+   ```
 
 5. Display the replica status of the entire cluster.
    ```sql

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-PROCESSLIST.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-PROCESSLIST.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [FULL] PROCESSLIST
-````
+```
 
 illustrate:
 
@@ -68,9 +68,9 @@ Other types can refer to [MySQL official website for explanation](https://dev.my
 
 1. View the threads running by the current user
 
-   ````SQL
+   ```SQL
    SHOW PROCESSLIST
-   ````
+   ```
    return
    ```
    MySQL [test]> show full processlist;

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-REPOSITORIES.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-REPOSITORIES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW REPOSITORIES;
-````
+```
 
 illustrate:
 
@@ -57,7 +57,7 @@ illustrate:
 
 ```sql
   SHOW REPOSITORIES;
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-RESOURCES.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-RESOURCES.md
@@ -45,7 +45,7 @@ SHOW RESOURCES
 ] | [LIKE "pattern"]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-RESTORE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-RESTORE.md
@@ -36,9 +36,9 @@ This statement is used to view RESTORE tasks
 
 grammar:
 
-````SQL
+```SQL
 SHOW [BRIEF] RESTORE [FROM DB_NAME]
-````
+```
 
 illustrate:
         1. Only the most recent RESTORE task is saved in Doris.
@@ -76,7 +76,7 @@ illustrate:
 
    ```sql
    SHOW RESTORE FROM example_db;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ROLES.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ROLES.md
@@ -36,17 +36,17 @@ This statement is used to display all created role information, including role n
 
 grammar:
 
-````SQL
+```SQL
 SHOW ROLES
-````
+```
 
 ### Example
 
 1. View created roles
 
-    ````SQL
+    ```SQL
     SHOW ROLES
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
@@ -39,11 +39,11 @@ View the currently running subtasks of a specified Routine Load job.
 ```sql
 SHOW ROUTINE LOAD TASK
 WHERE JobName = "job_name";
-````
+```
 
 The returned results are as follows:
 
-````text
+```text
               TaskId: d67ce537f1be4b86-abf47530b79ab8e6
                TxnId: 4
            TxnStatus: UNKNOWN
@@ -53,7 +53,7 @@ The returned results are as follows:
              Timeout: 20
                 BeId: 10002
 DataSourceProperties: {"0":19}
-````
+```
 
 - `TaskId`: The unique ID of the subtask.
 - `TxnId`: The import transaction ID corresponding to the subtask.
@@ -71,7 +71,7 @@ DataSourceProperties: {"0":19}
 
    ```sql
    SHOW ROUTINE LOAD TASK WHERE JobName = "test1";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-ROUTINE-LOAD.md
@@ -38,11 +38,11 @@ grammar:
 
 ```sql
 SHOW [ALL] ROUTINE LOAD [FOR jobName];
-````
+```
 
 Result description:
 
-````
+```
                   Id: job ID
                 Name: job name
           CreateTime: job creation time
@@ -63,7 +63,7 @@ DataSourceProperties: Data source configuration details
 ReasonOfStateChanged: The reason for the job state change
         ErrorLogUrls: The viewing address of the filtered unqualified data
             OtherMsg: other error messages
-````
+```
 
 * State
 
@@ -88,39 +88,39 @@ ReasonOfStateChanged: The reason for the job state change
 
    ```sql
    SHOW ALL ROUTINE LOAD FOR test1;
-   ````
+   ```
 
 2. Show the currently running routine import job named test1
 
    ```sql
    SHOW ROUTINE LOAD FOR test1;
-   ````
+   ```
 
 3. Display all routine import jobs (including stopped or canceled jobs) under example_db. The result is one or more lines.
 
    ```sql
    use example_db;
    SHOW ALL ROUTINE LOAD;
-   ````
+   ```
 
 4. Display all running routine import jobs under example_db
 
    ```sql
    use example_db;
    SHOW ROUTINE LOAD;
-   ````
+   ```
 
 5. Display the currently running routine import job named test1 under example_db
 
    ```sql
    SHOW ROUTINE LOAD FOR example_db.test1;
-   ````
+   ```
 
 6. Displays all routine import jobs named test1 under example_db (including stopped or canceled jobs). The result is one or more lines.
 
    ```sql
    SHOW ALL ROUTINE LOAD FOR example_db.test1;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-SMALL-FILES.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-SMALL-FILES.md
@@ -36,7 +36,7 @@ This statement is used to display files created by the CREATE FILE command withi
 
 ```sql
 SHOW FILE [FROM database];
-````
+```
 
 Return result description:
 
@@ -53,7 +53,7 @@ Return result description:
 
     ```sql
     SHOW FILE FROM my_database;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-SNAPSHOT.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-SNAPSHOT.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW SNAPSHOT ON `repo_name`
 [WHERE SNAPSHOT = "snapshot" [AND TIMESTAMP = "backup_timestamp"]];
-````
+```
 
 illustrate:
 
@@ -57,20 +57,20 @@ illustrate:
 
    ```sql
    SHOW SNAPSHOT ON example_repo;
-   ````
+   ```
 
 2. View only the backup named backup1 in the repository example_repo:
 
    ```sql
    SHOW SNAPSHOT ON example_repo WHERE SNAPSHOT = "backup1";
-   ````
+   ```
 
 3. View the details of the backup named backup1 in the warehouse example_repo with the time version "2018-05-05-15-34-26":
 
    ```sql
    SHOW SNAPSHOT ON example_repo
    WHERE SNAPSHOT = "backup1" AND TIMESTAMP = "2018-05-05-15-34-26";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-SQL-BLOCK-RULE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-SQL-BLOCK-RULE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
-````
+```
 
 ### Example
 
@@ -53,7 +53,7 @@ SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
     | test_rule2 | NULL | NULL | 30 | 0 | 10000000000 | false | true |
     +------------+----------------------------+---------+- -------------+------------+-------------+--------+- -------+
     2 rows in set (0.01 sec)
-    ````
+    ```
     
 2. Make a rule name query
 
@@ -66,7 +66,7 @@ SHOW SQL_BLOCK_RULE [FOR RULE_NAME];
     +------------+------+---------+---------------+---- -------+-------------+--------+--------+
     1 row in set (0.00 sec)
     
-    ````
+    ```
     
 
 ### Keywords

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-STATUS.md
@@ -42,7 +42,7 @@ SHOW ALTER TABLE MATERIALIZED VIEW
 [WHERE]
 [ORDER BY]
 [LIMIT OFFSET]
-````
+```
 
 - database: View jobs under the specified database. If not specified, the current database is used.
 - WHERE: You can filter the result column, currently only the following columns are supported:
@@ -70,7 +70,7 @@ RollupIndexName: r1
        Progress: NULL
         Timeout: 86400
 1 row in set (0.00 sec)
-````
+```
 
 - `JobId`: Job unique ID.
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-STREAM-LOAD.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-STREAM-LOAD.md
@@ -46,7 +46,7 @@ SHOW STREAM LOAD
 ]
 [ORDER BY...]
 [LIMIT limit][OFFSET offset];
-````
+```
 
 illustrate:
 
@@ -65,32 +65,32 @@ illustrate:
 
    ```sql
      SHOW STREAM LOAD;
-   ````
+   ```
 
 2. Display the Stream Load task of the specified db, the label contains the string "2014_01_02", and display the oldest 10
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE LABEL LIKE "2014_01_02" LIMIT 10;
-   ````
+   ```
 
 3. Display the Stream Load task of the specified db and specify the label as "load_example_db_20140102"
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE LABEL = "load_example_db_20140102";
-   ````
+   ```
 
 4. Display the Stream Load task of the specified db, specify the status as "success", and sort by StartTime in descending order
 
    ```sql
    SHOW STREAM LOAD FROM example_db WHERE STATUS = "success" ORDER BY StartTime DESC;
-   ````
+   ```
 
 5. Display the import tasks of the specified db and sort them in descending order of StartTime, and display 10 query results starting from offset 5
 
    ```sql
    SHOW STREAM LOAD FROM example_db ORDER BY StartTime DESC limit 5,10;
    SHOW STREAM LOAD FROM example_db ORDER BY StartTime DESC limit 10 offset 5;
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-SYNC-JOB.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-SYNC-JOB.md
@@ -40,7 +40,7 @@ grammar:
 
 ```sql
 SHOW SYNC JOB [FROM db_name]
-````
+```
 
 ### Example
 
@@ -48,13 +48,13 @@ SHOW SYNC JOB [FROM db_name]
 
     ```sql
     SHOW SYNC JOB;
-    ````
+    ```
 
 2. Display the status of all data synchronization jobs under the database `test_db`.
 
     ```sql
     SHOW SYNC JOB FROM `test_db`;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-ID.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-ID.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TABLE [table_id]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW TABLE [table_id]
 
      ```sql
      SHOW TABLE 10001;
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-STATUS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLE-STATUS.md
@@ -39,7 +39,7 @@ grammar:
 ```sql
 SHOW TABLE STATUS
 [FROM db] [LIKE "pattern"]
-````
+```
 
 illustrate:
 
@@ -51,13 +51,13 @@ illustrate:
 
      ```sql
      SHOW TABLE STATUS;
-     ````
+     ```
 
   2. View the information of the table whose name contains example under the specified database
 
      ```sql
      SHOW TABLE STATUS FROM db LIKE "%example%";
-     ````
+     ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLES.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLES.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW [FULL] TABLES [LIKE]
-````
+```
 
 illustrate:
 
@@ -60,7 +60,7 @@ illustrate:
      | left_table                      |
      +---------------------------------+
      5 rows in set (0.00 sec)
-     ````
+     ```
 
 2. Fuzzy query by table name
 
@@ -73,7 +73,7 @@ illustrate:
     | cmy2           |
     +----------------+
     2 rows in set (0.00 sec)
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLET.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLET.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TABLET tablet_id
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ SHOW TABLET tablet_id
 
     ```sql
     SHOW TABLET 10000;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TABLETS.md
@@ -42,7 +42,7 @@ SHOW TABLETS FROM [database.]table [PARTITIONS(p1,p2)]
 [WHERE where_condition]
 [ORDER BY col_name]
 [LIMIT [offset,] row_count]
-````
+```
 
 1. **Syntax Description:**
 
@@ -61,19 +61,19 @@ or compound them with operator `AND`.
 
     ```sql
     SHOW TABLETS FROM example_db.table_name;
-    ````
+    ```
 
 2. list all tablets of the specified partitions
 
     ```sql
     SHOW TABLETS FROM example_db.table_name PARTITIONS(p1, p2);
-    ````
+    ```
 
 3. list all DECOMMISSION tablets on the specified backend
 
     ```sql
     SHOW TABLETS FROM example_db.table_name WHERE state="DECOMMISSION" AND BackendId=11003;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TRANSACTION.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TRANSACTION.md
@@ -42,11 +42,11 @@ SHOW TRANSACTION
 WHERE
 [id=transaction_id]
 [label = label_name];
-````
+```
 
 Example of returned result:
 
-````
+```
      TransactionId: 4005
              Label: insert_8d807d5d-bcdd-46eb-be6d-3fa87aa4952d
        Coordinator: FE: 10.74.167.16
@@ -59,7 +59,7 @@ Example of returned result:
 ErrorReplicasCount: 0
         ListenerId: -1
          TimeoutMs: 300000
-````
+```
 
 * TransactionId: transaction id
 * Label: the label corresponding to the import task
@@ -84,19 +84,19 @@ ErrorReplicasCount: 0
 
    ```sql
    SHOW TRANSACTION WHERE ID=4005;
-   ````
+   ```
 
 2. In the specified db, view the transaction with id 4005:
 
    ```sql
    SHOW TRANSACTION FROM db WHERE ID=4005;
-   ````
+   ```
 
 3. View the transaction whose label is label_name:
 
    ```sql
    SHOW TRANSACTION WHERE LABEL = 'label_name';
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TRASH.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TRASH.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 SHOW TRASH [ON BackendHost:BackendHeartBeatPort];
-````
+```
 
 illustrate:
 
@@ -51,13 +51,13 @@ illustrate:
 
    ```sql
     SHOW TRASH;
-   ````
+   ```
 
 2. View the space occupied by garbage data of '192.168.0.1:9050' (specific disk information will be displayed).
 
    ```sql
    SHOW TRASH ON "192.168.0.1:9050";
-   ````
+   ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-TYPECAST.md
@@ -40,7 +40,7 @@ grammar
 
 ```sql
 SHOW TYPE_CAST [IN|FROM db]
-````
+```
 
  Parameters
 
@@ -48,7 +48,7 @@ SHOW TYPE_CAST [IN|FROM db]
 
 ### Example
 
-````sql
+```sql
 mysql> show type_cast in testDb\G
 **************************** 1. row ******************** ******
 Origin Type: TIMEV2
@@ -61,7 +61,7 @@ Origin Type: TIMEV2
   Cast Type: TIMEV2
 
 3 rows in set (0.00 sec)
-````
+```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-VARIABLES.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-VARIABLES.md
@@ -36,10 +36,10 @@ This statement is used to display Doris system variables, which can be queried b
 
 grammar:
 
-````sql
+```sql
 SHOW [GLOBAL | SESSION] VARIABLES
      [LIKE 'pattern' | WHERE expr]
-````
+```
 
 illustrate:
 
@@ -54,19 +54,19 @@ illustrate:
 
     ```sql
     show variables like 'max_connections';
-    ````
+    ```
 
 2. Matching through the percent sign (%) wildcard can match multiple items
 
     ```sql
     show variables like '%connec%';
-    ````
+    ```
 
 3. Use the Where clause for matching queries
 
     ```sql
     show variables where variable_name = 'version';
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-VIEW.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Show-Statements/SHOW-VIEW.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
   SHOW VIEW { FROM | IN } table [ FROM db ]
-````
+```
 
 ### Example
 
@@ -46,7 +46,7 @@ grammar:
 
     ```sql
     SHOW VIEW FROM testTbl;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Utility-Statements/DESCRIBE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Utility-Statements/DESCRIBE.md
@@ -38,7 +38,7 @@ grammar:
 
 ```sql
 DESC[RIBE] [db_name.]table_name [ALL];
-````
+```
 
 illustrate:
 
@@ -50,13 +50,13 @@ illustrate:
 
     ```sql
     DESC table_name;
-    ````
+    ```
 
 2. Display the schema of all indexes of the table
 
     ```sql
     DESC db1.table_name ALL;
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Utility-Statements/HELP.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Utility-Statements/HELP.md
@@ -36,9 +36,9 @@ The directory of help can be queried by changing the command
 
 grammar:
 
-```` sql
+``` sql
 HELP <item>
-````
+```
 
 All Doris commands can be listed with `help`
 
@@ -72,7 +72,7 @@ nowarning (\w) Don't show warnings after every statement.
 resetconnection(\x) Clean session context.
 
 For server side help, type 'help contents'
-````
+```
 
 Get the Doris SQL help contents via `help contents`
 
@@ -83,7 +83,7 @@ where <item> is one of the following
 categories:
    sql-functions
    sql-statements
-````
+```
 
 ### Example
 
@@ -91,19 +91,19 @@ categories:
 
    ```sql
    help contents
-   ````
+   ```
 
 2. The command to list all function directories of the Doris cluster
 
    ```sql
    help sql-functions
-   ````
+   ```
 
 3. List all functions under the date function
 
    ```sql
    help date-time-functions
-   ````
+   ```
 
 
 ### Keywords

--- a/versioned_docs/version-3.0/sql-manual/sql-statements/Utility-Statements/USE.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-statements/Utility-Statements/USE.md
@@ -36,9 +36,9 @@ The USE command allows us to use the database
 
 grammar:
 
-````SQL
+```SQL
 USE <[CATALOG_NAME].DATABASE_NAME>
-````
+```
 
 illustrate:
 1. `USE CATALOG_NAME.DATABASE_NAME` will switch the current catalog into `CATALOG_NAME` and then change the current database into `DATABASE_NAME`
@@ -50,13 +50,13 @@ illustrate:
     ```sql
     mysql> use demo;
     Database changed
-    ````
+    ```
 2. If the demo database exists in catalog hms_catalog, try switching the catalog and accessing it:
 
     ```sql
     mysql> use hms_catalog.demo;
     Database changed
-    ````
+    ```
 
 ### Keywords
 

--- a/versioned_docs/version-3.0/table-design/index/ngram-bloomfilter-index.md
+++ b/versioned_docs/version-3.0/table-design/index/ngram-bloomfilter-index.md
@@ -133,7 +133,7 @@ https://datasets-documentation.s3.eu-west-3.amazonaws.com/amazon_reviews/amazon_
 
 **Import the data using stream load:**
 
-```bash
+```shell
 curl --location-trusted -u root: -T amazon_reviews_2010.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load
 curl --location-trusted -u root: -T amazon_reviews_2011.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load
 curl --location-trusted -u root: -T amazon_reviews_2012.snappy.parquet -H "format:parquet" http://127.0.0.1:8030/api/${DB}/amazon_reviews/_stream_load


### PR DESCRIPTION
you could see some docs' codeblocks use `shell` rendered well like https://doris.apache.org/zh-CN/community/developer-guide/mac-dev/dev-prepare. but ones use `Bash` failed like some in https://doris.apache.org/zh-CN/blog/from-presto-trino-clickhouse-and-hive-to-apache-doris-sql-convertor-for-easy-migration

1. change `Bash` block to `shell` in codeblocks
2. change all  `{4,} to ```

except compilation-arm. it's modified in https://github.com/apache/doris-website/pull/926