### PR TITLE
[Doc] Fix `apache-doris/fe/conf/fe.conf` path error in QuickStart page

### DIFF
--- a/common_docs_zh/gettingStarted/quick-start.md
+++ b/common_docs_zh/gettingStarted/quick-start.md
@@ -31,7 +31,7 @@ under the License.
 
 -   选择一个 x86-64 上的主流 Linux 环境，推荐 CentOS 7.1 或者 Ubuntu 16.04 以上版本。更多运行环境请参考安装部署部分。
 
--   Java 8 运行环境（非 Oracle JDK 商业授权用户，建议使用免费的 Oracle JDK 8u202，[立即下载](https://www.oracle.com/java/technologies/javase/javase8-archive-downloads.html#license-lightbox))。
+-   Java 8 运行环境（非 Oracle JDK 商业授权用户，建议使用免费的 Oracle JDK 8u202，[立即下载](https://www.oracle.com/java/technologies/javase/javase8-archive-downloads.html#license-lightbox)）。
 
 -   建议在 Linux 上新建一个 Doris 用户。请避免使用 Root 用户，以防对操作系统误操作。
 
@@ -54,7 +54,7 @@ server1:~ doris$ mv apache-doris-2.0.12-bin-x64 apache-doris
 
 ### 配置 FE
 
-FE 的配置文件为 apache-doris/fe/conf/fe.conf。下面是一些需要关注的核心配置。除了 JAVA_HOME, 需要手动增加，并且指向你的 JDK8 运行环境。其它配置，可以使用默认值，即可支持单机快速体验。
+FE 的配置文件为 `apache-doris/fe/conf/fe.conf`。下面是一些需要关注的核心配置。除了 JAVA_HOME, 需要手动增加，并且指向你的 JDK8 运行环境。其它配置，可以使用默认值，即可支持单机快速体验。
 
 ```Plain
 # 增加 JAVA_HOME 配置，指向 JDK8 的运行环境。假如我们 JDK8 位于 /home/doris/jdk8, 则设置如下
@@ -78,7 +78,7 @@ server1:apache-doris/fe doris$ ./bin/start_fe.sh --daemon
 
 ### 配置 BE
 
-BE 的配置文件为 apache-doris/be/conf/be.conf。下面是一些需要关注的核心配置。除了 JAVA_HOME, 需要手动增加，并且指向你的 JDK8 运行环境。其它配置，可以使用默认值，即可支持我们的快速体验。
+BE 的配置文件为 `apache-doris/be/conf/be.conf`。下面是一些需要关注的核心配置。除了 JAVA_HOME, 需要手动增加，并且指向你的 JDK8 运行环境。其它配置，可以使用默认值，即可支持我们的快速体验。
 
 ```Plain
 # 增加 JAVA_HOME 配置，指向 JDK8 的运行环境。假如我们 JDK8 位于 /home/doris/jdk8, 则设置如下
@@ -205,7 +205,7 @@ curl  --location-trusted -u admin:admin_password -T data.csv -H "column_separato
 
 -   -T data.csv : 要导入的数据文件名
 
--   -u admin:admin_password:  Admin 账户与密码
+-   -u admin:admin_password : Admin 账户与密码
 
 -   127.0.0.1:8030 : 分别是 FE 的 IP 和 http_port
 

--- a/common_docs_zh/gettingStarted/quick-start.md
+++ b/common_docs_zh/gettingStarted/quick-start.md
@@ -112,7 +112,7 @@ mysql -uroot -P9030 -h127.0.0.1
 
 :::caution 注意
 
--   这里使用的 Root 用户是 Apache Doris 内置的超级管理员用户，具体的用户权限查看 [认证和鉴权](../../../admin-manual/auth/authentication-and-authorization.md)
+-   这里使用的 Root 用户是 Apache Doris 内置的超级管理员用户，具体的用户权限查看 [认证和鉴权](../../i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/auth/authentication-and-authorization.md)
 -   -P：这里是我们连接 Apache Doris 的查询端口，默认端口是 9030，对应的是 fe.conf 里的 `query_port`
 -   -h：这里是我们连接的 FE IP 地址，如果你的客户端和 FE 安装在同一个节点可以使用 127.0.0.1。
 

--- a/gettingStarted/quick-start.md
+++ b/gettingStarted/quick-start.md
@@ -53,7 +53,7 @@ server1:~ doris$ mv apache-doris-2.0.3-bin-x64 apache-doris
 
 ### Configure FE
 
-Go to the `apache-doris/fe/fe.conf` file for FE configuration. Below are some key configurations to pay attention to. Add JAVA_HOME manually and point it to your JDK8 runtime environment. For other configurations, you can go with the default values for a quick single-machine experience.
+Go to the `apache-doris/fe/conf/fe.conf` file for FE configuration. Below are some key configurations to pay attention to. Add JAVA_HOME manually and point it to your JDK8 runtime environment. For other configurations, you can go with the default values for a quick single-machine experience.
 
 ```Shell
 # Add JAVA_HOME and point it to your JDK8 runtime environment. Suppose your JDK8 is at /home/doris/jdk8, set it as follows:
@@ -262,4 +262,3 @@ Execute the following command under apache-doris/be to stop BE.
 ```Bash
 server1:apache-doris/be doris$ ./bin/stop_be.sh
 ```
-

--- a/src/theme/DocItem/Layout/pathTransfer.ts
+++ b/src/theme/DocItem/Layout/pathTransfer.ts
@@ -1,7 +1,7 @@
 const transformPathWithoutZhCN = (pathname: string): string => {
     if (pathname.includes('/ecosystem') || pathname.includes('/gettingStarted') ||
         pathname.includes('/benchmark') || pathname.includes('/faq') || pathname.includes('/releasenotes')) {
-        return `${pathname.replace(/^\/docs\/(?:2\.1|2\.0|1\.2|dev)/, '').replace('/docs','')}.md`;
+        return `${pathname.replace(/^\/docs\/(?:2\.1|2\.0|1\.2|dev)/, '').replace('/docs','').replace(/\/$/, '')}.md`;
     } else {
         const pathWithoutDocs = pathname.replace('/docs', '');
         if (pathname.includes('/2.1')) {


### PR DESCRIPTION
- update the QuickStart page 

![image](https://github.com/user-attachments/assets/bba9145f-5d60-44d0-9bab-256259739155)

- The path in the edit button may not work correctly

![page_error](https://github.com/user-attachments/assets/866f5759-e231-4cb0-b94f-53e8154e7dc6)
