### PR TITLE
[doc](typo) fix some typo in `remote-storage` section

### DIFF
--- a/docs/table-design/tiered-storage/remote-storage.md
+++ b/docs/table-design/tiered-storage/remote-storage.md
@@ -66,7 +66,7 @@ When creating an S3 resource, a remote S3 connection validation is performed to 
 
 Here is an example of creating an S3 resource:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (
@@ -97,13 +97,18 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning Notice
+If you set `"enable_unique_key_merge_on_write" = "true"` in UNIQUE table, you can't use this feature.
+:::
+
 And here is an example of creating an HDFS resource:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_hdfs" PROPERTIES (
         "type"="hdfs",
         "fs.defaultFS"="fs_host:default_fs_port",
@@ -128,19 +133,24 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy (
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning Notice
+If you set `"enable_unique_key_merge_on_write" = "true"` in UNIQUE table, you can't use this feature.
+:::
+
 Associate a storage policy with an existing table by using the following command:
 
-```Plain
+```sql
 ALTER TABLE create_table_not_have_policy SET ("storage_policy" = "test_policy");
 ```
 
 Associate a storage policy with an existing partition by using the following command:
 
-```Plain
+```sql
 ALTER TABLE create_table_partition MODIFY PARTITION (*) SET ("storage_policy" = "test_policy");
 ```
 
@@ -219,7 +229,7 @@ Furthermore, the garbage data on objects is not immediately cleaned up. The BE p
 
 The S3 SDK defaults to using the virtual-hosted style. However, some object storage systems (e.g., MinIO) may not have virtual-hosted style access enabled or supported. In such cases, you can add the `use_path_style` parameter to force the use of path-style access:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/tiered-storage/remote-storage.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/tiered-storage/remote-storage.md
@@ -64,7 +64,7 @@ under the License.
 
 下面演示如何创建 S3 RESOURCE：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (
@@ -95,13 +95,18 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning 注意
+UNIQUE 表如果设置了 `"enable_unique_key_merge_on_write" = "true"` 的话，无法使用此功能。
+:::
+
 以及如何创建 HDFS RESOURCE：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_hdfs" PROPERTIES (
         "type"="hdfs",
         "fs.defaultFS"="fs_host:default_fs_port",
@@ -127,19 +132,24 @@ CREATE RESOURCE "remote_hdfs" PROPERTIES (
     UNIQUE KEY(k1)
     DISTRIBUTED BY HASH (k1) BUCKETS 3
     PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
     );
 ```
 
+:::warning 注意
+UNIQUE 表如果设置了 `"enable_unique_key_merge_on_write" = "true"` 的话，无法使用此功能。
+:::
+
 或者对一个已存在的表，关联 Storage policy
 
-```Plain
+```sql
 ALTER TABLE create_table_not_have_policy set ("storage_policy" = "test_policy");
 ```
 
 或者对一个已存在的 partition，关联 Storage policy
 
-```Plain
+```sql
 ALTER TABLE create_table_partition MODIFY PARTITION (*) SET("storage_policy"="test_policy");
 ```
 
@@ -217,7 +227,7 @@ ALTER TABLE create_table_partition MODIFY PARTITION (*) SET("storage_policy"="te
 
 S3 SDK 默认使用 virtual-hosted style 方式。但某些对象存储系统 (如：minio) 可能没开启或没支持 virtual-hosted style 方式的访问，此时我们可以添加 use_path_style 参数来强制使用 path style 方式：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/table-design/cold-hot-separation.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/table-design/cold-hot-separation.md
@@ -156,7 +156,7 @@ ALTER TABLE create_table_partition MODIFY PARTITION (*) SET("storage_policy"="te
 :::tip
 注意，如果用户在建表时给整张 Table 和部分 Partition 指定了不同的 Storage Policy，Partition 设置的 Storage policy 会被无视，整张表的所有 Partition 都会使用 table 的 Policy. 如果您需要让某个 Partition 的 Policy 和别的不同，则可以使用上文中对一个已存在的 Partition，关联 Storage policy 的方式修改。
 
-具体可以参考 Docs 目录下[RESOURCE](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-RESOURCE)、 [POLICY](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-POLICY)、 [CREATE TABLE](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE)、 [ALTER TABLE](../sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN)等文档，里面有详细介绍。
+具体可以参考 Docs 目录下[RESOURCE](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-RESOURCE)、 [POLICY](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-POLICY)、 [CREATE TABLE](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE)、 [ALTER TABLE](../sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN)等文档，里面有详细介绍。
 :::
 
 ### 一些限制

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/table-design/cold-hot-separation.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/table-design/cold-hot-separation.md
@@ -64,7 +64,7 @@ under the License.
 
 下面演示如何创建 S3 RESOURCE：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (
@@ -95,13 +95,18 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning 注意
+UNIQUE 表如果设置了 `"enable_unique_key_merge_on_write" = "true"` 的话，无法使用此功能。
+:::
+
 以及如何创建 HDFS RESOURCE：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_hdfs" PROPERTIES (
         "type"="hdfs",
         "fs.defaultFS"="fs_host:default_fs_port",
@@ -127,26 +132,31 @@ CREATE RESOURCE "remote_hdfs" PROPERTIES (
     UNIQUE KEY(k1)
     DISTRIBUTED BY HASH (k1) BUCKETS 3
     PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
     );
 ```
 
+:::warning 注意
+UNIQUE 表如果设置了 `"enable_unique_key_merge_on_write" = "true"` 的话，无法使用此功能。
+:::
+
 或者对一个已存在的表，关联 Storage policy
 
-```Plain
+```sql
 ALTER TABLE create_table_not_have_policy set ("storage_policy" = "test_policy");
 ```
 
 或者对一个已存在的 partition，关联 Storage policy
 
-```Plain
+```sql
 ALTER TABLE create_table_partition MODIFY PARTITION (*) SET("storage_policy"="test_policy");
 ```
 
 :::tip
 注意，如果用户在建表时给整张 Table 和部分 Partition 指定了不同的 Storage Policy，Partition 设置的 Storage policy 会被无视，整张表的所有 Partition 都会使用 table 的 Policy. 如果您需要让某个 Partition 的 Policy 和别的不同，则可以使用上文中对一个已存在的 Partition，关联 Storage policy 的方式修改。
 
-具体可以参考 Docs 目录下[RESOURCE](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-RESOURCE)、 [POLICY](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-POLICY)、 [CREATE TABLE](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE)、 [ALTER TABLE](../sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN)等文档，里面有详细介绍。
+具体可以参考 Docs 目录下[RESOURCE](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-RESOURCE)、 [POLICY](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-POLICY)、 [CREATE TABLE](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE)、 [ALTER TABLE](../sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN)等文档，里面有详细介绍。
 :::
 
 ### 一些限制
@@ -217,7 +227,7 @@ ALTER TABLE create_table_partition MODIFY PARTITION (*) SET("storage_policy"="te
 
 S3 SDK 默认使用 virtual-hosted style 方式。但某些对象存储系统 (如：minio) 可能没开启或没支持 virtual-hosted style 方式的访问，此时我们可以添加 use_path_style 参数来强制使用 path style 方式：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/table-design/tiered-storage/remote-storage.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/table-design/tiered-storage/remote-storage.md
@@ -64,7 +64,7 @@ under the License.
 
 下面演示如何创建 S3 RESOURCE：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (
@@ -95,13 +95,18 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning 注意
+UNIQUE 表如果设置了 `"enable_unique_key_merge_on_write" = "true"` 的话，无法使用此功能。
+:::
+
 以及如何创建 HDFS RESOURCE：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_hdfs" PROPERTIES (
         "type"="hdfs",
         "fs.defaultFS"="fs_host:default_fs_port",
@@ -127,19 +132,24 @@ CREATE RESOURCE "remote_hdfs" PROPERTIES (
     UNIQUE KEY(k1)
     DISTRIBUTED BY HASH (k1) BUCKETS 3
     PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
     );
 ```
 
+:::warning 注意
+UNIQUE 表如果设置了 `"enable_unique_key_merge_on_write" = "true"` 的话，无法使用此功能。
+:::
+
 或者对一个已存在的表，关联 Storage policy
 
-```Plain
+```sql
 ALTER TABLE create_table_not_have_policy set ("storage_policy" = "test_policy");
 ```
 
 或者对一个已存在的 partition，关联 Storage policy
 
-```Plain
+```sql
 ALTER TABLE create_table_partition MODIFY PARTITION (*) SET("storage_policy"="test_policy");
 ```
 
@@ -217,7 +227,7 @@ ALTER TABLE create_table_partition MODIFY PARTITION (*) SET("storage_policy"="te
 
 S3 SDK 默认使用 virtual-hosted style 方式。但某些对象存储系统 (如：minio) 可能没开启或没支持 virtual-hosted style 方式的访问，此时我们可以添加 use_path_style 参数来强制使用 path style 方式：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/table-design/tiered-storage/remote-storage.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/table-design/tiered-storage/remote-storage.md
@@ -64,7 +64,7 @@ under the License.
 
 下面演示如何创建 S3 RESOURCE：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (
@@ -95,13 +95,18 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning 注意
+UNIQUE 表如果设置了 `"enable_unique_key_merge_on_write" = "true"` 的话，无法使用此功能。
+:::
+
 以及如何创建 HDFS RESOURCE：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_hdfs" PROPERTIES (
         "type"="hdfs",
         "fs.defaultFS"="fs_host:default_fs_port",
@@ -127,19 +132,24 @@ CREATE RESOURCE "remote_hdfs" PROPERTIES (
     UNIQUE KEY(k1)
     DISTRIBUTED BY HASH (k1) BUCKETS 3
     PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
     );
 ```
 
+:::warning 注意
+UNIQUE 表如果设置了 `"enable_unique_key_merge_on_write" = "true"` 的话，无法使用此功能。
+:::
+
 或者对一个已存在的表，关联 Storage policy
 
-```Plain
+```sql
 ALTER TABLE create_table_not_have_policy set ("storage_policy" = "test_policy");
 ```
 
 或者对一个已存在的 partition，关联 Storage policy
 
-```Plain
+```sql
 ALTER TABLE create_table_partition MODIFY PARTITION (*) SET("storage_policy"="test_policy");
 ```
 
@@ -217,7 +227,7 @@ ALTER TABLE create_table_partition MODIFY PARTITION (*) SET("storage_policy"="te
 
 S3 SDK 默认使用 virtual-hosted style 方式。但某些对象存储系统 (如：minio) 可能没开启或没支持 virtual-hosted style 方式的访问，此时我们可以添加 use_path_style 参数来强制使用 path style 方式：
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (

--- a/versioned_docs/version-2.0/table-design/cold-hot-separation.md
+++ b/versioned_docs/version-2.0/table-design/cold-hot-separation.md
@@ -157,7 +157,7 @@ ALTER TABLE create_table_partition MODIFY PARTITION (*) SET ("storage_policy" = 
 :::tip
 If you specify different storage policies for the entire table and some partitions during table creation, the storage policy set for the partitions will be ignored, and all partitions of the table will use the table's storage policy. If you want a specific partition to have a different storage policy than the others, you can use the method mentioned above to modify the association for that specific partition.
 
-For more details, please refer to the following documents in the Docs directory: [RESOURCE](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-RESOURCE), [POLICY](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-POLICY), [CREATE TABLE](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE), [ALTER TABLE](../sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN), which provide detailed explanations.
+For more details, please refer to the following documents in the Docs directory: [RESOURCE](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-RESOURCE), [POLICY](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-POLICY), [CREATE TABLE](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE), [ALTER TABLE](../sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN), which provide detailed explanations.
 :::
 
 ### Limitations

--- a/versioned_docs/version-2.0/table-design/cold-hot-separation.md
+++ b/versioned_docs/version-2.0/table-design/cold-hot-separation.md
@@ -66,7 +66,7 @@ When creating an S3 resource, a remote S3 connection validation is performed to 
 
 Here is an example of creating an S3 resource:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (
@@ -97,13 +97,18 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning Notice
+If you set `"enable_unique_key_merge_on_write" = "true"` in UNIQUE table, you can't use this feature.
+:::
+
 And here is an example of creating an HDFS resource:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_hdfs" PROPERTIES (
         "type"="hdfs",
         "fs.defaultFS"="fs_host:default_fs_port",
@@ -128,26 +133,31 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy (
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning Notice
+If you set `"enable_unique_key_merge_on_write" = "true"` in UNIQUE table, you can't use this feature.
+:::
+
 Associate a storage policy with an existing table by using the following command:
 
-```Plain
+```sql
 ALTER TABLE create_table_not_have_policy SET ("storage_policy" = "test_policy");
 ```
 
 Associate a storage policy with an existing partition by using the following command:
 
-```Plain
+```sql
 ALTER TABLE create_table_partition MODIFY PARTITION (*) SET ("storage_policy" = "test_policy");
 ```
 
 :::tip
 If you specify different storage policies for the entire table and some partitions during table creation, the storage policy set for the partitions will be ignored, and all partitions of the table will use the table's storage policy. If you want a specific partition to have a different storage policy than the others, you can use the method mentioned above to modify the association for that specific partition.
 
-For more details, please refer to the following documents in the Docs directory: [RESOURCE](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-RESOURCE), [POLICY](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-POLICY), [CREATE TABLE](../sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE), [ALTER TABLE](../sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN), which provide detailed explanations.
+For more details, please refer to the following documents in the Docs directory: [RESOURCE](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-RESOURCE), [POLICY](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-POLICY), [CREATE TABLE](../sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE), [ALTER TABLE](../sql-manual/sql-statements/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN), which provide detailed explanations.
 :::
 
 ### Limitations
@@ -219,7 +229,7 @@ Furthermore, the garbage data on objects is not immediately cleaned up. The BE p
 
 The S3 SDK defaults to using the virtual-hosted style. However, some object storage systems (e.g., MinIO) may not have virtual-hosted style access enabled or supported. In such cases, you can add the `use_path_style` parameter to force the use of path-style access:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (

--- a/versioned_docs/version-2.1/table-design/tiered-storage/remote-storage.md
+++ b/versioned_docs/version-2.1/table-design/tiered-storage/remote-storage.md
@@ -66,7 +66,7 @@ When creating an S3 resource, a remote S3 connection validation is performed to 
 
 Here is an example of creating an S3 resource:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (
@@ -97,13 +97,18 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning Notice
+If you set `"enable_unique_key_merge_on_write" = "true"` in UNIQUE table, you can't use this feature.
+:::
+
 And here is an example of creating an HDFS resource:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_hdfs" PROPERTIES (
         "type"="hdfs",
         "fs.defaultFS"="fs_host:default_fs_port",
@@ -128,19 +133,24 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy (
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning Notice
+If you set `"enable_unique_key_merge_on_write" = "true"` in UNIQUE table, you can't use this feature.
+:::
+
 Associate a storage policy with an existing table by using the following command:
 
-```Plain
+```sql
 ALTER TABLE create_table_not_have_policy SET ("storage_policy" = "test_policy");
 ```
 
 Associate a storage policy with an existing partition by using the following command:
 
-```Plain
+```sql
 ALTER TABLE create_table_partition MODIFY PARTITION (*) SET ("storage_policy" = "test_policy");
 ```
 
@@ -219,7 +229,7 @@ Furthermore, the garbage data on objects is not immediately cleaned up. The BE p
 
 The S3 SDK defaults to using the virtual-hosted style. However, some object storage systems (e.g., MinIO) may not have virtual-hosted style access enabled or supported. In such cases, you can add the `use_path_style` parameter to force the use of path-style access:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (

--- a/versioned_docs/version-3.0/table-design/tiered-storage/remote-storage.md
+++ b/versioned_docs/version-3.0/table-design/tiered-storage/remote-storage.md
@@ -66,7 +66,7 @@ When creating an S3 resource, a remote S3 connection validation is performed to 
 
 Here is an example of creating an S3 resource:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (
@@ -97,13 +97,18 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning Notice
+If you set `"enable_unique_key_merge_on_write" = "true"` in UNIQUE table, you can't use this feature.
+:::
+
 And here is an example of creating an HDFS resource:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_hdfs" PROPERTIES (
         "type"="hdfs",
         "fs.defaultFS"="fs_host:default_fs_port",
@@ -128,19 +133,24 @@ CREATE TABLE IF NOT EXISTS create_table_use_created_policy (
 UNIQUE KEY(k1)
 DISTRIBUTED BY HASH (k1) BUCKETS 3
 PROPERTIES(
+    "enable_unique_key_merge_on_write" = "false",
     "storage_policy" = "test_policy"
 );
 ```
 
+:::warning Notice
+If you set `"enable_unique_key_merge_on_write" = "true"` in UNIQUE table, you can't use this feature.
+:::
+
 Associate a storage policy with an existing table by using the following command:
 
-```Plain
+```sql
 ALTER TABLE create_table_not_have_policy SET ("storage_policy" = "test_policy");
 ```
 
 Associate a storage policy with an existing partition by using the following command:
 
-```Plain
+```sql
 ALTER TABLE create_table_partition MODIFY PARTITION (*) SET ("storage_policy" = "test_policy");
 ```
 
@@ -219,7 +229,7 @@ Furthermore, the garbage data on objects is not immediately cleaned up. The BE p
 
 The S3 SDK defaults to using the virtual-hosted style. However, some object storage systems (e.g., MinIO) may not have virtual-hosted style access enabled or supported. In such cases, you can add the `use_path_style` parameter to force the use of path-style access:
 
-```Plain
+```sql
 CREATE RESOURCE "remote_s3"
 PROPERTIES
 (


### PR DESCRIPTION
# Versions 

- [x] dev
- [x] 3.0
- [x] 2.1
- [x] 2.0

# Languages

- [x] Chinese
- [x] English
