### PR TITLE
[fix](outfile) Fix the data type mapping for complex types in Doris to the ORC and Parquet file formats.

### DIFF
--- a/docs/data-operate/export/export-overview.md
+++ b/docs/data-operate/export/export-overview.md
@@ -107,6 +107,9 @@ The following table shows the mapping between Doris data types and Parquet, ORC 
     |map|map|
     |array|array|
     |json| Not supported|
+    |bitmap | binary | binary
+    |quantile_state | binary | binary
+    |hll | binary | binary
 
 2. When Doris exports to Parquet file format, it first converts Doris in-memory data to Arrow in-memory data format, then writes out to Parquet file format. The mapping relationship between Doris data types and Arrow data types is:
 
@@ -130,3 +133,6 @@ The following table shows the mapping between Doris data types and Parquet, ORC 
     | map | map |
     | array | list |
     |json| utf8 |
+    |bitmap | binary | binary
+    |quantile_state | binary | binary
+    |hll | binary | binary

--- a/docs/data-operate/export/export-overview.md
+++ b/docs/data-operate/export/export-overview.md
@@ -106,7 +106,8 @@ The following table shows the mapping between Doris data types and Parquet, ORC 
     |struct|struct|
     |map|map|
     |array|array|
-    |json| Not supported|
+    |json | string|
+    |variant | string|
     |bitmap | binary | binary
     |quantile_state | binary | binary
     |hll | binary | binary
@@ -132,7 +133,8 @@ The following table shows the mapping between Doris data types and Parquet, ORC 
     | struct | struct |
     | map | map |
     | array | list |
-    |json| utf8 |
-    |bitmap | binary | binary
-    |quantile_state | binary | binary
-    |hll | binary | binary
+    | json | utf8 |
+    | variant | utf8|
+    | bitmap | binary | binary
+    | quantile_state | binary | binary
+    | hll | binary | binary

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/export/export-overview.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/export/export-overview.md
@@ -107,6 +107,9 @@ Parquet、ORC 文件格式拥有自己的数据类型。Apache Doris 的导出�
     |map|map|
     |array|array|
     |json|不支持|
+    |bitmap | binary | binary
+    |quantile_state | binary | binary
+    |hll | binary | binary
 
 
 2. Apache Doris 导出到 Parquet 文件格式时，会先将 Apache Doris 内存数据转换为 Arrow 内存数据格式，然后由 Arrow 写出到 Parquet 文件格式。Apache Doris 数据类型到 Arrow 数据类的映射关系为：
@@ -131,3 +134,6 @@ Parquet、ORC 文件格式拥有自己的数据类型。Apache Doris 的导出�
     |map|map|
     |array|list|
     |json|utf8|
+    |bitmap | binary | binary
+    |quantile_state | binary | binary
+    |hll | binary | binary

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/export/export-overview.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/export/export-overview.md
@@ -106,7 +106,8 @@ Parquet、ORC 文件格式拥有自己的数据类型。Apache Doris 的导出�
     |struct|struct|
     |map|map|
     |array|array|
-    |json|不支持|
+    |json|string|
+    |variant | string|
     |bitmap | binary | binary
     |quantile_state | binary | binary
     |hll | binary | binary
@@ -134,6 +135,7 @@ Parquet、ORC 文件格式拥有自己的数据类型。Apache Doris 的导出�
     |map|map|
     |array|list|
     |json|utf8|
+    |variant | utf8 |
     |bitmap | binary | binary
     |quantile_state | binary | binary
     |hll | binary | binary


### PR DESCRIPTION
# Versions 

- [x] dev
- [ ] 3.0
- [ ] 2.1
- [ ] 2.0

# Languages

- [x] Chinese
- [x] English
