### PR TITLE
[ecosystem]fix kafka server prompt address

### DIFF
--- a/docs/data-operate/import/data-source/kafka.md
+++ b/docs/data-operate/import/data-source/kafka.md
@@ -191,7 +191,7 @@ The Doris Kafka Connector is a tool for loading Kafka data streams into the Dori
 2. Configure `config/connect-distributed.properties`:
 
 ```Bash
-# Modify broker address
+# Modify kafka server address
 bootstrap.servers=127.0.0.1:9092
 
 # Modify group.id, which needs to be consistent across the same cluster

--- a/docs/ecosystem/doris-kafka-connector.md
+++ b/docs/ecosystem/doris-kafka-connector.md
@@ -48,7 +48,7 @@ Create the plugins directory under $KAFKA_HOME and put the downloaded doris-kafk
 Configure config/connect-standalone.properties
 
 ```properties
-# Modify broker address
+# Modify kafka server address
 bootstrap.servers=127.0.0.1:9092
 
 # Modify to the created plugins directory

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/ecosystem/doris-kafka-connector.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/ecosystem/doris-kafka-connector.md
@@ -48,7 +48,7 @@ maven 依赖
 配置 config/connect-standalone.properties
 
 ```properties
-# 修改 broker 地址
+# 修改 kafka server 地址
 bootstrap.servers=127.0.0.1:9092
 
 # 修改为创建的 plugins 目录

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/data-source/kafka.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/data-source/kafka.md
@@ -191,7 +191,7 @@ Doris Kafka Connector 是将 Kafka 数据流导入 Doris 数据库的工具。�
 2. 配置 `config/connect-distributed.properties`：
 
 ```Bash
-# 修改 broker 地址
+# 修改 kafka server 地址
 bootstrap.servers=127.0.0.1:9092
 
 # 修改 group.id，同一集群的需要一致

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/ecosystem/doris-kafka-connector.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/ecosystem/doris-kafka-connector.md
@@ -99,7 +99,7 @@ $KAFKA_HOME/bin/connect-standalone.sh -daemon $KAFKA_HOME/config/connect-standal
 配置 config/connect-distributed.properties
 
 ```properties
-# 修改 broker 地址
+# 修改 kafka server 地址
 bootstrap.servers=127.0.0.1:9092
 
 # 修改 group.id，同一集群的需要一致

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/data-source/kafka.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/data-operate/import/data-source/kafka.md
@@ -191,7 +191,7 @@ Doris Kafka Connector 是将 Kafka 数据流导入 Doris 数据库的工具。�
 2. 配置 `config/connect-distributed.properties`：
 
 ```Bash
-# 修改 broker 地址
+# 修改 kafka server 地址
 bootstrap.servers=127.0.0.1:9092
 
 # 修改 group.id，同一集群的需要一致

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/ecosystem/doris-kafka-connector.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/ecosystem/doris-kafka-connector.md
@@ -99,7 +99,7 @@ $KAFKA_HOME/bin/connect-standalone.sh -daemon $KAFKA_HOME/config/connect-standal
 配置 config/connect-distributed.properties
 
 ```properties
-# 修改 broker 地址
+# 修改 kafka server 地址
 bootstrap.servers=127.0.0.1:9092
 
 # 修改 group.id，同一集群的需要一致

--- a/versioned_docs/version-2.0/ecosystem/doris-kafka-connector.md
+++ b/versioned_docs/version-2.0/ecosystem/doris-kafka-connector.md
@@ -98,7 +98,7 @@ Create the plugins directory under $KAFKA_HOME and put the downloaded doris-kafk
 Configure config/connect-distributed.properties
 
 ```properties
-# Modify broker address
+# Modify kafka server address
 bootstrap.servers=127.0.0.1:9092
 
 # Modify group.id, the same cluster needs to be consistent

--- a/versioned_docs/version-2.1/data-operate/import/data-source/kafka.md
+++ b/versioned_docs/version-2.1/data-operate/import/data-source/kafka.md
@@ -191,7 +191,7 @@ The Doris Kafka Connector is a tool for loading Kafka data streams into the Dori
 2. Configure `config/connect-distributed.properties`:
 
 ```Bash
-# Modify broker address
+# Modify kafka server address
 bootstrap.servers=127.0.0.1:9092
 
 # Modify group.id, which needs to be consistent across the same cluster

--- a/versioned_docs/version-2.1/ecosystem/doris-kafka-connector.md
+++ b/versioned_docs/version-2.1/ecosystem/doris-kafka-connector.md
@@ -98,7 +98,7 @@ Create the plugins directory under $KAFKA_HOME and put the downloaded doris-kafk
 Configure config/connect-distributed.properties
 
 ```properties
-# Modify broker address
+# Modify kafka server address
 bootstrap.servers=127.0.0.1:9092
 
 # Modify group.id, the same cluster needs to be consistent

--- a/versioned_docs/version-3.0/data-operate/import/data-source/kafka.md
+++ b/versioned_docs/version-3.0/data-operate/import/data-source/kafka.md
@@ -191,7 +191,7 @@ The Doris Kafka Connector is a tool for loading Kafka data streams into the Dori
 2. Configure `config/connect-distributed.properties`:
 
 ```Bash
-# Modify broker address
+# Modify kafka server address
 bootstrap.servers=127.0.0.1:9092
 
 # Modify group.id, which needs to be consistent across the same cluster

--- a/versioned_docs/version-3.0/ecosystem/doris-kafka-connector.md
+++ b/versioned_docs/version-3.0/ecosystem/doris-kafka-connector.md
@@ -98,7 +98,7 @@ Create the plugins directory under $KAFKA_HOME and put the downloaded doris-kafk
 Configure config/connect-distributed.properties
 
 ```properties
-# Modify broker address
+# Modify kafka server address
 bootstrap.servers=127.0.0.1:9092
 
 # Modify group.id, the same cluster needs to be consistent


### PR DESCRIPTION
Fix the prompt of kafka server, because sometimes it is mistaken for doris broker load

## Versions 

- [x] dev
- [x] 3.0
- [x] 2.1
- [x] 2.0

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
