### PR TITLE
Fix incorrect timestamp usage in window function documentation

### DIFF
--- a/docs/sql-manual/sql-functions/window-functions/window-function.md
+++ b/docs/sql-manual/sql-functions/window-functions/window-function.md
@@ -51,7 +51,7 @@ Returns the same data type as the input expression.
 1. Assume we have the following stock data, with stock symbol JDR and daily closing prices:
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);    
 ...load some data...    
 select * from stock_ticker order by stock_symbol, closing_date
 ```


### PR DESCRIPTION
Fix incorrect timestamp usage in docs
Issue
Fixes #2006

Changes
Replaced timestamp with datetime in the window function docs.
Updated SQL examples to match Doris's supported data types.
Reason:
Doris does not support timestamp, and the current docs are misleading.