### PR TITLE
Fix incorrect Docker image references in documentation

### DIFF
--- a/versioned_docs/version-2.1/gettingStarted/quick-start.md
+++ b/versioned_docs/version-2.1/gettingStarted/quick-start.md
@@ -47,14 +47,14 @@ Copy the following content into the docker-compose.yaml file, and replace the `D
 version: "3"
 services:
   fe:
-    image: apache/doris.fe-ubuntu:${DORIS_QUICK_START_VERSION}
+    image: apache/doris:fe-${DORIS_QUICK_START_VERSION}
     hostname: fe
     environment:
      - FE_SERVERS=fe1:127.0.0.1:9010
      - FE_ID=1
     network_mode: host
   be:
-    image: apache/doris.be-ubuntu:${DORIS_QUICK_START_VERSION}
+    image: apache/doris:be-${DORIS_QUICK_START_VERSION}
     hostname: be
     environment:
      - FE_SERVERS=fe1:127.0.0.1:9010


### PR DESCRIPTION
The current documentation incorrectly refers to non-existent Docker images  'apache/doris.fe-ubuntu' and 'apache/doris.be-ubuntu'. The correct image  format is 'apache/doris:fe-<version>' and 'apache/doris:be-<version>',  which are regularly updated in the Docker registry.

Updated the guide to reflect the actual image naming convention.

## Versions 

- [ ] dev
- [ ] 3.0
- [x ] 2.1
- [ ] 2.0

## Languages

- [ ] Chinese
- [ x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
