### PR TITLE
Update quick-start.md

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/gettingStarted/quick-start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/gettingStarted/quick-start.md
@@ -227,7 +227,10 @@ mysql -uroot -P9030 -h127.0.0.1 -e 'SELECT `host`, `alive` FROM backends()'
        k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
    ) 
    COMMENT "my first table"
-   DISTRIBUTED BY HASH(k1) BUCKETS 1;
+   DISTRIBUTED BY HASH(k1) BUCKETS 1
+   PROPERTIES (
+    "replication_num" = "1"
+   );
    ```
 
 3. **导入测试数据**


### PR DESCRIPTION
[QuickStart][no-issue] Add the replace number of  1. Because there is only one be in the start-doris.sh script, by default, three replace are required.

## Versions 

- [ ] dev
- [ ] 3.0
- [ ] 2.1
- [ ] 2.0

## Languages

- [ ] Chinese
- [ ] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
