### PR TITLE
[doc][lakehouse]add some usage example for catalog_meta_cache_statistics

### DIFF
--- a/docs/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/docs/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -52,11 +52,11 @@ View the metadata cache information of the External Catalog in the currently con
 ```
 
 The METRIC_NAME column contains the following Caffeine cache performance metrics:
-> - eviction_count: The number of entries that have been evicted from the cache
-> - hit_ratio: The ratio of cache requests which were hits (ranges from 0.0 to 1.0)
-> - average_load_penalty: The average time spent loading new values (in nanoseconds)
-> - estimated_size: The approximate number of entries in the cache
-> - hit_count: The number of times cache lookup methods have returned a cached value
-> - read_count: The total number of times cache lookup methods have been called
+- eviction_count: The number of entries that have been evicted from the cache
+- hit_ratio: The ratio of cache requests which were hits (ranges from 0.0 to 1.0)
+- average_load_penalty: The average time spent loading new values (in nanoseconds)
+- estimated_size: The approximate number of entries in the cache
+- hit_count: The number of times cache lookup methods have returned a cached value
+- read_count: The total number of times cache lookup methods have been called
 
 

--- a/docs/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/docs/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -24,3 +24,39 @@ View the metadata cache information of the External Catalog in the currently con
 | METRIC_NAME  | text | The name of the metric  |
 | METRIC_VALUE | text | The value of the metric |
 
+
+## Usage Example
+
+```text
++----------------------+-----------------------------+----------------------+---------------------+
+| CATALOG_NAME         | CACHE_NAME                  | METRIC_NAME          | METRIC_VALUE        |
++----------------------+-----------------------------+----------------------+---------------------+
+| hive_iceberg_minio   | iceberg_table_cache         | eviction_count       | 0                   |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_ratio            | 0.8235294117647058  |
+| hive_iceberg_minio   | iceberg_table_cache         | average_load_penalty | 5.480102048333334E8 |
+| hive_iceberg_minio   | iceberg_table_cache         | estimated_size       | 6                   |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_count            | 28                  |
+| hive_iceberg_minio   | iceberg_table_cache         | read_count           | 34                  |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | eviction_count       | 0                   |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | hit_ratio            | 1.0                 |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | average_load_penalty | 0.0                 |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | estimated_size       | 0                   |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | hit_count            | 0                   |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | read_count           | 0                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | eviction_count       | 0                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_ratio            | 0.45454545454545453 |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | average_load_penalty | 5.604907246666666E8 |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | estimated_size       | 6                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_count            | 5                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | read_count           | 11                  |
+```
+
+The METRIC_NAME column contains the following Caffeine cache performance metrics:
+> - eviction_count: The number of entries that have been evicted from the cache
+> - hit_ratio: The ratio of cache requests which were hits (ranges from 0.0 to 1.0)
+> - average_load_penalty: The average time spent loading new values (in nanoseconds)
+> - estimated_size: The approximate number of entries in the cache
+> - hit_count: The number of times cache lookup methods have returned a cached value
+> - read_count: The total number of times cache lookup methods have been called
+
+

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -23,3 +23,35 @@
 | CACHE_NAME   | text | 缓存名字     |
 | METRIC_NAME  | text | 指标名字     |
 | METRIC_VALUE | text | 指标值       |
+
+
+## 使用示例
+
+```text
+mysql> select * from catalog_meta_cache_statistics;
++----------------------+-----------------------------+----------------------+----------------------+
+| CATALOG_NAME         | CACHE_NAME                  | METRIC_NAME          | METRIC_VALUE         |
++----------------------+-----------------------------+----------------------+----------------------+
+| hive_iceberg_minio   | iceberg_table_cache         | eviction_count       | 0                    |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_ratio            | 0.2413793103448276   |
+| hive_iceberg_minio   | iceberg_table_cache         | average_load_penalty | 2.4654859845454547E8 |
+| hive_iceberg_minio   | iceberg_table_cache         | estimated_size       | 22                   |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_count            | 7                    |
+| hive_iceberg_minio   | iceberg_table_cache         | read_count           | 29                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | eviction_count       | 0                    |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_ratio            | 1.0                  |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | average_load_penalty | 0.0                  |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | estimated_size       | 0                    |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_count            | 0                    |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | read_count           | 0                    |
++----------------------+-----------------------------+----------------------+----------------------+
+```
+
+METRIC_NAME 列包含以下 Caffeine 缓存性能指标：
+
+> - eviction_count：从缓存中驱逐的条目数量
+> - hit_ratio：缓存命中率，范围从 0.0 到 1.0
+> - average_load_penalty：加载新值的平均耗时（纳秒）
+> - estimated_size：缓存中条目的估计数量
+> - hit_count：缓存查找方法返回缓存值的次数
+> - read_count：缓存查找方法被调用的总次数

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -49,9 +49,9 @@ mysql> select * from catalog_meta_cache_statistics;
 
 METRIC_NAME 列包含以下 Caffeine 缓存性能指标：
 
-> - eviction_count：从缓存中驱逐的条目数量
-> - hit_ratio：缓存命中率，范围从 0.0 到 1.0
-> - average_load_penalty：加载新值的平均耗时（纳秒）
-> - estimated_size：缓存中条目的估计数量
-> - hit_count：缓存查找方法返回缓存值的次数
-> - read_count：缓存查找方法被调用的总次数
+- eviction_count：从缓存中驱逐的条目数量
+- hit_ratio：缓存命中率，范围从 0.0 到 1.0
+- average_load_penalty：加载新值的平均耗时（纳秒）
+- estimated_size：缓存中条目的估计数量
+- hit_count：缓存查找方法返回缓存值的次数
+- read_count：缓存查找方法被调用的总次数

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -23,3 +23,35 @@
 | CACHE_NAME   | text | 缓存名字     |
 | METRIC_NAME  | text | 指标名字     |
 | METRIC_VALUE | text | 指标值       |
+
+
+## 使用示例
+
+```text
+mysql> select * from catalog_meta_cache_statistics;
++----------------------+-----------------------------+----------------------+----------------------+
+| CATALOG_NAME         | CACHE_NAME                  | METRIC_NAME          | METRIC_VALUE         |
++----------------------+-----------------------------+----------------------+----------------------+
+| hive_iceberg_minio   | iceberg_table_cache         | eviction_count       | 0                    |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_ratio            | 0.2413793103448276   |
+| hive_iceberg_minio   | iceberg_table_cache         | average_load_penalty | 2.4654859845454547E8 |
+| hive_iceberg_minio   | iceberg_table_cache         | estimated_size       | 22                   |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_count            | 7                    |
+| hive_iceberg_minio   | iceberg_table_cache         | read_count           | 29                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | eviction_count       | 0                    |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_ratio            | 1.0                  |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | average_load_penalty | 0.0                  |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | estimated_size       | 0                    |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_count            | 0                    |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | read_count           | 0                    |
++----------------------+-----------------------------+----------------------+----------------------+
+```
+
+METRIC_NAME 列包含以下 Caffeine 缓存性能指标：
+
+> - eviction_count：从缓存中驱逐的条目数量
+> - hit_ratio：缓存命中率，范围从 0.0 到 1.0
+> - average_load_penalty：加载新值的平均耗时（纳秒）
+> - estimated_size：缓存中条目的估计数量
+> - hit_count：缓存查找方法返回缓存值的次数
+> - read_count：缓存查找方法被调用的总次数

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -49,9 +49,9 @@ mysql> select * from catalog_meta_cache_statistics;
 
 METRIC_NAME 列包含以下 Caffeine 缓存性能指标：
 
-> - eviction_count：从缓存中驱逐的条目数量
-> - hit_ratio：缓存命中率，范围从 0.0 到 1.0
-> - average_load_penalty：加载新值的平均耗时（纳秒）
-> - estimated_size：缓存中条目的估计数量
-> - hit_count：缓存查找方法返回缓存值的次数
-> - read_count：缓存查找方法被调用的总次数
+- eviction_count：从缓存中驱逐的条目数量
+- hit_ratio：缓存命中率，范围从 0.0 到 1.0
+- average_load_penalty：加载新值的平均耗时（纳秒）
+- estimated_size：缓存中条目的估计数量
+- hit_count：缓存查找方法返回缓存值的次数
+- read_count：缓存查找方法被调用的总次数

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -23,3 +23,35 @@
 | CACHE_NAME   | text | 缓存名字     |
 | METRIC_NAME  | text | 指标名字     |
 | METRIC_VALUE | text | 指标值       |
+
+
+## 使用示例
+
+```text
+mysql> select * from catalog_meta_cache_statistics;
++----------------------+-----------------------------+----------------------+----------------------+
+| CATALOG_NAME         | CACHE_NAME                  | METRIC_NAME          | METRIC_VALUE         |
++----------------------+-----------------------------+----------------------+----------------------+
+| hive_iceberg_minio   | iceberg_table_cache         | eviction_count       | 0                    |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_ratio            | 0.2413793103448276   |
+| hive_iceberg_minio   | iceberg_table_cache         | average_load_penalty | 2.4654859845454547E8 |
+| hive_iceberg_minio   | iceberg_table_cache         | estimated_size       | 22                   |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_count            | 7                    |
+| hive_iceberg_minio   | iceberg_table_cache         | read_count           | 29                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | eviction_count       | 0                    |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_ratio            | 1.0                  |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | average_load_penalty | 0.0                  |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | estimated_size       | 0                    |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_count            | 0                    |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | read_count           | 0                    |
++----------------------+-----------------------------+----------------------+----------------------+
+```
+
+METRIC_NAME 列包含以下 Caffeine 缓存性能指标：
+
+> - eviction_count：从缓存中驱逐的条目数量
+> - hit_ratio：缓存命中率，范围从 0.0 到 1.0
+> - average_load_penalty：加载新值的平均耗时（纳秒）
+> - estimated_size：缓存中条目的估计数量
+> - hit_count：缓存查找方法返回缓存值的次数
+> - read_count：缓存查找方法被调用的总次数

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -49,9 +49,9 @@ mysql> select * from catalog_meta_cache_statistics;
 
 METRIC_NAME 列包含以下 Caffeine 缓存性能指标：
 
-> - eviction_count：从缓存中驱逐的条目数量
-> - hit_ratio：缓存命中率，范围从 0.0 到 1.0
-> - average_load_penalty：加载新值的平均耗时（纳秒）
-> - estimated_size：缓存中条目的估计数量
-> - hit_count：缓存查找方法返回缓存值的次数
-> - read_count：缓存查找方法被调用的总次数
+- eviction_count：从缓存中驱逐的条目数量
+- hit_ratio：缓存命中率，范围从 0.0 到 1.0
+- average_load_penalty：加载新值的平均耗时（纳秒）
+- estimated_size：缓存中条目的估计数量
+- hit_count：缓存查找方法返回缓存值的次数
+- read_count：缓存查找方法被调用的总次数

--- a/versioned_docs/version-2.1/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/versioned_docs/version-2.1/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -24,3 +24,31 @@ View the metadata cache information of the External Catalog in the currently con
 | METRIC_NAME  | text | The name of the metric  |
 | METRIC_VALUE | text | The value of the metric |
 
+
+## Usage Example
+
+```text
++----------------------+-----------------------------+----------------------+---------------------+
+| CATALOG_NAME         | CACHE_NAME                  | METRIC_NAME          | METRIC_VALUE        |
++----------------------+-----------------------------+----------------------+---------------------+
+| hive_iceberg_minio   | iceberg_table_cache         | eviction_count       | 0                   |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_ratio            | 0.8235294117647058  |
+| hive_iceberg_minio   | iceberg_table_cache         | average_load_penalty | 5.480102048333334E8 |
+| hive_iceberg_minio   | iceberg_table_cache         | estimated_size       | 6                   |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_count            | 28                  |
+| hive_iceberg_minio   | iceberg_table_cache         | read_count           | 34                  |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | eviction_count       | 0                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_ratio            | 0.45454545454545453 |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | average_load_penalty | 5.604907246666666E8 |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | estimated_size       | 6                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_count            | 5                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | read_count           | 11                  |
+```
+
+The METRIC_NAME column contains the following Caffeine cache performance metrics:
+> - eviction_count: The number of entries that have been evicted from the cache
+> - hit_ratio: The ratio of cache requests which were hits (ranges from 0.0 to 1.0)
+> - average_load_penalty: The average time spent loading new values (in nanoseconds)
+> - estimated_size: The approximate number of entries in the cache
+> - hit_count: The number of times cache lookup methods have returned a cached value
+> - read_count: The total number of times cache lookup methods have been called

--- a/versioned_docs/version-2.1/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/versioned_docs/version-2.1/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -46,9 +46,9 @@ View the metadata cache information of the External Catalog in the currently con
 ```
 
 The METRIC_NAME column contains the following Caffeine cache performance metrics:
-> - eviction_count: The number of entries that have been evicted from the cache
-> - hit_ratio: The ratio of cache requests which were hits (ranges from 0.0 to 1.0)
-> - average_load_penalty: The average time spent loading new values (in nanoseconds)
-> - estimated_size: The approximate number of entries in the cache
-> - hit_count: The number of times cache lookup methods have returned a cached value
-> - read_count: The total number of times cache lookup methods have been called
+- eviction_count: The number of entries that have been evicted from the cache
+- hit_ratio: The ratio of cache requests which were hits (ranges from 0.0 to 1.0)
+- average_load_penalty: The average time spent loading new values (in nanoseconds)
+- estimated_size: The approximate number of entries in the cache
+- hit_count: The number of times cache lookup methods have returned a cached value
+- read_count: The total number of times cache lookup methods have been called

--- a/versioned_docs/version-3.0/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/versioned_docs/version-3.0/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -24,3 +24,37 @@ View the metadata cache information of the External Catalog in the currently con
 | METRIC_NAME  | text | The name of the metric  |
 | METRIC_VALUE | text | The value of the metric |
 
+## Usage Example
+
+
+```text
++----------------------+-----------------------------+----------------------+---------------------+
+| CATALOG_NAME         | CACHE_NAME                  | METRIC_NAME          | METRIC_VALUE        |
++----------------------+-----------------------------+----------------------+---------------------+
+| hive_iceberg_minio   | iceberg_table_cache         | eviction_count       | 0                   |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_ratio            | 0.8235294117647058  |
+| hive_iceberg_minio   | iceberg_table_cache         | average_load_penalty | 5.480102048333334E8 |
+| hive_iceberg_minio   | iceberg_table_cache         | estimated_size       | 6                   |
+| hive_iceberg_minio   | iceberg_table_cache         | hit_count            | 28                  |
+| hive_iceberg_minio   | iceberg_table_cache         | read_count           | 34                  |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | eviction_count       | 0                   |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | hit_ratio            | 1.0                 |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | average_load_penalty | 0.0                 |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | estimated_size       | 0                   |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | hit_count            | 0                   |
+| hive_iceberg_minio   | iceberg_snapshot_list_cache | read_count           | 0                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | eviction_count       | 0                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_ratio            | 0.45454545454545453 |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | average_load_penalty | 5.604907246666666E8 |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | estimated_size       | 6                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | hit_count            | 5                   |
+| hive_iceberg_minio   | iceberg_snapshot_cache      | read_count           | 11                  |
+```
+
+The METRIC_NAME column contains the following Caffeine cache performance metrics:
+> - eviction_count: The number of entries that have been evicted from the cache
+> - hit_ratio: The ratio of cache requests which were hits (ranges from 0.0 to 1.0)
+> - average_load_penalty: The average time spent loading new values (in nanoseconds)
+> - estimated_size: The approximate number of entries in the cache
+> - hit_count: The number of times cache lookup methods have returned a cached value
+> - read_count: The total number of times cache lookup methods have been called

--- a/versioned_docs/version-3.0/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
+++ b/versioned_docs/version-3.0/admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md
@@ -52,9 +52,9 @@ View the metadata cache information of the External Catalog in the currently con
 ```
 
 The METRIC_NAME column contains the following Caffeine cache performance metrics:
-> - eviction_count: The number of entries that have been evicted from the cache
-> - hit_ratio: The ratio of cache requests which were hits (ranges from 0.0 to 1.0)
-> - average_load_penalty: The average time spent loading new values (in nanoseconds)
-> - estimated_size: The approximate number of entries in the cache
-> - hit_count: The number of times cache lookup methods have returned a cached value
-> - read_count: The total number of times cache lookup methods have been called
+- eviction_count: The number of entries that have been evicted from the cache
+- hit_ratio: The ratio of cache requests which were hits (ranges from 0.0 to 1.0)
+- average_load_penalty: The average time spent loading new values (in nanoseconds)
+- estimated_size: The approximate number of entries in the cache
+- hit_count: The number of times cache lookup methods have returned a cached value
+- read_count: The total number of times cache lookup methods have been called


### PR DESCRIPTION
## Versions 
This PR adds practical usage examples for the `catalog_meta_cache_statistics` system table based on the Caffeine cache metrics implementation in ExternalMetaCacheMgr.
 

- [x] dev
- [x] 3.0
- [x] 2.1
- [ ] 2.0

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
