### PR TITLE
Update SYNC.md

### DIFF
--- a/versioned_docs/version-2.0/sql-manual/sql-reference/Utility-Statements/SYNC.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-reference/Utility-Statements/SYNC.md
@@ -23,6 +23,6 @@ Any user or role can perform this operation.
 
 Synchronize metadata:
 
-    ```sql
-    SYNC;
-    ```
+```sql
+SYNC;
+```


### PR DESCRIPTION
fixed markdown syntax. 
indentation was wrong for :
```sql
SYNC;
```

## Versions 

- [ ] dev
- [ ] 3.0
- [ ] 2.1
- [ ] 2.0

## Languages

- [ ] Chinese
- [ ] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
