### PR TITLE
[Fix](function) Fix wrong punctuation marks in function struct_element docs

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
@@ -12,7 +12,7 @@ Return a specific field within a data column of a struct.
 ## Syntax
 
 ```sql
-STRUCT_ELEMENT( <struct>, `<filed_location>/<filed_name>`)
+STRUCT_ELEMENT( <struct>, '<filed_location>/<filed_name>')
 ```
 
 ## Parameters

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
@@ -12,7 +12,7 @@
 ## 语法
 
 ```sql
-STRUCT_ELEMENT( <struct>, `<filed_location>/<filed_name>`)
+STRUCT_ELEMENT( <struct>, '<filed_location>/<filed_name>')
 ```
 
 ## 参数

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
@@ -12,7 +12,7 @@
 ## 语法
 
 ```sql
-STRUCT_ELEMENT( <struct>, `<filed_location>/<filed_name>`)
+STRUCT_ELEMENT( <struct>, '<filed_location>/<filed_name>')
 ```
 
 ## 参数

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
@@ -12,7 +12,7 @@
 ## 语法
 
 ```sql
-STRUCT_ELEMENT( <struct>, `<filed_location>/<filed_name>`)
+STRUCT_ELEMENT( <struct>, '<filed_location>/<filed_name>')
 ```
 
 ## 参数

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
@@ -12,7 +12,7 @@ Return a specific field within a data column of a struct.
 ## Syntax
 
 ```sql
-STRUCT_ELEMENT( <struct>, `<filed_location>/<filed_name>`)
+STRUCT_ELEMENT( <struct>, '<filed_location>/<filed_name>')
 ```
 
 ## Parameters

--- a/versioned_docs/version-3.0/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
+++ b/versioned_docs/version-3.0/sql-manual/sql-functions/scalar-functions/struct-functions/struct-element.md
@@ -12,7 +12,7 @@ Return a specific field within a data column of a struct.
 ## Syntax
 
 ```sql
-STRUCT_ELEMENT( <struct>, `<filed_location>/<filed_name>`)
+STRUCT_ELEMENT( <struct>, '<filed_location>/<filed_name>')
 ```
 
 ## Parameters


### PR DESCRIPTION
## Versions 

- [x] dev
- [x] 3.0
- [x] 2.1
- [ ] 2.0

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
