### PR TITLE
Update be-config.md

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/config/be-config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/config/be-config.md
@@ -449,7 +449,7 @@ thrift 服务器接收请求消息的大小（字节数）上限。如果客户�
 
 * 类型：int32
 * 描述：在列式 compaction 中，输出的 segment 文件最大值，单位是 m 字节。
-* 默认值：268435456
+* 默认值：1073741824
 
 #### `enable_ordered_data_compaction`
 
@@ -621,12 +621,6 @@ BaseCompaction:546859:
 * 类型：int32
 * 描述：当 segment 数量超过此阈值时触发 segment compaction，该配置也限制了单个 segment compaction 任务中的最大原始 segment 数量。
 * 默认值：10
-
-#### `segcompaction_candidate_max_rows`
-
-* 类型：int32
-* 描述：当 segment 的行数超过此大小时则会在 segment compaction 时被 compact，否则跳过
-* 默认值：1048576
 
 #### `segcompaction_candidate_max_rows`
 


### PR DESCRIPTION
## 调整信息
- vertical_compaction_max_segment_size 
默认值从268435456调整为1073741824(源码里面为该值) 
- segcompaction_candidate_max_rows
参数重复，且描述不一致，参照源码注释，删除错误的一条

## Versions 
- [ ] 2.1


## Languages

- [ ] Chinese
- [ ] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
