### PR TITLE
[dcc](hudi/iceberg) fix hudi incr query description and iceberg branch query typo

### DIFF
--- a/docs/lakehouse/catalogs/hudi-catalog.md
+++ b/docs/lakehouse/catalogs/hudi-catalog.md
@@ -201,7 +201,7 @@ By using `desc` to view the execution plan, you can see that Doris converts `@in
 ```text
 |   0:VHUDI_SCAN_NODE(113)                                                                                            |
 |      table: lineitem_mor                                                                                            |
-|      predicates: (_hoodie_commit_time[#0] >= '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
+|      predicates: (_hoodie_commit_time[#0] > '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
 |      inputSplitNum=1, totalFileSize=13099711, scanRanges=1              
 ```
 

--- a/docs/lakehouse/catalogs/iceberg-catalog.md
+++ b/docs/lakehouse/catalogs/iceberg-catalog.md
@@ -326,8 +326,8 @@ Multiple syntax forms are supported to be compatible with systems such as Spark/
 
 ```sql
 -- BRANCH
-SELECT * FROM iceberg_tbl@brand(branch1);
-SELECT * FROM iceberg_tbl@brand("name" = "branch1");
+SELECT * FROM iceberg_tbl@branch(branch1);
+SELECT * FROM iceberg_tbl@branch("name" = "branch1");
 SELECT * FROM iceberg_tbl FOR VERSION AS OF 'branch1';
 
 -- TAG

--- a/docs/lakehouse/catalogs/paimon-catalog.md
+++ b/docs/lakehouse/catalogs/paimon-catalog.md
@@ -350,8 +350,8 @@ Supports various syntax forms to be compatible with systems like Spark/Trino:
 
 ```sql
 -- BRANCH
-SELECT * FROM paimon_tbl@brand(branch1);
-SELECT * FROM paimon_tbl@brand("name" = "branch1");
+SELECT * FROM paimon_tbl@branch(branch1);
+SELECT * FROM paimon_tbl@branch("name" = "branch1");
 
 -- TAG
 SELECT * FROM paimon_tbl@tag(tag1);

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/hudi-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/hudi-catalog.md
@@ -208,7 +208,7 @@ SELECT * from hudi_table@incr('beginTime'='xxx', ['endTime'='xxx'], ['hoodie.rea
 ```text
 |   0:VHUDI_SCAN_NODE(113)                                                                                            |
 |      table: lineitem_mor                                                                                            |
-|      predicates: (_hoodie_commit_time[#0] >= '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
+|      predicates: (_hoodie_commit_time[#0] > '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
 |      inputSplitNum=1, totalFileSize=13099711, scanRanges=1              
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.md
@@ -336,8 +336,8 @@ SELECT * FROM iceberg_tbl FOR VERSION AS OF 868895038966572;
 
 ```sql
 -- BRANCH
-SELECT * FROM iceberg_tbl@brand(branch1);
-SELECT * FROM iceberg_tbl@brand("name" = "branch1");
+SELECT * FROM iceberg_tbl@branch(branch1);
+SELECT * FROM iceberg_tbl@branch("name" = "branch1");
 SELECT * FROM iceberg_tbl FOR VERSION AS OF 'branch1';
 
 -- TAG

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/paimon-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/paimon-catalog.md
@@ -350,8 +350,8 @@ Doris > SELECT * FROM paimon_tbl$tags;
 
 ```sql
 -- BRANCH
-SELECT * FROM paimon_tbl@brand(branch1);
-SELECT * FROM paimon_tbl@brand("name" = "branch1");
+SELECT * FROM paimon_tbl@branch(branch1);
+SELECT * FROM paimon_tbl@branch("name" = "branch1");
 
 -- TAG
 SELECT * FROM paimon_tbl@tag(tag1);

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/lakehouse/catalogs/hudi-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/lakehouse/catalogs/hudi-catalog.md
@@ -208,7 +208,7 @@ SELECT * from hudi_table@incr('beginTime'='xxx', ['endTime'='xxx'], ['hoodie.rea
 ```text
 |   0:VHUDI_SCAN_NODE(113)                                                                                            |
 |      table: lineitem_mor                                                                                            |
-|      predicates: (_hoodie_commit_time[#0] >= '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
+|      predicates: (_hoodie_commit_time[#0] > '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
 |      inputSplitNum=1, totalFileSize=13099711, scanRanges=1              
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/lakehouse/catalogs/iceberg-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/lakehouse/catalogs/iceberg-catalog.md
@@ -336,8 +336,8 @@ SELECT * FROM iceberg_tbl FOR VERSION AS OF 868895038966572;
 
 ```sql
 -- BRANCH
-SELECT * FROM iceberg_tbl@brand(branch1);
-SELECT * FROM iceberg_tbl@brand("name" = "branch1");
+SELECT * FROM iceberg_tbl@branch(branch1);
+SELECT * FROM iceberg_tbl@branch("name" = "branch1");
 SELECT * FROM iceberg_tbl FOR VERSION AS OF 'branch1';
 
 -- TAG

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/lakehouse/catalogs/paimon-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/lakehouse/catalogs/paimon-catalog.md
@@ -350,8 +350,8 @@ Doris > SELECT * FROM paimon_tbl$tags;
 
 ```sql
 -- BRANCH
-SELECT * FROM paimon_tbl@brand(branch1);
-SELECT * FROM paimon_tbl@brand("name" = "branch1");
+SELECT * FROM paimon_tbl@branch(branch1);
+SELECT * FROM paimon_tbl@branch("name" = "branch1");
 
 -- TAG
 SELECT * FROM paimon_tbl@tag(tag1);

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/lakehouse/catalogs/hudi-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/lakehouse/catalogs/hudi-catalog.md
@@ -208,7 +208,7 @@ SELECT * from hudi_table@incr('beginTime'='xxx', ['endTime'='xxx'], ['hoodie.rea
 ```text
 |   0:VHUDI_SCAN_NODE(113)                                                                                            |
 |      table: lineitem_mor                                                                                            |
-|      predicates: (_hoodie_commit_time[#0] >= '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
+|      predicates: (_hoodie_commit_time[#0] > '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
 |      inputSplitNum=1, totalFileSize=13099711, scanRanges=1              
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/lakehouse/catalogs/iceberg-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/lakehouse/catalogs/iceberg-catalog.md
@@ -336,8 +336,8 @@ SELECT * FROM iceberg_tbl FOR VERSION AS OF 868895038966572;
 
 ```sql
 -- BRANCH
-SELECT * FROM iceberg_tbl@brand(branch1);
-SELECT * FROM iceberg_tbl@brand("name" = "branch1");
+SELECT * FROM iceberg_tbl@branch(branch1);
+SELECT * FROM iceberg_tbl@branch("name" = "branch1");
 SELECT * FROM iceberg_tbl FOR VERSION AS OF 'branch1';
 
 -- TAG

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/lakehouse/catalogs/paimon-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.0/lakehouse/catalogs/paimon-catalog.md
@@ -350,8 +350,8 @@ Doris > SELECT * FROM paimon_tbl$tags;
 
 ```sql
 -- BRANCH
-SELECT * FROM paimon_tbl@brand(branch1);
-SELECT * FROM paimon_tbl@brand("name" = "branch1");
+SELECT * FROM paimon_tbl@branch(branch1);
+SELECT * FROM paimon_tbl@branch("name" = "branch1");
 
 -- TAG
 SELECT * FROM paimon_tbl@tag(tag1);

--- a/versioned_docs/version-2.1/lakehouse/catalogs/hudi-catalog.md
+++ b/versioned_docs/version-2.1/lakehouse/catalogs/hudi-catalog.md
@@ -201,7 +201,7 @@ By using `desc` to view the execution plan, you can see that Doris converts `@in
 ```text
 |   0:VHUDI_SCAN_NODE(113)                                                                                            |
 |      table: lineitem_mor                                                                                            |
-|      predicates: (_hoodie_commit_time[#0] >= '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
+|      predicates: (_hoodie_commit_time[#0] > '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
 |      inputSplitNum=1, totalFileSize=13099711, scanRanges=1              
 ```
 

--- a/versioned_docs/version-2.1/lakehouse/catalogs/iceberg-catalog.md
+++ b/versioned_docs/version-2.1/lakehouse/catalogs/iceberg-catalog.md
@@ -326,8 +326,8 @@ Multiple syntax forms are supported to be compatible with systems such as Spark/
 
 ```sql
 -- BRANCH
-SELECT * FROM iceberg_tbl@brand(branch1);
-SELECT * FROM iceberg_tbl@brand("name" = "branch1");
+SELECT * FROM iceberg_tbl@branch(branch1);
+SELECT * FROM iceberg_tbl@branch("name" = "branch1");
 SELECT * FROM iceberg_tbl FOR VERSION AS OF 'branch1';
 
 -- TAG

--- a/versioned_docs/version-2.1/lakehouse/catalogs/paimon-catalog.md
+++ b/versioned_docs/version-2.1/lakehouse/catalogs/paimon-catalog.md
@@ -350,8 +350,8 @@ Supports various syntax forms to be compatible with systems like Spark/Trino:
 
 ```sql
 -- BRANCH
-SELECT * FROM paimon_tbl@brand(branch1);
-SELECT * FROM paimon_tbl@brand("name" = "branch1");
+SELECT * FROM paimon_tbl@branch(branch1);
+SELECT * FROM paimon_tbl@branch("name" = "branch1");
 
 -- TAG
 SELECT * FROM paimon_tbl@tag(tag1);

--- a/versioned_docs/version-3.0/lakehouse/catalogs/hudi-catalog.md
+++ b/versioned_docs/version-3.0/lakehouse/catalogs/hudi-catalog.md
@@ -201,7 +201,7 @@ By using `desc` to view the execution plan, you can see that Doris converts `@in
 ```text
 |   0:VHUDI_SCAN_NODE(113)                                                                                            |
 |      table: lineitem_mor                                                                                            |
-|      predicates: (_hoodie_commit_time[#0] >= '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
+|      predicates: (_hoodie_commit_time[#0] > '20240311151019723'), (_hoodie_commit_time[#0] <= '20240311151606605') |
 |      inputSplitNum=1, totalFileSize=13099711, scanRanges=1              
 ```
 

--- a/versioned_docs/version-3.0/lakehouse/catalogs/iceberg-catalog.md
+++ b/versioned_docs/version-3.0/lakehouse/catalogs/iceberg-catalog.md
@@ -326,8 +326,8 @@ Multiple syntax forms are supported to be compatible with systems such as Spark/
 
 ```sql
 -- BRANCH
-SELECT * FROM iceberg_tbl@brand(branch1);
-SELECT * FROM iceberg_tbl@brand("name" = "branch1");
+SELECT * FROM iceberg_tbl@branch(branch1);
+SELECT * FROM iceberg_tbl@branch("name" = "branch1");
 SELECT * FROM iceberg_tbl FOR VERSION AS OF 'branch1';
 
 -- TAG

--- a/versioned_docs/version-3.0/lakehouse/catalogs/paimon-catalog.md
+++ b/versioned_docs/version-3.0/lakehouse/catalogs/paimon-catalog.md
@@ -350,8 +350,8 @@ Supports various syntax forms to be compatible with systems like Spark/Trino:
 
 ```sql
 -- BRANCH
-SELECT * FROM paimon_tbl@brand(branch1);
-SELECT * FROM paimon_tbl@brand("name" = "branch1");
+SELECT * FROM paimon_tbl@branch(branch1);
+SELECT * FROM paimon_tbl@branch("name" = "branch1");
 
 -- TAG
 SELECT * FROM paimon_tbl@tag(tag1);


### PR DESCRIPTION
1. fix hudi incr query description about https://github.com/apache/doris/pull/55003
2. replace `@brand` by `@branch`

## Versions 

- [x] dev
- [x] 3.0
- [x] 2.1
- [ ] 2.0

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
