### PR TITLE
fix:llvm version

### DIFF
--- a/community/developer-guide/mac-dev/dev-prepare.md
+++ b/community/developer-guide/mac-dev/dev-prepare.md
@@ -28,7 +28,7 @@ under the License.
 
 ```shell
 brew install automake autoconf libtool pkg-config texinfo coreutils gnu-getopt \
-python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@17 npm
+python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@20 openjdk@17 npm
 ```
 
 *The version of jdk installed using brew is 17, because on macOS, the arm64 version of brew does not have version 8 of jdk by default*

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/developer-guide/mac-dev/dev-prepare.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/developer-guide/mac-dev/dev-prepare.md
@@ -28,7 +28,7 @@ under the License.
 
 ```shell
 brew install automake autoconf libtool pkg-config texinfo coreutils gnu-getopt \
-python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@17 npm
+python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@20 openjdk@17 npm
 ```
 
 *使用 brew 安装的 jdk 版本为 17，因为在 macOS 上，arm64 版本的 brew 默认没有 8 版本的 jdk*

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/source-install/compilation-mac.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/source-install/compilation-mac.md
@@ -43,7 +43,7 @@ under the License.
 
 ```Shell
 brew install automake autoconf libtool pkg-config texinfo coreutils gnu-getopt \
-python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@11 npm
+python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@20 openjdk@11 npm
 ```
 
 在 MacOS 上，由于 brew 没有提供 JDK8 的安装包，所以在这里使用了 JDK11。也可以自己手动下载安装 JDK8。


### PR DESCRIPTION
## Versions 

- [x] dev
- [x] 3.0
- [ ] 2.1
- [ ] 2.0

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built

Fix llvm version mismatch on Mac (Apple Silicon)

When debugging Doris Back-End on Mac with Apple Silicon, I discovered that the [actual llvm version](https://github.com/apache/doris/blob/master/env.sh#L68) doesn't match the version specified in `env.sh`. This little "surprise" only cost me one day of my life! 😅