### PR TITLE
docs: fix incorrect column references in AGG_STATE example

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/table-design/data-model/aggregate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/table-design/data-model/aggregate.md
@@ -146,7 +146,12 @@ select group_concat_merge(v2) from aggstate;
 如果不想要最终的聚合结果，而希望保留中间结果，可以使用 `union` 操作：
 
 ```sql
-insert into aggstate select 3,sum_union(k2),group_concat_union(k3) from aggstate;
+insert into aggstate select 3,sum(v1),group_concat_union(v2) from aggstate;
+
+select sum(v1), group_concat_merge(v2) from aggstate;
+
+select sum(v1), group_concat_merge(v2) from aggstate where k1 != 2;
+
 ```
 
 此时表中计算如下：


### PR DESCRIPTION
The AGG_STATE example in zh-CN/docs/2.1/table-design/data-model/aggregate.md  was using non-existent columns `k2` and `k3`, which do not match the table schema.  

Updated the example queries to use the correct columns `v1` and `v2`:

```sql
insert into aggstate select 3,sum(v1),group_concat_union(v2) from aggstate;

select sum(v1), group_concat_merge(v2) from aggstate;

select sum(v1), group_concat_merge(v2) from aggstate where k1 != 2;

## Versions 

- [ ] dev
- [ ] 3.0
- [ ] 2.1
- [ ] 2.0

## Languages

- [ ] Chinese
- [ ] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
