### PR TITLE
Update overview.md

### DIFF
--- a/versioned_docs/version-3.x/table-design/overview.md
+++ b/versioned_docs/version-3.x/table-design/overview.md
@@ -11,7 +11,7 @@ Users can use the [CREATE TABLE](../sql-manual/sql-statements/table-and-view/tab
 
 ## Table name
 
-In Doris, table names are case-sensitive by default. You can configure [lower_case_table_names](../admin-manual/config/fe-config.md)to make them case-insensitive during the initial cluster setup. The default maximum length for table names is 64 bytes, but you can change this by configuring [table_name_length_limit](../admin-manual/config/fe-config.md). It is not recommended to set this value too high. For syntax on creating tables, please refer to [CREATE TABLE](../sql-manual/sql-statements/table-and-view/table/CREATE-TABLE). [Dynamic partitions](data-partitioning/dynamic-partitioning.md) can have these properties set individually.
+In Doris, table names are case-insensitive by default. You can configure [lower_case_table_names](../admin-manual/config/fe-config.md)to make them case-sensitive during the initial cluster setup. The default maximum length for table names is 64 bytes, but you can change this by configuring [table_name_length_limit](../admin-manual/config/fe-config.md). It is not recommended to set this value too high. For syntax on creating tables, please refer to [CREATE TABLE](../sql-manual/sql-statements/table-and-view/table/CREATE-TABLE). [Dynamic partitions](data-partitioning/dynamic-partitioning.md) can have these properties set individually.
 
 ## Table property
 


### PR DESCRIPTION
In Doris, table names are case-insensitive by default. You can configure lower_case_table_names=1 to make them case-sensitive during the initial cluster setup.

## Versions 
- [ ] 3.x



## Languages
- [ ] English

## Docs Checklist
- [ ] Test Cases Built
<img width="2092" height="928" alt="image" src="https://github.com/user-attachments/assets/69753f83-44c4-4e92-98ca-c634e48760a3" />
