### PR TITLE
[fix] The json_remove function was mistakenly implemented as json_set.

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/json-functions/json-remove.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/json-functions/json-remove.md
@@ -1,6 +1,6 @@
 ---
 {
-    "title": "JSON_SET",
+    "title": "JSON_REMOVE",
     "language": "en"
 }
 ---


### PR DESCRIPTION
## Versions 

- [x] dev
- [ ] 3.x
- [ ] 2.1
- [ ] 2.0

## Languages

- [ ] Chinese
- [x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
