### PR TITLE
GROUPING_ID not supported with ORDER BY in Nereids planner

### DIFF
--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/grouping-id.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/grouping-id.md
@@ -41,7 +41,7 @@ SELECT
   COUNT(uid) AS `Employee Count`
 FROM employee 
 GROUP BY ROLLUP(department, level)
-ORDER BY GROUPING_ID(department, level) ASC;
+ORDER BY department desc;
 ```
 
 *Expected Output:*
@@ -50,18 +50,18 @@ ORDER BY GROUPING_ID(department, level) ASC;
 +--------------------+---------------------------+----------------+
 | department         | Job Title                 | Employee Count |
 +--------------------+---------------------------+----------------+
-| Board of Directors | Senior                    |              2 |
 | Technology         | Senior                    |              3 |
-| Sales              | Senior                    |              1 |
-| Sales              | Assistant                 |              2 |
-| Sales              | Trainee                   |              1 |
-| Marketing          | Senior                    |              1 |
-| Marketing          | Trainee                   |              2 |
-| Marketing          | Assistant                 |              1 |
-| Board of Directors | Total: Board of Directors |              2 |
 | Technology         | Total: Technology         |              3 |
+| Sales              | Assistant                 |              2 |
 | Sales              | Total: Sales              |              4 |
+| Sales              | Trainee                   |              1 |
+| Sales              | Senior                    |              1 |
+| Marketing          | Senior                    |              1 |
+| Marketing          | Assistant                 |              1 |
 | Marketing          | Total: Marketing          |              4 |
+| Marketing          | Trainee                   |              2 |
+| Board of Directors | Senior                    |              2 |
+| Board of Directors | Total: Board of Directors |              2 |
 | NULL               | Total: Company            |             13 |
 +--------------------+---------------------------+----------------+
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/grouping-id.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/grouping-id.md
@@ -41,7 +41,7 @@ SELECT
   COUNT(uid) AS `Employee Count`
 FROM employee 
 GROUP BY ROLLUP(department, level)
-ORDER BY GROUPING_ID(department, level) ASC;
+ORDER BY department desc;
 ```
 
 *Expected Output:*
@@ -50,18 +50,18 @@ ORDER BY GROUPING_ID(department, level) ASC;
 +--------------------+---------------------------+----------------+
 | department         | Job Title                 | Employee Count |
 +--------------------+---------------------------+----------------+
-| Board of Directors | Senior                    |              2 |
 | Technology         | Senior                    |              3 |
-| Sales              | Senior                    |              1 |
-| Sales              | Assistant                 |              2 |
-| Sales              | Trainee                   |              1 |
-| Marketing          | Senior                    |              1 |
-| Marketing          | Trainee                   |              2 |
-| Marketing          | Assistant                 |              1 |
-| Board of Directors | Total: Board of Directors |              2 |
 | Technology         | Total: Technology         |              3 |
+| Sales              | Assistant                 |              2 |
 | Sales              | Total: Sales              |              4 |
+| Sales              | Trainee                   |              1 |
+| Sales              | Senior                    |              1 |
+| Marketing          | Senior                    |              1 |
+| Marketing          | Assistant                 |              1 |
 | Marketing          | Total: Marketing          |              4 |
+| Marketing          | Trainee                   |              2 |
+| Board of Directors | Senior                    |              2 |
+| Board of Directors | Total: Board of Directors |              2 |
 | NULL               | Total: Company            |             13 |
 +--------------------+---------------------------+----------------+
 ```


### PR DESCRIPTION
GROUPING_ID is not supported with ORDER BY in the Nereids planner. Since Nereids is used mostly in 3.x and fully in 4.x, the documentation should be updated. The error message is: LOGICAL_SORT cannot contain GroupingScalarFunction expression: Grouping_Id(department, level).

<img width="1186" height="257" alt="Screenshot from 2025-12-06 21-13-33" src="https://github.com/user-attachments/assets/0c9ad70d-a4e1-43f1-bdd1-531430fea9bc" />


## Versions 

- [ ] dev
- [x] 4.x
- [x] 3.x
- [ ] 2.1

## Languages

- [ ] Chinese
- [x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
