### PR TITLE
Fix typo in title from 'Apaceh' to 'Apache'

### DIFF
--- a/versioned_docs/version-4.x/ai/vector-search/ivf.md
+++ b/versioned_docs/version-4.x/ai/vector-search/ivf.md
@@ -22,7 +22,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# IVF and How to use it in Apaceh Doris
+# IVF and How to use it in Apache Doris
 
 
 IVF index is an efficient data structure used for Approximate Nearest Neighbor (ANN) search. It helps narrow down the scope of vectors during search, significantly improving search speed. Since Apache Doris 4.x, an ANN index based on IVF has been supported. This document walks through the IVF algorithm, key parameters, and engineering practices, and explains how to build and tune IVF‑based ANN indexes in production Doris clusters.


### PR DESCRIPTION
was just reading through and found this

## Versions 

- [ ] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1

## Languages

- [ ] Chinese
- [X] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
