### PR TITLE
Document AWS S3 Express One Zone connection details

### DIFF
--- a/versioned_docs/version-4.x/lakehouse/storages/s3.md
+++ b/versioned_docs/version-4.x/lakehouse/storages/s3.md
@@ -66,6 +66,13 @@ For instructions on AWS authentication and authorization configuration, please r
 
 Amazon S3 Express One Zone (also known as Directory Bucket) provides higher performance, but has a different endpoint format.
 
+To connect to an AWS S3 Express One Zone Directory Bucket you will need to add another property option listed below:
+
+```Properties
+"s3_validity_check" = "false"
+```
+* "s3_validity_check" = "false" disabled the pingS3 check that commonly fails during storage vault configuration for Directory Buckets.
+
 * Regular bucket: s3.us-east-1.amazonaws.com
 * Directory Bucket: s3express-usw2-az1.us-west-2.amazonaws.com
 
@@ -78,6 +85,7 @@ Example:
 "s3.secret_key"="sk",
 "s3.endpoint"="s3express-usw2-az1.us-west-2.amazonaws.com",
 "s3.region"="us-west-2"
+"s3_validity_check" = "false" 
 ```
 
 ## Permission Policies


### PR DESCRIPTION
Added instructions for connecting to AWS S3 Express One Zone Directory Bucket, including the new property option 's3_validity_check'.

## Versions 

- [x] dev
- [x] 4.x
- [x] 3.x
- [ ] 2.1

## Languages

- [ ] Chinese
- [x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
