### PR TITLE
[typo](docs) fix restore code fence rendering

### DIFF
--- a/docs/admin-manual/data-admin/backup-restore/restore.md
+++ b/docs/admin-manual/data-admin/backup-restore/restore.md
@@ -88,7 +88,7 @@ Restore partitions p1 and p2 of the table `backup_tbl`, as well as the table `ba
 
 ## 3. Check the Execution Status of the Restore Job
 
-      ```sql
+```sql
    mysql> SHOW RESTORE\G;
    *************************** 1. row ***************************
                   JobId: 17891851
@@ -127,4 +127,4 @@ Restore partitions p1 and p2 of the table `backup_tbl`, as well as the table `ba
                  Status: [OK]
                 Timeout: 86400
    1 row in set (0.01 sec)
-   ```
+```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/data-admin/backup-restore/restore.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/data-admin/backup-restore/restore.md
@@ -87,7 +87,7 @@ PROPERTIES
 
 ## 3. 查看恢复作业的执行情况
 
-    ```sql
+```sql
     mysql> SHOW RESTORE\G;
     *************************** 1. row ***************************
                   JobId: 17891851
@@ -126,4 +126,4 @@ PROPERTIES
                   Status: [OK]
                 Timeout: 86400
     1 row in set (0.01 sec)
-    ```
+```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/backup-restore/restore.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/backup-restore/restore.md
@@ -87,7 +87,7 @@ PROPERTIES
 
 ## 3. 查看恢复作业的执行情况
 
-    ```sql
+```sql
     mysql> SHOW RESTORE\G;
     *************************** 1. row ***************************
                   JobId: 17891851
@@ -126,4 +126,4 @@ PROPERTIES
                   Status: [OK]
                 Timeout: 86400
     1 row in set (0.01 sec)
-    ```
+```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/data-admin/backup-restore/restore.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/data-admin/backup-restore/restore.md
@@ -87,7 +87,7 @@ PROPERTIES
 
 ## 3. 查看恢复作业的执行情况
 
-    ```sql
+```sql
     mysql> SHOW RESTORE\G;
     *************************** 1. row ***************************
                   JobId: 17891851
@@ -126,4 +126,4 @@ PROPERTIES
                   Status: [OK]
                 Timeout: 86400
     1 row in set (0.01 sec)
-    ```
+```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/data-admin/backup-restore/restore.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/data-admin/backup-restore/restore.md
@@ -87,7 +87,7 @@ PROPERTIES
 
 ## 3. 查看恢复作业的执行情况
 
-    ```sql
+```sql
     mysql> SHOW RESTORE\G;
     *************************** 1. row ***************************
                   JobId: 17891851
@@ -126,4 +126,4 @@ PROPERTIES
                   Status: [OK]
                 Timeout: 86400
     1 row in set (0.01 sec)
-    ```
+```

--- a/versioned_docs/version-2.1/admin-manual/data-admin/backup-restore/restore.md
+++ b/versioned_docs/version-2.1/admin-manual/data-admin/backup-restore/restore.md
@@ -88,7 +88,7 @@ Restore partitions p1 and p2 of the table `backup_tbl`, as well as the table `ba
 
 ## 3. Check the Execution Status of the Restore Job
 
-      ```sql
+```sql
    mysql> SHOW RESTORE\G;
    *************************** 1. row ***************************
                   JobId: 17891851
@@ -127,4 +127,4 @@ Restore partitions p1 and p2 of the table `backup_tbl`, as well as the table `ba
                  Status: [OK]
                 Timeout: 86400
    1 row in set (0.01 sec)
-   ```
+```

--- a/versioned_docs/version-3.x/admin-manual/data-admin/backup-restore/restore.md
+++ b/versioned_docs/version-3.x/admin-manual/data-admin/backup-restore/restore.md
@@ -88,7 +88,7 @@ Restore partitions p1 and p2 of the table `backup_tbl`, as well as the table `ba
 
 ## 3. Check the Execution Status of the Restore Job
 
-      ```sql
+```sql
    mysql> SHOW RESTORE\G;
    *************************** 1. row ***************************
                   JobId: 17891851
@@ -127,4 +127,4 @@ Restore partitions p1 and p2 of the table `backup_tbl`, as well as the table `ba
                  Status: [OK]
                 Timeout: 86400
    1 row in set (0.01 sec)
-   ```
+```

--- a/versioned_docs/version-4.x/admin-manual/data-admin/backup-restore/restore.md
+++ b/versioned_docs/version-4.x/admin-manual/data-admin/backup-restore/restore.md
@@ -88,7 +88,7 @@ Restore partitions p1 and p2 of the table `backup_tbl`, as well as the table `ba
 
 ## 3. Check the Execution Status of the Restore Job
 
-  ```sql
+```sql
    mysql> SHOW RESTORE\G;
    *************************** 1. row ***************************
                   JobId: 17891851
@@ -127,4 +127,4 @@ Restore partitions p1 and p2 of the table `backup_tbl`, as well as the table `ba
                  Status: [OK]
                 Timeout: 86400
    1 row in set (0.01 sec)
-   ```
+```


### PR DESCRIPTION
## Summary
- verify the markdown rendering issue from #1790 still exists in current restore docs
- remove leading indentation from the final fenced code block in restore docs so the fence is parsed correctly
- apply the same fix to both English and Chinese docs for `current`, `version-2.1`, `version-3.x`, and `version-4.x`

## Validation
- checked the final `SHOW RESTORE\G` section in all affected files and confirmed opening/closing fences now start at column 1