### PR TITLE
[typo](docs) fix ntpd service commands in zh os-checking

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/preparation/os-checking.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/install/preparation/os-checking.md
@@ -136,6 +136,6 @@ Doris 的元数据要求时间精度要小于 5000ms，所以所有集群所有�
 通常情况下，可以通过配置 NTP 服务保证各节点时钟同步。
 
 ```bash
-sudo systemctl start_ntpd.service
-sudo systemctl enable_ntpd.service
+sudo systemctl start ntpd.service
+sudo systemctl enable ntpd.service
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/preparation/os-checking.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/install/preparation/os-checking.md
@@ -136,6 +136,6 @@ Doris 的元数据要求时间精度要小于 5000ms，所以所有集群所有�
 通常情况下，可以通过配置 NTP 服务保证各节点时钟同步。
 
 ```bash
-sudo systemctl start_ntpd.service
-sudo systemctl enable_ntpd.service
+sudo systemctl start ntpd.service
+sudo systemctl enable ntpd.service
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/install/preparation/os-checking.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/install/preparation/os-checking.md
@@ -136,6 +136,6 @@ Doris 的元数据要求时间精度要小于 5000ms，所以所有集群所有�
 通常情况下，可以通过配置 NTP 服务保证各节点时钟同步。
 
 ```bash
-sudo systemctl start_ntpd.service
-sudo systemctl enable_ntpd.service
+sudo systemctl start ntpd.service
+sudo systemctl enable ntpd.service
 ```


### PR DESCRIPTION
## Summary
- check #2434 and confirm the command typo still exists in current Chinese docs
- replace `systemctl start_ntpd.service` / `systemctl enable_ntpd.service` with correct `systemctl start ntpd.service` / `systemctl enable ntpd.service`
- apply the fix consistently to `current`, `version-2.1`, and `version-4.x`

## Reference
- redoes issue intent from #2434