### PR TITLE
[typo](docs) fix grant example placement in zh storage vault docs

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/managing-storage-vault.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/managing-storage-vault.md
@@ -184,11 +184,13 @@ GRANT
 - 通过 `SHOW STORAGE VAULTS` 查看该 Storage Vault 的信息；
 - 建表时在 `PROPERTIES` 中指定使用该 Storage Vault。
 
-### 撤销
+**示例**
 
 ```sql
 grant usage_priv on storage vault my_storage_vault to user1
 ```
+
+### 撤销
 
 撤销指定的 MySQL 用户的 Storage Vault 权限。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/compute-storage-decoupled/managing-storage-vault.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/compute-storage-decoupled/managing-storage-vault.md
@@ -183,11 +183,13 @@ GRANT
 - 通过 `SHOW STORAGE VAULTS` 查看该 Storage Vault 的信息；
 - 建表时在 `PROPERTIES` 中指定使用该 Storage Vault。
 
-### 撤销
+**示例**
 
 ```sql
 grant usage_priv on storage vault my_storage_vault to user1
 ```
+
+### 撤销
 
 撤销指定的 MySQL 用户的 Storage Vault 权限。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/compute-storage-decoupled/managing-storage-vault.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/compute-storage-decoupled/managing-storage-vault.md
@@ -184,11 +184,13 @@ GRANT
 - 通过 `SHOW STORAGE VAULTS` 查看该 Storage Vault 的信息；
 - 建表时在 `PROPERTIES` 中指定使用该 Storage Vault。
 
-### 撤销
+**示例**
 
 ```sql
 grant usage_priv on storage vault my_storage_vault to user1
 ```
+
+### 撤销
 
 撤销指定的 MySQL 用户的 Storage Vault 权限。
 


### PR DESCRIPTION
## Summary
- verify the issue in #1588 still exists: a `GRANT` example appears under the `撤销` section in Chinese storage-vault docs
- move the `grant usage_priv ...` example back to the `授予` section as its example
- keep `撤销` section focused on revoke syntax/example
- apply consistently to `current`, `version-3.x`, and `version-4.x`

## Reference
- redoes issue intent from #1588