### PR TITLE
[typo](docs) fix tablet-info curl examples

### DIFF
--- a/docs/admin-manual/open-api/be-http/tablet-info.md
+++ b/docs/admin-manual/open-api/be-http/tablet-info.md
@@ -54,7 +54,6 @@ None
 
 
     ```
-    curl http://127.0.0.1:8040/api/tablets_json?limit=all
+    curl http://127.0.0.1:8040/tablets_json?limit=all
 
     ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/open-api/be-http/tablet-info.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/open-api/be-http/tablet-info.md
@@ -52,7 +52,6 @@
 
 
     ```shell
-    curl http://127.0.0.1:8040/api/tablets_json?limit=123
+    curl http://127.0.0.1:8040/tablets_json?limit=123
 
     ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/tablet-info.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/admin-manual/be/tablet-info.md
@@ -51,7 +51,6 @@
 
 
     ```shell
-    curl http://127.0.0.1:8040/api/tablets_json?limit=123
+    curl http://127.0.0.1:8040/tablets_json?limit=123
 
     ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/open-api/be-http/tablet-info.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/open-api/be-http/tablet-info.md
@@ -52,7 +52,6 @@
 
 
     ```shell
-    curl http://127.0.0.1:8040/api/tablets_json?limit=123
+    curl http://127.0.0.1:8040/tablets_json?limit=123
 
     ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/open-api/be-http/tablet-info.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/open-api/be-http/tablet-info.md
@@ -52,7 +52,6 @@
 
 
     ```shell
-    curl http://127.0.0.1:8040/api/tablets_json?limit=123
+    curl http://127.0.0.1:8040/tablets_json?limit=123
 
     ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/open-api/be-http/tablet-info.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/open-api/be-http/tablet-info.md
@@ -52,7 +52,6 @@
 
 
     ```shell
-    curl http://127.0.0.1:8040/api/tablets_json?limit=123
+    curl http://127.0.0.1:8040/tablets_json?limit=123
 
     ```
-

--- a/versioned_docs/version-2.0/admin-manual/be/tablet-info.md
+++ b/versioned_docs/version-2.0/admin-manual/be/tablet-info.md
@@ -53,7 +53,6 @@ None
 
 
     ```
-    curl http://127.0.0.1:8040/api/tablets_json?limit=all
+    curl http://127.0.0.1:8040/tablets_json?limit=all
 
     ```
-

--- a/versioned_docs/version-2.1/admin-manual/open-api/be-http/tablet-info.md
+++ b/versioned_docs/version-2.1/admin-manual/open-api/be-http/tablet-info.md
@@ -54,7 +54,6 @@ None
 
 
     ```
-    curl http://127.0.0.1:8040/api/tablets_json?limit=all
+    curl http://127.0.0.1:8040/tablets_json?limit=all
 
     ```
-

--- a/versioned_docs/version-3.x/admin-manual/open-api/be-http/tablet-info.md
+++ b/versioned_docs/version-3.x/admin-manual/open-api/be-http/tablet-info.md
@@ -54,7 +54,6 @@ None
 
 
     ```
-    curl http://127.0.0.1:8040/api/tablets_json?limit=all
+    curl http://127.0.0.1:8040/tablets_json?limit=all
 
     ```
-

--- a/versioned_docs/version-4.x/admin-manual/open-api/be-http/tablet-info.md
+++ b/versioned_docs/version-4.x/admin-manual/open-api/be-http/tablet-info.md
@@ -54,7 +54,6 @@ None
 
 
     ```
-    curl http://127.0.0.1:8040/api/tablets_json?limit=all
+    curl http://127.0.0.1:8040/tablets_json?limit=all
 
     ```
-


### PR DESCRIPTION
## Summary
- verify #2459 issue still exists: tablet-info docs still use `/api/tablets_json` in curl examples
- replace endpoint with `/tablets_json` in all related EN + ZH docs
- apply consistently to `current`, `version-4.x`, `version-3.x`, `version-2.1`, and `version-2.0`

## Reference
- redoes issue intent from #2459