### PR TITLE
[typo](docs) fix zh INSERT typo in filter-ratio description

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/data-modification/DML/INSERT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/data-modification/DML/INSERT.md
@@ -202,7 +202,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
 4. 过滤阈值
 
-   与其他导入方式不同，INSERT 操作不能指定过滤阈值（`max_filter_ratio`）。默认的过滤阈值为 1，即素有错误行都可以被忽略。
+   与其他导入方式不同，INSERT 操作不能指定过滤阈值（`max_filter_ratio`）。默认的过滤阈值为 1，即忽略所有错误行。
 
    对于有要求数据不能够被过滤的业务场景，可以通过设置 [会话变量](../../session/variable/SET-VARIABLE) `enable_insert_strict` 为 `true` 来确保当有数据被过滤掉的时候，`INSERT` 不会被执行成功。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/data-modification/DML/INSERT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/data-modification/DML/INSERT.md
@@ -202,7 +202,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
 4. 过滤阈值
 
-   与其他导入方式不同，INSERT 操作不能指定过滤阈值（`max_filter_ratio`）。默认的过滤阈值为 1，即素有错误行都可以被忽略。
+   与其他导入方式不同，INSERT 操作不能指定过滤阈值（`max_filter_ratio`）。默认的过滤阈值为 1，即忽略所有错误行。
 
    对于有要求数据不能够被过滤的业务场景，可以通过设置 [会话变量](../../session/variable/SET-VARIABLE) `enable_insert_strict` 为 `true` 来确保当有数据被过滤掉的时候，`INSERT` 不会被执行成功。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-statements/data-modification/DML/INSERT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-statements/data-modification/DML/INSERT.md
@@ -202,7 +202,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
 4. 过滤阈值
 
-   与其他导入方式不同，INSERT 操作不能指定过滤阈值（`max_filter_ratio`）。默认的过滤阈值为 1，即素有错误行都可以被忽略。
+   与其他导入方式不同，INSERT 操作不能指定过滤阈值（`max_filter_ratio`）。默认的过滤阈值为 1，即忽略所有错误行。
 
    对于有要求数据不能够被过滤的业务场景，可以通过设置 [会话变量](../../session/variable/SET-VARIABLE) `enable_insert_strict` 为 `true` 来确保当有数据被过滤掉的时候，`INSERT` 不会被执行成功。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/data-modification/DML/INSERT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/data-modification/DML/INSERT.md
@@ -202,7 +202,7 @@ INSERT INTO test WITH LABEL `label1` (c1, c2) SELECT * from test2;
 
 4. 过滤阈值
 
-   与其他导入方式不同，INSERT 操作不能指定过滤阈值（`max_filter_ratio`）。默认的过滤阈值为 1，即素有错误行都可以被忽略。
+   与其他导入方式不同，INSERT 操作不能指定过滤阈值（`max_filter_ratio`）。默认的过滤阈值为 1，即忽略所有错误行。
 
    对于有要求数据不能够被过滤的业务场景，可以通过设置 [会话变量](../../session/variable/SET-VARIABLE) `enable_insert_strict` 为 `true` 来确保当有数据被过滤掉的时候，`INSERT` 不会被执行成功。
 


### PR DESCRIPTION
## Summary
- verify #2402 and confirm the typo still exists in Chinese INSERT docs (`素有`)
- update wording to `即忽略所有错误行` in the filter-threshold paragraph
- apply the same fix consistently to `current`, `version-2.1`, `version-3.x`, and `version-4.x`

## Reference
- redoes issue intent from #2402