### PR TITLE
[doc](import) clarify Azure and MinIO caution sections

### DIFF
--- a/docs/data-operate/import/data-source/azure-storage.md
+++ b/docs/data-operate/import/data-source/azure-storage.md
@@ -46,10 +46,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using S3 Load
 
 :::caution Caution
-Azure Storage requires HTTPS transmission by default, with the corresponding storage account configuration being `Secure transfer required: Enabled`.
-To access Azure Storage properly, you need to set `s3_client_http_scheme = https` in Doris's `be.conf`.
+When importing data from Azure Storage with S3 Load, note the following:
 
-The `s3.region` setting for Azure S3 properties can be omitted.
+- Azure Storage requires HTTPS transmission by default (`Secure transfer required: Enabled`). To access Azure Storage properly, set `s3_client_http_scheme = https` in Doris `be.conf`.
+- The `s3.region` setting in Azure S3 properties can be omitted.
 :::
 
 ```sql
@@ -136,10 +136,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using TVF
 
 :::caution Caution
-Azure Storage requires HTTPS transmission by default, with the corresponding storage account configuration being `Secure transfer required: Enabled`.
-To access Azure Storage properly, you need to set `s3_client_http_scheme = https` in Doris's `be.conf`.
+When importing data from Azure Storage with TVF, note the following:
 
-The `s3.region` setting for Azure S3 properties can be omitted.
+- Azure Storage requires HTTPS transmission by default (`Secure transfer required: Enabled`). To access Azure Storage properly, set `s3_client_http_scheme = https` in Doris `be.conf`.
+- The `s3.region` setting in Azure S3 properties can be omitted.
 :::
 
 ```sql

--- a/docs/data-operate/import/data-source/minio.md
+++ b/docs/data-operate/import/data-source/minio.md
@@ -49,13 +49,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using S3 Load
 
 :::caution Caution
-If you deployed MinIO in a local network and did not have TLS enabled, you need to explicitly add `http://` in the endpoint string.
+When importing data from MinIO with S3 Load, note the following:
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-The S3 SDK uses the virtual-hosted style by default. However, MinIO does not enable virtual-hosted style access by default. In this case, we can add the `use_path_style` parameter to force the use of the path style.
-
-- `"use_path_style" = "true"`
+- If MinIO is deployed in a local network without TLS, explicitly add `http://` in the endpoint, for example: `"s3.endpoint" = "http://localhost:9000"`.
+- The S3 SDK uses virtual-hosted style by default, while MinIO does not enable it by default. Add `"use_path_style" = "true"` to force path-style access.
 :::
 
 ```sql
@@ -143,14 +140,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using TVF
 
 :::caution Caution
-If you deployed MinIO in a local network and did not have TLS enabled, you need to explicitly add `http://` in the endpoint string.
+When importing data from MinIO with TVF, note the following:
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-
-The S3 SDK uses the virtual-hosted style by default. However, MinIO does not enable virtual-hosted style access by default. In this case, we can add the `use_path_style` parameter to force the use of the path style.
-
-- `"use_path_style" = "true"`
+- If MinIO is deployed in a local network without TLS, explicitly add `http://` in the endpoint, for example: `"s3.endpoint" = "http://localhost:9000"`.
+- The S3 SDK uses virtual-hosted style by default, while MinIO does not enable it by default. Add `"use_path_style" = "true"` to force path-style access.
 :::
 
 ```sql
@@ -196,4 +189,3 @@ mysql> select * from test_s3load;
 +---------+-----------+------+
 10 rows in set (0.04 sec)
 ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/azure-storage.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/azure-storage.md
@@ -46,10 +46,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 S3 Load 导入数据
 
 :::caution Caution
-Azure Storage 默认要求 HTTPS 传输，对应的存储账户配置是 `需要安全传输：已启用`。
-必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问 Azure Storage。
+使用 S3 Load 导入 Azure Storage 数据时，请注意：
 
-Azure S3 properties 中的 `s3.region` 可以省略。
+- Azure Storage 默认要求 HTTPS 传输（对应存储账户配置为 `需要安全传输：已启用`），必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问。
+- Azure S3 properties 中的 `s3.region` 可以省略。
 :::
 
 ```sql
@@ -136,10 +136,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 TVF 导入数据
 
 :::caution Caution
-Azure Storage 默认要求 HTTPs 传输，对应的存储账户配置是 `需要安全传输：已启用`。
-必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问 Azure Storage。
+使用 TVF 导入 Azure Storage 数据时，请注意：
 
-Azure S3 properties 中的 `s3.region` 可以省略。
+- Azure Storage 默认要求 HTTPS 传输（对应存储账户配置为 `需要安全传输：已启用`），必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问。
+- Azure S3 properties 中的 `s3.region` 可以省略。
 :::
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/minio.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/minio.md
@@ -49,13 +49,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 S3 Load 导入数据
 
 :::caution 注意
-如果您在本地网络中部署了 MinIO 并且未启用 TLS，则需要在 endpoint 字符串中明确添加 `http://`。
+使用 S3 Load 导入 MinIO 数据时，请注意：
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-S3 SDK 默认使用 virtual-hosted style 方式。但 MinIO 默认没开启 virtual-hosted style 方式的访问，此时我们可以添加 `use_path_style` 参数来强制使用 path style 方式。
-
-- `"use_path_style" = "true"`
+- 如果 MinIO 部署在本地网络且未启用 TLS，需要在 endpoint 中显式添加 `http://`，例如：`"s3.endpoint" = "http://localhost:9000"`。
+- S3 SDK 默认使用 virtual-hosted style，但 MinIO 默认未开启该访问方式。可添加 `"use_path_style" = "true"` 强制使用 path style。
 :::
 
 ```sql
@@ -143,13 +140,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 TVF 导入数据
 
 :::caution 注意
-如果您在本地网络中部署了 MinIO 并且未启用 TLS，则需要在 endpoint 字符串中明确添加 `http://`。
+使用 TVF 导入 MinIO 数据时，请注意：
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-S3 SDK 默认使用 virtual-hosted style 方式。但 MinIO 默认没开启 virtual-hosted style 方式的访问，此时我们可以添加 `use_path_style` 参数来强制使用 path style 方式。
-
-- `"use_path_style" = "true"`
+- 如果 MinIO 部署在本地网络且未启用 TLS，需要在 endpoint 中显式添加 `http://`，例如：`"s3.endpoint" = "http://localhost:9000"`。
+- S3 SDK 默认使用 virtual-hosted style，但 MinIO 默认未开启该访问方式。可添加 `"use_path_style" = "true"` 强制使用 path style。
 :::
 
 ```sql
@@ -195,4 +189,3 @@ mysql> select * from test_s3load;
 +---------+-----------+------+
 10 rows in set (0.04 sec)
 ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/data-source/azure-storage.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/data-source/azure-storage.md
@@ -46,10 +46,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 S3 Load 导入数据
 
 :::caution Caution
-Azure Storage 默认要求 HTTPS 传输，对应的存储账户配置是 `需要安全传输：已启用`。
-必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问 Azure Storage。
+使用 S3 Load 导入 Azure Storage 数据时，请注意：
 
-Azure S3 properties 中的 `s3.region` 可以省略。
+- Azure Storage 默认要求 HTTPS 传输（对应存储账户配置为 `需要安全传输：已启用`），必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问。
+- Azure S3 properties 中的 `s3.region` 可以省略。
 :::
 
 ```sql
@@ -136,10 +136,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 TVF 导入数据
 
 :::caution Caution
-Azure Storage 默认要求 HTTPs 传输，对应的存储账户配置是 `需要安全传输：已启用`。
-必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问 Azure Storage。
+使用 TVF 导入 Azure Storage 数据时，请注意：
 
-Azure S3 properties 中的 `s3.region` 可以省略。
+- Azure Storage 默认要求 HTTPS 传输（对应存储账户配置为 `需要安全传输：已启用`），必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问。
+- Azure S3 properties 中的 `s3.region` 可以省略。
 :::
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/data-source/minio.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/data-source/minio.md
@@ -49,13 +49,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 S3 Load 导入数据
 
 :::caution 注意
-如果您在本地网络中部署了 MinIO 并且未启用 TLS，则需要在 endpoint 字符串中明确添加 `http://`。
+使用 S3 Load 导入 MinIO 数据时，请注意：
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-S3 SDK 默认使用 virtual-hosted style 方式。但 MinIO 默认没开启 virtual-hosted style 方式的访问，此时我们可以添加 `use_path_style` 参数来强制使用 path style 方式。
-
-- `"use_path_style" = "true"`
+- 如果 MinIO 部署在本地网络且未启用 TLS，需要在 endpoint 中显式添加 `http://`，例如：`"s3.endpoint" = "http://localhost:9000"`。
+- S3 SDK 默认使用 virtual-hosted style，但 MinIO 默认未开启该访问方式。可添加 `"use_path_style" = "true"` 强制使用 path style。
 :::
 
 ```sql
@@ -143,13 +140,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 TVF 导入数据
 
 :::caution 注意
-如果您在本地网络中部署了 MinIO 并且未启用 TLS，则需要在 endpoint 字符串中明确添加 `http://`。
+使用 TVF 导入 MinIO 数据时，请注意：
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-S3 SDK 默认使用 virtual-hosted style 方式。但 MinIO 默认没开启 virtual-hosted style 方式的访问，此时我们可以添加 `use_path_style` 参数来强制使用 path style 方式。
-
-- `"use_path_style" = "true"`
+- 如果 MinIO 部署在本地网络且未启用 TLS，需要在 endpoint 中显式添加 `http://`，例如：`"s3.endpoint" = "http://localhost:9000"`。
+- S3 SDK 默认使用 virtual-hosted style，但 MinIO 默认未开启该访问方式。可添加 `"use_path_style" = "true"` 强制使用 path style。
 :::
 
 ```sql
@@ -195,4 +189,3 @@ mysql> select * from test_s3load;
 +---------+-----------+------+
 10 rows in set (0.04 sec)
 ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/data-source/azure-storage.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/data-source/azure-storage.md
@@ -46,10 +46,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 S3 Load 导入数据
 
 :::caution Caution
-Azure Storage 默认要求 HTTPS 传输，对应的存储账户配置是 `需要安全传输：已启用`。
-必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问 Azure Storage。
+使用 S3 Load 导入 Azure Storage 数据时，请注意：
 
-Azure S3 properties 中的 `s3.region` 可以省略。
+- Azure Storage 默认要求 HTTPS 传输（对应存储账户配置为 `需要安全传输：已启用`），必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问。
+- Azure S3 properties 中的 `s3.region` 可以省略。
 :::
 
 ```sql
@@ -136,10 +136,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 TVF 导入数据
 
 :::caution Caution
-Azure Storage 默认要求 HTTPs 传输，对应的存储账户配置是 `需要安全传输：已启用`。
-必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问 Azure Storage。
+使用 TVF 导入 Azure Storage 数据时，请注意：
 
-Azure S3 properties 中的 `s3.region` 可以省略。
+- Azure Storage 默认要求 HTTPS 传输（对应存储账户配置为 `需要安全传输：已启用`），必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问。
+- Azure S3 properties 中的 `s3.region` 可以省略。
 :::
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/data-source/minio.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/data-source/minio.md
@@ -49,13 +49,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 S3 Load 导入数据
 
 :::caution 注意
-如果您在本地网络中部署了 MinIO 并且未启用 TLS，则需要在 endpoint 字符串中明确添加 `http://`。
+使用 S3 Load 导入 MinIO 数据时，请注意：
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-S3 SDK 默认使用 virtual-hosted style 方式。但 MinIO 默认没开启 virtual-hosted style 方式的访问，此时我们可以添加 `use_path_style` 参数来强制使用 path style 方式。
-
-- `"use_path_style" = "true"`
+- 如果 MinIO 部署在本地网络且未启用 TLS，需要在 endpoint 中显式添加 `http://`，例如：`"s3.endpoint" = "http://localhost:9000"`。
+- S3 SDK 默认使用 virtual-hosted style，但 MinIO 默认未开启该访问方式。可添加 `"use_path_style" = "true"` 强制使用 path style。
 :::
 
 ```sql
@@ -143,13 +140,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 TVF 导入数据
 
 :::caution 注意
-如果您在本地网络中部署了 MinIO 并且未启用 TLS，则需要在 endpoint 字符串中明确添加 `http://`。
+使用 TVF 导入 MinIO 数据时，请注意：
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-S3 SDK 默认使用 virtual-hosted style 方式。但 MinIO 默认没开启 virtual-hosted style 方式的访问，此时我们可以添加 `use_path_style` 参数来强制使用 path style 方式。
-
-- `"use_path_style" = "true"`
+- 如果 MinIO 部署在本地网络且未启用 TLS，需要在 endpoint 中显式添加 `http://`，例如：`"s3.endpoint" = "http://localhost:9000"`。
+- S3 SDK 默认使用 virtual-hosted style，但 MinIO 默认未开启该访问方式。可添加 `"use_path_style" = "true"` 强制使用 path style。
 :::
 
 ```sql
@@ -195,4 +189,3 @@ mysql> select * from test_s3load;
 +---------+-----------+------+
 10 rows in set (0.04 sec)
 ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/azure-storage.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/azure-storage.md
@@ -46,10 +46,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 S3 Load 导入数据
 
 :::caution Caution
-Azure Storage 默认要求 HTTPS 传输，对应的存储账户配置是 `需要安全传输：已启用`。
-必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问 Azure Storage。
+使用 S3 Load 导入 Azure Storage 数据时，请注意：
 
-Azure S3 properties 中的 `s3.region` 可以省略。
+- Azure Storage 默认要求 HTTPS 传输（对应存储账户配置为 `需要安全传输：已启用`），必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问。
+- Azure S3 properties 中的 `s3.region` 可以省略。
 :::
 
 ```sql
@@ -136,10 +136,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 TVF 导入数据
 
 :::caution Caution
-Azure Storage 默认要求 HTTPs 传输，对应的存储账户配置是 `需要安全传输：已启用`。
-必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问 Azure Storage。
+使用 TVF 导入 Azure Storage 数据时，请注意：
 
-Azure S3 properties 中的 `s3.region` 可以省略。
+- Azure Storage 默认要求 HTTPS 传输（对应存储账户配置为 `需要安全传输：已启用`），必须在 Doris `be.conf` 中设置 `s3_client_http_scheme = https` 才能正常访问。
+- Azure S3 properties 中的 `s3.region` 可以省略。
 :::
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/minio.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/minio.md
@@ -49,13 +49,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 S3 Load 导入数据
 
 :::caution 注意
-如果您在本地网络中部署了 MinIO 并且未启用 TLS，则需要在 endpoint 字符串中明确添加 `http://`。
+使用 S3 Load 导入 MinIO 数据时，请注意：
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-S3 SDK 默认使用 virtual-hosted style 方式。但 MinIO 默认没开启 virtual-hosted style 方式的访问，此时我们可以添加 `use_path_style` 参数来强制使用 path style 方式。
-
-- `"use_path_style" = "true"`
+- 如果 MinIO 部署在本地网络且未启用 TLS，需要在 endpoint 中显式添加 `http://`，例如：`"s3.endpoint" = "http://localhost:9000"`。
+- S3 SDK 默认使用 virtual-hosted style，但 MinIO 默认未开启该访问方式。可添加 `"use_path_style" = "true"` 强制使用 path style。
 :::
 
 ```sql
@@ -143,13 +140,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### 第 3 步：使用 TVF 导入数据
 
 :::caution 注意
-如果您在本地网络中部署了 MinIO 并且未启用 TLS，则需要在 endpoint 字符串中明确添加 `http://`。
+使用 TVF 导入 MinIO 数据时，请注意：
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-S3 SDK 默认使用 virtual-hosted style 方式。但 MinIO 默认没开启 virtual-hosted style 方式的访问，此时我们可以添加 `use_path_style` 参数来强制使用 path style 方式。
-
-- `"use_path_style" = "true"`
+- 如果 MinIO 部署在本地网络且未启用 TLS，需要在 endpoint 中显式添加 `http://`，例如：`"s3.endpoint" = "http://localhost:9000"`。
+- S3 SDK 默认使用 virtual-hosted style，但 MinIO 默认未开启该访问方式。可添加 `"use_path_style" = "true"` 强制使用 path style。
 :::
 
 ```sql
@@ -195,4 +189,3 @@ mysql> select * from test_s3load;
 +---------+-----------+------+
 10 rows in set (0.04 sec)
 ```
-

--- a/versioned_docs/version-2.1/data-operate/import/data-source/azure-storage.md
+++ b/versioned_docs/version-2.1/data-operate/import/data-source/azure-storage.md
@@ -46,10 +46,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using S3 Load
 
 :::caution Caution
-Azure Storage requires HTTPS transmission by default, with the corresponding storage account configuration being `Secure transfer required: Enabled`.
-To access Azure Storage properly, you need to set `s3_client_http_scheme = https` in Doris's `be.conf`.
+When importing data from Azure Storage with S3 Load, note the following:
 
-The `s3.region` setting for Azure S3 properties can be omitted.
+- Azure Storage requires HTTPS transmission by default (`Secure transfer required: Enabled`). To access Azure Storage properly, set `s3_client_http_scheme = https` in Doris `be.conf`.
+- The `s3.region` setting in Azure S3 properties can be omitted.
 :::
 
 ```sql
@@ -136,10 +136,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using TVF
 
 :::caution Caution
-Azure Storage requires HTTPS transmission by default, with the corresponding storage account configuration being `Secure transfer required: Enabled`.
-To access Azure Storage properly, you need to set `s3_client_http_scheme = https` in Doris's `be.conf`.
+When importing data from Azure Storage with TVF, note the following:
 
-The `s3.region` setting for Azure S3 properties can be omitted.
+- Azure Storage requires HTTPS transmission by default (`Secure transfer required: Enabled`). To access Azure Storage properly, set `s3_client_http_scheme = https` in Doris `be.conf`.
+- The `s3.region` setting in Azure S3 properties can be omitted.
 :::
 
 ```sql

--- a/versioned_docs/version-2.1/data-operate/import/data-source/minio.md
+++ b/versioned_docs/version-2.1/data-operate/import/data-source/minio.md
@@ -49,13 +49,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using S3 Load
 
 :::caution Caution
-If you deployed MinIO in a local network and did not have TLS enabled, you need to explicitly add `http://` in the endpoint string.
+When importing data from MinIO with S3 Load, note the following:
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-The S3 SDK uses the virtual-hosted style by default. However, MinIO does not enable virtual-hosted style access by default. In this case, we can add the `use_path_style` parameter to force the use of the path style.
-
-- `"use_path_style" = "true"`
+- If MinIO is deployed in a local network without TLS, explicitly add `http://` in the endpoint, for example: `"s3.endpoint" = "http://localhost:9000"`.
+- The S3 SDK uses virtual-hosted style by default, while MinIO does not enable it by default. Add `"use_path_style" = "true"` to force path-style access.
 :::
 
 ```sql
@@ -143,14 +140,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using TVF
 
 :::caution Caution
-If you deployed MinIO in a local network and did not have TLS enabled, you need to explicitly add `http://` in the endpoint string.
+When importing data from MinIO with TVF, note the following:
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-
-The S3 SDK uses the virtual-hosted style by default. However, MinIO does not enable virtual-hosted style access by default. In this case, we can add the `use_path_style` parameter to force the use of the path style.
-
-- `"use_path_style" = "true"`
+- If MinIO is deployed in a local network without TLS, explicitly add `http://` in the endpoint, for example: `"s3.endpoint" = "http://localhost:9000"`.
+- The S3 SDK uses virtual-hosted style by default, while MinIO does not enable it by default. Add `"use_path_style" = "true"` to force path-style access.
 :::
 
 ```sql
@@ -196,4 +189,3 @@ mysql> select * from test_s3load;
 +---------+-----------+------+
 10 rows in set (0.04 sec)
 ```
-

--- a/versioned_docs/version-3.x/data-operate/import/data-source/azure-storage.md
+++ b/versioned_docs/version-3.x/data-operate/import/data-source/azure-storage.md
@@ -46,10 +46,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using S3 Load
 
 :::caution Caution
-Azure Storage requires HTTPS transmission by default, with the corresponding storage account configuration being `Secure transfer required: Enabled`.
-To access Azure Storage properly, you need to set `s3_client_http_scheme = https` in Doris's `be.conf`.
+When importing data from Azure Storage with S3 Load, note the following:
 
-The `s3.region` setting for Azure S3 properties can be omitted.
+- Azure Storage requires HTTPS transmission by default (`Secure transfer required: Enabled`). To access Azure Storage properly, set `s3_client_http_scheme = https` in Doris `be.conf`.
+- The `s3.region` setting in Azure S3 properties can be omitted.
 :::
 
 ```sql
@@ -136,10 +136,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using TVF
 
 :::caution Caution
-Azure Storage requires HTTPS transmission by default, with the corresponding storage account configuration being `Secure transfer required: Enabled`.
-To access Azure Storage properly, you need to set `s3_client_http_scheme = https` in Doris's `be.conf`.
+When importing data from Azure Storage with TVF, note the following:
 
-The `s3.region` setting for Azure S3 properties can be omitted.
+- Azure Storage requires HTTPS transmission by default (`Secure transfer required: Enabled`). To access Azure Storage properly, set `s3_client_http_scheme = https` in Doris `be.conf`.
+- The `s3.region` setting in Azure S3 properties can be omitted.
 :::
 
 ```sql

--- a/versioned_docs/version-3.x/data-operate/import/data-source/minio.md
+++ b/versioned_docs/version-3.x/data-operate/import/data-source/minio.md
@@ -49,13 +49,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using S3 Load
 
 :::caution Caution
-If you deployed MinIO in a local network and did not have TLS enabled, you need to explicitly add `http://` in the endpoint string.
+When importing data from MinIO with S3 Load, note the following:
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-The S3 SDK uses the virtual-hosted style by default. However, MinIO does not enable virtual-hosted style access by default. In this case, we can add the `use_path_style` parameter to force the use of the path style.
-
-- `"use_path_style" = "true"`
+- If MinIO is deployed in a local network without TLS, explicitly add `http://` in the endpoint, for example: `"s3.endpoint" = "http://localhost:9000"`.
+- The S3 SDK uses virtual-hosted style by default, while MinIO does not enable it by default. Add `"use_path_style" = "true"` to force path-style access.
 :::
 
 ```sql
@@ -143,14 +140,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using TVF
 
 :::caution Caution
-If you deployed MinIO in a local network and did not have TLS enabled, you need to explicitly add `http://` in the endpoint string.
+When importing data from MinIO with TVF, note the following:
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-
-The S3 SDK uses the virtual-hosted style by default. However, MinIO does not enable virtual-hosted style access by default. In this case, we can add the `use_path_style` parameter to force the use of the path style.
-
-- `"use_path_style" = "true"`
+- If MinIO is deployed in a local network without TLS, explicitly add `http://` in the endpoint, for example: `"s3.endpoint" = "http://localhost:9000"`.
+- The S3 SDK uses virtual-hosted style by default, while MinIO does not enable it by default. Add `"use_path_style" = "true"` to force path-style access.
 :::
 
 ```sql
@@ -196,4 +189,3 @@ mysql> select * from test_s3load;
 +---------+-----------+------+
 10 rows in set (0.04 sec)
 ```
-

--- a/versioned_docs/version-4.x/data-operate/import/data-source/azure-storage.md
+++ b/versioned_docs/version-4.x/data-operate/import/data-source/azure-storage.md
@@ -46,10 +46,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using S3 Load
 
 :::caution Caution
-Azure Storage requires HTTPS transmission by default, with the corresponding storage account configuration being `Secure transfer required: Enabled`.
-To access Azure Storage properly, you need to set `s3_client_http_scheme = https` in Doris's `be.conf`.
+When importing data from Azure Storage with S3 Load, note the following:
 
-The `s3.region` setting for Azure S3 properties can be omitted.
+- Azure Storage requires HTTPS transmission by default (`Secure transfer required: Enabled`). To access Azure Storage properly, set `s3_client_http_scheme = https` in Doris `be.conf`.
+- The `s3.region` setting in Azure S3 properties can be omitted.
 :::
 
 ```sql
@@ -136,10 +136,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using TVF
 
 :::caution Caution
-Azure Storage requires HTTPS transmission by default, with the corresponding storage account configuration being `Secure transfer required: Enabled`.
-To access Azure Storage properly, you need to set `s3_client_http_scheme = https` in Doris's `be.conf`.
+When importing data from Azure Storage with TVF, note the following:
 
-The `s3.region` setting for Azure S3 properties can be omitted.
+- Azure Storage requires HTTPS transmission by default (`Secure transfer required: Enabled`). To access Azure Storage properly, set `s3_client_http_scheme = https` in Doris `be.conf`.
+- The `s3.region` setting in Azure S3 properties can be omitted.
 :::
 
 ```sql

--- a/versioned_docs/version-4.x/data-operate/import/data-source/minio.md
+++ b/versioned_docs/version-4.x/data-operate/import/data-source/minio.md
@@ -49,13 +49,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using S3 Load
 
 :::caution Caution
-If you deployed MinIO in a local network and did not have TLS enabled, you need to explicitly add `http://` in the endpoint string.
+When importing data from MinIO with S3 Load, note the following:
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-The S3 SDK uses the virtual-hosted style by default. However, MinIO does not enable virtual-hosted style access by default. In this case, we can add the `use_path_style` parameter to force the use of the path style.
-
-- `"use_path_style" = "true"`
+- If MinIO is deployed in a local network without TLS, explicitly add `http://` in the endpoint, for example: `"s3.endpoint" = "http://localhost:9000"`.
+- The S3 SDK uses virtual-hosted style by default, while MinIO does not enable it by default. Add `"use_path_style" = "true"` to force path-style access.
 :::
 
 ```sql
@@ -143,14 +140,10 @@ DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ### Step 3: Load data using TVF
 
 :::caution Caution
-If you deployed MinIO in a local network and did not have TLS enabled, you need to explicitly add `http://` in the endpoint string.
+When importing data from MinIO with TVF, note the following:
 
-- `"s3.endpoint" = "http://localhost:9000"`
-
-
-The S3 SDK uses the virtual-hosted style by default. However, MinIO does not enable virtual-hosted style access by default. In this case, we can add the `use_path_style` parameter to force the use of the path style.
-
-- `"use_path_style" = "true"`
+- If MinIO is deployed in a local network without TLS, explicitly add `http://` in the endpoint, for example: `"s3.endpoint" = "http://localhost:9000"`.
+- The S3 SDK uses virtual-hosted style by default, while MinIO does not enable it by default. Add `"use_path_style" = "true"` to force path-style access.
 :::
 
 ```sql
@@ -196,4 +189,3 @@ mysql> select * from test_s3load;
 +---------+-----------+------+
 10 rows in set (0.04 sec)
 ```
-


### PR DESCRIPTION
## Summary
- verify #2382 is still open/conflicted and rework the same content improvements cleanly
- rewrite Azure and MinIO caution blocks into concise bullet-style guidance for both S3 Load and TVF
- avoid malformed markdown/admonition formatting and improve wording consistency in EN + ZH docs
- apply updates to `current`, `version-2.1`, `version-3.x`, and `version-4.x`

## Reference
- redoes issue intent from #2382