### PR TITLE
[typo](docs) fix SHOW COLLATION example command

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-COLLATION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-reference/Show-Statements/SHOW-COLLATION.md
@@ -29,7 +29,7 @@ SHOW COLLATION
 ## 示例
 
 ```sql
-how collation;
+show collation;
 ```
 
 ```


### PR DESCRIPTION
## Summary
- verify #2718 still applies: example command in zh `SHOW-COLLATION.md` uses `how collation;`
- fix typo to `show collation;`
- keep commit signed with original author identity

## Reference
- redoes issue intent from #2718