### PR TITLE
[fix](docs) replace timestamp with datetime in window examples

### DIFF
--- a/docs/query-data/window-function.md
+++ b/docs/query-data/window-function.md
@@ -498,7 +498,7 @@ The query results are as follows:
 1. Assume we have the following stock data, with stock symbol JDR and daily closing prices:
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);  
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);  
   
 INSERT INTO stock_ticker VALUES 
     ("JDR", 12.86, "2014-10-02 00:00:00"), 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/query-data/window-function.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/query-data/window-function.md
@@ -479,7 +479,7 @@ where year in (1999, 2000, 2001, 2002)
 1. 假设我们有如下的股票数据，股票代码是 JDR，closing price 是每天的收盘价。
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);    
 
 INSERT INTO stock_ticker VALUES 
     ("JDR", 12.86, "2014-10-02 00:00:00"), 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-functions/window-functions/WINDOW-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/sql-manual/sql-functions/window-functions/WINDOW-FUNCTION.md
@@ -56,7 +56,7 @@ ROWS BETWEEN [ { m | UNBOUNDED } PRECEDING | CURRENT ROW] [ AND [CURRENT ROW | {
 假设我们有如下的股票数据，股票代码是 JDR，closing price 是每天的收盘价。
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);    
 ...load some data...    
 select * from stock_ticker order by stock_symbol, closing_date
  | stock_symbol | closing_price | closing_date        |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/query/query-data/window-function.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/query/query-data/window-function.md
@@ -53,7 +53,7 @@ ROWS BETWEEN [ { m | UNBOUNDED } PRECEDING | CURRENT ROW] [ AND [CURRENT ROW | {
 假设我们有如下的股票数据，股票代码是 JDR，closing price 是每天的收盘价。
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);    
 ...load some data...    
 select * from stock_ticker order by stock_symbol, closing_date
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-functions/window-functions/WINDOW-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-functions/window-functions/WINDOW-FUNCTION.md
@@ -55,7 +55,7 @@ ROWS BETWEEN [ { m | UNBOUNDED } PRECEDING | CURRENT ROW] [ AND [CURRENT ROW | {
 假设我们有如下的股票数据，股票代码是 JDR，closing price 是每天的收盘价。
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);    
 ...load some data...    
 select * from stock_ticker order by stock_symbol, closing_date
 | stock_symbol | closing_price | closing_date        |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/overview.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/overview.md
@@ -46,7 +46,7 @@ function(<args>) OVER(
 1. 假设我们有如下的股票数据，股票代码是 JDR，closing price 是每天的收盘价。
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);    
 ...load some data...    
 select * from stock_ticker order by stock_symbol, closing_date
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/overview.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/overview.md
@@ -46,7 +46,7 @@ function(<args>) OVER(
 1. 假设我们有如下的股票数据，股票代码是 JDR，closing price 是每天的收盘价。
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);
 ...load some data...    
 select * from stock_ticker order by stock_symbol, closing_date
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/query-data/window-function.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/query-data/window-function.md
@@ -479,7 +479,7 @@ where year in (1999, 2000, 2001, 2002)
 1. 假设我们有如下的股票数据，股票代码是 JDR，closing price 是每天的收盘价。
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);    
 
 INSERT INTO stock_ticker VALUES 
     ("JDR", 12.86, "2014-10-02 00:00:00"), 

--- a/versioned_docs/version-1.2/sql-manual/sql-functions/window-functions/WINDOW-FUNCTION.md
+++ b/versioned_docs/version-1.2/sql-manual/sql-functions/window-functions/WINDOW-FUNCTION.md
@@ -56,7 +56,7 @@ ROWS BETWEEN [ { m | UNBOUNDED } PRECEDING | CURRENT ROW] [ AND [CURRENT ROW | {
 Suppose we have the following stock data, the stock symbol is JDR, and the closing price is the closing price of each day.
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);    
 ...load some data...    
 select * from stock_ticker order by stock_symbol, closing_date
  | stock_symbol | closing_price | closing_date        |

--- a/versioned_docs/version-2.0/query/query-data/window-function.md
+++ b/versioned_docs/version-2.0/query/query-data/window-function.md
@@ -51,7 +51,7 @@ ROWS BETWEEN [ { m | UNBOUNDED } PRECEDING | CURRENT ROW] [ AND [CURRENT ROW | {
 Taking the following stock data as an example, the stock code is JDR, and the "closing price" refers to the daily closing quotation.
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);
 ...load some data...    
 select * from stock_ticker order by stock_symbol, closing_date
 ```

--- a/versioned_docs/version-2.0/sql-manual/sql-functions/window-functions/WINDOW-FUNCTION.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-functions/window-functions/WINDOW-FUNCTION.md
@@ -55,7 +55,7 @@ ROWS BETWEEN [ { m | UNBOUNDED } PRECEDING | CURRENT ROW] [ AND [CURRENT ROW | {
 Suppose we have the following stock data, the stock symbol is JDR, and the closing price is the closing price of each day.
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);    
 ...load some data...    
 select * from stock_ticker order by stock_symbol, closing_date
  | stock_symbol | closing_price | closing_date        |

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/overview.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/overview.md
@@ -46,7 +46,7 @@ Returns the same data type as the input expression.
 1. Assume we have the following stock data, with stock symbol JDR and daily closing prices:
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);    
 ...load some data...    
 select * from stock_ticker order by stock_symbol, closing_date
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/overview.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/overview.md
@@ -46,7 +46,7 @@ Returns the same data type as the input expression.
 1. Assume we have the following stock data, with stock symbol JDR and daily closing prices:
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);    
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);    
 ...load some data...    
 select * from stock_ticker order by stock_symbol, closing_date
 ```

--- a/versioned_docs/version-4.x/query-data/window-function.md
+++ b/versioned_docs/version-4.x/query-data/window-function.md
@@ -498,7 +498,7 @@ The query results are as follows:
 1. Assume we have the following stock data, with stock symbol JDR and daily closing prices:
 
 ```sql
-create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date timestamp);  
+create table stock_ticker (stock_symbol string, closing_price decimal(8,2), closing_date datetime);  
   
 INSERT INTO stock_ticker VALUES 
     ("JDR", 12.86, "2014-10-02 00:00:00"), 


### PR DESCRIPTION
## Summary
- verify #2056 is still open and the example still uses unsupported `timestamp`
- replace `closing_date timestamp` with `closing_date datetime` in window-function example SQL
- propagate the same fix consistently across current and versioned EN + ZH docs where this example appears
- commit is authored with the original author identity from #2056

## Reference
- redoes issue intent from #2056