### PR TITLE
[docs] set replication_num in quick start table example

### DIFF
--- a/docs/gettingStarted/quick-start.mdx
+++ b/docs/gettingStarted/quick-start.mdx
@@ -215,7 +215,10 @@ Download the corresponding binary installation package from the Apache Doris web
        k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
    ) 
    COMMENT "my first table"
-   DISTRIBUTED BY HASH(k1) BUCKETS 1;
+   DISTRIBUTED BY HASH(k1) BUCKETS 1
+   PROPERTIES (
+    "replication_num" = "1"
+   );
    ```
 
 3. **Import test data:**
@@ -262,5 +265,4 @@ sudo ln -s /Applications/Docker.app/Contents/Resources/bin/docker /usr/local/bin
 **Q: Mac: "error getting credentials - err: exit status 1, out: \`\`"**
 
 A: This error is usually caused by Docker credential helper misconfiguration. For local development/testing, you can remove the `credsStore` field in `~/.docker/config.json` as a workaround. Note: This workaround stores credentials in plaintext and is only recommended for local development environments.
-
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/gettingStarted/quick-start.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/gettingStarted/quick-start.mdx
@@ -215,7 +215,10 @@ mysql -uroot -P9030 -h127.0.0.1 -e 'SELECT `host`, `alive` FROM backends()'
        k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
    ) 
    COMMENT "my first table"
-   DISTRIBUTED BY HASH(k1) BUCKETS 1;
+   DISTRIBUTED BY HASH(k1) BUCKETS 1
+   PROPERTIES (
+    "replication_num" = "1"
+   );
    ```
 
 3. **导入测试数据**
@@ -262,4 +265,3 @@ sudo ln -s /Applications/Docker.app/Contents/Resources/bin/docker /usr/local/bin
 **Q: Mac: "error getting credentials - err: exit status 1, out: \`\`"**
 
 A: 此错误通常由 Docker 凭据助手配置问题导致。对于本地开发/测试环境，可以删除 `~/.docker/config.json` 中的 `credsStore` 字段作为临时解决方案。注意：此方法会以明文存储凭据，仅建议在本地开发环境中使用。
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/gettingStarted/quick-start.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/gettingStarted/quick-start.mdx
@@ -217,7 +217,10 @@ mysql -uroot -P9030 -h127.0.0.1 -e 'SELECT `host`, `alive` FROM backends()'
        k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
    ) 
    COMMENT "my first table"
-   DISTRIBUTED BY HASH(k1) BUCKETS 1;
+   DISTRIBUTED BY HASH(k1) BUCKETS 1
+   PROPERTIES (
+    "replication_num" = "1"
+   );
    ```
 
 3. **导入测试数据**
@@ -246,7 +249,6 @@ mysql -uroot -P9030 -h127.0.0.1 -e 'SELECT `host`, `alive` FROM backends()'
    +------+------+------+------+
    4 rows in set (0.10 sec)
    ```
-
 
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/gettingStarted/quick-start.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/gettingStarted/quick-start.mdx
@@ -209,7 +209,10 @@ mysql -uroot -P9030 -h127.0.0.1 -e 'SELECT `host`, `alive` FROM backends()'
        k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
    ) 
    COMMENT "my first table"
-   DISTRIBUTED BY HASH(k1) BUCKETS 1;
+   DISTRIBUTED BY HASH(k1) BUCKETS 1
+   PROPERTIES (
+    "replication_num" = "1"
+   );
    ```
 
 3. **导入测试数据**
@@ -256,4 +259,3 @@ sudo ln -s /Applications/Docker.app/Contents/Resources/bin/docker /usr/local/bin
 **Q: Mac: "error getting credentials - err: exit status 1, out: \`\`"**
 
 A: 此错误通常由 Docker 凭据助手配置问题导致。对于本地开发/测试环境，可以删除 `~/.docker/config.json` 中的 `credsStore` 字段作为临时解决方案。注意：此方法会以明文存储凭据，仅建议在本地开发环境中使用。
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/gettingStarted/quick-start.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/gettingStarted/quick-start.mdx
@@ -215,7 +215,10 @@ mysql -uroot -P9030 -h127.0.0.1 -e 'SELECT `host`, `alive` FROM backends()'
        k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
    ) 
    COMMENT "my first table"
-   DISTRIBUTED BY HASH(k1) BUCKETS 1;
+   DISTRIBUTED BY HASH(k1) BUCKETS 1
+   PROPERTIES (
+    "replication_num" = "1"
+   );
    ```
 
 3. **导入测试数据**
@@ -262,4 +265,3 @@ sudo ln -s /Applications/Docker.app/Contents/Resources/bin/docker /usr/local/bin
 **Q: Mac: "error getting credentials - err: exit status 1, out: \`\`"**
 
 A: 此错误通常由 Docker 凭据助手配置问题导致。对于本地开发/测试环境，可以删除 `~/.docker/config.json` 中的 `credsStore` 字段作为临时解决方案。注意：此方法会以明文存储凭据，仅建议在本地开发环境中使用。
-

--- a/versioned_docs/version-2.1/gettingStarted/quick-start.mdx
+++ b/versioned_docs/version-2.1/gettingStarted/quick-start.mdx
@@ -215,7 +215,10 @@ Download the corresponding binary installation package from the Apache Doris web
        k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
    ) 
    COMMENT "my first table"
-   DISTRIBUTED BY HASH(k1) BUCKETS 1;
+   DISTRIBUTED BY HASH(k1) BUCKETS 1
+   PROPERTIES (
+    "replication_num" = "1"
+   );
    ```
 
 3. **Import test data:**
@@ -244,7 +247,6 @@ Download the corresponding binary installation package from the Apache Doris web
    +------+------+------+------+
    4 rows in set (0.10 sec)
    ```
-
 
 
 

--- a/versioned_docs/version-3.x/gettingStarted/quick-start.mdx
+++ b/versioned_docs/version-3.x/gettingStarted/quick-start.mdx
@@ -209,7 +209,10 @@ Download the corresponding binary installation package from the Apache Doris web
        k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
    ) 
    COMMENT "my first table"
-   DISTRIBUTED BY HASH(k1) BUCKETS 1;
+   DISTRIBUTED BY HASH(k1) BUCKETS 1
+   PROPERTIES (
+    "replication_num" = "1"
+   );
    ```
 
 3. **Import test data:**
@@ -256,5 +259,4 @@ sudo ln -s /Applications/Docker.app/Contents/Resources/bin/docker /usr/local/bin
 **Q: Mac: "error getting credentials - err: exit status 1, out: \`\`"**
 
 A: This error is usually caused by Docker credential helper misconfiguration. For local development/testing, you can remove the `credsStore` field in `~/.docker/config.json` as a workaround. Note: This workaround stores credentials in plaintext and is only recommended for local development environments.
-
 

--- a/versioned_docs/version-4.x/gettingStarted/quick-start.mdx
+++ b/versioned_docs/version-4.x/gettingStarted/quick-start.mdx
@@ -215,7 +215,10 @@ Download the corresponding binary installation package from the Apache Doris web
        k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
    ) 
    COMMENT "my first table"
-   DISTRIBUTED BY HASH(k1) BUCKETS 1;
+   DISTRIBUTED BY HASH(k1) BUCKETS 1
+   PROPERTIES (
+    "replication_num" = "1"
+   );
    ```
 
 3. **Import test data:**
@@ -262,5 +265,4 @@ sudo ln -s /Applications/Docker.app/Contents/Resources/bin/docker /usr/local/bin
 **Q: Mac: "error getting credentials - err: exit status 1, out: \`\`"**
 
 A: This error is usually caused by Docker credential helper misconfiguration. For local development/testing, you can remove the `credsStore` field in `~/.docker/config.json` as a workaround. Note: This workaround stores credentials in plaintext and is only recommended for local development environments.
-
 


### PR DESCRIPTION
## Summary
- redoes #2411 by fixing the quick-start table DDL for single-BE setups
- add `PROPERTIES (\"replication_num\" = \"1\")` to the `BUCKETS 1` example so table creation succeeds in the default quick-start environment
- apply consistently to current and versioned EN + ZH quick-start docs
- commit is signed with the original author identity from #2411

## Reference
- redoes issue intent from #2411