### PR TITLE
Update be-config.md

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/config/be-config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/config/be-config.md
@@ -425,7 +425,7 @@ Thrift 服务器接收请求消息的大小（字节数）上限。如果客户�
 
 * 类型：int32
 * 描述：在列式 compaction 中，输出的 segment 文件最大值，单位是 m 字节。
-* 默认值：268435456
+* 默认值：1073741824
 
 #### `enable_ordered_data_compaction`
 
@@ -590,12 +590,6 @@ BaseCompaction:546859:
 * 类型：int32
 * 描述：当 segment 数量超过此阈值时触发 segment compaction，该配置也限制了单个 segment compaction 任务中的最大原始 segment 数量。
 * 默认值：10
-
-#### `segcompaction_candidate_max_rows`
-
-* 类型：int32
-* 描述：当 segment 的行数超过此大小时则会在 segment compaction 时被 compact，否则跳过
-* 默认值：1048576
 
 #### `segcompaction_candidate_max_rows`
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/config/be-config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/config/be-config.md
@@ -437,7 +437,7 @@ Thrift 服务器接收请求消息的大小（字节数）上限。如果客户�
 
 * 类型：int32
 * 描述：在列式 compaction 中，输出的 segment 文件最大值，单位是 m 字节。
-* 默认值：268435456
+* 默认值：1073741824
 
 #### `enable_ordered_data_compaction`
 
@@ -609,12 +609,6 @@ BaseCompaction:546859:
 * 类型：int32
 * 描述：当 segment 数量超过此阈值时触发 segment compaction，该配置也限制了单个 segment compaction 任务中的最大原始 segment 数量。
 * 默认值：10
-
-#### `segcompaction_candidate_max_rows`
-
-* 类型：int32
-* 描述：当 segment 的行数超过此大小时则会在 segment compaction 时被 compact，否则跳过
-* 默认值：1048576
 
 #### `segcompaction_candidate_max_rows`
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/config/be-config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/config/be-config.md
@@ -425,7 +425,7 @@ Thrift 服务器接收请求消息的大小（字节数）上限。如果客户�
 
 * 类型：int32
 * 描述：在列式 compaction 中，输出的 segment 文件最大值，单位是 m 字节。
-* 默认值：268435456
+* 默认值：1073741824
 
 #### `enable_ordered_data_compaction`
 
@@ -590,12 +590,6 @@ BaseCompaction:546859:
 * 类型：int32
 * 描述：当 segment 数量超过此阈值时触发 segment compaction，该配置也限制了单个 segment compaction 任务中的最大原始 segment 数量。
 * 默认值：10
-
-#### `segcompaction_candidate_max_rows`
-
-* 类型：int32
-* 描述：当 segment 的行数超过此大小时则会在 segment compaction 时被 compact，否则跳过
-* 默认值：1048576
 
 #### `segcompaction_candidate_max_rows`
 


### PR DESCRIPTION
## Summary
- Update `vertical_compaction_max_segment_size` default value from `268435456` to `1073741824` in Chinese BE config docs.
- Remove duplicated `segcompaction_candidate_max_rows` entry and keep the accurate description.
- Scope this recreation to `dev`, `3.x`, and `4.x` only.

## Versions
- [x] dev
- [x] 4.x
- [x] 3.x
- [ ] 2.1
- [ ] 2.0

## Languages
- [x] Chinese
- [ ] English

## Docs Checklist
- [ ] Checked by AI
- [ ] Test Cases Built

Signed-off-by: yjt1993 <44218250+yjt1993@users.noreply.github.com>