### PR TITLE
[typo](docs) Aggregate Mode: Keep the sample code and documentation consistent

### DIFF
--- a/docs/table-design/data-model/aggregate.md
+++ b/docs/table-design/data-model/aggregate.md
@@ -45,17 +45,17 @@ When creating a table, the **AGGREGATE KEY** keyword can be used to specify the 
 CREATE TABLE IF NOT EXISTS example_tbl_agg
 (
     user_id             LARGEINT    NOT NULL,
-    load_dt             DATE        NOT NULL,
+    load_date           DATE        NOT NULL,
     city                VARCHAR(20),
     last_visit_dt       DATETIME    REPLACE DEFAULT "1970-01-01 00:00:00",
     cost                BIGINT      SUM DEFAULT "0",
     max_dwell           INT         MAX DEFAULT "0",
 )
-AGGREGATE KEY(user_id, load_dt, city)
+AGGREGATE KEY(user_id, load_date, city)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ```
 
-In the example above, a fact table for user information and access behavior is defined, where `user_id`, `load_dt`, and `city` are used as Key columns for aggregation. During data import, the Key columns are aggregated into one row, and the Value columns are aggregated according to the specified aggregation types. 
+In the example above, a fact table for user information and access behavior is defined, where `user_id`, `load_date`, and `city` are used as Key columns for aggregation. During data import, the Key columns are aggregated into one row, and the Value columns are aggregated according to the specified aggregation types. 
 
 The following types of dimension aggregation are supported in the Aggregate Key Table:
 
@@ -185,4 +185,3 @@ mysql> select sum_merge(k2) , group_concat_merge(k3)from aggstate where k1 != 2;
 |            16 | c,b,a,d,c,b,a          |
 +---------------+------------------------+
 ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/data-model/aggregate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/data-model/aggregate.md
@@ -32,17 +32,17 @@ Doris 的聚合模型专为高效处理大规模数据查询中的聚合操作�
 CREATE TABLE IF NOT EXISTS example_tbl_agg
 (
     user_id             LARGEINT    NOT NULL,
-    load_dt             DATE        NOT NULL,
+    load_date           DATE        NOT NULL,
     city                VARCHAR(20),
     last_visit_dt       DATETIME    REPLACE DEFAULT "1970-01-01 00:00:00",
     cost                BIGINT      SUM DEFAULT "0",
     max_dwell           INT         MAX DEFAULT "0",
 )
-AGGREGATE KEY(user_id, load_dt, city)
+AGGREGATE KEY(user_id, load_date, city)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ```
 
-上例中定义了用户信息和访问行为表，将 `user_id`、`load_dt` 及 `city` 作为 Key 列进行聚合。数据导入时，Key 列会聚合成一行，Value 列会按照指定的聚合类型进行维度聚合。
+上例中定义了用户信息和访问行为表，将 `user_id`、`load_date` 及 `city` 作为 Key 列进行聚合。数据导入时，Key 列会聚合成一行，Value 列会按照指定的聚合类型进行维度聚合。
 
 在聚合表中支持以下类型的维度聚合：
 
@@ -170,4 +170,3 @@ mysql> select sum_merge(k2) , group_concat_merge(k3)from aggstate where k1 != 2;
 |            16 | c,b,a,d,c,b,a          |
 +---------------+------------------------+
 ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/table-design/data-model/aggregate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/table-design/data-model/aggregate.md
@@ -32,18 +32,18 @@ Doris 的聚合表专为高效处理大规模数据查询中的聚合操作设�
 CREATE TABLE IF NOT EXISTS example_tbl_agg
 (
     user_id             LARGEINT    NOT NULL,
-    load_dt             DATE        NOT NULL,
+    load_date           DATE        NOT NULL,
     city                VARCHAR(20),
     last_visit_dt       DATETIME    REPLACE DEFAULT "1970-01-01 00:00:00",
     cost                BIGINT      SUM DEFAULT "0",
     max_dwell           INT         MAX DEFAULT "0",
 )
-AGGREGATE KEY(user_id, load_dt, city)
+AGGREGATE KEY(user_id, load_date, city)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ```
 
 
-上例中定义了用户信息和访问的行为事实表，将 `user_id`、`load_dt` 及 `city` 作为 Key 列进行聚合操作。数据导入时，Key 列会聚合成一行，Value 列会按照指定的聚合类型进行维度聚合。
+上例中定义了用户信息和访问的行为事实表，将 `user_id`、`load_date` 及 `city` 作为 Key 列进行聚合操作。数据导入时，Key 列会聚合成一行，Value 列会按照指定的聚合类型进行维度聚合。
 
 
 在聚合表中支持以下类型的维度聚合：
@@ -172,4 +172,3 @@ mysql> select sum_merge(k2) , group_concat_merge(k3)from aggstate where k1 != 2;
 |            16 | c,b,a,d,c,b,a          |
 +---------------+------------------------+
 ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/table-design/data-model/aggregate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/table-design/data-model/aggregate.md
@@ -32,17 +32,17 @@ Doris 的聚合模型专为高效处理大规模数据查询中的聚合操作�
 CREATE TABLE IF NOT EXISTS example_tbl_agg
 (
     user_id             LARGEINT    NOT NULL,
-    load_dt             DATE        NOT NULL,
+    load_date           DATE        NOT NULL,
     city                VARCHAR(20),
     last_visit_dt       DATETIME    REPLACE DEFAULT "1970-01-01 00:00:00",
     cost                BIGINT      SUM DEFAULT "0",
     max_dwell           INT         MAX DEFAULT "0",
 )
-AGGREGATE KEY(user_id, load_dt, city)
+AGGREGATE KEY(user_id, load_date, city)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ```
 
-上例中定义了用户信息和访问行为表，将 `user_id`、`load_dt` 及 `city` 作为 Key 列进行聚合。数据导入时，Key 列会聚合成一行，Value 列会按照指定的聚合类型进行维度聚合。
+上例中定义了用户信息和访问行为表，将 `user_id`、`load_date` 及 `city` 作为 Key 列进行聚合。数据导入时，Key 列会聚合成一行，Value 列会按照指定的聚合类型进行维度聚合。
 
 在聚合表中支持以下类型的维度聚合：
 
@@ -170,4 +170,3 @@ mysql> select sum_merge(k2) , group_concat_merge(k3)from aggstate where k1 != 2;
 |            16 | c,b,a,d,c,b,a          |
 +---------------+------------------------+
 ```
-

--- a/versioned_docs/version-3.x/table-design/data-model/aggregate.md
+++ b/versioned_docs/version-3.x/table-design/data-model/aggregate.md
@@ -45,17 +45,17 @@ When creating a table, the **AGGREGATE KEY** keyword can be used to specify the 
 CREATE TABLE IF NOT EXISTS example_tbl_agg
 (
     user_id             LARGEINT    NOT NULL,
-    load_dt             DATE        NOT NULL,
+    load_date           DATE        NOT NULL,
     city                VARCHAR(20),
     last_visit_dt       DATETIME    REPLACE DEFAULT "1970-01-01 00:00:00",
     cost                BIGINT      SUM DEFAULT "0",
     max_dwell           INT         MAX DEFAULT "0",
 )
-AGGREGATE KEY(user_id, load_dt, city)
+AGGREGATE KEY(user_id, load_date, city)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ```
 
-In the example above, a fact table for user information and access behavior is defined, where `user_id`, `load_dt`, and `city` are used as Key columns for aggregation. During data import, the Key columns are aggregated into one row, and the Value columns are aggregated according to the specified aggregation types. 
+In the example above, a fact table for user information and access behavior is defined, where `user_id`, `load_date`, and `city` are used as Key columns for aggregation. During data import, the Key columns are aggregated into one row, and the Value columns are aggregated according to the specified aggregation types. 
 
 The following types of dimension aggregation are supported in the Aggregate Key Table:
 
@@ -184,4 +184,3 @@ mysql> select sum_merge(k2) , group_concat_merge(k3)from aggstate where k1 != 2;
 |            16 | c,b,a,d,c,b,a          |
 +---------------+------------------------+
 ```
-

--- a/versioned_docs/version-4.x/table-design/data-model/aggregate.md
+++ b/versioned_docs/version-4.x/table-design/data-model/aggregate.md
@@ -45,17 +45,17 @@ When creating a table, the **AGGREGATE KEY** keyword can be used to specify the 
 CREATE TABLE IF NOT EXISTS example_tbl_agg
 (
     user_id             LARGEINT    NOT NULL,
-    load_dt             DATE        NOT NULL,
+    load_date           DATE        NOT NULL,
     city                VARCHAR(20),
     last_visit_dt       DATETIME    REPLACE DEFAULT "1970-01-01 00:00:00",
     cost                BIGINT      SUM DEFAULT "0",
     max_dwell           INT         MAX DEFAULT "0",
 )
-AGGREGATE KEY(user_id, load_dt, city)
+AGGREGATE KEY(user_id, load_date, city)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10;
 ```
 
-In the example above, a fact table for user information and access behavior is defined, where `user_id`, `load_dt`, and `city` are used as Key columns for aggregation. During data import, the Key columns are aggregated into one row, and the Value columns are aggregated according to the specified aggregation types. 
+In the example above, a fact table for user information and access behavior is defined, where `user_id`, `load_date`, and `city` are used as Key columns for aggregation. During data import, the Key columns are aggregated into one row, and the Value columns are aggregated according to the specified aggregation types. 
 
 The following types of dimension aggregation are supported in the Aggregate Key Table:
 
@@ -185,4 +185,3 @@ mysql> select sum_merge(k2) , group_concat_merge(k3)from aggstate where k1 != 2;
 |            16 | c,b,a,d,c,b,a          |
 +---------------+------------------------+
 ```
-


### PR DESCRIPTION
## Summary
- Keep aggregate model sample column names consistent by replacing `load_dt` with `load_date` in SQL examples and key definitions.
- Sync the related explanatory text with the corrected key column name.
- Scope this recreation to `dev`, `3.x`, and `4.x` only (both English and Chinese docs).

## Versions
- [x] dev
- [x] 4.x
- [x] 3.x
- [ ] 2.1
- [ ] 2.0

## Languages
- [x] Chinese
- [x] English

## Docs Checklist
- [ ] Checked by AI
- [ ] Test Cases Built

Signed-off-by: daveyyan <875267695@qq.com>