### PR TITLE
Update data-bucketing.md

### DIFF
--- a/docs/table-design/data-partitioning/data-bucketing.md
+++ b/docs/table-design/data-partitioning/data-bucketing.md
@@ -154,7 +154,7 @@ DISTRIBUTED BY HASH(region) BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 
 -- Set random bucket auto
-DISTRIBUTED BY HASH(region) BUCKETS AUTO
+DISTRIBUTED BY RANDOM BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/data-partitioning/data-bucketing.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/data-partitioning/data-bucketing.md
@@ -153,7 +153,7 @@ DISTRIBUTED BY HASH(region) BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 
 -- Set random bucket auto
-DISTRIBUTED BY HASH(region) BUCKETS AUTO
+DISTRIBUTED BY RANDOM BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 ```
 
@@ -192,4 +192,3 @@ SET ("dynamic_partition.buckets"="16");
 ```
 
 在修改分桶数量后，可以通过 SHOW PARTITION 命令查看修改后的分桶数量。
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/table-design/data-partitioning/data-bucketing.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/table-design/data-partitioning/data-bucketing.md
@@ -153,7 +153,7 @@ DISTRIBUTED BY HASH(region) BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 
 -- Set random bucket auto
-DISTRIBUTED BY HASH(region) BUCKETS AUTO
+DISTRIBUTED BY RANDOM BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 ```
 
@@ -192,4 +192,3 @@ SET ("dynamic_partition.buckets"="16");
 ```
 
 在修改分桶数量后，可以通过 SHOW PARTITION 命令查看修改后的分桶数量。
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/table-design/data-partitioning/data-bucketing.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/table-design/data-partitioning/data-bucketing.md
@@ -153,7 +153,7 @@ DISTRIBUTED BY HASH(region) BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 
 -- Set random bucket auto
-DISTRIBUTED BY HASH(region) BUCKETS AUTO
+DISTRIBUTED BY RANDOM BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 ```
 
@@ -192,4 +192,3 @@ SET ("dynamic_partition.buckets"="16");
 ```
 
 在修改分桶数量后，可以通过 SHOW PARTITION 命令查看修改后的分桶数量。
-

--- a/versioned_docs/version-3.x/table-design/data-partitioning/data-bucketing.md
+++ b/versioned_docs/version-3.x/table-design/data-partitioning/data-bucketing.md
@@ -154,7 +154,7 @@ DISTRIBUTED BY HASH(region) BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 
 -- Set random bucket auto
-DISTRIBUTED BY HASH(region) BUCKETS AUTO
+DISTRIBUTED BY RANDOM BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 ```
 

--- a/versioned_docs/version-4.x/table-design/data-partitioning/data-bucketing.md
+++ b/versioned_docs/version-4.x/table-design/data-partitioning/data-bucketing.md
@@ -154,7 +154,7 @@ DISTRIBUTED BY HASH(region) BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 
 -- Set random bucket auto
-DISTRIBUTED BY HASH(region) BUCKETS AUTO
+DISTRIBUTED BY RANDOM BUCKETS AUTO
 properties("estimate_partition_size" = "20G")
 ```
 


### PR DESCRIPTION
## Summary
- Fix the random bucket auto SQL example in `data-bucketing.md`.
- Replace `DISTRIBUTED BY HASH(region) BUCKETS AUTO` with `DISTRIBUTED BY RANDOM BUCKETS AUTO` in the 3.x Chinese doc.

## Versions
- [x] dev
- [x] 3.x
- [ ] 2.1
- [ ] 2.0

## Languages
- [x] Chinese
- [ ] English

## Docs Checklist
- [ ] Checked by AI
- [ ] Test Cases Built