### PR TITLE
docs:Update database-connect.md

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/db-connect/database-connect.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/db-connect/database-connect.md
@@ -63,7 +63,7 @@ try {
 }
 ```
 
-如果需要在连接时初始换会话变量（Session Variables），可以使用下列格式：
+如果需要在连接时初始化会话变量（Session Variables），可以使用下列格式：
 
 ```
 jdbc:mysql://FE_IP:FE_PORT/demo?sessionVariables=key1=val1,key2=val2

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/db-connect/database-connect.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/db-connect/database-connect.md
@@ -63,7 +63,7 @@ try {
 }
 ```
 
-如果需要在连接时初始换会话变量（Session Variables），可以使用下列格式：
+如果需要在连接时初始化会话变量（Session Variables），可以使用下列格式：
 
 ```
 jdbc:mysql://FE_IP:FE_PORT/demo?sessionVariables=key1=val1,key2=val2

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/db-connect/database-connect.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/db-connect/database-connect.md
@@ -63,7 +63,7 @@ try {
 }
 ```
 
-如果需要在连接时初始换会话变量（Session Variables），可以使用下列格式：
+如果需要在连接时初始化会话变量（Session Variables），可以使用下列格式：
 
 ```
 jdbc:mysql://FE_IP:FE_PORT/demo?sessionVariables=key1=val1,key2=val2


### PR DESCRIPTION
## Summary
- Fix the Chinese typo in JDBC connection docs: `初始换会话变量` -> `初始化会话变量`.
- Apply this fix to `dev`, `3.x`, and `4.x` Chinese docs.
- Checked English docs for `dev`, `3.x`, and `4.x`; no corresponding typo was found.

## Versions
- [x] dev
- [x] 4.x
- [x] 3.x
- [ ] 2.1
- [ ] 2.0

## Languages
- [x] Chinese
- [ ] English

## Docs Checklist
- [ ] Checked by AI
- [ ] Test Cases Built

Signed-off-by: Henry <1152487659@qq.com>