### PR TITLE
Update auto-partitioning.md

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/table-design/data-partitioning/auto-partitioning.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/table-design/data-partitioning/auto-partitioning.md
@@ -243,7 +243,7 @@ auto partition by range (date_trunc(k0, 'year'))
 )
 DISTRIBUTED BY HASH(`k0`) BUCKETS 2
 properties(
-    "dynamic_partition.enable" = "true",
+    "dynamic_partition.enable" = "false",
     "dynamic_partition.prefix" = "p",
     "dynamic_partition.start" = "-50",
     "dynamic_partition.end" = "0", --- Dynamic Partition 不创建分区

--- a/versioned_docs/version-3.x/table-design/data-partitioning/auto-partitioning.md
+++ b/versioned_docs/version-3.x/table-design/data-partitioning/auto-partitioning.md
@@ -246,7 +246,7 @@ auto partition by range (date_trunc(k0, 'year'))
 )
 DISTRIBUTED BY HASH(`k0`) BUCKETS 2
 properties(
-    "dynamic_partition.enable" = "true",
+    "dynamic_partition.enable" = "false",
     "dynamic_partition.prefix" = "p",
     "dynamic_partition.start" = "-50",
     "dynamic_partition.end" = "0", --- Dynamic Partition No Partition Creation


### PR DESCRIPTION
## Summary
- Update the auto partition + dynamic partition example to use `\"dynamic_partition.enable\" = \"false\"` when `dynamic_partition.end = \"0\"`.
- Apply this correction to `3.x` for both English and Chinese docs.
- Checked `dev` and `4.x` (English + Chinese); this example block is not present there, so no additional changes are needed.

## Versions
- [ ] dev
- [ ] 4.x
- [x] 3.x
- [ ] 2.1
- [ ] 2.0

## Languages
- [x] Chinese
- [x] English

## Docs Checklist
- [ ] Checked by AI
- [ ] Test Cases Built

## Reference
- Original PR: https://github.com/apache/doris-website/pull/2501