### PR TITLE
Update parallelism-tuning.md

### DIFF
--- a/docs/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
+++ b/docs/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
@@ -37,8 +37,8 @@ Doris allows users to manually specify the parallelism of a query to adjust the 
 Use SQL HINT to specify the parallelism of a single SQL statement. This allows for flexible control of the parallelism of different SQL statements to achieve the best execution results.
 
 ```sql
-select /*+SET_VAR("parallel_pipeline_task_num=8")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
-select /*+SET_VAR("parallel_pipeline_task_num=8,runtime_filter_mode=global")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8,runtime_filter_mode=global)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
 ```
 
 ### Session Level Adjustment

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/query-acceleration/tuning/parallelism-tuning.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/query-acceleration/tuning/parallelism-tuning.md
@@ -46,8 +46,8 @@ Doris 可以手动指定查询的并行度，以调整查询执行时并行执�
 通过 SQL HINT 来指定单个 SQL 的并行度，这样可以灵活控制不同 SQL 的并行度来取得最佳的执行效果
 
 ```SQL
-select /*+SET_VAR("parallel_pipeline_task_num=8")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
-select /*+SET_VAR("parallel_pipeline_task_num=8,runtime_filter_mode=global")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8,runtime_filter_mode=global)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
 ```
 
 #### 会话级别调整：
@@ -65,4 +65,3 @@ set parallel_pipeline_task_num = 8;
 ```SQL
 set global parallel_pipeline_task_num = 8;
 ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
@@ -46,8 +46,8 @@ Doris 可以手动指定查询的并行度，以调整查询执行时并行执�
 通过 SQL HINT 来指定单个 SQL 的并行度，这样可以灵活控制不同 SQL 的并行度来取得最佳的执行效果
 
 ```SQL
-select /*+SET_VAR("parallel_pipeline_task_num=8")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
-select /*+SET_VAR("parallel_pipeline_task_num=8,runtime_filter_mode=global")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8,runtime_filter_mode=global)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
 ```
 
 ### 会话级别调整
@@ -142,4 +142,3 @@ set parallel_pipeline_task_num = 16;
 
 1. 建议从 CPU 利用率出发。通过 PROFILE 工具输出观察是否是 CPU 瓶颈，尝试进行并行度的合理修改
 2. 单 SQL 调整比较安全，尽量不要全局做过于激进的修改
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
@@ -43,8 +43,8 @@ Doris 可以手动指定查询的并行度，以调整查询执行时并行执�
 通过 SQL HINT 来指定单个 SQL 的并行度，这样可以灵活控制不同 SQL 的并行度来取得最佳的执行效果
 
 ```SQL
-select /*+SET_VAR("parallel_pipeline_task_num=8")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
-select /*+SET_VAR("parallel_pipeline_task_num=8,runtime_filter_mode=global")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8,runtime_filter_mode=global)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
 ```
 
 ### 会话级别调整

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/query-acceleration/tuning/parallelism-tuning.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/query-acceleration/tuning/parallelism-tuning.md
@@ -45,8 +45,8 @@ Doris 可以手动指定查询的并行度，以调整查询执行时并行执�
 通过 SQL HINT 来指定单个 SQL 的并行度，这样可以灵活控制不同 SQL 的并行度来取得最佳的执行效果
 
 ```SQL
-select /*+SET_VAR("parallel_pipeline_task_num=8")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
-select /*+SET_VAR("parallel_pipeline_task_num=8,runtime_filter_mode=global")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8,runtime_filter_mode=global)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
 ```
 
 #### 会话级别调整：

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
@@ -37,8 +37,8 @@ Doris 可以手动指定查询的并行度，以调整查询执行时并行执�
 通过 SQL HINT 来指定单个 SQL 的并行度，这样可以灵活控制不同 SQL 的并行度来取得最佳的执行效果
 
 ```SQL
-select /*+SET_VAR("parallel_pipeline_task_num=8")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
-select /*+SET_VAR("parallel_pipeline_task_num=8,runtime_filter_mode=global")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8,runtime_filter_mode=global)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
 ```
 
 ### 会话级别调整

--- a/versioned_docs/version-3.x/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
+++ b/versioned_docs/version-3.x/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
@@ -46,8 +46,8 @@ Doris allows users to manually specify the parallelism of a query to adjust the 
 Use SQL HINT to specify the parallelism of a single SQL statement. This allows for flexible control of the parallelism of different SQL statements to achieve the best execution results.
 
 ```sql
-select /*+SET_VAR("parallel_pipeline_task_num=8")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
-select /*+SET_VAR("parallel_pipeline_task_num=8,runtime_filter_mode=global")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8,runtime_filter_mode=global)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
 ```
 
 ### Session Level Adjustment
@@ -142,4 +142,3 @@ Usually, users do not need to adjust the query parallelism. If adjustment is req
 
 1. It is recommended to start from the CPU utilization. Observe whether it is a CPU bottleneck through the PROFILE tool output and try to make reasonable modifications to the parallelism.
 2. Adjusting a single SQL is relatively safe. Try not to make overly aggressive global modifications.
-

--- a/versioned_docs/version-4.x/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
+++ b/versioned_docs/version-4.x/query-acceleration/tuning/tuning-execution/parallelism-tuning.md
@@ -43,8 +43,8 @@ Doris allows users to manually specify the parallelism of a query to adjust the 
 Use SQL HINT to specify the parallelism of a single SQL statement. This allows for flexible control of the parallelism of different SQL statements to achieve the best execution results.
 
 ```sql
-select /*+SET_VAR("parallel_pipeline_task_num=8")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
-select /*+SET_VAR("parallel_pipeline_task_num=8,runtime_filter_mode=global")*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
+select /*+SET_VAR(parallel_pipeline_task_num=8,runtime_filter_mode=global)*/ * from nation, lineitem where lineitem.l_suppkey = nation.n_nationkey
 ```
 
 ### Session Level Adjustment


### PR DESCRIPTION
## Summary
- Recreate the `SET_VAR` SQL hint syntax fix from #2511 by removing extra quotes around parameters.
- Apply this fix to `dev`, `3.x`, and `4.x` docs for both English and Chinese.

## Versions
- [x] dev
- [x] 4.x
- [x] 3.x
- [ ] 2.1
- [ ] 2.0

## Languages
- [x] Chinese
- [x] English

## Reference
- Original PR: https://github.com/apache/doris-website/pull/2511