### PR TITLE
[fix](doc) remove deprecated storage_cooldown_second

### DIFF
--- a/docs/admin-manual/config/fe-config.md
+++ b/docs/admin-manual/config/fe-config.md
@@ -2144,12 +2144,6 @@ MasterOnly：true
 
 After dropping database(table/partition), you can recover it by using RECOVER stmt. And this specifies the maximal data retention time. After time, the data will be deleted permanently.
 
-#### `storage_cooldown_second`
-
-Default：`30 * 24 * 3600L`  （30 day）
-
-When create a table(or partition), you can specify its storage medium(HDD or SSD). If set to SSD, this specifies the default duration that tablets will stay on SSD.  After that, tablets will be moved to HDD automatically.  You can set storage cooldown time in CREATE TABLE stmt.
-
 #### `default_storage_medium`
 
 Default：HDD
@@ -2773,4 +2767,3 @@ Description:  The mode in which FE runs. `cloud` indicates the decoupled storage
 Default: ""
 
 Endpoints of the meta service should be specified in the format 'host1:port,host2:port'. This configuration is necessary for the storage and compute disaggregated mode.
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/config/fe-config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/config/fe-config.md
@@ -2159,12 +2159,6 @@ tablet 状态更新间隔
 
 删除数据库（表/分区）后，您可以使用 RECOVER stmt 恢复它。这指定了最大数据保留时间。一段时间后，数据将被永久删除。
 
-#### `storage_cooldown_second`
-
-默认值：`30 * 24 * 3600L`  （30 天）
-
-创建表（或分区）时，可以指定其存储介质（HDD 或 SSD）。如果设置为 SSD，这将指定 tablet 在 SSD 上停留的默认时间。之后，tablet 将自动移动到 HDD。您可以在 `CREATE TABLE stmt` 中设置存储冷却时间。
-
 #### `default_storage_medium`
 
 默认值：HDD
@@ -2781,4 +2775,3 @@ Doris 为了兼用 mysql 周边工具生态，会内置一个名为 mysql 的数
 默认值： ""
 
 Meta Service 的端点应以 'host1:port,host2:port' 的格式指定。此配置对于存储和计算分离模式是必要的。
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/config/fe-config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/config/fe-config.md
@@ -2151,12 +2151,6 @@ tablet 状态更新间隔
 
 删除数据库（表/分区）后，您可以使用 RECOVER stmt 恢复它。这指定了最大数据保留时间。一段时间后，数据将被永久删除。
 
-#### `storage_cooldown_second`
-
-默认值：`30 * 24 * 3600L`  （30 天）
-
-创建表（或分区）时，可以指定其存储介质（HDD 或 SSD）。如果设置为 SSD，这将指定 tablet 在 SSD 上停留的默认时间。之后，tablet 将自动移动到 HDD。您可以在 `CREATE TABLE stmt` 中设置存储冷却时间。
-
 #### `default_storage_medium`
 
 默认值：HDD
@@ -2773,4 +2767,3 @@ Doris 为了兼用 mysql 周边工具生态，会内置一个名为 mysql 的数
 默认值： ""
 
 Meta Service 的端点应以 'host1:port,host2:port' 的格式指定。此配置对于存算分离模式是必要的。
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/config/fe-config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/config/fe-config.md
@@ -2159,12 +2159,6 @@ tablet 状态更新间隔
 
 删除数据库（表/分区）后，您可以使用 RECOVER stmt 恢复它。这指定了最大数据保留时间。一段时间后，数据将被永久删除。
 
-#### `storage_cooldown_second`
-
-默认值：`30 * 24 * 3600L`  （30 天）
-
-创建表（或分区）时，可以指定其存储介质（HDD 或 SSD）。如果设置为 SSD，这将指定 tablet 在 SSD 上停留的默认时间。之后，tablet 将自动移动到 HDD。您可以在 `CREATE TABLE stmt` 中设置存储冷却时间。
-
 #### `default_storage_medium`
 
 默认值：HDD
@@ -2781,4 +2775,3 @@ Doris 为了兼用 mysql 周边工具生态，会内置一个名为 mysql 的数
 默认值： ""
 
 Meta Service 的端点应以 'host1:port,host2:port' 的格式指定。此配置对于存储和计算分离模式是必要的。
-

--- a/versioned_docs/version-3.x/admin-manual/config/fe-config.md
+++ b/versioned_docs/version-3.x/admin-manual/config/fe-config.md
@@ -2153,12 +2153,6 @@ MasterOnly：true
 
 After dropping database(table/partition), you can recover it by using RECOVER stmt. And this specifies the maximal data retention time. After time, the data will be deleted permanently.
 
-#### `storage_cooldown_second`
-
-Default：`30 * 24 * 3600L`  （30 day）
-
-When create a table(or partition), you can specify its storage medium(HDD or SSD). If set to SSD, this specifies the default duration that tablets will stay on SSD.  After that, tablets will be moved to HDD automatically.  You can set storage cooldown time in CREATE TABLE stmt.
-
 #### `default_storage_medium`
 
 Default：HDD
@@ -2776,4 +2770,3 @@ Description:  The mode in which FE runs. `cloud` indicates the decoupled storage
 Default: ""
 
 Endpoints of the meta service should be specified in the format 'host1:port,host2:port'. This configuration is necessary for the storage and compute disaggregated mode.
-

--- a/versioned_docs/version-4.x/admin-manual/config/fe-config.md
+++ b/versioned_docs/version-4.x/admin-manual/config/fe-config.md
@@ -2144,12 +2144,6 @@ MasterOnly：true
 
 After dropping database(table/partition), you can recover it by using RECOVER stmt. And this specifies the maximal data retention time. After time, the data will be deleted permanently.
 
-#### `storage_cooldown_second`
-
-Default：`30 * 24 * 3600L`  （30 day）
-
-When create a table(or partition), you can specify its storage medium(HDD or SSD). If set to SSD, this specifies the default duration that tablets will stay on SSD.  After that, tablets will be moved to HDD automatically.  You can set storage cooldown time in CREATE TABLE stmt.
-
 #### `default_storage_medium`
 
 Default：HDD
@@ -2773,4 +2767,3 @@ Description:  The mode in which FE runs. `cloud` indicates the decoupled storage
 Default: ""
 
 Endpoints of the meta service should be specified in the format 'host1:port,host2:port'. This configuration is necessary for the storage and compute disaggregated mode.
-


### PR DESCRIPTION
## Summary
- Reapply the `storage_cooldown_second` cleanup from #3368.
- Remove the deprecated section from FE config docs in `dev`, `3.x`, and `4.x` for both English and Chinese.
- Explicitly exclude `1.2`, `2.0`, and `2.1` from this PR.

## Versions
- [x] dev
- [x] 4.x
- [x] 3.x
- [ ] 2.1
- [ ] 2.0
- [ ] 1.2

## Languages
- [x] Chinese
- [x] English

## Reference
- Original PR: https://github.com/apache/doris-website/pull/3368