### PR TITLE
[enhance](auth) introduction of configuration property to prohibit login with empty LDAP password

### DIFF
--- a/docs/admin-manual/auth/authentication/ldap.md
+++ b/docs/admin-manual/auth/authentication/ldap.md
@@ -55,7 +55,7 @@ In LDAP, data is organized in a tree structure. Here's an example of a typical L
     ldap_user_basedn = ou=people,o=emr
     ldap_user_filter = (&(uid={login}))
     ldap_group_basedn = ou=group,o=emr
-    # specify ldap_use_sslto true to use to switch to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
+    # specify ldap_use_ssl to true to use to switch to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
     ldap_use_ssl = true 
     ```
 

--- a/docs/admin-manual/auth/authentication/ldap.md
+++ b/docs/admin-manual/auth/authentication/ldap.md
@@ -55,7 +55,7 @@ In LDAP, data is organized in a tree structure. Here's an example of a typical L
     ldap_user_basedn = ou=people,o=emr
     ldap_user_filter = (&(uid={login}))
     ldap_group_basedn = ou=group,o=emr
-    # specify ldap_use_ssl to use to switch to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
+    # specify ldap_use_sslto true to use to switch to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
     ldap_use_ssl = true 
     ```
 

--- a/docs/admin-manual/auth/authentication/ldap.md
+++ b/docs/admin-manual/auth/authentication/ldap.md
@@ -167,9 +167,9 @@ After enabling LDAP, login behaviors under different user states are as follows:
 
 > **About Empty Password Security:**
 >
-> The ldap_allow_empty_pass configuration provides additional security control:
-> When `true` (default): Users can accidentally or intentionally log in without a password, which might be convenient for development environments but poses security risks in production.
-> When `false`: Empty passwords are strictly rejected, ensuring all users must provide valid credentials. This is recommended for production environments to prevent unauthorized access.
+> The `ldap_allow_empty_pass` configuration provides additional security control:
+> - When `true` (default): Users can accidentally or intentionally log in without a password, which might be convenient for development environments but poses security risks in production.
+> - When `false`: Empty passwords are strictly rejected, ensuring all users must provide valid credentials. This is recommended for production environments to prevent unauthorized access.
 
 ### Login Examples
 

--- a/docs/admin-manual/auth/authentication/ldap.md
+++ b/docs/admin-manual/auth/authentication/ldap.md
@@ -57,6 +57,8 @@ In LDAP, data is organized in a tree structure. Here's an example of a typical L
     ldap_group_basedn = ou=group,o=emr
     # specify ldap_use_ssl to true to use to switch to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
     ldap_use_ssl = true 
+    # specify ldap_allow_empty_pass to false to prohibit login with non specified LDAP password, specify true or comment property to use default behavior and allow login with empty LDAP password
+    ldap_allow_empty_pass = false 
     ```
 
     > To enable LDAPS (encrypted connection to the LDAP server), see the [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection) section below.
@@ -136,6 +138,12 @@ LDAP authentication means password verification through LDAP service to suppleme
 2. If the user doesn't exist in LDAP, it falls back to Doris local password verification.
 3. If the LDAP password is correct but there's no corresponding account in Doris, a temporary user is created for login.
 
+> Note on Empty Passwords:
+>
+> By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). 
+> This behavior can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`.
+> With such setting Doris will reject all login attempts with empty password and return an error message.
+
 ### Login Behavior Overview
 
 After enabling LDAP, login behaviors under different user states are as follows:
@@ -144,8 +152,11 @@ After enabling LDAP, login behaviors under different user states are as follows:
 | --------- | ---------- | ------------- | ------------ | -------------- |
 | Exists | Exists | LDAP password | Success | Doris user |
 | Exists | Exists | Doris password | Failed | - |
+| Exists | Exists |	Empty password | Success if `ldap_allow_empty_pass = true`, otherwise Failed | Doris user (if allowed) |
 | Not exists | Exists | Doris password | Success | Doris user |
 | Exists | Not exists | LDAP password | Success | LDAP temporary user |
+| Exists | Not exists | Empty password | Success if `ldap_allow_empty_pass = true`, otherwise Failed | LDAP temporary user (if allowed) |
+
 
 > **About Temporary Users:**
 >
@@ -153,6 +164,12 @@ After enabling LDAP, login behaviors under different user states are as follows:
 > - Doris doesn't create persistent user metadata for temporary users.
 > - Temporary user permissions are determined by LDAP group authorization (see "Group Authorization" section below).
 > - If temporary users have no corresponding group permissions, they default to `select_priv` on `information_schema`.
+
+> **About Empty Password Security:**
+>
+> The ldap_allow_empty_pass configuration provides additional security control:
+> When `true` (default): Users can accidentally or intentionally log in without a password, which might be convenient for development environments but poses security risks in production.
+> When `false`: Empty passwords are strictly rejected, ensuring all users must provide valid credentials. This is recommended for production environments to prevent unauthorized access.
 
 ### Login Examples
 
@@ -303,6 +320,7 @@ You can refresh the cache with the `refresh ldap` statement. See [REFRESH-LDAP](
 
 - Doris's LDAP functionality only supports cleartext password verification for the client-to-FE segment, meaning that when users log in, passwords are transmitted in plaintext between `client` and `fe`. SSL/TLS encryption between the client and Doris FE must be configured separately (see [Client Connection](#step-2-client-connection)).
 - For the FE-to-LDAP segment, the connection is unencrypted by default (`ldap_use_ssl = false`). To encrypt this segment, set `ldap_use_ssl = true` to use LDAPS (see [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection)).
+- Empty password behavior: By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). This can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`. 
 
 ## FAQ
 

--- a/docs/admin-manual/auth/authentication/ldap.md
+++ b/docs/admin-manual/auth/authentication/ldap.md
@@ -143,6 +143,7 @@ LDAP authentication means password verification through LDAP service to suppleme
 > By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). 
 > This behavior can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`.
 > With such setting Doris will reject all login attempts with empty password and return an error message.
+> New plugin-based LDAP authentication mode (since 4.1.0) always rejects attempts to login with empty LDAP password despite of value `ldap_allow_empty_pass = true`
 
 ### Login Behavior Overview
 
@@ -320,7 +321,8 @@ You can refresh the cache with the `refresh ldap` statement. See [REFRESH-LDAP](
 
 - Doris's LDAP functionality only supports cleartext password verification for the client-to-FE segment, meaning that when users log in, passwords are transmitted in plaintext between `client` and `fe`. SSL/TLS encryption between the client and Doris FE must be configured separately (see [Client Connection](#step-2-client-connection)).
 - For the FE-to-LDAP segment, the connection is unencrypted by default (`ldap_use_ssl = false`). To encrypt this segment, set `ldap_use_ssl = true` to use LDAPS (see [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection)).
-- Empty password behavior: By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). This can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`. 
+- **Empty password behavior in legacy LDAP authentication mode:** By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). This can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`. 
+- **Empty password behavior in new plugin-based LDAP authentication:** By default, logins for users with empty LDAP passwords are rejected by LDAP authentication plugin despite of actual value of setting `ldap_allow_empty_pass` in `ldap.conf`. 
 
 ## FAQ
 

--- a/docs/admin-manual/auth/authentication/ldap.md
+++ b/docs/admin-manual/auth/authentication/ldap.md
@@ -49,11 +49,14 @@ In LDAP, data is organized in a tree structure. Here's an example of a typical L
     ```
     ldap_authentication_enabled = true
     ldap_host = ladp-host
-    ldap_port = 389
+    # change ldap_port value if ldap_use_ssl specified to true as different port (636) is used for LDAPS
+    ldap_port = 389 
     ldap_admin_name = uid=admin,o=emr
     ldap_user_basedn = ou=people,o=emr
     ldap_user_filter = (&(uid={login}))
     ldap_group_basedn = ou=group,o=emr
+    # specify ldap_use_ssl to use to switch to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
+    ldap_use_ssl = true 
     ```
 
     > To enable LDAPS (encrypted connection to the LDAP server), see the [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection) section below.

--- a/docs/admin-manual/auth/authentication/ldap.md
+++ b/docs/admin-manual/auth/authentication/ldap.md
@@ -226,6 +226,13 @@ LDAP authentication login means using the LDAP service for password verification
 2. If the user does not exist in LDAP, it falls back to Doris local password verification.
 3. If the LDAP password is correct but there is no corresponding account in Doris, a temporary user is created for login.
 
+> Note on Empty Passwords:
+>
+> By default, in legacy authentication mode Doris doesn't allow login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = false`). 
+> Because of this Doris will reject all login attempts with empty password and return an error message.
+> This behavior can be disabled by setting `ldap_allow_empty_pass = true` in `ldap.conf` to allow successfull login with empty password for existing user.
+> New plugin-based LDAP authentication mode (since 4.1.0) always rejects attempts to login with empty LDAP password despite of value `ldap_allow_empty_pass = true`
+
 ### Login Behavior Overview
 
 After LDAP is enabled, the login behavior under different user states is as follows:
@@ -233,9 +240,12 @@ After LDAP is enabled, the login behavior under different user states is as foll
 | LDAP user | Doris user | Password used | Login result | Login identity |
 | --------- | ---------- | -------------- | ------------ | -------------- |
 | Exists | Exists | LDAP password | Success | Doris user |
-| Exists | Exists | Doris password | Failure | - |
+| Exists | Exists | Doris password | Failed | - |
+| Exists | Exists |	Empty password | Success if `ldap_allow_empty_pass = true`, otherwise Failed | Doris user (if allowed) |
 | Does not exist | Exists | Doris password | Success | Doris user |
 | Exists | Does not exist | LDAP password | Success | LDAP temporary user |
+| Exists | Does not exist | Empty password | Success if `ldap_allow_empty_pass = true`, otherwise Failed | LDAP temporary user (if allowed) |
+
 
 :::info About temporary users
 
@@ -245,6 +255,12 @@ After LDAP is enabled, the login behavior under different user states is as foll
 - If the temporary user has no corresponding group privileges or configured default roles, it has the `select_priv` privilege on `information_schema` by default.
 
 :::
+
+> **About Empty Password Security:**
+>
+> The `ldap_allow_empty_pass` configuration provides additional security control:
+> - When `true`: Users can accidentally or intentionally log in without a password, which might be convenient for development environments but poses security risks in production.
+> - When `false` (default): Empty passwords are strictly rejected, ensuring all users must provide valid credentials. This is recommended for production environments to prevent unauthorized access.
 
 ### Login Examples
 
@@ -457,6 +473,8 @@ You can refresh the cache with the `refresh ldap` statement. For details, see [R
 
 - The LDAP feature of Doris supports only cleartext password verification on the channel from the client to FE, that is, when the user logs in, the password is transmitted in cleartext between the `client` and `fe`. SSL/TLS encryption between the client and Doris FE must be configured separately (see [Client Connection](#step-2-client-connection)).
 - The channel from FE to the LDAP server uses cleartext transmission by default (`ldap_use_ssl = false`). To encrypt this channel, set `ldap_use_ssl = true` to enable LDAPS (see [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection)).
+- **Empty password behavior in legacy LDAP authentication mode:** By default, Doris doesn't allow login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = false`). This can be disabled by setting `ldap_allow_empty_pass = true` in `ldap.conf`. 
+- **Empty password behavior in new plugin-based LDAP authentication:** By default, logins for users with empty LDAP passwords are rejected by LDAP authentication plugin despite of actual value of setting `ldap_allow_empty_pass` in `ldap.conf`. 
 
 ## Frequently Asked Questions
 

--- a/versioned_docs/version-3.x/admin-manual/auth/authentication/ldap.md
+++ b/versioned_docs/version-3.x/admin-manual/auth/authentication/ldap.md
@@ -57,6 +57,8 @@ In LDAP, data is organized in a tree structure. Here's an example of a typical L
     ldap_group_basedn = ou=group,o=emr
     # specify ldap_use_ssl to true to use to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
     ldap_use_ssl = true 
+    # specify ldap_allow_empty_pass to false to prohibit login with non specified LDAP password, specify true or comment property to use default behavior and allow login with empty LDAP password
+    ldap_allow_empty_pass = false 
     ```
 
     > To enable LDAPS (encrypted connection to the LDAP server), see the [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection) section below.
@@ -136,6 +138,12 @@ LDAP authentication means password verification through LDAP service to suppleme
 2. If the user doesn't exist in LDAP, it falls back to Doris local password verification.
 3. If the LDAP password is correct but there's no corresponding account in Doris, a temporary user is created for login.
 
+> Note on Empty Passwords:
+>
+> By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). 
+> This behavior can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`.
+> With such setting Doris will reject all login attempts with empty password and return an error message.
+
 ### Login Behavior Overview
 
 After enabling LDAP, login behaviors under different user states are as follows:
@@ -144,8 +152,10 @@ After enabling LDAP, login behaviors under different user states are as follows:
 | --------- | ---------- | ------------- | ------------ | -------------- |
 | Exists | Exists | LDAP password | Success | Doris user |
 | Exists | Exists | Doris password | Failed | - |
+| Exists | Exists |	Empty password | Success if `ldap_allow_empty_pass = true`, otherwise Failed | Doris user (if allowed) |
 | Not exists | Exists | Doris password | Success | Doris user |
 | Exists | Not exists | LDAP password | Success | LDAP temporary user |
+| Exists | Not exists | Empty password | Success if `ldap_allow_empty_pass = true`, otherwise Failed | LDAP temporary user (if allowed) |
 
 > **About Temporary Users:**
 >
@@ -153,6 +163,12 @@ After enabling LDAP, login behaviors under different user states are as follows:
 > - Doris doesn't create persistent user metadata for temporary users.
 > - Temporary user permissions are determined by LDAP group authorization (see "Group Authorization" section below).
 > - If temporary users have no corresponding group permissions, they default to `select_priv` on `information_schema`.
+
+> **About Empty Password Security:**
+>
+> The `ldap_allow_empty_pass` configuration provides additional security control:
+> - When `true` (default): Users can accidentally or intentionally log in without a password, which might be convenient for development environments but poses security risks in production.
+> - When `false`: Empty passwords are strictly rejected, ensuring all users must provide valid credentials. This is recommended for production environments to prevent unauthorized access.
 
 ### Login Examples
 
@@ -303,6 +319,7 @@ You can refresh the cache with the `refresh ldap` statement. See [REFRESH-LDAP](
 
 - Doris's LDAP functionality only supports cleartext password verification for the client-to-FE segment, meaning that when users log in, passwords are transmitted in plaintext between `client` and `fe`. SSL/TLS encryption between the client and Doris FE must be configured separately (see [Client Connection](#step-2-client-connection)).
 - For the FE-to-LDAP segment, the connection is unencrypted by default (`ldap_use_ssl = false`). To encrypt this segment, set `ldap_use_ssl = true` to use LDAPS (see [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection)).
+- Empty password behavior: By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). This can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`. 
 
 ## FAQ
 

--- a/versioned_docs/version-3.x/admin-manual/auth/authentication/ldap.md
+++ b/versioned_docs/version-3.x/admin-manual/auth/authentication/ldap.md
@@ -49,11 +49,14 @@ In LDAP, data is organized in a tree structure. Here's an example of a typical L
     ```
     ldap_authentication_enabled = true
     ldap_host = ladp-host
-    ldap_port = 389
+    # change ldap_port value if ldap_use_ssl specified to true as different port (636) is used for LDAPS
+    ldap_port = 389 
     ldap_admin_name = uid=admin,o=emr
     ldap_user_basedn = ou=people,o=emr
     ldap_user_filter = (&(uid={login}))
     ldap_group_basedn = ou=group,o=emr
+    # specify ldap_use_ssl to true to use to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
+    ldap_use_ssl = true 
     ```
 
     > To enable LDAPS (encrypted connection to the LDAP server), see the [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection) section below.

--- a/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
+++ b/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
@@ -55,7 +55,7 @@ In LDAP, data is organized in a tree structure. Here's an example of a typical L
     ldap_user_basedn = ou=people,o=emr
     ldap_user_filter = (&(uid={login}))
     ldap_group_basedn = ou=group,o=emr
-    # specify ldap_use_ssl to true to switch to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
+    # specify ldap_use_ssl to true to use to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
     ldap_use_ssl = true 
     ```
 

--- a/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
+++ b/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
@@ -62,6 +62,7 @@ In LDAP, data is organized in a tree structure. Here's an example of a typical L
     ```
 
     > To enable LDAPS (encrypted connection to the LDAP server), see the [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection) section below.
+
 3. After starting `fe`, log in to Doris with `root` or `admin` account and set the LDAP admin password:
 
     ```sql
@@ -139,9 +140,10 @@ LDAP authentication means password verification through LDAP service to suppleme
 
 > Note on Empty Passwords:
 >
-> By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). 
+> By default, in legacy authentication mode Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). 
 > This behavior can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`.
 > With such setting Doris will reject all login attempts with empty password and return an error message.
+> New plugin-based LDAP authentication mode (since 4.1.0) always rejects attempts to login with empty LDAP password despite of value `ldap_allow_empty_pass = true`
 
 ### Login Behavior Overview
 
@@ -316,15 +318,10 @@ You can refresh the cache with the `refresh ldap` statement. See [REFRESH-LDAP](
 
 ## Known Limitations
 
-<<<<<<< HEAD
 - Doris's LDAP functionality only supports cleartext password verification for the client-to-FE segment, meaning that when users log in, passwords are transmitted in plaintext between `client` and `fe`. SSL/TLS encryption between the client and Doris FE must be configured separately (see [Client Connection](#step-2-client-connection)).
 - For the FE-to-LDAP segment, the connection is unencrypted by default (`ldap_use_ssl = false`). To encrypt this segment, set `ldap_use_ssl = true` to use LDAPS (see [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection)).
-=======
-- Currently, Doris's LDAP functionality only supports cleartext password verification, meaning that when users log in, passwords are transmitted in plaintext between `client` and `fe`, but connection between `fe` and LDAP service can be secured optionally.
--   **For `ldap_use_ssl = false` (default behavior)**: Passwords are transmitted in plain text between the Doris FE and the LDAP server.
--   **To secure the connection**: Set `ldap_use_ssl = true` to encrypt traffic between Doris FE and the LDAP server. Note that SSL/TLS encryption between the **client and Doris FE** must be configured separately.
--   **Empty password behavior:** By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). This can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`. 
->>>>>>> a2a830554a (add docs for allow_empty_pass option for 3.x and 4.x versions)
+- **Empty password behavior in legacy LDAP authentication mode:** By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). This can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`. 
+- **Empty password behavior in new plugin-based LDAP authentication:** By default, logins for users with empty LDAP passwords are rejected by LDAP authentication plugin despite of actual value of setting `ldap_allow_empty_pass` in `ldap.conf`. 
 
 ## FAQ
 

--- a/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
+++ b/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
@@ -49,12 +49,14 @@ In LDAP, data is organized in a tree structure. Here's an example of a typical L
     ```
     ldap_authentication_enabled = true
     ldap_host = ladp-host
-    ldap_port = 389 # change it if ldap_use_ssl specified to true as different port (636) is used for LDAPS
+    # change ldap_port value if ldap_use_ssl specified to true as different port (636) is used for LDAPS
+    ldap_port = 389 
     ldap_admin_name = uid=admin,o=emr
     ldap_user_basedn = ou=people,o=emr
     ldap_user_filter = (&(uid={login}))
     ldap_group_basedn = ou=group,o=emr
-    ldap_use_ssl = true # specify true to switch to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
+    # specify ldap_use_ssl to true to switch to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
+    ldap_use_ssl = true 
     ```
 
     > To enable LDAPS (encrypted connection to the LDAP server), see the [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection) section below.

--- a/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
+++ b/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
@@ -57,6 +57,8 @@ In LDAP, data is organized in a tree structure. Here's an example of a typical L
     ldap_group_basedn = ou=group,o=emr
     # specify ldap_use_ssl to true to use to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
     ldap_use_ssl = true 
+    # specify ldap_allow_empty_pass to false to prohibit login with non specified LDAP password, specify true or comment property to use default behavior and allow login with empty LDAP password
+    ldap_allow_empty_pass = false 
     ```
 
     > To enable LDAPS (encrypted connection to the LDAP server), see the [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection) section below.
@@ -135,6 +137,12 @@ LDAP authentication means password verification through LDAP service to suppleme
 2. If the user doesn't exist in LDAP, it falls back to Doris local password verification.
 3. If the LDAP password is correct but there's no corresponding account in Doris, a temporary user is created for login.
 
+> Note on Empty Passwords:
+>
+> By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). 
+> This behavior can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`.
+> With such setting Doris will reject all login attempts with empty password and return an error message.
+
 ### Login Behavior Overview
 
 After enabling LDAP, login behaviors under different user states are as follows:
@@ -143,8 +151,10 @@ After enabling LDAP, login behaviors under different user states are as follows:
 | --------- | ---------- | ------------- | ------------ | -------------- |
 | Exists | Exists | LDAP password | Success | Doris user |
 | Exists | Exists | Doris password | Failed | - |
+| Exists | Exists |	Empty password | Success if `ldap_allow_empty_pass = true`, otherwise Failed | Doris user (if allowed) |
 | Not exists | Exists | Doris password | Success | Doris user |
 | Exists | Not exists | LDAP password | Success | LDAP temporary user |
+| Exists | Not exists | Empty password | Success if `ldap_allow_empty_pass = true`, otherwise Failed | LDAP temporary user (if allowed) |
 
 > **About Temporary Users:**
 >
@@ -152,6 +162,12 @@ After enabling LDAP, login behaviors under different user states are as follows:
 > - Doris doesn't create persistent user metadata for temporary users.
 > - Temporary user permissions are determined by LDAP group authorization (see "Group Authorization" section below).
 > - If temporary users have no corresponding group permissions, they default to `select_priv` on `information_schema`.
+
+> **About Empty Password Security:**
+>
+> The `ldap_allow_empty_pass` configuration provides additional security control:
+> - When `true` (default): Users can accidentally or intentionally log in without a password, which might be convenient for development environments but poses security risks in production.
+> - When `false`: Empty passwords are strictly rejected, ensuring all users must provide valid credentials. This is recommended for production environments to prevent unauthorized access.
 
 ### Login Examples
 
@@ -300,8 +316,15 @@ You can refresh the cache with the `refresh ldap` statement. See [REFRESH-LDAP](
 
 ## Known Limitations
 
+<<<<<<< HEAD
 - Doris's LDAP functionality only supports cleartext password verification for the client-to-FE segment, meaning that when users log in, passwords are transmitted in plaintext between `client` and `fe`. SSL/TLS encryption between the client and Doris FE must be configured separately (see [Client Connection](#step-2-client-connection)).
 - For the FE-to-LDAP segment, the connection is unencrypted by default (`ldap_use_ssl = false`). To encrypt this segment, set `ldap_use_ssl = true` to use LDAPS (see [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection)).
+=======
+- Currently, Doris's LDAP functionality only supports cleartext password verification, meaning that when users log in, passwords are transmitted in plaintext between `client` and `fe`, but connection between `fe` and LDAP service can be secured optionally.
+-   **For `ldap_use_ssl = false` (default behavior)**: Passwords are transmitted in plain text between the Doris FE and the LDAP server.
+-   **To secure the connection**: Set `ldap_use_ssl = true` to encrypt traffic between Doris FE and the LDAP server. Note that SSL/TLS encryption between the **client and Doris FE** must be configured separately.
+-   **Empty password behavior:** By default, Doris allows login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = true`). This can be disabled by setting `ldap_allow_empty_pass = false` in `ldap.conf`. 
+>>>>>>> a2a830554a (add docs for allow_empty_pass option for 3.x and 4.x versions)
 
 ## FAQ
 

--- a/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
+++ b/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
@@ -49,15 +49,15 @@ In LDAP, data is organized in a tree structure. Here's an example of a typical L
     ```
     ldap_authentication_enabled = true
     ldap_host = ladp-host
-    ldap_port = 389
+    ldap_port = 389 # change it if ldap_use_ssl specified to true as different port (636) is used for LDAPS
     ldap_admin_name = uid=admin,o=emr
     ldap_user_basedn = ou=people,o=emr
     ldap_user_filter = (&(uid={login}))
     ldap_group_basedn = ou=group,o=emr
+    ldap_use_ssl = true # specify true to switch to secured LDAPS protocol, specify false or comment property to use default behavior with plain LDAP
     ```
 
     > To enable LDAPS (encrypted connection to the LDAP server), see the [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection) section below.
-
 3. After starting `fe`, log in to Doris with `root` or `admin` account and set the LDAP admin password:
 
     ```sql

--- a/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
+++ b/versioned_docs/version-4.x/admin-manual/auth/authentication/ldap.md
@@ -226,6 +226,13 @@ LDAP authentication login means using the LDAP service for password verification
 2. If the user does not exist in LDAP, it falls back to Doris local password verification.
 3. If the LDAP password is correct but there is no corresponding account in Doris, a temporary user is created for login.
 
+> Note on Empty Passwords:
+>
+> By default, in legacy authentication mode Doris doesn't allow login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = false`). 
+> Because of this Doris will reject all login attempts with empty password and return an error message.
+> This behavior can be disabled by setting `ldap_allow_empty_pass = true` in `ldap.conf` to allow successfull login with empty password for existing user.
+> New plugin-based LDAP authentication mode (since 4.1.0) always rejects attempts to login with empty LDAP password despite of value `ldap_allow_empty_pass = true`
+
 ### Login Behavior Overview
 
 After LDAP is enabled, the login behavior under different user states is as follows:
@@ -233,9 +240,11 @@ After LDAP is enabled, the login behavior under different user states is as foll
 | LDAP user | Doris user | Password used | Login result | Login identity |
 | --------- | ---------- | -------------- | ------------ | -------------- |
 | Exists | Exists | LDAP password | Success | Doris user |
-| Exists | Exists | Doris password | Failure | - |
-| Does not exist | Exists | Doris password | Success | Doris user |
+| Exists | Exists | Doris password | Failed | - |
+| Exists | Exists |	Empty password | Success if `ldap_allow_empty_pass = true`, otherwise Failed | Doris user (if allowed) |
+| Does not exists | Exists | Doris password | Success | Doris user |
 | Exists | Does not exist | LDAP password | Success | LDAP temporary user |
+| Exists | Does not exist | Empty password | Success if `ldap_allow_empty_pass = true`, otherwise Failed | LDAP temporary user (if allowed) |
 
 :::info About temporary users
 
@@ -245,6 +254,12 @@ After LDAP is enabled, the login behavior under different user states is as foll
 - If the temporary user has no corresponding group privileges or configured default roles, it has the `select_priv` privilege on `information_schema` by default.
 
 :::
+
+> **About Empty Password Security:**
+>
+> The `ldap_allow_empty_pass` configuration provides additional security control:
+> - When `true`: Users can accidentally or intentionally log in without a password, which might be convenient for development environments but poses security risks in production.
+> - When `false` (default): Empty passwords are strictly rejected, ensuring all users must provide valid credentials. This is recommended for production environments to prevent unauthorized access.
 
 ### Login Examples
 
@@ -457,6 +472,8 @@ You can refresh the cache with the `refresh ldap` statement. For details, see [R
 
 - The LDAP feature of Doris supports only cleartext password verification on the channel from the client to FE, that is, when the user logs in, the password is transmitted in cleartext between the `client` and `fe`. SSL/TLS encryption between the client and Doris FE must be configured separately (see [Client Connection](#step-2-client-connection)).
 - The channel from FE to the LDAP server uses cleartext transmission by default (`ldap_use_ssl = false`). To encrypt this channel, set `ldap_use_ssl = true` to enable LDAPS (see [LDAPS (Encrypted Connection)](#ldaps-encrypted-connection)).
+- **Empty password behavior in legacy LDAP authentication mode:** By default, Doris doesn't allow login with an empty password if the user exists in LDAP (`ldap_allow_empty_pass = false`). This can be disabled by setting `ldap_allow_empty_pass = true` in `ldap.conf`. 
+- **Empty password behavior in new plugin-based LDAP authentication:** By default, logins for users with empty LDAP passwords are rejected by LDAP authentication plugin despite of actual value of setting `ldap_allow_empty_pass` in `ldap.conf`. 
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
This PR adds documentation for the option to disable login with empty LDAP password introduced in code PR #60372.

Changes:

Added documentation for the new ldap_allow_empty_pass configuration property in ldap.conf.

Updated the configuration examples in the relevant documentation files.

Documentation version coverage: The changes have been applied to mentioned directories to cover the requested branches:

docs/ (latest),
versioned_docs/version-4.0/
Related PR: https://github.com/apache/doris/pull/61440
Issue: close https://github.com/apache/doris/issues/60353

## Versions 

- [X] dev
- [X] 4.x
- [ ] 3.x
- [ ] 2.1

## Languages

- [ ] Chinese
- [X] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
