### PR TITLE
[docs](auto-partition) fix dynamic_partition.enable value in 3.x example

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/table-design/data-partitioning/auto-partitioning.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/table-design/data-partitioning/auto-partitioning.md
@@ -243,7 +243,7 @@ auto partition by range (date_trunc(k0, 'year'))
 )
 DISTRIBUTED BY HASH(`k0`) BUCKETS 2
 properties(
-    "dynamic_partition.enable" = "false",
+    "dynamic_partition.enable" = "true",
     "dynamic_partition.prefix" = "p",
     "dynamic_partition.start" = "-50",
     "dynamic_partition.end" = "0", --- Dynamic Partition 不创建分区

--- a/versioned_docs/version-3.x/table-design/data-partitioning/auto-partitioning.md
+++ b/versioned_docs/version-3.x/table-design/data-partitioning/auto-partitioning.md
@@ -246,7 +246,7 @@ auto partition by range (date_trunc(k0, 'year'))
 )
 DISTRIBUTED BY HASH(`k0`) BUCKETS 2
 properties(
-    "dynamic_partition.enable" = "false",
+    "dynamic_partition.enable" = "true",
     "dynamic_partition.prefix" = "p",
     "dynamic_partition.start" = "-50",
     "dynamic_partition.end" = "0", --- Dynamic Partition No Partition Creation


### PR DESCRIPTION
- Change `dynamic_partition.enable` from `"false"` to `"true"` in auto partition example
- Apply to both EN and ZH versions of 3.x docs

## Versions 

- [ ] dev
- [ ] 4.x
- [x] 3.x
- [ ] 2.1

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
