### PR TITLE
[docs](ldb-toolchain) use bash instead of sh to invoke ldb_toolchain_gen.sh

### DIFF
--- a/community/source-install/compilation-with-ldb-toolchain.md
+++ b/community/source-install/compilation-with-ldb-toolchain.md
@@ -50,7 +50,7 @@ For more information, please visit <https://github.com/amosbird/ldb_toolchain_ge
 2. **Execute the following command to generate ldb toolchain.**
 
 ```bash
-sh ldb_toolchain_gen.sh /path/to/ldb_toolchain/
+bash ldb_toolchain_gen.sh /path/to/ldb_toolchain/
 ```
 
 `/path/to/ldb_toolchain/` is the installation directory for the toolchain. After successful execution, the following directory structure will be generated under `/path/to/ldb_toolchain/`:

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/source-install/compilation-with-ldb-toolchain.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/source-install/compilation-with-ldb-toolchain.md
@@ -52,7 +52,7 @@ LDB Toolchain 全称 Linux Distribution Based Toolchain Generator，它有助于
 **2. 执行以下命令生成 ldb toolchain**
 
 ```bash
-sh ldb_toolchain_gen.sh /path/to/ldb_toolchain/
+bash ldb_toolchain_gen.sh /path/to/ldb_toolchain/
 ```
 
 其中 `/path/to/ldb_toolchain/` 为安装 Toolchain 目录。执行成功后，会在 `/path/to/ldb_toolchain/` 下生成如下目录结构：


### PR DESCRIPTION
Fixes #3538

## Versions 

- [ ] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
