### PR TITLE
[fix](i18n) fix Chinese sidebar translations for current and 4.x

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -23,29 +23,13 @@
     "message": "SQL 手册",
     "description": "The label for category Reference in sidebar docs"
   },
-  "sidebar.docs.category.Releases": {
-    "message": "版本发布",
-    "description": "The label for category Releases in sidebar docs"
-  },
-  "sidebar.docs.category.Tutorials": {
-    "message": "使用教程",
-    "description": "The label for category Tutorials in sidebar docs"
-  },
   "sidebar.docs.category.Lakehouse Best Practices": {
     "message": "湖仓一体最佳实践",
     "description": "The label for category Lakehouse Best Practices in sidebar docs"
   },
-  "sidebar.docs.category.Quick Start": {
-    "message": "快速体验",
-    "description": "The label for category Quick Start in sidebar docs"
-  },
   "sidebar.docs.category.Installation and Deployment": {
     "message": "安装部署",
     "description": "The label for category Installation and Deployment in sidebar docs"
-  },
-  "sidebar.docs.category.Cluster Deployment": {
-    "message": "集群部署",
-    "description": "The label for category Cluster Deployment in sidebar docs"
   },
   "sidebar.docs.category.Deploying on Kubernetes": {
     "message": "在 Kubernetes 部署",
@@ -103,10 +87,6 @@
     "message": "倒排索引",
     "description": "The label for category Inverted Index in sidebar docs"
   },
-  "sidebar.docs.category.Data Manipulation": {
-    "message": "数据操作",
-    "description": "The label for category Data Manipulation in sidebar docs"
-  },
   "sidebar.docs.category.Loading Data": {
     "message": "数据导入",
     "description": "The label for category Loading Data in sidebar docs"
@@ -114,10 +94,6 @@
   "sidebar.docs.category.Data Update and Delete": {
     "message": "数据更新与删除",
     "description": "The label for category Data Update and Delete in sidebar docs"
-  },
-  "sidebar.docs.category.Complex Type": {
-    "message": "复杂类型",
-    "description": "The label for category Complex Type in sidebar docs"
   },
   "sidebar.docs.category.Data Source": {
     "message": "数据源",
@@ -159,10 +135,6 @@
     "message": "数据导出",
     "description": "The label for category Export in sidebar docs"
   },
-  "sidebar.docs.category.Job Scheduler": {
-    "message": "作业调度",
-    "description": "The label for category job scheduler in sidebar docs"
-  },
   "sidebar.releasenotes.category.Previous Release": {
     "message": "历史版本",
     "description": "The label for category Release notes in sidebar docs"
@@ -187,10 +159,6 @@
     "message": "开放文件格式",
     "description": "The label for category File Format in sidebar docs"
   },
-  "sidebar.docs.category.SQL Dialect Convertor": {
-    "message": "SQL 方言转换",
-    "description": "The label for category SQL Dialect Convertor in sidebar docs"
-  },
   "sidebar.docs.category.Data Queries": {
     "message": "数据查询",
     "description": "The label for category Data Queries in sidebar docs"
@@ -199,53 +167,13 @@
     "message": "自定义函数",
     "description": "The label for category User Defined Functions in sidebar docs"
   },
-  "sidebar.docs.category.Queries Acceleration": {
-    "message": "查询加速",
-    "description": "The label for category Queries Acceleration in sidebar docs"
-  },
-  "sidebar.docs.category.Performance Tuning Overview": {
-    "message": "查询调优概述",
-    "description": "The label for category Performance Tuning Overview in sidebar docs"
-  },
-  "sidebar.docs.category.Materialize View": {
-    "message": "物化视图",
-    "description": "The label for category View and Materialize View in sidebar docs"
-  },
-  "sidebar.docs.category.Async-Materialized View": {
-    "message": "异步物化视图",
-    "description": "The label for category View and Materialize View in sidebar docs"
-  },
-  "sidebar.docs.category.Distincting Counts": {
-    "message": "高效去重",
-    "description": "The label for category Distincting Counts in sidebar docs"
-  },
   "sidebar.docs.category.Hints": {
     "message": "Hints",
     "description": "The label for category Hints in sidebar docs"
   },
-  "sidebar.docs.category.Tuning": {
-    "message": "查询优化实践",
-    "description": "The label for category Tuning in sidebar docs"
-  },
-  "sidebar.docs.category.Tuning Plan": {
-    "message": "计划调优",
-    "description": "The label for category Tuning Plan in sidebar docs"
-  },
-  "sidebar.docs.category.Tuning Execution": {
-    "message": "执行调优",
-    "description": "The label for category Tuning Execution in sidebar docs"
-  },
-  "sidebar.docs.category.Optimization Technology Principle": {
-    "message": "优化技术原理",
-    "description": "The label for category Optimization Technology Principle in sidebar docs"
-  },
   "sidebar.docs.category.Security": {
     "message": "安全合规",
     "description": "The label for category Security in sidebar docs"
-  },
-  "sidebar.docs.category.Security Overview": {
-    "message": "安全概述",
-    "description": "The label for category Security Overview in sidebar docs"
   },
   "sidebar.docs.category.Encryption in Transit": {
     "message": "传输加密",
@@ -267,18 +195,6 @@
     "message": "鉴权管控",
     "description": "The label for category Authorization in sidebar docs"
   },
-  "sidebar.docs.category.Alter Table": {
-    "message": "表结构变更",
-    "description": "The label for category Alter Table in sidebar docs"
-  },
-  "sidebar.docs.category.Doris Partition": {
-    "message": "Doris 表分区",
-    "description": "The label for category Doris Partition in sidebar docs"
-  },
-  "sidebar.docs.category.Best Practice": {
-    "message": "最佳实践",
-    "description": "The label for category Best Practice in sidebar docs"
-  },
   "sidebar.docs.category.Ecosystem": {
     "message": "生态扩展",
     "description": "The label for category Ecosystem in sidebar docs"
@@ -286,18 +202,6 @@
   "sidebar.docs.category.Doris Operator": {
     "message": "Doris Operator",
     "description": "The label for category Doris Operator in sidebar docs"
-  },
-  "sidebar.docs.category.BI and Database IDE": {
-    "message": "BI 与数据库 IDE",
-    "description": "The label for category BI and Database IDE in sidebar docs"
-  },
-  "sidebar.docs.category.Doris Manager": {
-    "message": "Doris Manager",
-    "description": "The label for category Doris Manager in sidebar docs"
-  },
-  "sidebar.docs.category.Managing Doris": {
-    "message": "管理指南",
-    "description": "The label for category Managing Doris in sidebar docs"
   },
   "sidebar.docs.category.Managing Cluster": {
     "message": "集群管理",
@@ -311,17 +215,9 @@
     "message": "负载管理",
     "description": "The label for category Managing Workload in sidebar docs"
   },
-  "sidebar.docs.category.Managing Resource": {
-    "message": "资源管理",
-    "description": "The label for category Managing Resource in sidebar docs"
-  },
   "sidebar.docs.category.Resource Isolation": {
     "message": "资源隔离",
     "description": "The label for category Resource Isolation in sidebar docs"
-  },
-  "sidebar.docs.category.Managing User Privilege": {
-    "message": "安全管理",
-    "description": "The label for category Managing User Privilege in sidebar docs"
   },
   "sidebar.docs.category.Trouble Shooting": {
     "message": "故障诊断处理",
@@ -378,14 +274,6 @@
   "sidebar.docs.category.BE HTTP API": {
     "message": "BE HTTP API",
     "description": "The label for category BE HTTP API in sidebar docs"
-  },
-  "sidebar.docs.category.Monitor Metrics": {
-    "message": "监控",
-    "description": "The label for category Monitor in sidebar docs"
-  },
-  "sidebar.docs.category.SQL Reference": {
-    "message": "SQL 手册",
-    "description": "The label for category SQL Manual in sidebar docs"
   },
   "sidebar.docs.category.SQL Functions": {
     "message": "SQL 函数",
@@ -563,10 +451,6 @@
     "message": "向量函数",
     "description": "The label for category vector distance functions in sidebar docs"
   },
-  "sidebar.docs.category.LLM Functions": {
-    "message": "LLM 函数",
-    "description": "The label for category llm functions in sidebar docs"
-  },
   "sidebar.docs.category.Bitwise Functions": {
     "message": "位处理函数",
     "description": "The label for category Bitwise Functions in sidebar docs"
@@ -586,10 +470,6 @@
   "sidebar.docs.category.JSON Functions": {
     "message": "JSON 函数",
     "description": "The label for category JSON Functions in sidebar docs"
-  },
-  "sidebar.docs.category.VARIANT Functions": {
-    "message": "VARIANT 函数",
-    "description": "The label for category VARIANT Functions in sidebar docs"
   },
   "sidebar.docs.category.IP Functions": {
     "message": "IP 函数",
@@ -643,49 +523,9 @@
     "message": "分析函数 (窗口函数)",
     "description": "The label for category Analytic(Window) Functions in sidebar docs"
   },
-  "sidebar.docs.category.Debug Functions": {
-    "message": "调试函数",
-    "description": "The label for category Debug Functions in sidebar docs"
-  },
-  "sidebar.docs.category.Cluster management": {
-    "message": "集群管理",
-    "description": "The label for category Cluster management in sidebar docs"
-  },
-  "sidebar.docs.category.DDL": {
-    "message": "DDL",
-    "description": "The label for category DDL in sidebar docs"
-  },
-  "sidebar.docs.category.Alter": {
-    "message": "Alter",
-    "description": "The label for category Alter in sidebar docs"
-  },
-  "sidebar.docs.category.Create": {
-    "message": "Create",
-    "description": "The label for category Create in sidebar docs"
-  },
-  "sidebar.docs.category.Drop": {
-    "message": "Drop",
-    "description": "The label for category Drop in sidebar docs"
-  },
   "sidebar.docs.category.DML": {
     "message": "DML",
     "description": "The label for category DML in sidebar docs"
-  },
-  "sidebar.docs.category.Load": {
-    "message": "Load",
-    "description": "The label for category Load in sidebar docs"
-  },
-  "sidebar.docs.category.Manipulation": {
-    "message": "操作",
-    "description": "The label for category Manipulation in sidebar docs"
-  },
-  "sidebar.docs.category.Database Administration": {
-    "message": "数据库管理",
-    "description": "The label for category Database Administration in sidebar docs"
-  },
-  "sidebar.docs.category.Show": {
-    "message": "Show",
-    "description": "The label for category Show in sidebar docs"
   },
   "sidebar.docs.category.Aggregation Data Type": {
     "message": "聚合类型",
@@ -727,10 +567,6 @@
     "message": "条件操作符",
     "description": "The label for category Conditional Operators in sidebar docs"
   },
-  "sidebar.docs.category.Utility": {
-    "message": "辅助命令",
-    "description": "The label for category Utility in sidebar docs"
-  },
   "sidebar.docs.category.FAQ": {
     "message": "常见问题",
     "description": "The label for category FAQ in sidebar docs"
@@ -738,30 +574,6 @@
   "sidebar.docs.category.Benchmark": {
     "message": "性能测试",
     "description": "The label for category Benchmark in sidebar docs"
-  },
-  "sidebar.docs.category.Release notes": {
-    "message": "版本发布",
-    "description": "The label for category Release notes in sidebar docs"
-  },
-  "sidebar.docs.category.cluster management": {
-    "message": "集群管理",
-    "description": "The label for category cluster management in sidebar docs"
-  },
-  "sidebar.docs.category.System Table": {
-    "message": "System Table",
-    "description": "The label for category System Table in sidebar docs"
-  },
-  "sidebar.docs.category.HTTP API": {
-    "message": "HTTP API",
-    "description": "The label for category HTTP API in sidebar docs"
-  },
-  "sidebar.docs.category.Cloud Service Authentication": {
-    "message": "云服务认证接入",
-    "description": "The label for category Lakehouse.Cloud Service Authentication in sidebar docs"
-  },
-  "sidebar.docs.category.External Table": {
-    "message": "外部表",
-    "description": "The label for category Lakehouse.External Table in sidebar docs"
   },
   "sidebar.docs.category.Observability": {
     "message": "可观测性",
@@ -795,10 +607,6 @@
     "message": "冷热数据分层",
     "description": "The label for category Tiered Storage in sidebar docs"
   },
-  "sidebar.docs.category.Business Continuity & Data Recovery": {
-    "message": "业务连续性和数据恢复",
-    "description": "The label for category Business Continuity & Data Recovery in sidebar docs"
-  },
   "sidebar.docs.category.Backup & Restore": {
     "message": "备份与恢复",
     "description": "The label for category Backup & Restore in sidebar docs"
@@ -806,5 +614,133 @@
   "sidebar.docs.category.Integrations": {
     "message": "集成",
     "description": "The label for category Integrations in sidebar docs"
+  },
+  "sidebar.docs.category.AI": {
+    "message": "AI",
+    "description": "The label for category AI in sidebar docs"
+  },
+  "sidebar.docs.category.Async Materialized View": {
+    "message": "异步物化视图",
+    "description": "The label for category Async Materialized View in sidebar docs"
+  },
+  "sidebar.docs.category.BI": {
+    "message": "BI 工具",
+    "description": "The label for category BI in sidebar docs"
+  },
+  "sidebar.docs.category.Binary Data Type": {
+    "message": "二进制类型",
+    "description": "The label for category Binary Data Type in sidebar docs"
+  },
+  "sidebar.docs.category.Caching": {
+    "message": "查询缓存",
+    "description": "The label for category Caching in sidebar docs"
+  },
+  "sidebar.docs.category.Distinct Counts": {
+    "message": "高效去重",
+    "description": "The label for category Distinct Counts in sidebar docs"
+  },
+  "sidebar.docs.category.Doris Kafka Connector": {
+    "message": "Doris Kafka Connector",
+    "description": "The label for category Doris Kafka Connector in sidebar docs"
+  },
+  "sidebar.docs.category.Execution Tuning": {
+    "message": "执行调优",
+    "description": "The label for category Execution Tuning in sidebar docs"
+  },
+  "sidebar.docs.category.Flink Doris Connector": {
+    "message": "Flink Doris Connector",
+    "description": "The label for category Flink Doris Connector in sidebar docs"
+  },
+  "sidebar.docs.category.Getting Started with Performance Tuning": {
+    "message": "性能调优入门",
+    "description": "The label for category Getting Started with Performance Tuning in sidebar docs"
+  },
+  "sidebar.docs.category.High Concurrency & Point Queries": {
+    "message": "高并发与点查",
+    "description": "The label for category High Concurrency & Point Queries in sidebar docs"
+  },
+  "sidebar.docs.category.Hudi Catalog": {
+    "message": "Hudi Catalog",
+    "description": "The label for category Hudi Catalog in sidebar docs"
+  },
+  "sidebar.docs.category.Iceberg Catalog": {
+    "message": "Iceberg Catalog",
+    "description": "The label for category Iceberg Catalog in sidebar docs"
+  },
+  "sidebar.docs.category.Join Optimization": {
+    "message": "Join 优化",
+    "description": "The label for category Join Optimization in sidebar docs"
+  },
+  "sidebar.docs.category.Load Performance": {
+    "message": "导入性能",
+    "description": "The label for category Load Performance in sidebar docs"
+  },
+  "sidebar.docs.category.Materialized View": {
+    "message": "物化视图",
+    "description": "The label for category Materialized View in sidebar docs"
+  },
+  "sidebar.docs.category.MaxCompute Catalog": {
+    "message": "MaxCompute Catalog",
+    "description": "The label for category MaxCompute Catalog in sidebar docs"
+  },
+  "sidebar.docs.category.More": {
+    "message": "更多",
+    "description": "The label for category More in sidebar docs"
+  },
+  "sidebar.docs.category.MySQL": {
+    "message": "MySQL",
+    "description": "The label for category MySQL in sidebar docs"
+  },
+  "sidebar.docs.category.Optimization Technology Principles": {
+    "message": "优化技术原理",
+    "description": "The label for category Optimization Technology Principles in sidebar docs"
+  },
+  "sidebar.docs.category.Paimon Catalog": {
+    "message": "Paimon Catalog",
+    "description": "The label for category Paimon Catalog in sidebar docs"
+  },
+  "sidebar.docs.category.Performance": {
+    "message": "性能优化",
+    "description": "The label for category Performance in sidebar docs"
+  },
+  "sidebar.docs.category.PostgreSQL": {
+    "message": "PostgreSQL",
+    "description": "The label for category PostgreSQL in sidebar docs"
+  },
+  "sidebar.docs.category.Query Performance": {
+    "message": "查询性能",
+    "description": "The label for category Query Performance in sidebar docs"
+  },
+  "sidebar.docs.category.Query Profile & Parameters": {
+    "message": "查询 Profile 与参数",
+    "description": "The label for category Query Profile & Parameters in sidebar docs"
+  },
+  "sidebar.docs.category.Read-Write Separation": {
+    "message": "读写分离",
+    "description": "The label for category Read-Write Separation in sidebar docs"
+  },
+  "sidebar.docs.category.SQL Clients": {
+    "message": "SQL 客户端",
+    "description": "The label for category SQL Clients in sidebar docs"
+  },
+  "sidebar.docs.category.Schema & Index Optimization": {
+    "message": "Schema 与索引优化",
+    "description": "The label for category Schema & Index Optimization in sidebar docs"
+  },
+  "sidebar.docs.category.Spark Doris Connector": {
+    "message": "Spark Doris Connector",
+    "description": "The label for category Spark Doris Connector in sidebar docs"
+  },
+  "sidebar.docs.category.VARIANT": {
+    "message": "VARIANT",
+    "description": "The label for category VARIANT in sidebar docs"
+  },
+  "sidebar.docs.category.VARIANT Reference": {
+    "message": "VARIANT 参考",
+    "description": "The label for category VARIANT Reference in sidebar docs"
+  },
+  "sidebar.docs.category.Variant Functions": {
+    "message": "VARIANT 函数",
+    "description": "The label for category Variant Functions in sidebar docs"
   }
 }

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x.json
@@ -23,29 +23,13 @@
     "message": "SQL 手册",
     "description": "The label for category Reference in sidebar docs"
   },
-  "sidebar.docs.category.Releases": {
-    "message": "版本发布",
-    "description": "The label for category Releases in sidebar docs"
-  },
-  "sidebar.docs.category.Tutorials": {
-    "message": "使用教程",
-    "description": "The label for category Tutorials in sidebar docs"
-  },
   "sidebar.docs.category.Lakehouse Best Practices": {
     "message": "湖仓一体最佳实践",
     "description": "The label for category Lakehouse Best Practices in sidebar docs"
   },
-  "sidebar.docs.category.Quick Start": {
-    "message": "快速体验",
-    "description": "The label for category Quick Start in sidebar docs"
-  },
   "sidebar.docs.category.Installation and Deployment": {
     "message": "安装部署",
     "description": "The label for category Installation and Deployment in sidebar docs"
-  },
-  "sidebar.docs.category.Cluster Deployment": {
-    "message": "集群部署",
-    "description": "The label for category Cluster Deployment in sidebar docs"
   },
   "sidebar.docs.category.Deploying on Kubernetes": {
     "message": "在 Kubernetes 部署",
@@ -103,10 +87,6 @@
     "message": "倒排索引",
     "description": "The label for category Inverted Index in sidebar docs"
   },
-  "sidebar.docs.category.Data Manipulation": {
-    "message": "数据操作",
-    "description": "The label for category Data Manipulation in sidebar docs"
-  },
   "sidebar.docs.category.Loading Data": {
     "message": "数据导入",
     "description": "The label for category Loading Data in sidebar docs"
@@ -114,10 +94,6 @@
   "sidebar.docs.category.Data Update and Delete": {
     "message": "数据更新与删除",
     "description": "The label for category Data Update and Delete in sidebar docs"
-  },
-  "sidebar.docs.category.Complex Type": {
-    "message": "复杂类型",
-    "description": "The label for category Complex Type in sidebar docs"
   },
   "sidebar.docs.category.Data Source": {
     "message": "数据源",
@@ -159,10 +135,6 @@
     "message": "数据导出",
     "description": "The label for category Export in sidebar docs"
   },
-  "sidebar.docs.category.Job Scheduler": {
-    "message": "作业调度",
-    "description": "The label for category job scheduler in sidebar docs"
-  },
   "sidebar.releasenotes.category.Previous Release": {
     "message": "历史版本",
     "description": "The label for category Release notes in sidebar docs"
@@ -187,10 +159,6 @@
     "message": "开放文件格式",
     "description": "The label for category File Format in sidebar docs"
   },
-  "sidebar.docs.category.SQL Dialect Convertor": {
-    "message": "SQL 方言转换",
-    "description": "The label for category SQL Dialect Convertor in sidebar docs"
-  },
   "sidebar.docs.category.Data Queries": {
     "message": "数据查询",
     "description": "The label for category Data Queries in sidebar docs"
@@ -199,53 +167,13 @@
     "message": "自定义函数",
     "description": "The label for category User Defined Functions in sidebar docs"
   },
-  "sidebar.docs.category.Queries Acceleration": {
-    "message": "查询加速",
-    "description": "The label for category Queries Acceleration in sidebar docs"
-  },
-  "sidebar.docs.category.Performance Tuning Overview": {
-    "message": "查询调优概述",
-    "description": "The label for category Performance Tuning Overview in sidebar docs"
-  },
-  "sidebar.docs.category.Materialize View": {
-    "message": "物化视图",
-    "description": "The label for category View and Materialize View in sidebar docs"
-  },
-  "sidebar.docs.category.Async-Materialized View": {
-    "message": "异步物化视图",
-    "description": "The label for category View and Materialize View in sidebar docs"
-  },
-  "sidebar.docs.category.Distincting Counts": {
-    "message": "高效去重",
-    "description": "The label for category Distincting Counts in sidebar docs"
-  },
   "sidebar.docs.category.Hints": {
     "message": "Hints",
     "description": "The label for category Hints in sidebar docs"
   },
-  "sidebar.docs.category.Tuning": {
-    "message": "查询优化实践",
-    "description": "The label for category Tuning in sidebar docs"
-  },
-  "sidebar.docs.category.Tuning Plan": {
-    "message": "计划调优",
-    "description": "The label for category Tuning Plan in sidebar docs"
-  },
-  "sidebar.docs.category.Tuning Execution": {
-    "message": "执行调优",
-    "description": "The label for category Tuning Execution in sidebar docs"
-  },
-  "sidebar.docs.category.Optimization Technology Principle": {
-    "message": "优化技术原理",
-    "description": "The label for category Optimization Technology Principle in sidebar docs"
-  },
   "sidebar.docs.category.Security": {
     "message": "安全合规",
     "description": "The label for category Security in sidebar docs"
-  },
-  "sidebar.docs.category.Security Overview": {
-    "message": "安全概述",
-    "description": "The label for category Security Overview in sidebar docs"
   },
   "sidebar.docs.category.Encryption in Transit": {
     "message": "传输加密",
@@ -267,18 +195,6 @@
     "message": "鉴权管控",
     "description": "The label for category Authorization in sidebar docs"
   },
-  "sidebar.docs.category.Alter Table": {
-    "message": "表结构变更",
-    "description": "The label for category Alter Table in sidebar docs"
-  },
-  "sidebar.docs.category.Doris Partition": {
-    "message": "Doris 表分区",
-    "description": "The label for category Doris Partition in sidebar docs"
-  },
-  "sidebar.docs.category.Best Practice": {
-    "message": "最佳实践",
-    "description": "The label for category Best Practice in sidebar docs"
-  },
   "sidebar.docs.category.Ecosystem": {
     "message": "生态扩展",
     "description": "The label for category Ecosystem in sidebar docs"
@@ -286,18 +202,6 @@
   "sidebar.docs.category.Doris Operator": {
     "message": "Doris Operator",
     "description": "The label for category Doris Operator in sidebar docs"
-  },
-  "sidebar.docs.category.BI and Database IDE": {
-    "message": "BI 与数据库 IDE",
-    "description": "The label for category BI and Database IDE in sidebar docs"
-  },
-  "sidebar.docs.category.Doris Manager": {
-    "message": "Doris Manager",
-    "description": "The label for category Doris Manager in sidebar docs"
-  },
-  "sidebar.docs.category.Managing Doris": {
-    "message": "管理指南",
-    "description": "The label for category Managing Doris in sidebar docs"
   },
   "sidebar.docs.category.Managing Cluster": {
     "message": "集群管理",
@@ -311,17 +215,9 @@
     "message": "负载管理",
     "description": "The label for category Managing Workload in sidebar docs"
   },
-  "sidebar.docs.category.Managing Resource": {
-    "message": "资源管理",
-    "description": "The label for category Managing Resource in sidebar docs"
-  },
   "sidebar.docs.category.Resource Isolation": {
     "message": "资源隔离",
     "description": "The label for category Resource Isolation in sidebar docs"
-  },
-  "sidebar.docs.category.Managing User Privilege": {
-    "message": "安全管理",
-    "description": "The label for category Managing User Privilege in sidebar docs"
   },
   "sidebar.docs.category.Trouble Shooting": {
     "message": "故障诊断处理",
@@ -378,14 +274,6 @@
   "sidebar.docs.category.BE HTTP API": {
     "message": "BE HTTP API",
     "description": "The label for category BE HTTP API in sidebar docs"
-  },
-  "sidebar.docs.category.Monitor Metrics": {
-    "message": "监控",
-    "description": "The label for category Monitor in sidebar docs"
-  },
-  "sidebar.docs.category.SQL Reference": {
-    "message": "SQL 手册",
-    "description": "The label for category SQL Manual in sidebar docs"
   },
   "sidebar.docs.category.SQL Functions": {
     "message": "SQL 函数",
@@ -563,10 +451,6 @@
     "message": "向量函数",
     "description": "The label for category vector distance functions in sidebar docs"
   },
-  "sidebar.docs.category.LLM Functions": {
-    "message": "LLM 函数",
-    "description": "The label for category llm functions in sidebar docs"
-  },
   "sidebar.docs.category.Bitwise Functions": {
     "message": "位处理函数",
     "description": "The label for category Bitwise Functions in sidebar docs"
@@ -586,10 +470,6 @@
   "sidebar.docs.category.JSON Functions": {
     "message": "JSON 函数",
     "description": "The label for category JSON Functions in sidebar docs"
-  },
-  "sidebar.docs.category.VARIANT Functions": {
-    "message": "VARIANT 函数",
-    "description": "The label for category VARIANT Functions in sidebar docs"
   },
   "sidebar.docs.category.IP Functions": {
     "message": "IP 函数",
@@ -643,49 +523,9 @@
     "message": "分析函数 (窗口函数)",
     "description": "The label for category Analytic(Window) Functions in sidebar docs"
   },
-  "sidebar.docs.category.Debug Functions": {
-    "message": "调试函数",
-    "description": "The label for category Debug Functions in sidebar docs"
-  },
-  "sidebar.docs.category.Cluster management": {
-    "message": "集群管理",
-    "description": "The label for category Cluster management in sidebar docs"
-  },
-  "sidebar.docs.category.DDL": {
-    "message": "DDL",
-    "description": "The label for category DDL in sidebar docs"
-  },
-  "sidebar.docs.category.Alter": {
-    "message": "Alter",
-    "description": "The label for category Alter in sidebar docs"
-  },
-  "sidebar.docs.category.Create": {
-    "message": "Create",
-    "description": "The label for category Create in sidebar docs"
-  },
-  "sidebar.docs.category.Drop": {
-    "message": "Drop",
-    "description": "The label for category Drop in sidebar docs"
-  },
   "sidebar.docs.category.DML": {
     "message": "DML",
     "description": "The label for category DML in sidebar docs"
-  },
-  "sidebar.docs.category.Load": {
-    "message": "Load",
-    "description": "The label for category Load in sidebar docs"
-  },
-  "sidebar.docs.category.Manipulation": {
-    "message": "操作",
-    "description": "The label for category Manipulation in sidebar docs"
-  },
-  "sidebar.docs.category.Database Administration": {
-    "message": "数据库管理",
-    "description": "The label for category Database Administration in sidebar docs"
-  },
-  "sidebar.docs.category.Show": {
-    "message": "Show",
-    "description": "The label for category Show in sidebar docs"
   },
   "sidebar.docs.category.Aggregation Data Type": {
     "message": "聚合类型",
@@ -727,10 +567,6 @@
     "message": "条件操作符",
     "description": "The label for category Conditional Operators in sidebar docs"
   },
-  "sidebar.docs.category.Utility": {
-    "message": "辅助命令",
-    "description": "The label for category Utility in sidebar docs"
-  },
   "sidebar.docs.category.FAQ": {
     "message": "常见问题",
     "description": "The label for category FAQ in sidebar docs"
@@ -738,30 +574,6 @@
   "sidebar.docs.category.Benchmark": {
     "message": "性能测试",
     "description": "The label for category Benchmark in sidebar docs"
-  },
-  "sidebar.docs.category.Release notes": {
-    "message": "版本发布",
-    "description": "The label for category Release notes in sidebar docs"
-  },
-  "sidebar.docs.category.cluster management": {
-    "message": "集群管理",
-    "description": "The label for category cluster management in sidebar docs"
-  },
-  "sidebar.docs.category.System Table": {
-    "message": "System Table",
-    "description": "The label for category System Table in sidebar docs"
-  },
-  "sidebar.docs.category.HTTP API": {
-    "message": "HTTP API",
-    "description": "The label for category HTTP API in sidebar docs"
-  },
-  "sidebar.docs.category.Cloud Service Authentication": {
-    "message": "云服务认证接入",
-    "description": "The label for category Lakehouse.Cloud Service Authentication in sidebar docs"
-  },
-  "sidebar.docs.category.External Table": {
-    "message": "外部表",
-    "description": "The label for category Lakehouse.External Table in sidebar docs"
   },
   "sidebar.docs.category.Observability": {
     "message": "可观测性",
@@ -795,10 +607,6 @@
     "message": "冷热数据分层",
     "description": "The label for category Tiered Storage in sidebar docs"
   },
-  "sidebar.docs.category.Business Continuity & Data Recovery": {
-    "message": "业务连续性和数据恢复",
-    "description": "The label for category Business Continuity & Data Recovery in sidebar docs"
-  },
   "sidebar.docs.category.Backup & Restore": {
     "message": "备份与恢复",
     "description": "The label for category Backup & Restore in sidebar docs"
@@ -806,5 +614,133 @@
   "sidebar.docs.category.Integrations": {
     "message": "集成",
     "description": "The label for category Integrations in sidebar docs"
+  },
+  "sidebar.docs.category.AI": {
+    "message": "AI",
+    "description": "The label for category AI in sidebar docs"
+  },
+  "sidebar.docs.category.Async Materialized View": {
+    "message": "异步物化视图",
+    "description": "The label for category Async Materialized View in sidebar docs"
+  },
+  "sidebar.docs.category.BI": {
+    "message": "BI 工具",
+    "description": "The label for category BI in sidebar docs"
+  },
+  "sidebar.docs.category.Binary Data Type": {
+    "message": "二进制类型",
+    "description": "The label for category Binary Data Type in sidebar docs"
+  },
+  "sidebar.docs.category.Caching": {
+    "message": "查询缓存",
+    "description": "The label for category Caching in sidebar docs"
+  },
+  "sidebar.docs.category.Distinct Counts": {
+    "message": "高效去重",
+    "description": "The label for category Distinct Counts in sidebar docs"
+  },
+  "sidebar.docs.category.Doris Kafka Connector": {
+    "message": "Doris Kafka Connector",
+    "description": "The label for category Doris Kafka Connector in sidebar docs"
+  },
+  "sidebar.docs.category.Execution Tuning": {
+    "message": "执行调优",
+    "description": "The label for category Execution Tuning in sidebar docs"
+  },
+  "sidebar.docs.category.Flink Doris Connector": {
+    "message": "Flink Doris Connector",
+    "description": "The label for category Flink Doris Connector in sidebar docs"
+  },
+  "sidebar.docs.category.Getting Started with Performance Tuning": {
+    "message": "性能调优入门",
+    "description": "The label for category Getting Started with Performance Tuning in sidebar docs"
+  },
+  "sidebar.docs.category.High Concurrency & Point Queries": {
+    "message": "高并发与点查",
+    "description": "The label for category High Concurrency & Point Queries in sidebar docs"
+  },
+  "sidebar.docs.category.Hudi Catalog": {
+    "message": "Hudi Catalog",
+    "description": "The label for category Hudi Catalog in sidebar docs"
+  },
+  "sidebar.docs.category.Iceberg Catalog": {
+    "message": "Iceberg Catalog",
+    "description": "The label for category Iceberg Catalog in sidebar docs"
+  },
+  "sidebar.docs.category.Join Optimization": {
+    "message": "Join 优化",
+    "description": "The label for category Join Optimization in sidebar docs"
+  },
+  "sidebar.docs.category.Load Performance": {
+    "message": "导入性能",
+    "description": "The label for category Load Performance in sidebar docs"
+  },
+  "sidebar.docs.category.Materialized View": {
+    "message": "物化视图",
+    "description": "The label for category Materialized View in sidebar docs"
+  },
+  "sidebar.docs.category.MaxCompute Catalog": {
+    "message": "MaxCompute Catalog",
+    "description": "The label for category MaxCompute Catalog in sidebar docs"
+  },
+  "sidebar.docs.category.More": {
+    "message": "更多",
+    "description": "The label for category More in sidebar docs"
+  },
+  "sidebar.docs.category.MySQL": {
+    "message": "MySQL",
+    "description": "The label for category MySQL in sidebar docs"
+  },
+  "sidebar.docs.category.Optimization Technology Principles": {
+    "message": "优化技术原理",
+    "description": "The label for category Optimization Technology Principles in sidebar docs"
+  },
+  "sidebar.docs.category.Paimon Catalog": {
+    "message": "Paimon Catalog",
+    "description": "The label for category Paimon Catalog in sidebar docs"
+  },
+  "sidebar.docs.category.Performance": {
+    "message": "性能优化",
+    "description": "The label for category Performance in sidebar docs"
+  },
+  "sidebar.docs.category.PostgreSQL": {
+    "message": "PostgreSQL",
+    "description": "The label for category PostgreSQL in sidebar docs"
+  },
+  "sidebar.docs.category.Query Performance": {
+    "message": "查询性能",
+    "description": "The label for category Query Performance in sidebar docs"
+  },
+  "sidebar.docs.category.Query Profile & Parameters": {
+    "message": "查询 Profile 与参数",
+    "description": "The label for category Query Profile & Parameters in sidebar docs"
+  },
+  "sidebar.docs.category.Read-Write Separation": {
+    "message": "读写分离",
+    "description": "The label for category Read-Write Separation in sidebar docs"
+  },
+  "sidebar.docs.category.SQL Clients": {
+    "message": "SQL 客户端",
+    "description": "The label for category SQL Clients in sidebar docs"
+  },
+  "sidebar.docs.category.Schema & Index Optimization": {
+    "message": "Schema 与索引优化",
+    "description": "The label for category Schema & Index Optimization in sidebar docs"
+  },
+  "sidebar.docs.category.Spark Doris Connector": {
+    "message": "Spark Doris Connector",
+    "description": "The label for category Spark Doris Connector in sidebar docs"
+  },
+  "sidebar.docs.category.VARIANT": {
+    "message": "VARIANT",
+    "description": "The label for category VARIANT in sidebar docs"
+  },
+  "sidebar.docs.category.VARIANT Reference": {
+    "message": "VARIANT 参考",
+    "description": "The label for category VARIANT Reference in sidebar docs"
+  },
+  "sidebar.docs.category.Variant Functions": {
+    "message": "VARIANT 函数",
+    "description": "The label for category Variant Functions in sidebar docs"
   }
 }


### PR DESCRIPTION
## Summary
- **Add 32 missing Chinese translations** for sidebar categories that were displaying English on the zh-CN site (e.g., `Performance` → 性能优化, `Query Performance` → 查询性能, `Caching` → 查询缓存, `Join Optimization` → Join 优化)
- **Remove 48 orphaned translation keys** left behind from sidebar restructuring that no longer match any sidebar label (e.g., old `Tuning`/`Tuning Plan`/`Tuning Execution` hierarchy, renamed `Distincting Counts` → `Distinct Counts`, `Materialize View` → `Materialized View`)
- Applies to both `current.json` and `version-4.x.json`

## Details

### Missing translations added (32)
New sidebar categories from the Performance section restructuring, Ecosystem section, Lakehouse catalogs, and data types that had no Chinese translation:

| English | Chinese |
|---|---|
| Performance | 性能优化 |
| Getting Started with Performance Tuning | 性能调优入门 |
| Query Performance | 查询性能 |
| Schema & Index Optimization | Schema 与索引优化 |
| Materialized View | 物化视图 |
| Async Materialized View | 异步物化视图 |
| Join Optimization | Join 优化 |
| Caching | 查询缓存 |
| Execution Tuning | 执行调优 |
| High Concurrency & Point Queries | 高并发与点查 |
| Distinct Counts | 高效去重 |
| Query Profile & Parameters | 查询 Profile 与参数 |
| Load Performance | 导入性能 |
| Optimization Technology Principles | 优化技术原理 |
| Read-Write Separation | 读写分离 |
| BI | BI 工具 |
| SQL Clients | SQL 客户端 |
| More | 更多 |
| Variant Functions | VARIANT 函数 |
| Binary Data Type | 二进制类型 |
| VARIANT / VARIANT Reference | VARIANT / VARIANT 参考 |

Proper nouns kept as-is: connector names (Spark/Flink/Kafka), catalog names (Iceberg/Paimon/Hudi/MaxCompute), database names (MySQL/PostgreSQL).

### Orphaned keys removed (48)
Translation keys that no longer match any sidebar label due to renames, restructuring, or removal. Examples:
- `Async-Materialized View` (hyphen removed in sidebar)
- `Distincting Counts` → renamed to `Distinct Counts`
- `Materialize View` → renamed to `Materialized View`
- `VARIANT Functions` → case changed to `Variant Functions`
- Old Performance hierarchy: `Queries Acceleration`, `Tuning`, `Tuning Plan`, `Tuning Execution`, `Performance Tuning Overview`
- Removed categories: `DDL`, `DML`, `Create`, `Drop`, `Show`, `Alter`, `Load`, etc.

## Test plan
- [ ] Verify Chinese site sidebar renders all categories in Chinese (no English fallback labels)
- [ ] Verify English site is unaffected
- [ ] Check both `/docs/` (current) and `/docs/4.x/` versions


🤖 Generated with [Claude Code](https://claude.com/claude-code)