### PR TITLE
[doc](iceberg) Document JDBC catalog name

### DIFF
--- a/docs/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/docs/lakehouse/catalogs/iceberg-catalog.mdx
@@ -55,6 +55,8 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
 
   * `dlf`: Uses Alibaba Cloud DLF as the metadata service.
 
+  * `jdbc`: Uses Iceberg JDBC Catalog as the metadata service.
+
   * `s3tables`: Uses AWS S3 Tables Catalog to visit [S3 Table Bucket](https://aws.amazon.com/s3/features/tables/).
 
 * `<warehouse>`
@@ -1062,6 +1064,7 @@ This is an experimental feature, supported since version 4.1.0.
             CREATE CATALOG iceberg_jdbc_postgresql PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_postgresql',
                 'iceberg.jdbc.uri' = 'jdbc:postgresql://127.0.0.1:5432/iceberg_db',
                 'iceberg.jdbc.user' = 'iceberg_user',
                 'iceberg.jdbc.password' = 'password',
@@ -1083,6 +1086,7 @@ This is an experimental feature, supported since version 4.1.0.
             CREATE CATALOG iceberg_jdbc_mysql PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_mysql',
                 'iceberg.jdbc.uri' = 'jdbc:mysql://127.0.0.1:3306/iceberg_db',
                 'iceberg.jdbc.user' = 'iceberg_user',
                 'iceberg.jdbc.password' = 'password',
@@ -1104,6 +1108,7 @@ This is an experimental feature, supported since version 4.1.0.
             CREATE CATALOG iceberg_jdbc_sqlite PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_sqlite',
                 'iceberg.jdbc.uri' = 'jdbc:sqlite:/tmp/iceberg_catalog.db',
                 'iceberg.jdbc.init-catalog-tables' = 'true',
                 'iceberg.jdbc.schema-version' = 'V1',

--- a/docs/lakehouse/metastores/iceberg-jdbc.md
+++ b/docs/lakehouse/metastores/iceberg-jdbc.md
@@ -17,8 +17,9 @@ This is an experimental feature, supported since version 4.1.0.
 | Property Name | Description | Default Value | Required |
 | --- | --- | --- | --- | 
 | iceberg.jdbc.uri | Specifies the JDBC connection URI | - | Yes |
-| iceberg.jdbc.user | JDBC connection username | - | Yes |
-| iceberg.jdbc.password | JDBC connection password | - | Yes |
+| iceberg.jdbc.catalog_name | Specifies the `catalog_name` isolation key in Iceberg JDBC metadata tables. This value can be different from the Doris catalog name. | - | Yes |
+| iceberg.jdbc.user | JDBC connection username | - | No |
+| iceberg.jdbc.password | JDBC connection password | - | No |
 | warehouse | Specifies the iceberg warehouse | - | Yes |
 | iceberg.jdbc.init-catalog-tables | Whether to automatically initialize Catalog-related table structures on first use | `true` | No |
 | iceberg.jdbc.schema-version | Schema version used by JDBC Catalog, supports `V0` and `V1` | `V0` | No |
@@ -31,6 +32,10 @@ This is an experimental feature, supported since version 4.1.0.
 > 1. Iceberg JDBC Catalog supports various relational databases as backend storage, including PostgreSQL, MySQL, SQLite, etc.
 >
 > 2. Ensure the JDBC driver JAR file is accessible. You can specify the driver location via `iceberg.jdbc.driver_url`.
+>
+> 3. `iceberg.jdbc.catalog_name` must match the Iceberg JDBC catalog name used by the writer, such as `spark_catalog` for metadata written by Spark.
+>
+> 4. If `iceberg.jdbc.driver_url` is specified, `iceberg.jdbc.driver_class` must also be specified.
 
 ## Example Configurations
 
@@ -42,6 +47,7 @@ Using PostgreSQL database to store Iceberg metadata:
 CREATE CATALOG iceberg_jdbc_postgresql PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_postgresql',
     'iceberg.jdbc.uri' = 'jdbc:postgresql://127.0.0.1:5432/iceberg_db',
     'iceberg.jdbc.user' = 'iceberg_user',
     'iceberg.jdbc.password' = 'password',
@@ -65,13 +71,14 @@ Using MySQL database to store Iceberg metadata:
 CREATE CATALOG iceberg_jdbc_mysql PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_mysql',
     'iceberg.jdbc.uri' = 'jdbc:mysql://127.0.0.1:3306/iceberg_db',
     'iceberg.jdbc.user' = 'iceberg_user',
     'iceberg.jdbc.password' = 'password',
     'iceberg.jdbc.init-catalog-tables' = 'true',
     'iceberg.jdbc.schema-version' = 'V1',
     'iceberg.jdbc.driver_class' = 'com.mysql.cj.jdbc.Driver',
-    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>'
+    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>',
     'warehouse' = 's3://bucket/warehouse',
     's3.access_key' = '<ak>',
     's3.secret_key' = '<sk>',
@@ -88,11 +95,12 @@ Using SQLite database to store Iceberg metadata (suitable for testing environmen
 CREATE CATALOG iceberg_jdbc_sqlite PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_sqlite',
     'iceberg.jdbc.uri' = 'jdbc:sqlite:/tmp/iceberg_catalog.db',
     'iceberg.jdbc.init-catalog-tables' = 'true',
     'iceberg.jdbc.schema-version' = 'V1',
     'iceberg.jdbc.driver_class' = 'org.sqlite.JDBC',
-    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>'
+    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>',
     'warehouse' = 's3://bucket/warehouse',
     's3.access_key' = '<ak>',
     's3.secret_key' = '<sk>',

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
@@ -2,7 +2,7 @@
 {
     "title": "Iceberg Catalog",
     "language": "zh-CN",
-    "description": "Apache Doris Iceberg Catalog 完整指南：支持 HMS、Glue、REST 等多种元数据服务，实现数据湖查询加速、数据读写、分区管理、Schema 变更等功能，提供 HDFS、S3、OSS 等存储系统集成方案。"
+    "description": "Apache Doris Iceberg Catalog 完整指南：支持 HMS、Glue、REST、JDBC 等多种元数据服务，实现数据湖查询加速、数据读写、分区管理、Schema 变更等功能，提供 HDFS、S3、OSS 等存储系统集成方案。"
 }
 ---
 
@@ -54,6 +54,8 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
   * `glue`：使用 AWS Glue 作为元数据服务。
 
   * `dlf`：使用阿里云 DLF 作为元数据服务。
+
+  * `jdbc`：使用 Iceberg JDBC Catalog 作为元数据服务。
 
   * `s3tables`：使用 AWS S3 Tables Catalog 访问 [S3 Table Bucket](https://aws.amazon.com/s3/features/tables/)。
 
@@ -1055,6 +1057,7 @@ Iceberg 的元数据层级关系是 Catalog -> Namespace -> Table。其中 Names
             CREATE CATALOG iceberg_jdbc_postgresql PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_postgresql',
                 'iceberg.jdbc.uri' = 'jdbc:postgresql://127.0.0.1:5432/iceberg_db',
                 'iceberg.jdbc.user' = 'iceberg_user',
                 'iceberg.jdbc.password' = 'password',
@@ -1076,6 +1079,7 @@ Iceberg 的元数据层级关系是 Catalog -> Namespace -> Table。其中 Names
             CREATE CATALOG iceberg_jdbc_mysql PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_mysql',
                 'iceberg.jdbc.uri' = 'jdbc:mysql://127.0.0.1:3306/iceberg_db',
                 'iceberg.jdbc.user' = 'iceberg_user',
                 'iceberg.jdbc.password' = 'password',
@@ -1097,6 +1101,7 @@ Iceberg 的元数据层级关系是 Catalog -> Namespace -> Table。其中 Names
             CREATE CATALOG iceberg_jdbc_sqlite PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_sqlite',
                 'iceberg.jdbc.uri' = 'jdbc:sqlite:/tmp/iceberg_catalog.db',
                 'iceberg.jdbc.init-catalog-tables' = 'true',
                 'iceberg.jdbc.schema-version' = 'V1',

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/metastores/iceberg-jdbc.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/metastores/iceberg-jdbc.md
@@ -17,8 +17,9 @@
 |属性名称 | 描述 | 默认值 | 是否必须 |
 | --- | --- | --- | --- | 
 | iceberg.jdbc.uri | 指定 JDBC 连接地址 | - | 是 |
-| iceberg.jdbc.user | JDBC 连接用户名 | - | 是 |
-| iceberg.jdbc.password | JDBC 连接密码 | - | 是 |
+| iceberg.jdbc.catalog_name | 指定 Iceberg JDBC 元数据表中的 `catalog_name` 隔离键，该值可以与 Doris 本地 Catalog 名不同 | - | 是 |
+| iceberg.jdbc.user | JDBC 连接用户名 | - | 否 |
+| iceberg.jdbc.password | JDBC 连接密码 | - | 否 |
 | warehouse | 指定 iceberg warehouse | - | 是 |
 | iceberg.jdbc.init-catalog-tables | 是否在首次使用时自动初始化 Catalog 相关的表结构 | `true` | 否 |
 | iceberg.jdbc.schema-version | JDBC Catalog 使用的 Schema 版本，支持 `V0` 和 `V1` | `V0` | 否 |
@@ -31,6 +32,10 @@
 > 1. Iceberg JDBC Catalog 支持多种关系型数据库作为后端存储，包括 PostgreSQL、MySQL、SQLite 等。
 >
 > 2. 需要确保 JDBC 驱动 JAR 包可访问。可以通过 `iceberg.jdbc.driver_url` 指定驱动位置。
+>
+> 3. `iceberg.jdbc.catalog_name` 必须与写入端使用的 Iceberg JDBC catalog 名一致，例如读取 Spark 写入的元数据时通常为 `spark_catalog`。
+>
+> 4. 如果指定了 `iceberg.jdbc.driver_url`，也必须同时指定 `iceberg.jdbc.driver_class`。
 
 ## 示例配置
 
@@ -42,6 +47,7 @@
 CREATE CATALOG iceberg_jdbc_postgresql PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_postgresql',
     'iceberg.jdbc.uri' = 'jdbc:postgresql://127.0.0.1:5432/iceberg_db',
     'iceberg.jdbc.user' = 'iceberg_user',
     'iceberg.jdbc.password' = 'password',
@@ -65,13 +71,14 @@ CREATE CATALOG iceberg_jdbc_postgresql PROPERTIES (
 CREATE CATALOG iceberg_jdbc_mysql PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_mysql',
     'iceberg.jdbc.uri' = 'jdbc:mysql://127.0.0.1:3306/iceberg_db',
     'iceberg.jdbc.user' = 'iceberg_user',
     'iceberg.jdbc.password' = 'password',
     'iceberg.jdbc.init-catalog-tables' = 'true',
     'iceberg.jdbc.schema-version' = 'V1',
     'iceberg.jdbc.driver_class' = 'com.mysql.cj.jdbc.Driver',
-    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>'
+    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>',
     'warehouse' = 's3://bucket/warehouse',
     's3.access_key' = '<ak>',
     's3.secret_key' = '<sk>',
@@ -88,11 +95,12 @@ CREATE CATALOG iceberg_jdbc_mysql PROPERTIES (
 CREATE CATALOG iceberg_jdbc_sqlite PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_sqlite',
     'iceberg.jdbc.uri' = 'jdbc:sqlite:/tmp/iceberg_catalog.db',
     'iceberg.jdbc.init-catalog-tables' = 'true',
     'iceberg.jdbc.schema-version' = 'V1',
     'iceberg.jdbc.driver_class' = 'org.sqlite.JDBC',
-    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>'
+    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>',
     'warehouse' = 's3://bucket/warehouse',
     's3.access_key' = '<ak>',
     's3.secret_key' = '<sk>',

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/iceberg-catalog.mdx
@@ -2,7 +2,7 @@
 {
     "title": "Iceberg Catalog",
     "language": "zh-CN",
-    "description": "Apache Doris Iceberg Catalog 完整指南：支持 HMS、Glue、REST 等多种元数据服务，实现数据湖查询加速、数据读写、分区管理、Schema 变更等功能，提供 HDFS、S3、OSS 等存储系统集成方案。"
+    "description": "Apache Doris Iceberg Catalog 完整指南：支持 HMS、Glue、REST、JDBC 等多种元数据服务，实现数据湖查询加速、数据读写、分区管理、Schema 变更等功能，提供 HDFS、S3、OSS 等存储系统集成方案。"
 }
 ---
 
@@ -54,6 +54,8 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
   * `glue`：使用 AWS Glue 作为元数据服务。
 
   * `dlf`：使用阿里云 DLF 作为元数据服务。
+
+  * `jdbc`：使用 Iceberg JDBC Catalog 作为元数据服务。
 
   * `s3tables`：使用 AWS S3 Tables Catalog 访问 [S3 Table Bucket](https://aws.amazon.com/s3/features/tables/)。
 
@@ -1055,6 +1057,7 @@ Iceberg 的元数据层级关系是 Catalog -> Namespace -> Table。其中 Names
             CREATE CATALOG iceberg_jdbc_postgresql PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_postgresql',
                 'iceberg.jdbc.uri' = 'jdbc:postgresql://127.0.0.1:5432/iceberg_db',
                 'iceberg.jdbc.user' = 'iceberg_user',
                 'iceberg.jdbc.password' = 'password',
@@ -1076,6 +1079,7 @@ Iceberg 的元数据层级关系是 Catalog -> Namespace -> Table。其中 Names
             CREATE CATALOG iceberg_jdbc_mysql PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_mysql',
                 'iceberg.jdbc.uri' = 'jdbc:mysql://127.0.0.1:3306/iceberg_db',
                 'iceberg.jdbc.user' = 'iceberg_user',
                 'iceberg.jdbc.password' = 'password',
@@ -1097,6 +1101,7 @@ Iceberg 的元数据层级关系是 Catalog -> Namespace -> Table。其中 Names
             CREATE CATALOG iceberg_jdbc_sqlite PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_sqlite',
                 'iceberg.jdbc.uri' = 'jdbc:sqlite:/tmp/iceberg_catalog.db',
                 'iceberg.jdbc.init-catalog-tables' = 'true',
                 'iceberg.jdbc.schema-version' = 'V1',

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/metastores/iceberg-jdbc.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/metastores/iceberg-jdbc.md
@@ -17,8 +17,9 @@
 |属性名称 | 描述 | 默认值 | 是否必须 |
 | --- | --- | --- | --- | 
 | iceberg.jdbc.uri | 指定 JDBC 连接地址 | - | 是 |
-| iceberg.jdbc.user | JDBC 连接用户名 | - | 是 |
-| iceberg.jdbc.password | JDBC 连接密码 | - | 是 |
+| iceberg.jdbc.catalog_name | 指定 Iceberg JDBC 元数据表中的 `catalog_name` 隔离键，该值可以与 Doris 本地 Catalog 名不同 | - | 是 |
+| iceberg.jdbc.user | JDBC 连接用户名 | - | 否 |
+| iceberg.jdbc.password | JDBC 连接密码 | - | 否 |
 | warehouse | 指定 iceberg warehouse | - | 是 |
 | iceberg.jdbc.init-catalog-tables | 是否在首次使用时自动初始化 Catalog 相关的表结构 | `true` | 否 |
 | iceberg.jdbc.schema-version | JDBC Catalog 使用的 Schema 版本，支持 `V0` 和 `V1` | `V0` | 否 |
@@ -31,6 +32,10 @@
 > 1. Iceberg JDBC Catalog 支持多种关系型数据库作为后端存储，包括 PostgreSQL、MySQL、SQLite 等。
 >
 > 2. 需要确保 JDBC 驱动 JAR 包可访问。可以通过 `iceberg.jdbc.driver_url` 指定驱动位置。
+>
+> 3. `iceberg.jdbc.catalog_name` 必须与写入端使用的 Iceberg JDBC catalog 名一致，例如读取 Spark 写入的元数据时通常为 `spark_catalog`。
+>
+> 4. 如果指定了 `iceberg.jdbc.driver_url`，也必须同时指定 `iceberg.jdbc.driver_class`。
 
 ## 示例配置
 
@@ -42,6 +47,7 @@
 CREATE CATALOG iceberg_jdbc_postgresql PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_postgresql',
     'iceberg.jdbc.uri' = 'jdbc:postgresql://127.0.0.1:5432/iceberg_db',
     'iceberg.jdbc.user' = 'iceberg_user',
     'iceberg.jdbc.password' = 'password',
@@ -65,13 +71,14 @@ CREATE CATALOG iceberg_jdbc_postgresql PROPERTIES (
 CREATE CATALOG iceberg_jdbc_mysql PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_mysql',
     'iceberg.jdbc.uri' = 'jdbc:mysql://127.0.0.1:3306/iceberg_db',
     'iceberg.jdbc.user' = 'iceberg_user',
     'iceberg.jdbc.password' = 'password',
     'iceberg.jdbc.init-catalog-tables' = 'true',
     'iceberg.jdbc.schema-version' = 'V1',
     'iceberg.jdbc.driver_class' = 'com.mysql.cj.jdbc.Driver',
-    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>'
+    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>',
     'warehouse' = 's3://bucket/warehouse',
     's3.access_key' = '<ak>',
     's3.secret_key' = '<sk>',
@@ -88,11 +95,12 @@ CREATE CATALOG iceberg_jdbc_mysql PROPERTIES (
 CREATE CATALOG iceberg_jdbc_sqlite PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_sqlite',
     'iceberg.jdbc.uri' = 'jdbc:sqlite:/tmp/iceberg_catalog.db',
     'iceberg.jdbc.init-catalog-tables' = 'true',
     'iceberg.jdbc.schema-version' = 'V1',
     'iceberg.jdbc.driver_class' = 'org.sqlite.JDBC',
-    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>'
+    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>',
     'warehouse' = 's3://bucket/warehouse',
     's3.access_key' = '<ak>',
     's3.secret_key' = '<sk>',

--- a/versioned_docs/version-4.x/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/versioned_docs/version-4.x/lakehouse/catalogs/iceberg-catalog.mdx
@@ -55,6 +55,8 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
 
   * `dlf`: Uses Alibaba Cloud DLF as the metadata service.
 
+  * `jdbc`: Uses Iceberg JDBC Catalog as the metadata service.
+
   * `s3tables`: Uses AWS S3 Tables Catalog to visit [S3 Table Bucket](https://aws.amazon.com/s3/features/tables/).
 
 * `<warehouse>`
@@ -1062,6 +1064,7 @@ This is an experimental feature, supported since version 4.1.0.
             CREATE CATALOG iceberg_jdbc_postgresql PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_postgresql',
                 'iceberg.jdbc.uri' = 'jdbc:postgresql://127.0.0.1:5432/iceberg_db',
                 'iceberg.jdbc.user' = 'iceberg_user',
                 'iceberg.jdbc.password' = 'password',
@@ -1083,6 +1086,7 @@ This is an experimental feature, supported since version 4.1.0.
             CREATE CATALOG iceberg_jdbc_mysql PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_mysql',
                 'iceberg.jdbc.uri' = 'jdbc:mysql://127.0.0.1:3306/iceberg_db',
                 'iceberg.jdbc.user' = 'iceberg_user',
                 'iceberg.jdbc.password' = 'password',
@@ -1104,6 +1108,7 @@ This is an experimental feature, supported since version 4.1.0.
             CREATE CATALOG iceberg_jdbc_sqlite PROPERTIES (
                 'type' = 'iceberg',
                 'iceberg.catalog.type' = 'jdbc',
+                'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_sqlite',
                 'iceberg.jdbc.uri' = 'jdbc:sqlite:/tmp/iceberg_catalog.db',
                 'iceberg.jdbc.init-catalog-tables' = 'true',
                 'iceberg.jdbc.schema-version' = 'V1',

--- a/versioned_docs/version-4.x/lakehouse/metastores/iceberg-jdbc.md
+++ b/versioned_docs/version-4.x/lakehouse/metastores/iceberg-jdbc.md
@@ -17,8 +17,9 @@ This is an experimental feature, supported since version 4.1.0.
 | Property Name | Description | Default Value | Required |
 | --- | --- | --- | --- | 
 | iceberg.jdbc.uri | Specifies the JDBC connection URI | - | Yes |
-| iceberg.jdbc.user | JDBC connection username | - | Yes |
-| iceberg.jdbc.password | JDBC connection password | - | Yes |
+| iceberg.jdbc.catalog_name | Specifies the `catalog_name` isolation key in Iceberg JDBC metadata tables. This value can be different from the Doris catalog name. | - | Yes |
+| iceberg.jdbc.user | JDBC connection username | - | No |
+| iceberg.jdbc.password | JDBC connection password | - | No |
 | warehouse | Specifies the iceberg warehouse | - | Yes |
 | iceberg.jdbc.init-catalog-tables | Whether to automatically initialize Catalog-related table structures on first use | `true` | No |
 | iceberg.jdbc.schema-version | Schema version used by JDBC Catalog, supports `V0` and `V1` | `V0` | No |
@@ -31,6 +32,10 @@ This is an experimental feature, supported since version 4.1.0.
 > 1. Iceberg JDBC Catalog supports various relational databases as backend storage, including PostgreSQL, MySQL, SQLite, etc.
 >
 > 2. Ensure the JDBC driver JAR file is accessible. You can specify the driver location via `iceberg.jdbc.driver_url`.
+>
+> 3. `iceberg.jdbc.catalog_name` must match the Iceberg JDBC catalog name used by the writer, such as `spark_catalog` for metadata written by Spark.
+>
+> 4. If `iceberg.jdbc.driver_url` is specified, `iceberg.jdbc.driver_class` must also be specified.
 
 ## Example Configurations
 
@@ -42,6 +47,7 @@ Using PostgreSQL database to store Iceberg metadata:
 CREATE CATALOG iceberg_jdbc_postgresql PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_postgresql',
     'iceberg.jdbc.uri' = 'jdbc:postgresql://127.0.0.1:5432/iceberg_db',
     'iceberg.jdbc.user' = 'iceberg_user',
     'iceberg.jdbc.password' = 'password',
@@ -65,13 +71,14 @@ Using MySQL database to store Iceberg metadata:
 CREATE CATALOG iceberg_jdbc_mysql PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_mysql',
     'iceberg.jdbc.uri' = 'jdbc:mysql://127.0.0.1:3306/iceberg_db',
     'iceberg.jdbc.user' = 'iceberg_user',
     'iceberg.jdbc.password' = 'password',
     'iceberg.jdbc.init-catalog-tables' = 'true',
     'iceberg.jdbc.schema-version' = 'V1',
     'iceberg.jdbc.driver_class' = 'com.mysql.cj.jdbc.Driver',
-    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>'
+    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>',
     'warehouse' = 's3://bucket/warehouse',
     's3.access_key' = '<ak>',
     's3.secret_key' = '<sk>',
@@ -88,11 +95,12 @@ Using SQLite database to store Iceberg metadata (suitable for testing environmen
 CREATE CATALOG iceberg_jdbc_sqlite PROPERTIES (
     'type' = 'iceberg',
     'iceberg.catalog.type' = 'jdbc',
+    'iceberg.jdbc.catalog_name' = 'iceberg_jdbc_sqlite',
     'iceberg.jdbc.uri' = 'jdbc:sqlite:/tmp/iceberg_catalog.db',
     'iceberg.jdbc.init-catalog-tables' = 'true',
     'iceberg.jdbc.schema-version' = 'V1',
     'iceberg.jdbc.driver_class' = 'org.sqlite.JDBC',
-    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>'
+    'iceberg.jdbc.driver_url' = '<jdbc_driver_jar>',
     'warehouse' = 's3://bucket/warehouse',
     's3.access_key' = '<ak>',
     's3.secret_key' = '<sk>',


### PR DESCRIPTION
## Description

Document the required `iceberg.jdbc.catalog_name` property for Iceberg JDBC Catalog.

This updates the current and 4.x Iceberg Catalog docs in both English and Chinese:

- Add `jdbc` to the supported `iceberg.catalog.type` values.
- Add required `iceberg.jdbc.catalog_name` to the Iceberg JDBC Catalog parameter table.
- Explain that it maps to the `catalog_name` isolation key in Iceberg JDBC metadata tables and can differ from the Doris local catalog name.
- Update PostgreSQL, MySQL, and SQLite examples to include the property.
- Correct `iceberg.jdbc.user` and `iceberg.jdbc.password` from required to optional.
- Note that `iceberg.jdbc.driver_class` is required when `iceberg.jdbc.driver_url` is specified.

Related Doris PR: https://github.com/apache/doris/pull/62806

## Testing

- `git diff --check HEAD~1..HEAD`
