### PR TITLE
chore(docs): add governance pilot fixtures to exercise lint rules

### DIFF
--- a/docs/_governance-pilot/feature-doc-bad.md
+++ b/docs/_governance-pilot/feature-doc-bad.md
@@ -1,0 +1,13 @@
+---
+title: "Fixture: feature doc missing sections"
+description: "This fixture is tagged as a feature doc but intentionally omits most required sections so that feature-doc-section-required fires for each one."
+doc_type: feature
+---
+
+# Fixture: feature doc missing sections
+
+## Random other section
+
+Only an unrelated section is present. Overview, Quick Start,
+Parameters/Options, Examples, Error handling and Best practices are all
+missing on purpose.

--- a/docs/_governance-pilot/frontmatter-missing.md
+++ b/docs/_governance-pilot/frontmatter-missing.md
@@ -1,0 +1,13 @@
+---
+language: en
+---
+
+# Fixture: frontmatter missing
+
+This page intentionally omits both `title` and `description` front matter to
+trigger the frontmatter-title-required and frontmatter-description-required
+rules.
+
+## Body
+
+Some text to satisfy the body requirement.

--- a/docs/_governance-pilot/frontmatter-type-errors.md
+++ b/docs/_governance-pilot/frontmatter-type-errors.md
@@ -1,0 +1,16 @@
+---
+title: "Fixture: frontmatter type errors"
+description: "This fixture has frontmatter fields with the wrong types to trigger the frontmatter type rules in the docs governance lint."
+slug: 12345
+keywords: 42
+tags: "should-be-array"
+sidebar_position: "not-a-number"
+---
+
+# Fixture: frontmatter type errors
+
+Intentionally wrong types on `slug`, `keywords`, `tags`, `sidebar_position`.
+
+## Body
+
+Content body.

--- a/docs/_governance-pilot/i18n-sync-only-en.md
+++ b/docs/_governance-pilot/i18n-sync-only-en.md
@@ -1,0 +1,12 @@
+---
+title: "Fixture: i18n sync only English"
+description: "This fixture intentionally ships only the English current-version copy so the i18n-sync lint reports missing zh-CN, missing 4.x, and the Japanese candidate."
+---
+
+# Fixture: i18n sync only English
+
+This doc exists only in English `current`. The i18n sync lint should report:
+
+- `i18n-sync-version-missing` for the 4.x counterpart
+- `i18n-sync-locale-missing` for the zh-CN counterpart
+- `i18n-sync-locale-candidate` for the Japanese candidate

--- a/docs/_governance-pilot/links-broken.md
+++ b/docs/_governance-pilot/links-broken.md
@@ -1,0 +1,24 @@
+---
+title: "Fixture: broken links"
+description: "This fixture intentionally contains broken internal links and missing anchors to trigger the blocking changed-only link gate."
+---
+
+# Fixture: broken links
+
+## Missing internal file
+
+See [this missing doc](./does-not-exist.md) which should trigger the
+internal-file-missing rule.
+
+## Missing anchor in existing doc
+
+See [missing anchor](../gettingStarted/what-is-apache-doris.md#this-anchor-does-not-exist)
+which should trigger the missing-anchor rule.
+
+## Missing route
+
+Also [this route](/docs/this-route-does-not-exist) should not resolve.
+
+## External link (report-only today)
+
+See the [example external link](https://this-domain-absolutely-does-not-exist-doris-governance.invalid/some-page).

--- a/docs/_governance-pilot/markdown-structure-bad.md
+++ b/docs/_governance-pilot/markdown-structure-bad.md
@@ -1,0 +1,32 @@
+---
+title: "Fixture: markdown structure issues"
+description: "This fixture intentionally violates Markdown structure rules to trigger code fence, heading and CJK spacing lints."
+---
+
+# First H1 heading
+
+Some intro text in English. 这里是中文和English单词直接相连，没空格，应该触发 markdown-cjk-spacing 规则。例如 Doris3.0 这种写法也会触发。
+
+####  Skipped from H1 to H4 to trigger heading increment rule
+
+Body under an invalid heading jump.
+
+##
+
+Above heading is empty so it should trigger markdown-empty-heading.
+
+# Second H1 which should not exist
+
+This second H1 should trigger markdown-single-h1.
+
+## Code fence without language
+
+```
+SELECT * FROM tbl;
+```
+
+## Code fence with language (control)
+
+```sql
+SELECT 1;
+```

--- a/docs/_governance-pilot/seo-bad-a.md
+++ b/docs/_governance-pilot/seo-bad-a.md
@@ -1,0 +1,9 @@
+---
+title: "Fixture SEO Duplicate Title"
+description: "Apache Doris documentation."
+---
+
+# Fixture SEO duplicate title (a)
+
+Intentionally a very short and generic description. This page shares its
+title with `seo-bad-b.md` to trigger the duplicate-title rule.

--- a/docs/_governance-pilot/seo-bad-b.md
+++ b/docs/_governance-pilot/seo-bad-b.md
@@ -1,0 +1,9 @@
+---
+title: "Fixture SEO Duplicate Title"
+description: "Docs."
+---
+
+# Fixture SEO duplicate title (b)
+
+Intentionally duplicate title + too-short generic description to exercise
+seo-title-duplicate, seo-description-length and seo-description-generic.

--- a/docs/_governance-pilot/sidebar-orphan.md
+++ b/docs/_governance-pilot/sidebar-orphan.md
@@ -1,0 +1,13 @@
+---
+title: "Fixture: sidebar orphan"
+description: "This fixture is a new doc that is intentionally not registered in sidebars.ts to trigger the sidebar orphan rule."
+---
+
+# Fixture: sidebar orphan
+
+This doc id is not added to `sidebars.ts`, so it should be reported as an
+orphan by the sidebar lint.
+
+## Body
+
+Nothing linkable here.

--- a/docs/sql-manual/sql-functions/scalar-functions/string-functions/doris-governance-fixture-bad.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/string-functions/doris-governance-fixture-bad.md
@@ -1,0 +1,40 @@
+---
+title: "doris_governance_fixture_bad"
+description: "Fixture SQL function documentation with intentionally broken structure to trigger the SQL function governance lint rules."
+---
+
+# doris_governance_fixture_bad
+
+## Syntax
+
+```sql
+doris_governance_fixture_bad(expr)
+```
+
+```python
+# extra code block in Syntax section to violate sql-function-syntax-sql-code-block
+print("bad")
+```
+
+## Description
+
+Intentionally placed after Syntax, violating sql-function-section-order.
+
+## Parameters
+
+Parameters are described as a bullet list to violate sql-function-parameters-table:
+
+- `expr`: some expression.
+
+## Return Value
+
+Returns something useful.
+
+## Example
+
+```sql
+SELECT doris_governance_fixture_bad('x');
+```
+
+No expected `text` output block is provided, so sql-function-example-output
+should fire here.

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/faq/bi-faq.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/faq/bi-faq.md
@@ -6,6 +6,8 @@
 }
 ---
 
+<!-- governance-pilot: fixture edit to exercise i18n-sync-source-counterpart; remove before merge -->
+
 ## Power BI
 
 ### Q1. JDBC 拉取表到 Desktop Power BI 时报错 Timeout expired. The timeout period elapsed prior to completion of the operation or the server is not responding.


### PR DESCRIPTION
Fixture PR to verify each docs governance check family end-to-end: front matter, markdown structure, sidebar orphan, link gate, SEO/GEO, SQL function doc quality, feature doc quality, and i18n/version sync.

Locally triggers 31 distinct rules, including the blocking changed-only internal link gate (link-missing-target and link-missing-anchor). Fixtures live under docs/_governance-pilot/ plus one SQL function fixture under docs/sql-manual/sql-functions/... A single-line fixture edit is added to an existing zh-CN FAQ to exercise i18n-sync-source-counterpart; that line is a marked HTML comment.

Not intended to merge as-is; the author will review before pushing.