### PR TITLE
[docs] Fix CREATE INDEX examples in 3.x and 4.x Chinese docs and English docs

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-statements/table-and-view/index/CREATE-INDEX.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-statements/table-and-view/index/CREATE-INDEX.md
@@ -84,11 +84,11 @@ CREATE INDEX [IF NOT EXISTS] <index_name>
 - 在 table1 上创建倒排索引 index1
 
     ```sql
-    CREATE INDEX index1 ON table1 USING INVERTED;
+    CREATE INDEX index1 ON table1(col1) USING INVERTED;
     ```
 
 - 在 table1 上创建 NGram BloomFilter 索引 index2
 
     ```sql
-    CREATE INDEX index2 ON table1 USING NGRAM_BF PROPERTIES("gram_size"="3", "bf_size"="1024");
+    CREATE INDEX index2 ON table1(col1) USING NGRAM_BF PROPERTIES("gram_size"="3", "bf_size"="1024");
     ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/table-and-view/index/CREATE-INDEX.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/table-and-view/index/CREATE-INDEX.md
@@ -84,13 +84,13 @@ CREATE INDEX [IF NOT EXISTS] <index_name>
 - 在 table1 上创建倒排索引 index1
 
     ```sql
-    CREATE INDEX index1 ON table1 USING INVERTED;
+    CREATE INDEX index1 ON table1(col1) USING INVERTED;
     ```
 
 - 在 table1 上创建 NGram BloomFilter 索引 index2
 
     ```sql
-    CREATE INDEX index2 ON table1 USING NGRAM_BF PROPERTIES("gram_size"="3", "bf_size"="1024");
+    CREATE INDEX index2 ON table1(col1) USING NGRAM_BF PROPERTIES("gram_size"="3", "bf_size"="1024");
     ```
 
 - 在table1 上创建 ANN 索引 index3

--- a/versioned_docs/version-3.x/sql-manual/sql-statements/table-and-view/index/CREATE-INDEX.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-statements/table-and-view/index/CREATE-INDEX.md
@@ -87,7 +87,7 @@ The user executing this SQL command must have at least the following permissions
   
 
   ```sql
-  CREATE INDEX index1 ON table1 USING INVERTED;
+  CREATE INDEX index1 ON table1(col1) USING INVERTED;
   ```
 
 - Create an NGram BloomFilter index `index2` on `table1`
@@ -95,5 +95,5 @@ The user executing this SQL command must have at least the following permissions
   
 
   ```sql
-  CREATE INDEX index2 ON table1 USING NGRAM_BF PROPERTIES("gram_size"="3", "bf_size"="1024");
+  CREATE INDEX index2 ON table1(col1) USING NGRAM_BF PROPERTIES("gram_size"="3", "bf_size"="1024");
   ```

--- a/versioned_docs/version-4.x/sql-manual/sql-statements/table-and-view/index/CREATE-INDEX.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-statements/table-and-view/index/CREATE-INDEX.md
@@ -87,8 +87,7 @@ The user executing this SQL command must have at least the following permissions
   
 
   ```sql
-it fails .. must mention to add col. in the documentation
-CREATE INDEX index1 ON t1sa (col1) USING INVERTED;
+  CREATE INDEX index1 ON table1(col1) USING INVERTED;
   ```
 
 - Create an NGram BloomFilter index `index2` on `table1`
@@ -96,7 +95,7 @@ CREATE INDEX index1 ON t1sa (col1) USING INVERTED;
   
 
   ```sql
-  CREATE INDEX index2 ON table1 USING NGRAM_BF PROPERTIES("gram_size"="3", "bf_size"="1024");
+  CREATE INDEX index2 ON table1(col1) USING NGRAM_BF PROPERTIES("gram_size"="3", "bf_size"="1024");
   ```
 
 


### PR DESCRIPTION
## What changed

Fix incorrect SQL examples in the Chinese `CREATE INDEX` documentation for Doris 3.x and 4.x.

The examples missed the required indexed column list after the table name. This PR also clarifies that the column list is mandatory in the syntax description.

## Versions

- [ ] dev
- [x] 3.x
- [x] 4.x
- [ ] 2.1

## Languages

- [x] English
- [x] Chinese
