### PR TITLE
[doc] add MySQL and PostgreSQL data source pages

### DIFF
--- a/docs/data-operate/import/data-source/migrate-data-from-other-oltp.md
+++ b/docs/data-operate/import/data-source/migrate-data-from-other-oltp.md
@@ -34,7 +34,7 @@ AS
 SELECT * FROM iceberg_catalog.iceberg_db.table1;
 ```
 
-For more details, refer to [Catalog Data Load](../../../lakehouse/catalog-overview.md#data-import)。
+For more details, refer to [Catalog Data Load](../../../lakehouse/catalog-overview.md#data-ingestion)。
 
 ## Flink Doris Connector
 
@@ -133,7 +133,7 @@ You can leverage Flink to achieve offline and real-time synchronization for TP s
       --sink-conf sink.label-prefix=label \
       --table-conf replication_num=1 
   ```    
-  For more details, refer to [Full Database Synchronization](../../../ecosystem/flink-doris-connector.md#full-database-synchronization)
+  For more details, refer to [Full Database Synchronization](../../../ecosystem/flink-doris-connector/flink-doris-connector.md#full-database-synchronization)
 
 ## Spark Connector
 You can use the JDBC Source and Doris Sink of the Spark Connector to complete the data write.
@@ -153,7 +153,7 @@ val jdbcDF = spark.read
   .option("password", "")
   .save() 
 ```
-For more details, refer to [JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector.md#batch-write)
+For more details, refer to [JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector/spark-doris-connector.md#batch-write)
 
 ## DataX / Seatunnel / CloudCanal and other third-party tools.
 

--- a/docs/data-operate/import/data-source/migrate-data-from-other-oltp.md
+++ b/docs/data-operate/import/data-source/migrate-data-from-other-oltp.md
@@ -155,30 +155,6 @@ val jdbcDF = spark.read
 ```
 For more details, refer to [JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector.md#batch-write)
 
-## Streaming Job
-
-Use Streaming Job to synchronize data from MySQL or Postgres.
-
-```sql
-CREATE JOB multi_table_sync
-ON STREAMING
-FROM MYSQL (
-        "jdbc_url" = "jdbc:mysql://127.0.0.1:3306",
-        "driver_url" = "mysql-connector-j-8.0.31.jar",
-        "driver_class" = "com.mysql.cj.jdbc.Driver",
-        "user" = "root",
-        "password" = "123456",
-        "database" = "test",
-        "include_tables" = "user_info,order_info",
-        "offset" = "initial"
-)
-TO DATABASE target_test_db (
-    "table.create.properties.replication_num" = "1"
-)
-```
-
-For more details, refer to: [Postgres/MySQL Continuous Load](../streaming-job/streaming-job-multi-table.md)
-
 ## DataX / Seatunnel / CloudCanal and other third-party tools.
 
 In addition, you can also use third-party synchronization tools for data synchronization. For more details, please refer to:

--- a/docs/data-operate/import/data-source/mysql.md
+++ b/docs/data-operate/import/data-source/mysql.md
@@ -1,0 +1,248 @@
+---
+{
+    "title": "MySQL",
+    "language": "en",
+    "description": "Doris provides multiple ways to load data from MySQL, including ad-hoc loading via JDBC Catalog, continuous full + incremental synchronization via Streaming Job, and CDC sync via Flink Doris Connector."
+}
+---
+
+Doris provides the following ways to load data from MySQL:
+
+- **Loading MySQL data via JDBC Catalog**
+
+Doris uses JDBC Catalog to map MySQL as an external catalog, allowing direct SQL queries against MySQL data. Combined with `INSERT INTO` or `CREATE TABLE AS SELECT`, this is suitable for one-time migration or periodic batch loading.
+
+- **Continuously syncing MySQL data via Streaming Job**
+
+Doris uses Streaming Job to continuously sync full and incremental data from MySQL to Doris. By integrating [Flink CDC](https://github.com/apache/flink-cdc) reading capability, Doris keeps the job running, reads Binlog from MySQL and writes it to Doris tables with exactly-once semantics. Two modes are supported: table-level sync and database-level sync. Available since Doris 4.1.0.
+
+- **Loading MySQL data via Flink Doris Connector**
+
+Use Flink Doris Connector together with Flink MySQL CDC for real-time synchronization. This is suitable for scenarios that require additional Flink stream processing logic. The connector also provides a one-click full-database synchronization tool. For details, see [Flink Doris Connector](../../../ecosystem/flink-doris-connector/flink-doris-connector.md).
+
+- **Loading MySQL data via third-party tools**
+
+Data integration tools such as [DataX](../../../ecosystem/datax), [SeaTunnel](../../../ecosystem/seatunnel), and [CloudCanal](../../../ecosystem/cloudcanal) also support syncing data from MySQL to Doris.
+
+In most cases, you can use JDBC Catalog directly for one-time data migration. When continuous full + incremental synchronization is required, Streaming Job is recommended.
+
+## Loading MySQL data via JDBC Catalog
+
+Use JDBC Catalog to map MySQL as an external catalog, then use `INSERT INTO` or `CREATE TABLE AS SELECT` to load data. For detailed syntax, see [JDBC MySQL Catalog](../../../lakehouse/catalogs/jdbc-mysql-catalog.md).
+
+### Step 1: Prepare data in MySQL
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+### Step 2: Create a Catalog in Doris
+
+```sql
+CREATE CATALOG mysql_catalog PROPERTIES (
+    "type"         = "jdbc",
+    "user"         = "root",
+    "password"     = "123456",
+    "jdbc_url"     = "jdbc:mysql://127.0.0.1:3306/test",
+    "driver_url"   = "mysql-connector-java-8.0.25.jar",
+    "driver_class" = "com.mysql.cj.jdbc.Driver"
+);
+```
+
+### Step 3: Create the target table in Doris
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id     INT,
+    name   VARCHAR(64),
+    age    INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+### Step 4: Load data with INSERT INTO
+
+```sql
+INSERT INTO doris_db.students
+SELECT id, name, age FROM mysql_catalog.test.students;
+```
+
+If the target table does not exist yet, you can also use `CREATE TABLE AS SELECT` to create the table and load data in one step:
+
+```sql
+CREATE TABLE doris_db.students
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT * FROM mysql_catalog.test.students;
+```
+
+### Step 5: Verify loaded data
+
+```sql
+SELECT * FROM doris_db.students;
++----+-------+------+
+| id | name  | age  |
++----+-------+------+
+|  1 | Emily |   25 |
+|  2 | Bob   |   30 |
++----+-------+------+
+```
+
+## Continuously syncing MySQL data via Streaming Job
+
+Streaming Job continuously reads MySQL Binlog via Flink CDC and writes it to Doris. Two modes are supported:
+
+- [MySQL Database-Level Sync](../streaming-job/continuous-load-mysql-database.md): sync at the database level (use `include_tables` to sync one, several, or all tables). Doris automatically creates downstream tables on first sync. Provides at-least-once semantics.
+- [MySQL Table-Level Sync](../streaming-job/continuous-load-mysql-table.md): sync at the table level. The target table must be pre-created in Doris. Supports flexible column mapping, data transformation, and exactly-once semantics.
+
+### Limitations
+
+1. Only primary key tables (Unique Key) are supported.
+2. Load privilege is required. Database-level sync also needs Create privilege when auto-creating downstream tables on first run.
+3. Available since Doris 4.1.0.
+
+### Prerequisites
+
+Before submitting a Streaming Job, Binlog must be enabled on the MySQL side and the user must be granted the corresponding REPLICATION privileges. For environment-specific setup steps, see:
+
+- [Amazon RDS MySQL Setup Guide](../streaming-job/prerequisites/amazon-rds-mysql.md)
+- [Amazon Aurora MySQL Setup Guide](../streaming-job/prerequisites/amazon-aurora-mysql.md)
+- See [Continuous Load Overview](../streaming-job/continuous-load-overview.md) for notes and required permissions of each mode.
+
+### Operation Example: Database-Level Sync
+
+Database-level sync uses the `FROM MYSQL ... TO DATABASE ...` syntax. The target is a Doris database, and the downstream tables are automatically created on first sync.
+
+#### Step 1: Prepare data in MySQL
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### Step 2: Create the target database in Doris
+
+Database-level sync **does not require pre-creating tables**, but the target database that hosts them must exist:
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+```
+
+#### Step 3: Create a Streaming Job
+
+The example below uses `include_tables` to sync only the `students` table (multiple tables can be comma-separated; leave empty to sync the whole database):
+
+```sql
+CREATE JOB mysql_db_sync
+ON STREAMING
+FROM MYSQL (
+    "jdbc_url"       = "jdbc:mysql://127.0.0.1:3306",
+    "driver_url"     = "mysql-connector-java-8.0.25.jar",
+    "driver_class"   = "com.mysql.cj.jdbc.Driver",
+    "user"           = "root",
+    "password"       = "123456",
+    "database"       = "test",
+    "include_tables" = "students",
+    "offset"         = "initial"
+)
+TO DATABASE doris_db (
+    "table.create.properties.replication_num" = "1"  -- set to 1 in single-BE deployments
+);
+```
+
+#### Step 4: Check job status
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### Step 5: Inspect auto-created Doris tables and loaded data
+
+```sql
+SHOW TABLES FROM doris_db;
+SELECT * FROM doris_db.students;
+```
+
+For more common operations and full parameter reference, see [MySQL Database-Level Sync](../streaming-job/continuous-load-mysql-database.md).
+
+### Operation Example: Table-Level Sync
+
+#### Step 1: Prepare data in MySQL
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### Step 2: Create the target table in Doris
+
+Table-level sync requires the target table to exist beforehand:
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id     INT,
+    name   VARCHAR(64),
+    age    INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+#### Step 3: Create a Streaming Job
+
+Use [CREATE STREAMING JOB](../../../sql-manual/sql-statements/job/CREATE-STREAMING-JOB.md) with the `INSERT INTO ... SELECT * FROM cdc_stream(...)` syntax:
+
+```sql
+CREATE JOB mysql_students_sync
+ON STREAMING
+DO
+INSERT INTO doris_db.students
+SELECT * FROM cdc_stream(
+    "type"         = "mysql",
+    "jdbc_url"     = "jdbc:mysql://127.0.0.1:3306",
+    "driver_url"   = "mysql-connector-java-8.0.25.jar",
+    "driver_class" = "com.mysql.cj.jdbc.Driver",
+    "user"         = "root",
+    "password"     = "123456",
+    "database"     = "test",
+    "table"        = "students",
+    "offset"       = "initial"
+);
+```
+
+#### Step 4: Check job status
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### Step 5: Verify loaded data
+
+```sql
+SELECT * FROM doris_db.students;
+```
+
+For more common operations (pause, resume, delete, check task, etc.) and full parameter reference, see [MySQL Table-Level Sync](../streaming-job/continuous-load-mysql-table.md).

--- a/docs/data-operate/import/data-source/postgresql.md
+++ b/docs/data-operate/import/data-source/postgresql.md
@@ -1,0 +1,250 @@
+---
+{
+    "title": "PostgreSQL",
+    "language": "en",
+    "description": "Doris provides multiple ways to load data from PostgreSQL, including ad-hoc loading via JDBC Catalog, continuous full + incremental synchronization via Streaming Job, and CDC sync via Flink Doris Connector."
+}
+---
+
+Doris provides the following ways to load data from PostgreSQL:
+
+- **Loading PostgreSQL data via JDBC Catalog**
+
+Doris uses JDBC Catalog to map PostgreSQL as an external catalog, allowing direct SQL queries against PostgreSQL data. Combined with `INSERT INTO` or `CREATE TABLE AS SELECT`, this is suitable for one-time migration or periodic batch loading.
+
+- **Continuously syncing PostgreSQL data via Streaming Job**
+
+Doris uses Streaming Job to continuously sync full and incremental data from PostgreSQL to Doris. By integrating [Flink CDC](https://github.com/apache/flink-cdc) reading capability, Doris keeps the job running, reads WAL from PostgreSQL and writes it to Doris tables with exactly-once semantics. Two modes are supported: table-level sync and database-level sync. Available since Doris 4.1.0.
+
+- **Loading PostgreSQL data via Flink Doris Connector**
+
+Use Flink Doris Connector together with Flink Postgres CDC for real-time synchronization. This is suitable for scenarios that require additional Flink stream processing logic. The connector also provides a one-click full-database synchronization tool. For details, see [Flink Doris Connector](../../../ecosystem/flink-doris-connector/flink-doris-connector.md).
+
+- **Loading PostgreSQL data via third-party tools**
+
+Data integration tools such as [DataX](../../../ecosystem/datax), [SeaTunnel](../../../ecosystem/seatunnel), and [CloudCanal](../../../ecosystem/cloudcanal) also support syncing data from PostgreSQL to Doris.
+
+In most cases, you can use JDBC Catalog directly for one-time data migration. When continuous full + incremental synchronization is required, Streaming Job is recommended.
+
+## Loading PostgreSQL data via JDBC Catalog
+
+Use JDBC Catalog to map PostgreSQL as an external catalog, then use `INSERT INTO` or `CREATE TABLE AS SELECT` to load data. For detailed syntax, see [JDBC PostgreSQL Catalog](../../../lakehouse/catalogs/jdbc-pg-catalog.md).
+
+### Step 1: Prepare data in PostgreSQL
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+### Step 2: Create a Catalog in Doris
+
+```sql
+CREATE CATALOG pg_catalog PROPERTIES (
+    "type"         = "jdbc",
+    "user"         = "postgres",
+    "password"     = "postgres",
+    "jdbc_url"     = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"   = "postgresql-42.5.1.jar",
+    "driver_class" = "org.postgresql.Driver"
+);
+```
+
+### Step 3: Create the target table in Doris
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id    INT,
+    name  VARCHAR(64),
+    age   INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+### Step 4: Load data with INSERT INTO
+
+```sql
+INSERT INTO doris_db.students
+SELECT id, name, age FROM pg_catalog.postgres.public.students;
+```
+
+If the target table does not exist yet, you can also use `CREATE TABLE AS SELECT` to create the table and load data in one step:
+
+```sql
+CREATE TABLE doris_db.students
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT * FROM pg_catalog.postgres.public.students;
+```
+
+### Step 5: Verify loaded data
+
+```sql
+SELECT * FROM doris_db.students;
++----+-------+------+
+| id | name  | age  |
++----+-------+------+
+|  1 | Emily |   25 |
+|  2 | Bob   |   30 |
++----+-------+------+
+```
+
+## Continuously syncing PostgreSQL data via Streaming Job
+
+Streaming Job continuously reads PostgreSQL WAL via Flink CDC and writes it to Doris. Two modes are supported:
+
+- [PostgreSQL Database-Level Sync](../streaming-job/continuous-load-postgresql-database.md): sync at the database level (use `include_tables` to sync one, several, or all tables). Doris automatically creates downstream tables on first sync. Provides at-least-once semantics.
+- [PostgreSQL Table-Level Sync](../streaming-job/continuous-load-postgresql-table.md): sync at the table level. The target table must be pre-created in Doris. Supports flexible column mapping, data transformation, and exactly-once semantics.
+
+### Limitations
+
+1. Only primary key tables (Unique Key) are supported.
+2. Load privilege is required. Database-level sync also needs Create privilege when auto-creating downstream tables on first run.
+3. Available since Doris 4.1.0.
+
+### Prerequisites
+
+Before submitting a Streaming Job, logical replication (`wal_level=logical`) must be enabled on the PostgreSQL side and the user must be granted the corresponding REPLICATION privileges. For environment-specific setup steps, see:
+
+- [Amazon RDS PostgreSQL Setup Guide](../streaming-job/prerequisites/amazon-rds-postgresql.md)
+- [Amazon Aurora PostgreSQL Setup Guide](../streaming-job/prerequisites/amazon-aurora-postgresql.md)
+- See [Continuous Load Overview](../streaming-job/continuous-load-overview.md) for notes and required permissions of each mode.
+
+### Operation Example: Database-Level Sync
+
+Database-level sync uses the `FROM POSTGRES ... TO DATABASE ...` syntax. The target is a Doris database, and the downstream tables are automatically created on first sync.
+
+#### Step 1: Prepare data in PostgreSQL
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### Step 2: Create the target database in Doris
+
+Database-level sync **does not require pre-creating tables**, but the target database that hosts them must exist:
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+```
+
+#### Step 3: Create a Streaming Job
+
+The example below uses `include_tables` to sync only the `students` table (multiple tables can be comma-separated; leave empty to sync the whole database):
+
+```sql
+CREATE JOB pg_db_sync
+ON STREAMING
+FROM POSTGRES (
+    "jdbc_url"       = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"     = "postgresql-42.5.1.jar",
+    "driver_class"   = "org.postgresql.Driver",
+    "user"           = "postgres",
+    "password"       = "postgres",
+    "database"       = "postgres",
+    "schema"         = "public",
+    "include_tables" = "students",
+    "offset"         = "initial"
+)
+TO DATABASE doris_db (
+    "table.create.properties.replication_num" = "1"  -- set to 1 in single-BE deployments
+);
+```
+
+#### Step 4: Check job status
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### Step 5: Inspect auto-created Doris tables and loaded data
+
+```sql
+SHOW TABLES FROM doris_db;
+SELECT * FROM doris_db.students;
+```
+
+For more common operations and full parameter reference, see [PostgreSQL Database-Level Sync](../streaming-job/continuous-load-postgresql-database.md).
+
+### Operation Example: Table-Level Sync
+
+#### Step 1: Prepare data in PostgreSQL
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### Step 2: Create the target table in Doris
+
+Table-level sync requires the target table to exist beforehand:
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id    INT,
+    name  VARCHAR(64),
+    age   INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+#### Step 3: Create a Streaming Job
+
+Use [CREATE STREAMING JOB](../../../sql-manual/sql-statements/job/CREATE-STREAMING-JOB.md) with the `INSERT INTO ... SELECT * FROM cdc_stream(...)` syntax:
+
+```sql
+CREATE JOB pg_students_sync
+ON STREAMING
+DO
+INSERT INTO doris_db.students
+SELECT * FROM cdc_stream(
+    "type"         = "postgres",
+    "jdbc_url"     = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"   = "postgresql-42.5.1.jar",
+    "driver_class" = "org.postgresql.Driver",
+    "user"         = "postgres",
+    "password"     = "postgres",
+    "database"     = "postgres",
+    "schema"       = "public",
+    "table"        = "students",
+    "offset"       = "initial"
+);
+```
+
+#### Step 4: Check job status
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### Step 5: Verify loaded data
+
+```sql
+SELECT * FROM doris_db.students;
+```
+
+For more common operations (pause, resume, delete, check task, etc.) and full parameter reference, see [PostgreSQL Table-Level Sync](../streaming-job/continuous-load-postgresql-table.md).

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/migrate-data-from-other-oltp.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/migrate-data-from-other-oltp.md
@@ -133,7 +133,7 @@ SELECT * FROM iceberg_catalog.iceberg_db.table1;
       --sink-conf sink.label-prefix=label \
       --table-conf replication_num=1 
   ```    
-  具体可参考：[整库同步](../../../ecosystem/flink-doris-connector.md#整库同步)
+  具体可参考：[整库同步](../../../ecosystem/flink-doris-connector/flink-doris-connector.md#整库同步)
 
 ## Spark Connector
 可以通过 Spark Connector 的 JDBC Source 和 Doris Sink 完成数据的写入。
@@ -153,7 +153,7 @@ val jdbcDF = spark.read
   .option("password", "")
   .save() 
 ```
-具体可参考：[JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector.md#批量写入)
+具体可参考：[JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector/spark-doris-connector.md#批量写入)
 
 ## DataX / Seatunnel / CloudCanal 等三方工具
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/migrate-data-from-other-oltp.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/migrate-data-from-other-oltp.md
@@ -155,30 +155,6 @@ val jdbcDF = spark.read
 ```
 具体可参考：[JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector.md#批量写入)
 
-## Streaming Job
-
-使用 Streaming Job 同步 MySQL 或者 Postgres 的数据
-
-```sql
-CREATE JOB multi_table_sync
-ON STREAMING
-FROM MYSQL (
-        "jdbc_url" = "jdbc:mysql://127.0.0.1:3306",
-        "driver_url" = "mysql-connector-j-8.0.31.jar",
-        "driver_class" = "com.mysql.cj.jdbc.Driver",
-        "user" = "root",
-        "password" = "123456",
-        "database" = "test",
-        "include_tables" = "user_info,order_info",
-        "offset" = "initial"
-)
-TO DATABASE target_test_db (
-    "table.create.properties.replication_num" = "1"
-)
-```
-
-具体可参考： [Postgres/MySQL Continuous Load](../streaming-job/streaming-job-multi-table.md)
-
 ## DataX / Seatunnel / CloudCanal 等三方工具
 
 除此之外，也可以使用第三方同步工具来进行数据同步，更多可参考：

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/mysql.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/mysql.md
@@ -1,0 +1,248 @@
+---
+{
+    "title": "MySQL",
+    "language": "zh-CN",
+    "description": "Doris 提供多种方式从 MySQL 导入数据，包括通过 JDBC Catalog 按需查询/导入、通过 Streaming Job 进行全量+增量持续同步，以及借助 Flink Doris Connector 完成 CDC 同步。"
+}
+---
+
+Doris 提供以下方式从 MySQL 导入数据：
+
+- **使用 JDBC Catalog 导入 MySQL 数据**
+
+Doris 通过 JDBC Catalog 将 MySQL 映射为外部 Catalog，可以直接以 SQL 的方式查询 MySQL 中的数据，并通过 `INSERT INTO` 或 `CREATE TABLE AS SELECT` 完成数据导入，适用于一次性迁移或周期性批量导入场景。
+
+- **使用 Streaming Job 持续同步 MySQL 数据**
+
+Doris 通过 Streaming Job 将 MySQL 的全量与增量数据持续同步到 Doris 中。Streaming Job 集成了 [Flink CDC](https://github.com/apache/flink-cdc) 的读取能力，提交作业后 Doris 会持续运行任务，从 MySQL 读取 Binlog 并写入到 Doris 表中，支持 exactly-once 语义，分为表级同步和库级同步两种模式。该方式自 Doris 4.1.0 起支持。
+
+- **使用 Flink Doris Connector 导入 MySQL 数据**
+
+可以通过 Flink Doris Connector 配合 Flink MySQL CDC 实现实时同步，适用于需要在 Flink 中对数据进行额外流式处理的场景。Connector 同时提供一键整库同步工具，更多信息请参考 [Flink Doris Connector](../../../ecosystem/flink-doris-connector/flink-doris-connector.md)。
+
+- **使用第三方工具导入 MySQL 数据**
+
+[DataX](../../../ecosystem/datax)、[SeaTunnel](../../../ecosystem/seatunnel)、[CloudCanal](../../../ecosystem/cloudcanal) 等数据集成工具同样支持将 MySQL 数据同步到 Doris。
+
+在大多数场景下，可以直接使用 JDBC Catalog 进行一次性的数据迁移；当需要持续同步全量+增量数据时，推荐使用 Streaming Job。
+
+## 使用 JDBC Catalog 导入 MySQL 数据
+
+通过 JDBC Catalog 把 MySQL 映射为 Doris 的外部 Catalog，再使用 `INSERT INTO` 或 `CREATE TABLE AS SELECT` 完成数据导入。详细语法请参考 [JDBC MySQL Catalog](../../../lakehouse/catalogs/jdbc-mysql-catalog.md)。
+
+### 第 1 步：在 MySQL 中准备数据
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+### 第 2 步：在 Doris 中创建 Catalog
+
+```sql
+CREATE CATALOG mysql_catalog PROPERTIES (
+    "type"         = "jdbc",
+    "user"         = "root",
+    "password"     = "123456",
+    "jdbc_url"     = "jdbc:mysql://127.0.0.1:3306/test",
+    "driver_url"   = "mysql-connector-java-8.0.25.jar",
+    "driver_class" = "com.mysql.cj.jdbc.Driver"
+);
+```
+
+### 第 3 步：在 Doris 中创建目标表
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id     INT,
+    name   VARCHAR(64),
+    age    INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+### 第 4 步：通过 INSERT INTO 导入数据
+
+```sql
+INSERT INTO doris_db.students
+SELECT id, name, age FROM mysql_catalog.test.students;
+```
+
+如果目标表尚未创建，也可以使用 `CREATE TABLE AS SELECT` 一步完成建表与导入：
+
+```sql
+CREATE TABLE doris_db.students
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT * FROM mysql_catalog.test.students;
+```
+
+### 第 5 步：检查导入数据
+
+```sql
+SELECT * FROM doris_db.students;
++----+-------+------+
+| id | name  | age  |
++----+-------+------+
+|  1 | Emily |   25 |
+|  2 | Bob   |   30 |
++----+-------+------+
+```
+
+## 使用 Streaming Job 持续同步 MySQL 数据
+
+Streaming Job 通过集成 Flink CDC 持续读取 MySQL 的 Binlog 并写入 Doris，支持以下两种模式：
+
+- [MySQL 库级同步](../streaming-job/continuous-load-mysql-database.md)：以库为单位同步（通过 `include_tables` 可控制同步一张、多张或全部表），首次同步时由 Doris 自动建表，提供 at-least-once 语义。
+- [MySQL 表级同步](../streaming-job/continuous-load-mysql-table.md)：以表为单位同步，目标表需预先在 Doris 中创建，支持灵活的列映射和数据转换，提供 exactly-once 语义。
+
+### 使用限制
+
+1. 仅支持主键表（Unique Key）同步。
+2. 需要 Load 权限，库级同步首次自动建表时还需 Create 权限。
+3. 该功能自 Doris 4.1.0 起支持。
+
+### 前置配置
+
+提交 Streaming Job 之前，需要在 MySQL 端开启 Binlog 并授予用户相应的 REPLICATION 权限。不同部署环境的具体配置步骤请参考：
+
+- [Amazon RDS MySQL 配置指南](../streaming-job/prerequisites/amazon-rds-mysql.md)
+- [Amazon Aurora MySQL 配置指南](../streaming-job/prerequisites/amazon-aurora-mysql.md)
+- 各模式的注意事项与权限要求详见 [持续导入概览](../streaming-job/continuous-load-overview.md)
+
+### 操作示例：库级同步
+
+库级同步使用 `FROM MYSQL ... TO DATABASE ...` 语法，目标是一个 Doris database，首次同步时由 Doris 自动创建下游表。
+
+#### 第 1 步：在 MySQL 中准备数据
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### 第 2 步：在 Doris 中创建目标 database
+
+库级同步**不需要预建表**，但需要先创建用于承接同步表的 database：
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+```
+
+#### 第 3 步：创建 Streaming Job
+
+下面的示例通过 `include_tables` 仅同步 `students` 一张表（多张表用逗号分隔，留空则同步整库）：
+
+```sql
+CREATE JOB mysql_db_sync
+ON STREAMING
+FROM MYSQL (
+    "jdbc_url"       = "jdbc:mysql://127.0.0.1:3306",
+    "driver_url"     = "mysql-connector-java-8.0.25.jar",
+    "driver_class"   = "com.mysql.cj.jdbc.Driver",
+    "user"           = "root",
+    "password"       = "123456",
+    "database"       = "test",
+    "include_tables" = "students",
+    "offset"         = "initial"
+)
+TO DATABASE doris_db (
+    "table.create.properties.replication_num" = "1"  -- 单 BE 部署时设置为 1
+);
+```
+
+#### 第 4 步：查看导入状态
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### 第 5 步：检查自动创建的 Doris 表与导入数据
+
+```sql
+SHOW TABLES FROM doris_db;
+SELECT * FROM doris_db.students;
+```
+
+更多通用操作和完整参数说明，请参考 [MySQL 库级同步](../streaming-job/continuous-load-mysql-database.md)。
+
+### 操作示例：表级同步
+
+#### 第 1 步：在 MySQL 中准备数据
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### 第 2 步：在 Doris 中创建目标表
+
+表级同步要求目标表预先存在：
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id     INT,
+    name   VARCHAR(64),
+    age    INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+#### 第 3 步：创建 Streaming Job
+
+通过 [CREATE STREAMING JOB](../../../sql-manual/sql-statements/job/CREATE-STREAMING-JOB.md) 创建表级同步作业，使用 `INSERT INTO ... SELECT * FROM cdc_stream(...)` 语法：
+
+```sql
+CREATE JOB mysql_students_sync
+ON STREAMING
+DO
+INSERT INTO doris_db.students
+SELECT * FROM cdc_stream(
+    "type"         = "mysql",
+    "jdbc_url"     = "jdbc:mysql://127.0.0.1:3306",
+    "driver_url"   = "mysql-connector-java-8.0.25.jar",
+    "driver_class" = "com.mysql.cj.jdbc.Driver",
+    "user"         = "root",
+    "password"     = "123456",
+    "database"     = "test",
+    "table"        = "students",
+    "offset"       = "initial"
+);
+```
+
+#### 第 4 步：查看导入状态
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### 第 5 步：检查导入数据
+
+```sql
+SELECT * FROM doris_db.students;
+```
+
+更多通用操作（暂停、恢复、删除、查看 Task 等）以及完整参数说明，请参考 [MySQL 表级同步](../streaming-job/continuous-load-mysql-table.md)。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/postgresql.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/data-source/postgresql.md
@@ -1,0 +1,250 @@
+---
+{
+    "title": "PostgreSQL",
+    "language": "zh-CN",
+    "description": "Doris 提供多种方式从 PostgreSQL 导入数据，包括通过 JDBC Catalog 按需查询/导入、通过 Streaming Job 进行全量+增量持续同步，以及借助 Flink Doris Connector 完成 CDC 同步。"
+}
+---
+
+Doris 提供以下方式从 PostgreSQL 导入数据：
+
+- **使用 JDBC Catalog 导入 PostgreSQL 数据**
+
+Doris 通过 JDBC Catalog 将 PostgreSQL 映射为外部 Catalog，可以直接以 SQL 的方式查询 PostgreSQL 中的数据，并通过 `INSERT INTO` 或 `CREATE TABLE AS SELECT` 完成数据导入，适用于一次性迁移或周期性批量导入场景。
+
+- **使用 Streaming Job 持续同步 PostgreSQL 数据**
+
+Doris 通过 Streaming Job 将 PostgreSQL 的全量与增量数据持续同步到 Doris 中。Streaming Job 集成了 [Flink CDC](https://github.com/apache/flink-cdc) 的读取能力，提交作业后 Doris 会持续运行任务，从 PostgreSQL 读取 WAL 并写入到 Doris 表中，支持 exactly-once 语义，分为表级同步和库级同步两种模式。该方式自 Doris 4.1.0 起支持。
+
+- **使用 Flink Doris Connector 导入 PostgreSQL 数据**
+
+可以通过 Flink Doris Connector 配合 Flink Postgres CDC 实现实时同步，适用于需要在 Flink 中对数据进行额外流式处理的场景。Connector 同时提供一键整库同步工具，更多信息请参考 [Flink Doris Connector](../../../ecosystem/flink-doris-connector/flink-doris-connector.md)。
+
+- **使用第三方工具导入 PostgreSQL 数据**
+
+[DataX](../../../ecosystem/datax)、[SeaTunnel](../../../ecosystem/seatunnel)、[CloudCanal](../../../ecosystem/cloudcanal) 等数据集成工具同样支持将 PostgreSQL 数据同步到 Doris。
+
+在大多数场景下，可以直接使用 JDBC Catalog 进行一次性的数据迁移；当需要持续同步全量+增量数据时，推荐使用 Streaming Job。
+
+## 使用 JDBC Catalog 导入 PostgreSQL 数据
+
+通过 JDBC Catalog 把 PostgreSQL 映射为 Doris 的外部 Catalog，再使用 `INSERT INTO` 或 `CREATE TABLE AS SELECT` 完成数据导入。详细语法请参考 [JDBC PostgreSQL Catalog](../../../lakehouse/catalogs/jdbc-pg-catalog.md)。
+
+### 第 1 步：在 PostgreSQL 中准备数据
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+### 第 2 步：在 Doris 中创建 Catalog
+
+```sql
+CREATE CATALOG pg_catalog PROPERTIES (
+    "type"         = "jdbc",
+    "user"         = "postgres",
+    "password"     = "postgres",
+    "jdbc_url"     = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"   = "postgresql-42.5.1.jar",
+    "driver_class" = "org.postgresql.Driver"
+);
+```
+
+### 第 3 步：在 Doris 中创建目标表
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id    INT,
+    name  VARCHAR(64),
+    age   INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+### 第 4 步：通过 INSERT INTO 导入数据
+
+```sql
+INSERT INTO doris_db.students
+SELECT id, name, age FROM pg_catalog.postgres.public.students;
+```
+
+如果目标表尚未创建，也可以使用 `CREATE TABLE AS SELECT` 一步完成建表与导入：
+
+```sql
+CREATE TABLE doris_db.students
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT * FROM pg_catalog.postgres.public.students;
+```
+
+### 第 5 步：检查导入数据
+
+```sql
+SELECT * FROM doris_db.students;
++----+-------+------+
+| id | name  | age  |
++----+-------+------+
+|  1 | Emily |   25 |
+|  2 | Bob   |   30 |
++----+-------+------+
+```
+
+## 使用 Streaming Job 持续同步 PostgreSQL 数据
+
+Streaming Job 通过集成 Flink CDC 持续读取 PostgreSQL 的 WAL 并写入 Doris，支持以下两种模式：
+
+- [PostgreSQL 库级同步](../streaming-job/continuous-load-postgresql-database.md)：以库为单位同步（通过 `include_tables` 可控制同步一张、多张或全部表），首次同步时由 Doris 自动建表，提供 at-least-once 语义。
+- [PostgreSQL 表级同步](../streaming-job/continuous-load-postgresql-table.md)：以表为单位同步，目标表需预先在 Doris 中创建，支持灵活的列映射和数据转换，提供 exactly-once 语义。
+
+### 使用限制
+
+1. 仅支持主键表（Unique Key）同步。
+2. 需要 Load 权限，库级同步首次自动建表时还需 Create 权限。
+3. 该功能自 Doris 4.1.0 起支持。
+
+### 前置配置
+
+提交 Streaming Job 之前，需要在 PostgreSQL 端开启逻辑复制（`wal_level=logical`），并授予用户相应的复制（REPLICATION）权限。不同部署环境的具体配置步骤请参考：
+
+- [Amazon RDS PostgreSQL 配置指南](../streaming-job/prerequisites/amazon-rds-postgresql.md)
+- [Amazon Aurora PostgreSQL 配置指南](../streaming-job/prerequisites/amazon-aurora-postgresql.md)
+- 各模式的注意事项与权限要求详见 [持续导入概览](../streaming-job/continuous-load-overview.md)
+
+### 操作示例：库级同步
+
+库级同步使用 `FROM POSTGRES ... TO DATABASE ...` 语法，目标是一个 Doris database，首次同步时由 Doris 自动创建下游表。
+
+#### 第 1 步：在 PostgreSQL 中准备数据
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### 第 2 步：在 Doris 中创建目标 database
+
+库级同步**不需要预建表**，但需要先创建用于承接同步表的 database：
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+```
+
+#### 第 3 步：创建 Streaming Job
+
+下面的示例通过 `include_tables` 仅同步 `students` 一张表（多张表用逗号分隔，留空则同步整库）：
+
+```sql
+CREATE JOB pg_db_sync
+ON STREAMING
+FROM POSTGRES (
+    "jdbc_url"       = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"     = "postgresql-42.5.1.jar",
+    "driver_class"   = "org.postgresql.Driver",
+    "user"           = "postgres",
+    "password"       = "postgres",
+    "database"       = "postgres",
+    "schema"         = "public",
+    "include_tables" = "students",
+    "offset"         = "initial"
+)
+TO DATABASE doris_db (
+    "table.create.properties.replication_num" = "1"  -- 单 BE 部署时设置为 1
+);
+```
+
+#### 第 4 步：查看导入状态
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### 第 5 步：检查自动创建的 Doris 表与导入数据
+
+```sql
+SHOW TABLES FROM doris_db;
+SELECT * FROM doris_db.students;
+```
+
+更多通用操作和完整参数说明，请参考 [PostgreSQL 库级同步](../streaming-job/continuous-load-postgresql-database.md)。
+
+### 操作示例：表级同步
+
+#### 第 1 步：在 PostgreSQL 中准备数据
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### 第 2 步：在 Doris 中创建目标表
+
+表级同步要求目标表预先存在：
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id    INT,
+    name  VARCHAR(64),
+    age   INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+#### 第 3 步：创建 Streaming Job
+
+通过 [CREATE STREAMING JOB](../../../sql-manual/sql-statements/job/CREATE-STREAMING-JOB.md) 创建表级同步作业，使用 `INSERT INTO ... SELECT * FROM cdc_stream(...)` 语法：
+
+```sql
+CREATE JOB pg_students_sync
+ON STREAMING
+DO
+INSERT INTO doris_db.students
+SELECT * FROM cdc_stream(
+    "type"         = "postgres",
+    "jdbc_url"     = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"   = "postgresql-42.5.1.jar",
+    "driver_class" = "org.postgresql.Driver",
+    "user"         = "postgres",
+    "password"     = "postgres",
+    "database"     = "postgres",
+    "schema"       = "public",
+    "table"        = "students",
+    "offset"       = "initial"
+);
+```
+
+#### 第 4 步：查看导入状态
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### 第 5 步：检查导入数据
+
+```sql
+SELECT * FROM doris_db.students;
+```
+
+更多通用操作（暂停、恢复、删除、查看 Task 等）以及完整参数说明，请参考 [PostgreSQL 表级同步](../streaming-job/continuous-load-postgresql-table.md)。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/migrate-data-from-other-oltp.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/migrate-data-from-other-oltp.md
@@ -133,7 +133,7 @@ SELECT * FROM iceberg_catalog.iceberg_db.table1;
       --sink-conf sink.label-prefix=label \
       --table-conf replication_num=1 
   ```    
-  具体可参考：[整库同步](../../../ecosystem/flink-doris-connector.md#整库同步)
+  具体可参考：[整库同步](../../../ecosystem/flink-doris-connector/flink-doris-connector.md#整库同步)
 
 ## Spark Connector
 可以通过 Spark Connector 的 JDBC Source 和 Doris Sink 完成数据的写入。
@@ -153,7 +153,7 @@ val jdbcDF = spark.read
   .option("password", "")
   .save() 
 ```
-具体可参考：[JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector.md#批量写入)
+具体可参考：[JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector/spark-doris-connector.md#批量写入)
 
 ## DataX / Seatunnel / CloudCanal 等三方工具
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/migrate-data-from-other-oltp.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/migrate-data-from-other-oltp.md
@@ -155,30 +155,6 @@ val jdbcDF = spark.read
 ```
 具体可参考：[JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector.md#批量写入)
 
-## Streaming Job
-
-使用 Streaming Job 同步 MySQL 或者 Postgres 的数据
-
-```sql
-CREATE JOB multi_table_sync
-ON STREAMING
-FROM MYSQL (
-        "jdbc_url" = "jdbc:mysql://127.0.0.1:3306",
-        "driver_url" = "mysql-connector-j-8.0.31.jar",
-        "driver_class" = "com.mysql.cj.jdbc.Driver",
-        "user" = "root",
-        "password" = "123456",
-        "database" = "test",
-        "include_tables" = "user_info,order_info",
-        "offset" = "initial"
-)
-TO DATABASE target_test_db (
-    "table.create.properties.replication_num" = "1"
-)
-```
-
-具体可参考： [Postgres/MySQL Continuous Load](../streaming-job/streaming-job-multi-table.md)
-
 ## DataX / Seatunnel / CloudCanal 等三方工具
 
 除此之外，也可以使用第三方同步工具来进行数据同步，更多可参考：

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/mysql.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/mysql.md
@@ -1,0 +1,248 @@
+---
+{
+    "title": "MySQL",
+    "language": "zh-CN",
+    "description": "Doris 提供多种方式从 MySQL 导入数据，包括通过 JDBC Catalog 按需查询/导入、通过 Streaming Job 进行全量+增量持续同步，以及借助 Flink Doris Connector 完成 CDC 同步。"
+}
+---
+
+Doris 提供以下方式从 MySQL 导入数据：
+
+- **使用 JDBC Catalog 导入 MySQL 数据**
+
+Doris 通过 JDBC Catalog 将 MySQL 映射为外部 Catalog，可以直接以 SQL 的方式查询 MySQL 中的数据，并通过 `INSERT INTO` 或 `CREATE TABLE AS SELECT` 完成数据导入，适用于一次性迁移或周期性批量导入场景。
+
+- **使用 Streaming Job 持续同步 MySQL 数据**
+
+Doris 通过 Streaming Job 将 MySQL 的全量与增量数据持续同步到 Doris 中。Streaming Job 集成了 [Flink CDC](https://github.com/apache/flink-cdc) 的读取能力，提交作业后 Doris 会持续运行任务，从 MySQL 读取 Binlog 并写入到 Doris 表中，支持 exactly-once 语义，分为表级同步和库级同步两种模式。该方式自 Doris 4.1.0 起支持。
+
+- **使用 Flink Doris Connector 导入 MySQL 数据**
+
+可以通过 Flink Doris Connector 配合 Flink MySQL CDC 实现实时同步，适用于需要在 Flink 中对数据进行额外流式处理的场景。Connector 同时提供一键整库同步工具，更多信息请参考 [Flink Doris Connector](../../../ecosystem/flink-doris-connector/flink-doris-connector.md)。
+
+- **使用第三方工具导入 MySQL 数据**
+
+[DataX](../../../ecosystem/datax)、[SeaTunnel](../../../ecosystem/seatunnel)、[CloudCanal](../../../ecosystem/cloudcanal) 等数据集成工具同样支持将 MySQL 数据同步到 Doris。
+
+在大多数场景下，可以直接使用 JDBC Catalog 进行一次性的数据迁移；当需要持续同步全量+增量数据时，推荐使用 Streaming Job。
+
+## 使用 JDBC Catalog 导入 MySQL 数据
+
+通过 JDBC Catalog 把 MySQL 映射为 Doris 的外部 Catalog，再使用 `INSERT INTO` 或 `CREATE TABLE AS SELECT` 完成数据导入。详细语法请参考 [JDBC MySQL Catalog](../../../lakehouse/catalogs/jdbc-mysql-catalog.md)。
+
+### 第 1 步：在 MySQL 中准备数据
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+### 第 2 步：在 Doris 中创建 Catalog
+
+```sql
+CREATE CATALOG mysql_catalog PROPERTIES (
+    "type"         = "jdbc",
+    "user"         = "root",
+    "password"     = "123456",
+    "jdbc_url"     = "jdbc:mysql://127.0.0.1:3306/test",
+    "driver_url"   = "mysql-connector-java-8.0.25.jar",
+    "driver_class" = "com.mysql.cj.jdbc.Driver"
+);
+```
+
+### 第 3 步：在 Doris 中创建目标表
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id     INT,
+    name   VARCHAR(64),
+    age    INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+### 第 4 步：通过 INSERT INTO 导入数据
+
+```sql
+INSERT INTO doris_db.students
+SELECT id, name, age FROM mysql_catalog.test.students;
+```
+
+如果目标表尚未创建，也可以使用 `CREATE TABLE AS SELECT` 一步完成建表与导入：
+
+```sql
+CREATE TABLE doris_db.students
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT * FROM mysql_catalog.test.students;
+```
+
+### 第 5 步：检查导入数据
+
+```sql
+SELECT * FROM doris_db.students;
++----+-------+------+
+| id | name  | age  |
++----+-------+------+
+|  1 | Emily |   25 |
+|  2 | Bob   |   30 |
++----+-------+------+
+```
+
+## 使用 Streaming Job 持续同步 MySQL 数据
+
+Streaming Job 通过集成 Flink CDC 持续读取 MySQL 的 Binlog 并写入 Doris，支持以下两种模式：
+
+- [MySQL 库级同步](../streaming-job/continuous-load-mysql-database.md)：以库为单位同步（通过 `include_tables` 可控制同步一张、多张或全部表），首次同步时由 Doris 自动建表，提供 at-least-once 语义。
+- [MySQL 表级同步](../streaming-job/continuous-load-mysql-table.md)：以表为单位同步，目标表需预先在 Doris 中创建，支持灵活的列映射和数据转换，提供 exactly-once 语义。
+
+### 使用限制
+
+1. 仅支持主键表（Unique Key）同步。
+2. 需要 Load 权限，库级同步首次自动建表时还需 Create 权限。
+3. 该功能自 Doris 4.1.0 起支持。
+
+### 前置配置
+
+提交 Streaming Job 之前，需要在 MySQL 端开启 Binlog 并授予用户相应的 REPLICATION 权限。不同部署环境的具体配置步骤请参考：
+
+- [Amazon RDS MySQL 配置指南](../streaming-job/prerequisites/amazon-rds-mysql.md)
+- [Amazon Aurora MySQL 配置指南](../streaming-job/prerequisites/amazon-aurora-mysql.md)
+- 各模式的注意事项与权限要求详见 [持续导入概览](../streaming-job/continuous-load-overview.md)
+
+### 操作示例：库级同步
+
+库级同步使用 `FROM MYSQL ... TO DATABASE ...` 语法，目标是一个 Doris database，首次同步时由 Doris 自动创建下游表。
+
+#### 第 1 步：在 MySQL 中准备数据
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### 第 2 步：在 Doris 中创建目标 database
+
+库级同步**不需要预建表**，但需要先创建用于承接同步表的 database：
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+```
+
+#### 第 3 步：创建 Streaming Job
+
+下面的示例通过 `include_tables` 仅同步 `students` 一张表（多张表用逗号分隔，留空则同步整库）：
+
+```sql
+CREATE JOB mysql_db_sync
+ON STREAMING
+FROM MYSQL (
+    "jdbc_url"       = "jdbc:mysql://127.0.0.1:3306",
+    "driver_url"     = "mysql-connector-java-8.0.25.jar",
+    "driver_class"   = "com.mysql.cj.jdbc.Driver",
+    "user"           = "root",
+    "password"       = "123456",
+    "database"       = "test",
+    "include_tables" = "students",
+    "offset"         = "initial"
+)
+TO DATABASE doris_db (
+    "table.create.properties.replication_num" = "1"  -- 单 BE 部署时设置为 1
+);
+```
+
+#### 第 4 步：查看导入状态
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### 第 5 步：检查自动创建的 Doris 表与导入数据
+
+```sql
+SHOW TABLES FROM doris_db;
+SELECT * FROM doris_db.students;
+```
+
+更多通用操作和完整参数说明，请参考 [MySQL 库级同步](../streaming-job/continuous-load-mysql-database.md)。
+
+### 操作示例：表级同步
+
+#### 第 1 步：在 MySQL 中准备数据
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### 第 2 步：在 Doris 中创建目标表
+
+表级同步要求目标表预先存在：
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id     INT,
+    name   VARCHAR(64),
+    age    INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+#### 第 3 步：创建 Streaming Job
+
+通过 [CREATE STREAMING JOB](../../../sql-manual/sql-statements/job/CREATE-STREAMING-JOB.md) 创建表级同步作业，使用 `INSERT INTO ... SELECT * FROM cdc_stream(...)` 语法：
+
+```sql
+CREATE JOB mysql_students_sync
+ON STREAMING
+DO
+INSERT INTO doris_db.students
+SELECT * FROM cdc_stream(
+    "type"         = "mysql",
+    "jdbc_url"     = "jdbc:mysql://127.0.0.1:3306",
+    "driver_url"   = "mysql-connector-java-8.0.25.jar",
+    "driver_class" = "com.mysql.cj.jdbc.Driver",
+    "user"         = "root",
+    "password"     = "123456",
+    "database"     = "test",
+    "table"        = "students",
+    "offset"       = "initial"
+);
+```
+
+#### 第 4 步：查看导入状态
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### 第 5 步：检查导入数据
+
+```sql
+SELECT * FROM doris_db.students;
+```
+
+更多通用操作（暂停、恢复、删除、查看 Task 等）以及完整参数说明，请参考 [MySQL 表级同步](../streaming-job/continuous-load-mysql-table.md)。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/postgresql.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/data-source/postgresql.md
@@ -1,0 +1,250 @@
+---
+{
+    "title": "PostgreSQL",
+    "language": "zh-CN",
+    "description": "Doris 提供多种方式从 PostgreSQL 导入数据，包括通过 JDBC Catalog 按需查询/导入、通过 Streaming Job 进行全量+增量持续同步，以及借助 Flink Doris Connector 完成 CDC 同步。"
+}
+---
+
+Doris 提供以下方式从 PostgreSQL 导入数据：
+
+- **使用 JDBC Catalog 导入 PostgreSQL 数据**
+
+Doris 通过 JDBC Catalog 将 PostgreSQL 映射为外部 Catalog，可以直接以 SQL 的方式查询 PostgreSQL 中的数据，并通过 `INSERT INTO` 或 `CREATE TABLE AS SELECT` 完成数据导入，适用于一次性迁移或周期性批量导入场景。
+
+- **使用 Streaming Job 持续同步 PostgreSQL 数据**
+
+Doris 通过 Streaming Job 将 PostgreSQL 的全量与增量数据持续同步到 Doris 中。Streaming Job 集成了 [Flink CDC](https://github.com/apache/flink-cdc) 的读取能力，提交作业后 Doris 会持续运行任务，从 PostgreSQL 读取 WAL 并写入到 Doris 表中，支持 exactly-once 语义，分为表级同步和库级同步两种模式。该方式自 Doris 4.1.0 起支持。
+
+- **使用 Flink Doris Connector 导入 PostgreSQL 数据**
+
+可以通过 Flink Doris Connector 配合 Flink Postgres CDC 实现实时同步，适用于需要在 Flink 中对数据进行额外流式处理的场景。Connector 同时提供一键整库同步工具，更多信息请参考 [Flink Doris Connector](../../../ecosystem/flink-doris-connector/flink-doris-connector.md)。
+
+- **使用第三方工具导入 PostgreSQL 数据**
+
+[DataX](../../../ecosystem/datax)、[SeaTunnel](../../../ecosystem/seatunnel)、[CloudCanal](../../../ecosystem/cloudcanal) 等数据集成工具同样支持将 PostgreSQL 数据同步到 Doris。
+
+在大多数场景下，可以直接使用 JDBC Catalog 进行一次性的数据迁移；当需要持续同步全量+增量数据时，推荐使用 Streaming Job。
+
+## 使用 JDBC Catalog 导入 PostgreSQL 数据
+
+通过 JDBC Catalog 把 PostgreSQL 映射为 Doris 的外部 Catalog，再使用 `INSERT INTO` 或 `CREATE TABLE AS SELECT` 完成数据导入。详细语法请参考 [JDBC PostgreSQL Catalog](../../../lakehouse/catalogs/jdbc-pg-catalog.md)。
+
+### 第 1 步：在 PostgreSQL 中准备数据
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+### 第 2 步：在 Doris 中创建 Catalog
+
+```sql
+CREATE CATALOG pg_catalog PROPERTIES (
+    "type"         = "jdbc",
+    "user"         = "postgres",
+    "password"     = "postgres",
+    "jdbc_url"     = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"   = "postgresql-42.5.1.jar",
+    "driver_class" = "org.postgresql.Driver"
+);
+```
+
+### 第 3 步：在 Doris 中创建目标表
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id    INT,
+    name  VARCHAR(64),
+    age   INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+### 第 4 步：通过 INSERT INTO 导入数据
+
+```sql
+INSERT INTO doris_db.students
+SELECT id, name, age FROM pg_catalog.postgres.public.students;
+```
+
+如果目标表尚未创建，也可以使用 `CREATE TABLE AS SELECT` 一步完成建表与导入：
+
+```sql
+CREATE TABLE doris_db.students
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT * FROM pg_catalog.postgres.public.students;
+```
+
+### 第 5 步：检查导入数据
+
+```sql
+SELECT * FROM doris_db.students;
++----+-------+------+
+| id | name  | age  |
++----+-------+------+
+|  1 | Emily |   25 |
+|  2 | Bob   |   30 |
++----+-------+------+
+```
+
+## 使用 Streaming Job 持续同步 PostgreSQL 数据
+
+Streaming Job 通过集成 Flink CDC 持续读取 PostgreSQL 的 WAL 并写入 Doris，支持以下两种模式：
+
+- [PostgreSQL 库级同步](../streaming-job/continuous-load-postgresql-database.md)：以库为单位同步（通过 `include_tables` 可控制同步一张、多张或全部表），首次同步时由 Doris 自动建表，提供 at-least-once 语义。
+- [PostgreSQL 表级同步](../streaming-job/continuous-load-postgresql-table.md)：以表为单位同步，目标表需预先在 Doris 中创建，支持灵活的列映射和数据转换，提供 exactly-once 语义。
+
+### 使用限制
+
+1. 仅支持主键表（Unique Key）同步。
+2. 需要 Load 权限，库级同步首次自动建表时还需 Create 权限。
+3. 该功能自 Doris 4.1.0 起支持。
+
+### 前置配置
+
+提交 Streaming Job 之前，需要在 PostgreSQL 端开启逻辑复制（`wal_level=logical`），并授予用户相应的复制（REPLICATION）权限。不同部署环境的具体配置步骤请参考：
+
+- [Amazon RDS PostgreSQL 配置指南](../streaming-job/prerequisites/amazon-rds-postgresql.md)
+- [Amazon Aurora PostgreSQL 配置指南](../streaming-job/prerequisites/amazon-aurora-postgresql.md)
+- 各模式的注意事项与权限要求详见 [持续导入概览](../streaming-job/continuous-load-overview.md)
+
+### 操作示例：库级同步
+
+库级同步使用 `FROM POSTGRES ... TO DATABASE ...` 语法，目标是一个 Doris database，首次同步时由 Doris 自动创建下游表。
+
+#### 第 1 步：在 PostgreSQL 中准备数据
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### 第 2 步：在 Doris 中创建目标 database
+
+库级同步**不需要预建表**，但需要先创建用于承接同步表的 database：
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+```
+
+#### 第 3 步：创建 Streaming Job
+
+下面的示例通过 `include_tables` 仅同步 `students` 一张表（多张表用逗号分隔，留空则同步整库）：
+
+```sql
+CREATE JOB pg_db_sync
+ON STREAMING
+FROM POSTGRES (
+    "jdbc_url"       = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"     = "postgresql-42.5.1.jar",
+    "driver_class"   = "org.postgresql.Driver",
+    "user"           = "postgres",
+    "password"       = "postgres",
+    "database"       = "postgres",
+    "schema"         = "public",
+    "include_tables" = "students",
+    "offset"         = "initial"
+)
+TO DATABASE doris_db (
+    "table.create.properties.replication_num" = "1"  -- 单 BE 部署时设置为 1
+);
+```
+
+#### 第 4 步：查看导入状态
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### 第 5 步：检查自动创建的 Doris 表与导入数据
+
+```sql
+SHOW TABLES FROM doris_db;
+SELECT * FROM doris_db.students;
+```
+
+更多通用操作和完整参数说明，请参考 [PostgreSQL 库级同步](../streaming-job/continuous-load-postgresql-database.md)。
+
+### 操作示例：表级同步
+
+#### 第 1 步：在 PostgreSQL 中准备数据
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### 第 2 步：在 Doris 中创建目标表
+
+表级同步要求目标表预先存在：
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id    INT,
+    name  VARCHAR(64),
+    age   INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+#### 第 3 步：创建 Streaming Job
+
+通过 [CREATE STREAMING JOB](../../../sql-manual/sql-statements/job/CREATE-STREAMING-JOB.md) 创建表级同步作业，使用 `INSERT INTO ... SELECT * FROM cdc_stream(...)` 语法：
+
+```sql
+CREATE JOB pg_students_sync
+ON STREAMING
+DO
+INSERT INTO doris_db.students
+SELECT * FROM cdc_stream(
+    "type"         = "postgres",
+    "jdbc_url"     = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"   = "postgresql-42.5.1.jar",
+    "driver_class" = "org.postgresql.Driver",
+    "user"         = "postgres",
+    "password"     = "postgres",
+    "database"     = "postgres",
+    "schema"       = "public",
+    "table"        = "students",
+    "offset"       = "initial"
+);
+```
+
+#### 第 4 步：查看导入状态
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### 第 5 步：检查导入数据
+
+```sql
+SELECT * FROM doris_db.students;
+```
+
+更多通用操作（暂停、恢复、删除、查看 Task 等）以及完整参数说明，请参考 [PostgreSQL 表级同步](../streaming-job/continuous-load-postgresql-table.md)。

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -176,6 +176,8 @@ const sidebars: SidebarsConfig = {
                                 'data-operate/import/data-source/snowflake',
                                 'data-operate/import/data-source/bigquery',
                                 'data-operate/import/data-source/redshift',
+                                'data-operate/import/data-source/mysql',
+                                'data-operate/import/data-source/postgresql',
                                 'data-operate/import/data-source/migrate-data-from-other-olap',
                                 'data-operate/import/data-source/migrate-data-from-other-oltp',
                             ],

--- a/versioned_docs/version-4.x/data-operate/import/data-source/migrate-data-from-other-oltp.md
+++ b/versioned_docs/version-4.x/data-operate/import/data-source/migrate-data-from-other-oltp.md
@@ -133,7 +133,7 @@ You can leverage Flink to achieve offline and real-time synchronization for TP s
       --sink-conf sink.label-prefix=label \
       --table-conf replication_num=1 
   ```    
-  For more details, refer to [Full Database Synchronization](../../../ecosystem/flink-doris-connector.md#full-database-synchronization)
+  For more details, refer to [Full Database Synchronization](../../../ecosystem/flink-doris-connector/flink-doris-connector.md#full-database-synchronization)
 
 ## Spark Connector
 You can use the JDBC Source and Doris Sink of the Spark Connector to complete the data write.
@@ -153,7 +153,7 @@ val jdbcDF = spark.read
   .option("password", "")
   .save() 
 ```
-For more details, refer to [JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector.md#batch-write)
+For more details, refer to [JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector/spark-doris-connector.md#batch-write)
 
 ## DataX / Seatunnel / CloudCanal and other third-party tools.
 

--- a/versioned_docs/version-4.x/data-operate/import/data-source/migrate-data-from-other-oltp.md
+++ b/versioned_docs/version-4.x/data-operate/import/data-source/migrate-data-from-other-oltp.md
@@ -34,7 +34,7 @@ AS
 SELECT * FROM iceberg_catalog.iceberg_db.table1;
 ```
 
-For more details, refer to [Catalog Data Load](../../../lakehouse/catalog-overview.md#data-import)。
+For more details, refer to [Catalog Data Load](../../../lakehouse/catalog-overview.md#data-ingestion)。
 
 ## Flink Doris Connector
 

--- a/versioned_docs/version-4.x/data-operate/import/data-source/migrate-data-from-other-oltp.md
+++ b/versioned_docs/version-4.x/data-operate/import/data-source/migrate-data-from-other-oltp.md
@@ -155,30 +155,6 @@ val jdbcDF = spark.read
 ```
 For more details, refer to [JDBC To Other Databases](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html)，[Spark Doris Connector](../../../ecosystem/spark-doris-connector.md#batch-write)
 
-## Streaming Job
-
-Use Streaming Job to synchronize data from MySQL or Postgres.
-
-```sql
-CREATE JOB multi_table_sync
-ON STREAMING
-FROM MYSQL (
-        "jdbc_url" = "jdbc:mysql://127.0.0.1:3306",
-        "driver_url" = "mysql-connector-j-8.0.31.jar",
-        "driver_class" = "com.mysql.cj.jdbc.Driver",
-        "user" = "root",
-        "password" = "123456",
-        "database" = "test",
-        "include_tables" = "user_info,order_info",
-        "offset" = "initial"
-)
-TO DATABASE target_test_db (
-    "table.create.properties.replication_num" = "1"
-)
-```
-
-For more details, refer to: [Postgres/MySQL Continuous Load](../streaming-job/streaming-job-multi-table.md)
-
 ## DataX / Seatunnel / CloudCanal and other third-party tools.
 
 In addition, you can also use third-party synchronization tools for data synchronization. For more details, please refer to:

--- a/versioned_docs/version-4.x/data-operate/import/data-source/mysql.md
+++ b/versioned_docs/version-4.x/data-operate/import/data-source/mysql.md
@@ -1,0 +1,248 @@
+---
+{
+    "title": "MySQL",
+    "language": "en",
+    "description": "Doris provides multiple ways to load data from MySQL, including ad-hoc loading via JDBC Catalog, continuous full + incremental synchronization via Streaming Job, and CDC sync via Flink Doris Connector."
+}
+---
+
+Doris provides the following ways to load data from MySQL:
+
+- **Loading MySQL data via JDBC Catalog**
+
+Doris uses JDBC Catalog to map MySQL as an external catalog, allowing direct SQL queries against MySQL data. Combined with `INSERT INTO` or `CREATE TABLE AS SELECT`, this is suitable for one-time migration or periodic batch loading.
+
+- **Continuously syncing MySQL data via Streaming Job**
+
+Doris uses Streaming Job to continuously sync full and incremental data from MySQL to Doris. By integrating [Flink CDC](https://github.com/apache/flink-cdc) reading capability, Doris keeps the job running, reads Binlog from MySQL and writes it to Doris tables with exactly-once semantics. Two modes are supported: table-level sync and database-level sync. Available since Doris 4.1.0.
+
+- **Loading MySQL data via Flink Doris Connector**
+
+Use Flink Doris Connector together with Flink MySQL CDC for real-time synchronization. This is suitable for scenarios that require additional Flink stream processing logic. The connector also provides a one-click full-database synchronization tool. For details, see [Flink Doris Connector](../../../ecosystem/flink-doris-connector/flink-doris-connector.md).
+
+- **Loading MySQL data via third-party tools**
+
+Data integration tools such as [DataX](../../../ecosystem/datax), [SeaTunnel](../../../ecosystem/seatunnel), and [CloudCanal](../../../ecosystem/cloudcanal) also support syncing data from MySQL to Doris.
+
+In most cases, you can use JDBC Catalog directly for one-time data migration. When continuous full + incremental synchronization is required, Streaming Job is recommended.
+
+## Loading MySQL data via JDBC Catalog
+
+Use JDBC Catalog to map MySQL as an external catalog, then use `INSERT INTO` or `CREATE TABLE AS SELECT` to load data. For detailed syntax, see [JDBC MySQL Catalog](../../../lakehouse/catalogs/jdbc-mysql-catalog.md).
+
+### Step 1: Prepare data in MySQL
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+### Step 2: Create a Catalog in Doris
+
+```sql
+CREATE CATALOG mysql_catalog PROPERTIES (
+    "type"         = "jdbc",
+    "user"         = "root",
+    "password"     = "123456",
+    "jdbc_url"     = "jdbc:mysql://127.0.0.1:3306/test",
+    "driver_url"   = "mysql-connector-java-8.0.25.jar",
+    "driver_class" = "com.mysql.cj.jdbc.Driver"
+);
+```
+
+### Step 3: Create the target table in Doris
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id     INT,
+    name   VARCHAR(64),
+    age    INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+### Step 4: Load data with INSERT INTO
+
+```sql
+INSERT INTO doris_db.students
+SELECT id, name, age FROM mysql_catalog.test.students;
+```
+
+If the target table does not exist yet, you can also use `CREATE TABLE AS SELECT` to create the table and load data in one step:
+
+```sql
+CREATE TABLE doris_db.students
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT * FROM mysql_catalog.test.students;
+```
+
+### Step 5: Verify loaded data
+
+```sql
+SELECT * FROM doris_db.students;
++----+-------+------+
+| id | name  | age  |
++----+-------+------+
+|  1 | Emily |   25 |
+|  2 | Bob   |   30 |
++----+-------+------+
+```
+
+## Continuously syncing MySQL data via Streaming Job
+
+Streaming Job continuously reads MySQL Binlog via Flink CDC and writes it to Doris. Two modes are supported:
+
+- [MySQL Database-Level Sync](../streaming-job/continuous-load-mysql-database.md): sync at the database level (use `include_tables` to sync one, several, or all tables). Doris automatically creates downstream tables on first sync. Provides at-least-once semantics.
+- [MySQL Table-Level Sync](../streaming-job/continuous-load-mysql-table.md): sync at the table level. The target table must be pre-created in Doris. Supports flexible column mapping, data transformation, and exactly-once semantics.
+
+### Limitations
+
+1. Only primary key tables (Unique Key) are supported.
+2. Load privilege is required. Database-level sync also needs Create privilege when auto-creating downstream tables on first run.
+3. Available since Doris 4.1.0.
+
+### Prerequisites
+
+Before submitting a Streaming Job, Binlog must be enabled on the MySQL side and the user must be granted the corresponding REPLICATION privileges. For environment-specific setup steps, see:
+
+- [Amazon RDS MySQL Setup Guide](../streaming-job/prerequisites/amazon-rds-mysql.md)
+- [Amazon Aurora MySQL Setup Guide](../streaming-job/prerequisites/amazon-aurora-mysql.md)
+- See [Continuous Load Overview](../streaming-job/continuous-load-overview.md) for notes and required permissions of each mode.
+
+### Operation Example: Database-Level Sync
+
+Database-level sync uses the `FROM MYSQL ... TO DATABASE ...` syntax. The target is a Doris database, and the downstream tables are automatically created on first sync.
+
+#### Step 1: Prepare data in MySQL
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### Step 2: Create the target database in Doris
+
+Database-level sync **does not require pre-creating tables**, but the target database that hosts them must exist:
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+```
+
+#### Step 3: Create a Streaming Job
+
+The example below uses `include_tables` to sync only the `students` table (multiple tables can be comma-separated; leave empty to sync the whole database):
+
+```sql
+CREATE JOB mysql_db_sync
+ON STREAMING
+FROM MYSQL (
+    "jdbc_url"       = "jdbc:mysql://127.0.0.1:3306",
+    "driver_url"     = "mysql-connector-java-8.0.25.jar",
+    "driver_class"   = "com.mysql.cj.jdbc.Driver",
+    "user"           = "root",
+    "password"       = "123456",
+    "database"       = "test",
+    "include_tables" = "students",
+    "offset"         = "initial"
+)
+TO DATABASE doris_db (
+    "table.create.properties.replication_num" = "1"  -- set to 1 in single-BE deployments
+);
+```
+
+#### Step 4: Check job status
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### Step 5: Inspect auto-created Doris tables and loaded data
+
+```sql
+SHOW TABLES FROM doris_db;
+SELECT * FROM doris_db.students;
+```
+
+For more common operations and full parameter reference, see [MySQL Database-Level Sync](../streaming-job/continuous-load-mysql-database.md).
+
+### Operation Example: Table-Level Sync
+
+#### Step 1: Prepare data in MySQL
+
+```sql
+CREATE TABLE test.students (
+    id     INT PRIMARY KEY,
+    name   VARCHAR(64),
+    age    INT
+);
+
+INSERT INTO test.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### Step 2: Create the target table in Doris
+
+Table-level sync requires the target table to exist beforehand:
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id     INT,
+    name   VARCHAR(64),
+    age    INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+#### Step 3: Create a Streaming Job
+
+Use [CREATE STREAMING JOB](../../../sql-manual/sql-statements/job/CREATE-STREAMING-JOB.md) with the `INSERT INTO ... SELECT * FROM cdc_stream(...)` syntax:
+
+```sql
+CREATE JOB mysql_students_sync
+ON STREAMING
+DO
+INSERT INTO doris_db.students
+SELECT * FROM cdc_stream(
+    "type"         = "mysql",
+    "jdbc_url"     = "jdbc:mysql://127.0.0.1:3306",
+    "driver_url"   = "mysql-connector-java-8.0.25.jar",
+    "driver_class" = "com.mysql.cj.jdbc.Driver",
+    "user"         = "root",
+    "password"     = "123456",
+    "database"     = "test",
+    "table"        = "students",
+    "offset"       = "initial"
+);
+```
+
+#### Step 4: Check job status
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### Step 5: Verify loaded data
+
+```sql
+SELECT * FROM doris_db.students;
+```
+
+For more common operations (pause, resume, delete, check task, etc.) and full parameter reference, see [MySQL Table-Level Sync](../streaming-job/continuous-load-mysql-table.md).

--- a/versioned_docs/version-4.x/data-operate/import/data-source/postgresql.md
+++ b/versioned_docs/version-4.x/data-operate/import/data-source/postgresql.md
@@ -1,0 +1,250 @@
+---
+{
+    "title": "PostgreSQL",
+    "language": "en",
+    "description": "Doris provides multiple ways to load data from PostgreSQL, including ad-hoc loading via JDBC Catalog, continuous full + incremental synchronization via Streaming Job, and CDC sync via Flink Doris Connector."
+}
+---
+
+Doris provides the following ways to load data from PostgreSQL:
+
+- **Loading PostgreSQL data via JDBC Catalog**
+
+Doris uses JDBC Catalog to map PostgreSQL as an external catalog, allowing direct SQL queries against PostgreSQL data. Combined with `INSERT INTO` or `CREATE TABLE AS SELECT`, this is suitable for one-time migration or periodic batch loading.
+
+- **Continuously syncing PostgreSQL data via Streaming Job**
+
+Doris uses Streaming Job to continuously sync full and incremental data from PostgreSQL to Doris. By integrating [Flink CDC](https://github.com/apache/flink-cdc) reading capability, Doris keeps the job running, reads WAL from PostgreSQL and writes it to Doris tables with exactly-once semantics. Two modes are supported: table-level sync and database-level sync. Available since Doris 4.1.0.
+
+- **Loading PostgreSQL data via Flink Doris Connector**
+
+Use Flink Doris Connector together with Flink Postgres CDC for real-time synchronization. This is suitable for scenarios that require additional Flink stream processing logic. The connector also provides a one-click full-database synchronization tool. For details, see [Flink Doris Connector](../../../ecosystem/flink-doris-connector/flink-doris-connector.md).
+
+- **Loading PostgreSQL data via third-party tools**
+
+Data integration tools such as [DataX](../../../ecosystem/datax), [SeaTunnel](../../../ecosystem/seatunnel), and [CloudCanal](../../../ecosystem/cloudcanal) also support syncing data from PostgreSQL to Doris.
+
+In most cases, you can use JDBC Catalog directly for one-time data migration. When continuous full + incremental synchronization is required, Streaming Job is recommended.
+
+## Loading PostgreSQL data via JDBC Catalog
+
+Use JDBC Catalog to map PostgreSQL as an external catalog, then use `INSERT INTO` or `CREATE TABLE AS SELECT` to load data. For detailed syntax, see [JDBC PostgreSQL Catalog](../../../lakehouse/catalogs/jdbc-pg-catalog.md).
+
+### Step 1: Prepare data in PostgreSQL
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+### Step 2: Create a Catalog in Doris
+
+```sql
+CREATE CATALOG pg_catalog PROPERTIES (
+    "type"         = "jdbc",
+    "user"         = "postgres",
+    "password"     = "postgres",
+    "jdbc_url"     = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"   = "postgresql-42.5.1.jar",
+    "driver_class" = "org.postgresql.Driver"
+);
+```
+
+### Step 3: Create the target table in Doris
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id    INT,
+    name  VARCHAR(64),
+    age   INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+### Step 4: Load data with INSERT INTO
+
+```sql
+INSERT INTO doris_db.students
+SELECT id, name, age FROM pg_catalog.postgres.public.students;
+```
+
+If the target table does not exist yet, you can also use `CREATE TABLE AS SELECT` to create the table and load data in one step:
+
+```sql
+CREATE TABLE doris_db.students
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT * FROM pg_catalog.postgres.public.students;
+```
+
+### Step 5: Verify loaded data
+
+```sql
+SELECT * FROM doris_db.students;
++----+-------+------+
+| id | name  | age  |
++----+-------+------+
+|  1 | Emily |   25 |
+|  2 | Bob   |   30 |
++----+-------+------+
+```
+
+## Continuously syncing PostgreSQL data via Streaming Job
+
+Streaming Job continuously reads PostgreSQL WAL via Flink CDC and writes it to Doris. Two modes are supported:
+
+- [PostgreSQL Database-Level Sync](../streaming-job/continuous-load-postgresql-database.md): sync at the database level (use `include_tables` to sync one, several, or all tables). Doris automatically creates downstream tables on first sync. Provides at-least-once semantics.
+- [PostgreSQL Table-Level Sync](../streaming-job/continuous-load-postgresql-table.md): sync at the table level. The target table must be pre-created in Doris. Supports flexible column mapping, data transformation, and exactly-once semantics.
+
+### Limitations
+
+1. Only primary key tables (Unique Key) are supported.
+2. Load privilege is required. Database-level sync also needs Create privilege when auto-creating downstream tables on first run.
+3. Available since Doris 4.1.0.
+
+### Prerequisites
+
+Before submitting a Streaming Job, logical replication (`wal_level=logical`) must be enabled on the PostgreSQL side and the user must be granted the corresponding REPLICATION privileges. For environment-specific setup steps, see:
+
+- [Amazon RDS PostgreSQL Setup Guide](../streaming-job/prerequisites/amazon-rds-postgresql.md)
+- [Amazon Aurora PostgreSQL Setup Guide](../streaming-job/prerequisites/amazon-aurora-postgresql.md)
+- See [Continuous Load Overview](../streaming-job/continuous-load-overview.md) for notes and required permissions of each mode.
+
+### Operation Example: Database-Level Sync
+
+Database-level sync uses the `FROM POSTGRES ... TO DATABASE ...` syntax. The target is a Doris database, and the downstream tables are automatically created on first sync.
+
+#### Step 1: Prepare data in PostgreSQL
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### Step 2: Create the target database in Doris
+
+Database-level sync **does not require pre-creating tables**, but the target database that hosts them must exist:
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+```
+
+#### Step 3: Create a Streaming Job
+
+The example below uses `include_tables` to sync only the `students` table (multiple tables can be comma-separated; leave empty to sync the whole database):
+
+```sql
+CREATE JOB pg_db_sync
+ON STREAMING
+FROM POSTGRES (
+    "jdbc_url"       = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"     = "postgresql-42.5.1.jar",
+    "driver_class"   = "org.postgresql.Driver",
+    "user"           = "postgres",
+    "password"       = "postgres",
+    "database"       = "postgres",
+    "schema"         = "public",
+    "include_tables" = "students",
+    "offset"         = "initial"
+)
+TO DATABASE doris_db (
+    "table.create.properties.replication_num" = "1"  -- set to 1 in single-BE deployments
+);
+```
+
+#### Step 4: Check job status
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### Step 5: Inspect auto-created Doris tables and loaded data
+
+```sql
+SHOW TABLES FROM doris_db;
+SELECT * FROM doris_db.students;
+```
+
+For more common operations and full parameter reference, see [PostgreSQL Database-Level Sync](../streaming-job/continuous-load-postgresql-database.md).
+
+### Operation Example: Table-Level Sync
+
+#### Step 1: Prepare data in PostgreSQL
+
+```sql
+CREATE TABLE public.students (
+    id    INT PRIMARY KEY,
+    name  VARCHAR(64),
+    age   INT
+);
+
+INSERT INTO public.students VALUES (1, 'Emily', 25), (2, 'Bob', 30);
+```
+
+#### Step 2: Create the target table in Doris
+
+Table-level sync requires the target table to exist beforehand:
+
+```sql
+CREATE DATABASE IF NOT EXISTS doris_db;
+
+CREATE TABLE doris_db.students (
+    id    INT,
+    name  VARCHAR(64),
+    age   INT
+)
+UNIQUE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+```
+
+#### Step 3: Create a Streaming Job
+
+Use [CREATE STREAMING JOB](../../../sql-manual/sql-statements/job/CREATE-STREAMING-JOB.md) with the `INSERT INTO ... SELECT * FROM cdc_stream(...)` syntax:
+
+```sql
+CREATE JOB pg_students_sync
+ON STREAMING
+DO
+INSERT INTO doris_db.students
+SELECT * FROM cdc_stream(
+    "type"         = "postgres",
+    "jdbc_url"     = "jdbc:postgresql://127.0.0.1:5432/postgres",
+    "driver_url"   = "postgresql-42.5.1.jar",
+    "driver_class" = "org.postgresql.Driver",
+    "user"         = "postgres",
+    "password"     = "postgres",
+    "database"     = "postgres",
+    "schema"       = "public",
+    "table"        = "students",
+    "offset"       = "initial"
+);
+```
+
+#### Step 4: Check job status
+
+```sql
+SELECT * FROM jobs("type"="insert") WHERE ExecuteType = "STREAMING";
+```
+
+#### Step 5: Verify loaded data
+
+```sql
+SELECT * FROM doris_db.students;
+```
+
+For more common operations (pause, resume, delete, check task, etc.) and full parameter reference, see [PostgreSQL Table-Level Sync](../streaming-job/continuous-load-postgresql-table.md).

--- a/versioned_sidebars/version-4.x-sidebars.json
+++ b/versioned_sidebars/version-4.x-sidebars.json
@@ -180,6 +180,8 @@
                                 "data-operate/import/data-source/snowflake",
                                 "data-operate/import/data-source/bigquery",
                                 "data-operate/import/data-source/redshift",
+                                "data-operate/import/data-source/mysql",
+                                "data-operate/import/data-source/postgresql",
                                 "data-operate/import/data-source/migrate-data-from-other-olap",
                                 "data-operate/import/data-source/migrate-data-from-other-oltp"
                             ]


### PR DESCRIPTION
## Summary

Add dedicated MySQL and PostgreSQL pages under **Data Loading → Data Source** to surface Doris's continuous load (Streaming Job) capability for MySQL and PostgreSQL, which were previously only discoverable inside the generic `migrate-data-from-other-oltp` page.

Each new page covers four import paths, with **JDBC Catalog** as the primary one-time-migration option and **Streaming Job (Continuous Load)** as the recommended path for full + incremental sync since 4.1.0:

- JDBC Catalog (with a 5-step example: source prep → catalog → target table → INSERT/CTAS → verify)
- Streaming Job — including a Limitations section, a Prerequisites section linking to RDS / Aurora setup guides and the Continuous Load overview, plus complete 5-step examples for both **database-level sync** (using `FROM MYSQL/POSTGRES … TO DATABASE …` with `include_tables = "students"`) and **table-level sync** (using `INSERT INTO … SELECT * FROM cdc_stream(...)`)
- Flink Doris Connector (link to existing doc)
- Third-party tools (DataX / SeaTunnel / CloudCanal)

The Streaming Job section in `migrate-data-from-other-oltp.md` is removed (it referenced a stale `streaming-job-multi-table.md` link), since the same content now lives in the dedicated MySQL/PostgreSQL pages.

## Files changed

New (×4 files for each of mysql, postgresql):
- `docs/data-operate/import/data-source/{mysql,postgresql}.md` (English dev)
- `versioned_docs/version-4.x/data-operate/import/data-source/{mysql,postgresql}.md` (English 4.x)
- `i18n/zh-CN/.../current/data-operate/import/data-source/{mysql,postgresql}.md` (Chinese dev)
- `i18n/zh-CN/.../version-4.x/data-operate/import/data-source/{mysql,postgresql}.md` (Chinese 4.x)

Modified:
- `migrate-data-from-other-oltp.md` (×4 — dev/4.x × en/zh): remove obsolete Streaming Job section
- `sidebars.ts` and `versioned_sidebars/version-4.x-sidebars.json`: insert `mysql` and `postgresql` between `redshift` and `migrate-data-from-other-olap`