### PR TITLE
[ci] split bilingual build per locale and enable docs-next in cron deploy

### DIFF
--- a/.github/workflows/cron-deploy-website.yml
+++ b/.github/workflows/cron-deploy-website.yml
@@ -37,10 +37,14 @@ jobs:
                   npm install -g yarn
                   yarn cache clean
                   export NODE_OPTIONS=--max-old-space-size=8192
-                  export SKIP_DOCS_NEXT=1
                   yarn
                   node ./scripts/update_github_info.js
-                  PWA_SERVICE_WORKER_URL=https://doris.apache.org/sw.js yarn docusaurus build --locale en --locale zh-CN
+                  # Build each locale separately into its own out-dir to halve per-process peak memory and avoid OOM on the GitHub-hosted runner.
+                  PWA_SERVICE_WORKER_URL=https://doris.apache.org/sw.js yarn docusaurus build --locale en --out-dir build-en
+                  PWA_SERVICE_WORKER_URL=https://doris.apache.org/sw.js yarn docusaurus build --locale zh-CN --out-dir build-zh
+                  rm -rf ./build && mkdir ./build
+                  cp -a ./build-en/. ./build/
+                  cp -a ./build-zh/zh-CN/. ./build/zh-CN/
                   if [ ! -d "./ja-build" ]; then
                       echo "ja-build directory not found, aborting to avoid publishing incorrect ja content."
                       exit 1

--- a/.github/workflows/manual-deploy-website.yml
+++ b/.github/workflows/manual-deploy-website.yml
@@ -42,7 +42,12 @@ jobs:
                   yarn cache clean
                   export NODE_OPTIONS=--max-old-space-size=8192
                   yarn
-                  PWA_SERVICE_WORKER_URL=https://doris.apache.org/sw.js yarn docusaurus build --locale en --locale zh-CN
+                  # Build each locale separately into its own out-dir to halve per-process peak memory and avoid OOM on the GitHub-hosted runner.
+                  PWA_SERVICE_WORKER_URL=https://doris.apache.org/sw.js yarn docusaurus build --locale en --out-dir build-en
+                  PWA_SERVICE_WORKER_URL=https://doris.apache.org/sw.js yarn docusaurus build --locale zh-CN --out-dir build-zh
+                  rm -rf ./build && mkdir ./build
+                  cp -a ./build-en/. ./build/
+                  cp -a ./build-zh/zh-CN/. ./build/zh-CN/
                   if [ ! -d "./ja-build" ]; then
                       echo "ja-build directory not found, aborting to avoid publishing incorrect ja content."
                       exit 1


### PR DESCRIPTION
Split docusaurus build into separate `--locale en` and `--locale zh-CN` runs (each with its own `--out-dir`), then merge into `build/`, to halve per-process peak memory and avoid the runner-OOM that took down the 2-hour cron deploy. Also drop `SKIP_DOCS_NEXT=1` from the cron deploy so docs-next ships with the rest of the site.
