### PR TITLE
[chore] require next-version docs update when legacy docs change

### DIFF
--- a/.github/workflows/check-legacy-docs-frozen.yml
+++ b/.github/workflows/check-legacy-docs-frozen.yml
@@ -2,9 +2,7 @@ name: Check Legacy Docs Frozen
 
 on:
   pull_request:
-    # Include `labeled` / `unlabeled` so that adding or removing the
-    # `allow-legacy-docs` label re-runs this check automatically.
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 jobs:
   check-legacy-docs:
@@ -16,8 +14,6 @@ jobs:
           fetch-depth: 0
 
       - name: Detect changes in legacy docs directories
-        env:
-          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           set -e
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
@@ -27,29 +23,20 @@ jobs:
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
 
           LEGACY=$(echo "$CHANGED" | grep -E '^(docs/|i18n/zh-CN/docusaurus-plugin-content-docs/current/)' || true)
+          NEXT=$(echo "$CHANGED" | grep -E '^(docs-next/|i18n/zh-CN/docusaurus-plugin-content-docs-next/current/)' || true)
 
-          if [ -n "$LEGACY" ]; then
-            # Bypass: maintainers can attach the `allow-legacy-docs` label to
-            # explicitly approve a legacy-docs change (e.g. a critical fix that
-            # must ship before the next-version cutover).
-            if echo "$PR_LABELS" | grep -q '"allow-legacy-docs"'; then
-              echo "::warning::Legacy doc changes detected, but the 'allow-legacy-docs' label is set — bypassing the check."
-              echo ""
-              echo "Legacy doc files changed in this PR (allowed by label):"
-              echo "$LEGACY" | sed 's/^/   - /'
-              exit 0
-            fi
-
-            echo "::error::Modifying legacy documentation directories is not allowed."
+          if [ -n "$LEGACY" ] && [ -z "$NEXT" ]; then
+            echo "::error::Legacy docs changed without corresponding next-version docs changes."
             echo ""
             echo "❌ The following legacy doc files were changed in this PR:"
             echo "$LEGACY" | sed 's/^/   - /'
             echo ""
-            echo "The following directories are frozen and must not be modified:"
-            echo "   - docs/"
-            echo "   - i18n/zh-CN/docusaurus-plugin-content-docs/current/"
+            echo "But no changes were detected in the next-version directories:"
+            echo "   - docs-next/"
+            echo "   - i18n/zh-CN/docusaurus-plugin-content-docs-next/current/"
             echo ""
-            echo "Please move your changes to the corresponding next-version directory:"
+            echo "If you modify legacy docs, you MUST also apply the equivalent changes"
+            echo "to the corresponding next-version directory:"
             echo "   English:  docs/<path>"
             echo "         ->  docs-next/<path>"
             echo "   中文:     i18n/zh-CN/docusaurus-plugin-content-docs/current/<path>"
@@ -58,11 +45,11 @@ jobs:
             echo "Note: a few top-level folders were renamed in the new structure, e.g."
             echo "   gettingStarted  ->  getting-started"
             echo "   ecosystem       ->  connection-integration  (structure also changed; please review)"
-            echo ""
-            echo "If a change to legacy docs is genuinely required (e.g. a critical fix that"
-            echo "must ship before the next-version cutover), please discuss with the maintainers,"
-            echo "and a maintainer can attach the 'allow-legacy-docs' label to bypass this check."
             exit 1
           fi
 
-          echo "✅ No changes in legacy docs directories."
+          if [ -n "$LEGACY" ]; then
+            echo "✅ Legacy docs changed, and next-version docs were also updated."
+          else
+            echo "✅ No changes in legacy docs directories."
+          fi


### PR DESCRIPTION
Replace the legacy-docs freeze with a paired-update rule: if a PR modifies legacy docs but does not also touch the corresponding next-version directory, the check fails. The allow-legacy-docs label bypass is removed since edits are now permitted as long as they are mirrored to the next-version tree.