### PR TITLE
[feat](next) add search box to docs-next pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -356,15 +356,14 @@ const config = {
                 highlightSearchTermsOnTargetPage: true,
                 // indexPages: true,
                 indexDocs: true,
-                // 灰度期保持只索引旧版 docs, 不索引 docs-next
-                // 阶段 4 切换默认时改为:
-                // ['docs-next', 'zh-CN/docs-next', 'docs', 'zh-CN/docs', 'ja/docs']
-                docsRouteBasePath: ['docs', 'ja/docs', 'zh-CN/docs'],
+                docsRouteBasePath: ['docs-next', 'zh-CN/docs-next', 'docs', 'ja/docs', 'zh-CN/docs'],
                 indexBlog: false,
                 explicitSearchResultPath: true,
                 searchBarShortcut: true,
                 searchBarShortcutHint: true,
                 searchResultLimits: 100,
+                searchContextByPaths: ['docs-next', 'docs'],
+                useAllContextsWithNoSearchContext: true,
             },
         ],
     ],

--- a/local_dev.sh
+++ b/local_dev.sh
@@ -295,6 +295,10 @@ cmd_build_docs_next_only() {
         do_install
     fi
 
+    # Disable the legacy docs plugin: DOCS_VERSIONS=current is meant for
+    # docs-next, but the legacy docs plugin has no `current` version and
+    # would fail validation on lastVersion.
+    export SKIP_DOCS=true
     apply_versions_env "current"
     export NODE_OPTIONS="--max-old-space-size=${OPT_MAX_MEM}"
 
@@ -313,6 +317,9 @@ cmd_build_docs_next_all() {
         do_install
     fi
 
+    # Same rationale as cmd_build_docs_next_only: avoid feeding "current"
+    # into the legacy docs plugin's lastVersion validation.
+    export SKIP_DOCS=true
     apply_versions_env "current"
     export NODE_OPTIONS="--max-old-space-size=${OPT_MAX_MEM}"
 

--- a/src/components/home-next/DocsSearchSection.scss
+++ b/src/components/home-next/DocsSearchSection.scss
@@ -1,0 +1,73 @@
+// DocsSearchSection — strip placed below NavbarNext on docs-next pages,
+// holds the global SearchBar so it doesn't crowd the main navbar.
+
+.docs-next-search-section {
+    position: sticky;
+    top: calc(var(--home-next-banner-height, 0px) + 64px);
+    z-index: 99;
+    width: 100%;
+    background: #FAF6EE;
+    border-bottom: 1px solid rgba(15, 26, 20, 0.08);
+
+    &__inner {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding: 12px 56px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    // Reset / restyle the SearchBar so it works as a standalone block
+    // instead of a navbar item. Note: this file is a plain SCSS (not a
+    // CSS module), so target the global class directly without :global().
+    .navbar__search {
+        width: 100%;
+        max-width: 1080px;
+        margin: 0;
+
+        input.navbar__search-input {
+            width: 100% !important;
+            height: 2.5rem !important;
+            border: 1px solid rgba(15, 26, 20, 0.12) !important;
+            background-color: #fff !important;
+            background-image: url('/images/search-icon.svg');
+            background-position: 0.75rem center;
+            background-repeat: no-repeat;
+            padding-left: 2.5rem !important;
+            border-radius: 8px;
+            color: #4c576c !important;
+            transition: border-color 0.15s, box-shadow 0.15s;
+
+            &:hover {
+                border-color: rgba(15, 26, 20, 0.24) !important;
+            }
+
+            &:focus {
+                border-color: #06805F !important;
+                box-shadow: 0 0 0 3px rgba(6, 128, 95, 0.12);
+                outline: none !important;
+            }
+        }
+    }
+}
+
+@media (max-width: 1180px) {
+    .docs-next-search-section__inner {
+        padding: 12px 32px;
+    }
+}
+
+@media (max-width: 1020px) {
+    .docs-next-search-section__inner {
+        padding: 10px 24px;
+    }
+}
+
+@media (max-width: 640px) {
+    .docs-next-search-section {
+        &__inner {
+            padding: 10px 20px;
+        }
+    }
+}

--- a/src/components/home-next/DocsSearchSection.tsx
+++ b/src/components/home-next/DocsSearchSection.tsx
@@ -1,0 +1,28 @@
+import React, { JSX, useEffect, useRef } from 'react';
+import SearchBar from '@theme/SearchBar';
+import './DocsSearchSection.scss';
+
+const PLACEHOLDER = 'Search documentation';
+
+export function DocsSearchSection(): JSX.Element {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    // SearchBar's placeholder is locale-translated by Docusaurus, so on zh-CN
+    // it renders "搜索". Force English here since this section is meant to be
+    // a stable, locale-agnostic entry point for docs search.
+    useEffect(() => {
+        const input = containerRef.current?.querySelector<HTMLInputElement>('input.navbar__search-input');
+        if (input) {
+            input.setAttribute('placeholder', PLACEHOLDER);
+            input.setAttribute('aria-label', PLACEHOLDER);
+        }
+    }, []);
+
+    return (
+        <div className="docs-next-search-section" ref={containerRef}>
+            <div className="docs-next-search-section__inner">
+                <SearchBar />
+            </div>
+        </div>
+    );
+}

--- a/src/theme/Layout/index.tsx
+++ b/src/theme/Layout/index.tsx
@@ -18,6 +18,7 @@ import styles from './styles.module.css';
 import { useHistory } from '@docusaurus/router';
 import { NavbarNext } from '@site/src/components/home-next/NavbarNext';
 import { PreviewBanner } from '@site/src/components/home-next/PreviewBanner';
+import { DocsSearchSection } from '@site/src/components/home-next/DocsSearchSection';
 import { isDocsNextPath, isReleasesPath, isEventsPath } from '@site/src/utils/locale';
 interface DataType {
     showSearchPageMobile: boolean;
@@ -92,6 +93,7 @@ export default function Layout(props: Props): JSX.Element {
                 <AnnouncementBar />
                 {useNextNavbar && <PreviewBanner />}
                 {useNextNavbar ? <NavbarNext /> : <Navbar />}
+                {isDocsNextPage && <DocsSearchSection />}
                 {!useNextNavbar && showSearchPageMobile ? (
                     <div ref={searchPageDom}>
                         <NavbarSearch>

--- a/src/theme/SearchBar/SearchBar.jsx
+++ b/src/theme/SearchBar/SearchBar.jsx
@@ -49,7 +49,7 @@ function getVersionUrl(baseUrl, pathname, locales, currentLocale, defaultLocale)
         versionUrl += '/';
     }
     const normalizedPathname = normalizePathname(pathname, locales);
-    if (normalizedPathname?.startsWith('/docs')) {
+    if (normalizedPathname === '/docs' || normalizedPathname?.startsWith('/docs/')) {
         const version = normalizedPathname.split('/')[2];
         if (VERSIONS.includes(version) && version !== DEFAULT_VERSION) {
             versionUrl += `docs/${version}/`;


### PR DESCRIPTION
- Index docs-next under docusaurus-search-local, scope results per /docs vs /docs-next via searchContextByPaths.
- Render a dedicated SearchBar strip below NavbarNext on docs-next (NavbarNext otherwise has no search affordance).
- Fix getVersionUrl so /docs-next/dev/* no longer maps to a non-existent /docs/dev/ search-index path.
- SKIP_DOCS in cmd_build_docs_next_{only,all} so the legacy docs plugin does not choke on DOCS_VERSIONS=current during docs-next-only runs.