### PR TITLE
[doc](opt) Add mv task job mv_info opt docs

### DIFF
--- a/docs/sql-manual/sql-functions/table-valued-functions/jobs.md
+++ b/docs/sql-manual/sql-functions/table-valued-functions/jobs.md
@@ -49,34 +49,78 @@ JOBS(
 
     | Field                | Description                                                 |
     |----------------------|-------------------------------------------------------------|
-    | Id                   | job ID                                                      |
-    | Name                 | job name                                                    |
-    | MvId                 | Materialized View ID                                        |
-    | MvName               | Materialized View Name                                      |
-    | MvDatabaseId         | DB ID of the materialized view                              |
-    | MvDatabaseName       | Name of the database to which the materialized view belongs |
-    | ExecuteType          | Execution type                                              |
-    | RecurringStrategy    | Loop strategy                                               |
-    | Status               | Job status                                                  |
-    | CreateTime           | Task creation time                                          |
+    | Id                   | Job ID. For MV jobs, it corresponds to `tasks("type"="mv").JobId`. |
+    | Name                 | Job name. For MV jobs, it corresponds to `mv_infos("database"="...").JobName` and `tasks("type"="mv").JobName`. |
+    | MvId                 | ID of the materialized view maintained by this job. |
+    | MvName               | Name of the materialized view maintained by this job. |
+    | MvDatabaseId         | ID of the database that contains the materialized view. |
+    | MvDatabaseName       | Name of the database that contains the materialized view. |
+    | ExecuteType          | Job execution type. For MV jobs, possible values are `MANUAL` and `RECURRING`. `MANUAL` means refresh tasks are triggered manually, by commit, or by internal events. `RECURRING` means refresh tasks are scheduled periodically. |
+    | RecurringStrategy    | Scheduling description derived from `ExecuteType`. `MANUAL TRIGGER` means the job does not run on a timer. `EVERY ... STARTS ... [ENDS ...]` means the job runs periodically. |
+    | Status               | Job status. Possible values: `PENDING` means the job is waiting for scheduling; `RUNNING` means the job can produce tasks; `PAUSED` means the job is paused and can be resumed; `STOPPED` means the job has been stopped and cannot be resumed; `FINISHED` means the job has finished. |
+    | CreateTime           | Time when the job was created. |
+
+### MV job enum fields
+
+The following enum fields are commonly used when checking materialized view refresh jobs:
+
+- `ExecuteType`: how the job creates refresh tasks.
+  - `MANUAL`: the job does not run on its own timer. A task is created only when a refresh is triggered manually, by commit, or by the system.
+  - `RECURRING`: the job runs on a schedule and periodically creates refresh tasks.
+- `RecurringStrategy`: human-readable scheduling rule generated from `ExecuteType`.
+  - `MANUAL TRIGGER`: the job is not scheduled periodically. This is the usual value when `ExecuteType` is `MANUAL`.
+  - `EVERY <interval> <unit> STARTS <time> [ENDS <time>]`: the job is scheduled periodically. For example, `EVERY 10 MINUTE STARTS 2025-01-17 14:42:53`.
+- `Status`: current state of the job itself.
+  - `PENDING`: the job is waiting to be scheduled.
+  - `RUNNING`: the job is active and can create refresh tasks.
+  - `PAUSED`: the job is paused. It will not create new refresh tasks until it is resumed.
+  - `STOPPED`: the job has been stopped and cannot be resumed.
+  - `FINISHED`: the job has finished. This is uncommon for long-lived MV refresh jobs, but it can appear in the generic job framework.
+
+For materialized views, one materialized view has one refresh job, and one refresh job can create many refresh tasks. Use `jobs("type"="mv").Name` to connect the job to `mv_infos("database"="...").JobName` and `tasks("type"="mv").JobName`.
 
 
 ## Examples
 
-View jobs in all materialized views
+View the refresh job of a materialized view.
 
 ```sql
-select * from jobs("type"="mv");
+select *
+from jobs("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"\G
 ```
 ```text
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| Id    | Name             | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | ExecuteType | RecurringStrategy | Status  | CreateTime          |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 12:26:06 |
-| 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-07 22:13:31 |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
+*************************** 1. row ***************************
+               Id: 19508
+             Name: inner_mtmv_19494
+             MvId: 19494
+           MvName: mv1
+     MvDatabaseId: 16016
+   MvDatabaseName: test
+      ExecuteType: MANUAL
+RecurringStrategy: MANUAL TRIGGER
+           Status: RUNNING
+       CreateTime: 2025-01-07 22:13:31
+```
+
+In this result:
+
+- `Id` is the MV refresh job ID. It is the same value as `JobId` in `tasks("type"="mv")`.
+- `Name` is the MV refresh job name. It is the same value as `JobName` in `mv_infos("database"="test")` and `tasks("type"="mv")`.
+- `MvId` and `MvName` identify the materialized view maintained by this job.
+- `MvDatabaseId` and `MvDatabaseName` identify the database that contains the materialized view.
+- `ExecuteType` is `MANUAL`, so this job does not run by its own timer. A refresh task is created when the materialized view is manually refreshed, refreshed on commit, or triggered by the system.
+- `RecurringStrategy` is `MANUAL TRIGGER`, which matches `ExecuteType = MANUAL`. For a scheduled materialized view, this field is displayed as `EVERY ... STARTS ...`.
+- `Status` is `RUNNING`, so the job can generate refresh tasks. If it is `PAUSED`, resume the materialized view job before expecting new tasks.
+- `CreateTime` is the time when this MV refresh job was created.
+
+To view the tasks generated by this job, use the job name:
+
+```sql
+select *
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc;
 ```
 
 View all insert jobs

--- a/docs/sql-manual/sql-functions/table-valued-functions/mv_infos.md
+++ b/docs/sql-manual/sql-functions/table-valued-functions/mv_infos.md
@@ -26,42 +26,91 @@ MV_INFOS("database"="<database>")
 |------------------------|---------|---------------------------------------------------------------------|
 | Id                     | BIGINT  | Materialized view ID                                                |
 | Name                   | TEXT    | Materialized view name                                              |
-| JobName                | TEXT    | Job name corresponding to the materialized view                      |
-| State                  | TEXT    | State of the materialized view                                       |
-| SchemaChangeDetail     | TEXT    | Reason for the state change to SchemaChange                         |
-| RefreshState           | TEXT    | Refresh state of the materialized view                               |
-| RefreshInfo            | TEXT    | Refresh strategy information defined for the materialized view       |
+| JobName                | TEXT    | Name of the refresh job corresponding to the materialized view. It can be used to query `jobs("type"="mv")` and `tasks("type"="mv")`. |
+| State                  | TEXT    | Metadata state of the materialized view. Possible values: `INIT`, `NORMAL`, and `SCHEMA_CHANGE`. |
+| SchemaChangeDetail     | TEXT    | Reason why `State` becomes `SCHEMA_CHANGE`. Empty when the materialized view is not in schema change state. |
+| RefreshState           | TEXT    | State of the latest refresh. Possible values: `INIT`, `SUCCESS`, and `FAIL`. |
+| RefreshInfo            | TEXT    | Refresh strategy defined for the materialized view, including build mode, refresh method, and trigger mode. |
 | QuerySql               | TEXT    | SQL query defined for the materialized view                          |
-| EnvInfo                | TEXT    | Environment information when the materialized view was created       |
 | MvProperties           | TEXT    | Materialized view properties                                         |
 | MvPartitionInfo        | TEXT    | Partition information of the materialized view                       |
-| SyncWithBaseTables     | BOOLEAN | Whether the data is synchronized with the base table. To check which partition is not synchronized, use [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS) |
+| SyncWithBaseTables     | BOOLEAN | Whether the data of the materialized view is synchronized with its base tables. To check which partition is not synchronized, use [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS). |
+
+`RefreshInfo` is displayed as `BUILD <BuildMode> REFRESH <RefreshMethod> ON <RefreshTrigger> [schedule]`. The meaning of each part is described in the enum section below.
+
+### MV info enum fields
+
+The following enum fields are commonly used when checking materialized view definitions and health:
+
+- `State`: metadata state of the materialized view.
+  - `INIT`: the materialized view has been created but has not reached normal usable metadata state yet.
+  - `NORMAL`: the materialized view metadata is normal. This is the expected state in most cases.
+  - `SCHEMA_CHANGE`: a schema change on a base table or related object affected this materialized view. Check `SchemaChangeDetail` for the reason. The materialized view can usually be queried directly, but it may not be available for transparent rewrite until it is refreshed successfully.
+- `RefreshState`: result state of the latest refresh.
+  - `INIT`: no refresh result has been recorded yet.
+  - `SUCCESS`: the latest refresh finished successfully.
+  - `FAIL`: the latest refresh failed. Use `JobName` to query `tasks("type"="mv")` and check the failed task's `ErrorMsg`.
+- `RefreshInfo.BuildMode`: when Doris builds the materialized view data.
+  - `IMMEDIATE`: build the materialized view immediately after creation.
+  - `DEFERRED`: do not build it at creation time. The materialized view needs a later refresh before it has fresh data.
+- `RefreshInfo.RefreshMethod`: how Doris chooses data to refresh.
+  - `COMPLETE`: always refresh the materialized view completely.
+  - `AUTO`: Doris decides whether to refresh all partitions or only changed partitions.
+- `RefreshInfo.RefreshTrigger`: what triggers refresh tasks.
+  - `MANUAL`: refresh is triggered manually.
+  - `COMMIT`: refresh is triggered by data changes on related base tables.
+  - `SCHEDULE`: refresh is triggered by a schedule. The schedule details appear after `ON SCHEDULE` in `RefreshInfo`.
+- `MvPartitionInfo.partitionType`: how the materialized view is partitioned.
+  - `FOLLOW_BASE_TABLE`: materialized view partitions follow a base table partition column.
+  - `SELF_MANAGE`: the materialized view manages its own partitions.
+  - `EXPR`: materialized view partitions are defined by an expression.
+- `SyncWithBaseTables`: whether materialized view data is synchronized with base tables.
+  - `1` or `true`: synchronized.
+  - `0` or `false`: not fully synchronized. For partitioned materialized views, use `SHOW PARTITIONS FROM <mv_name>` to check partition-level synchronization.
 
 ## Examples
 
-View all materialized views under test
+View a materialized view under database `test`.
 
 ```sql
-select * from mv_infos("database"="test");
+select *
+from mv_infos("database"="test")
+where Name = "mv1"\G
 ```
 ```text
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name                     | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                                                                                         | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1                      | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`                                                                      | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-| 21788 | test_tablet_type_mtmv_mv | inner_mtmv_21788 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`test_tablet_type_mtmv_table`.`k2`, `internal`.`test`.`test_tablet_type_mtmv_table`.`k3` from `internal`.`test`.`test_tablet_type_mtmv_table` | {}                                                        | MTMVPartitionInfo{partitionType=SELF_MANAGE}                                                              |                  0 |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
+*************************** 1. row ***************************
+                Id: 19494
+              Name: mv1
+           JobName: inner_mtmv_19494
+             State: NORMAL
+SchemaChangeDetail:
+      RefreshState: SUCCESS
+       RefreshInfo: BUILD DEFERRED REFRESH AUTO ON MANUAL
+          QuerySql: SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`
+      MvProperties: {partition_sync_limit=100, partition_sync_time_unit=YEAR}
+   MvPartitionInfo: MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'}
+SyncWithBaseTables: 1
 ```
 
-View the materialized view named mv1 under test
+In this result:
+
+- `Id` and `Name` identify the materialized view.
+- `JobName` is the refresh job name for this materialized view. Use it to query the job or refresh tasks, for example `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`.
+- `State` is `NORMAL`, which means the materialized view metadata is normal. `INIT` means the materialized view has just been created or initialized. `SCHEMA_CHANGE` means a schema change on a base table affected this materialized view; in this state, check `SchemaChangeDetail`.
+- `SchemaChangeDetail` is empty because `State` is not `SCHEMA_CHANGE`.
+- `RefreshState` is `SUCCESS`, which means the latest refresh succeeded. `INIT` means no successful refresh state has been recorded yet. `FAIL` means the latest refresh failed; query `tasks("type"="mv")` with `JobName` to find the failed task and its `ErrorMsg`.
+- `RefreshInfo` is `BUILD DEFERRED REFRESH AUTO ON MANUAL`. `BUILD DEFERRED` means the materialized view was not built immediately at creation time. `REFRESH AUTO` means Doris decides whether to refresh all partitions or only changed partitions. `ON MANUAL` means refresh is triggered manually rather than by a schedule.
+- `QuerySql` is the query definition of the materialized view.
+- `MvProperties` shows the properties of the materialized view. In this example, partition synchronization is limited by `partition_sync_limit=100` and `partition_sync_time_unit=YEAR`.
+- `MvPartitionInfo` shows how the materialized view is partitioned. `FOLLOW_BASE_TABLE` means the materialized view follows a base table partition column. `SELF_MANAGE` means the materialized view manages its own partitions. `EXPR` means the materialized view uses an expression-based partition definition.
+- `SyncWithBaseTables` is `1`, which means the materialized view data is synchronized with its base tables. `0` means it is not fully synchronized. For partitioned materialized views, use `SHOW PARTITIONS FROM <mv_name>` to check partition-level synchronization.
+
+To view the latest refresh task of this materialized view:
 
 ```sql
-select * from mv_infos("database"="test") where Name = "mv1";
-```
-```text
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                    | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1  | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user` | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
+select *
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc
+limit 1;
 ```

--- a/docs/sql-manual/sql-functions/table-valued-functions/tasks.md
+++ b/docs/sql-manual/sql-functions/table-valued-functions/tasks.md
@@ -41,52 +41,111 @@ TASKS(
    | **LoadStatistic**| Load statistics                |
    | **User**     | User                               |
 
--  **`tasks("type"="mv")`** Tasks return value of type MV
+-  **`tasks("type"="mv")`** tasks return value of type MV
 
-   | Field Name            | Description                                                                 |
-   |-----------------------|-----------------------------------------------------------------------------|
-   | **TaskId**            | Task id                                                                     |
-   | **JobId**             | Job id                                                                      |
-   | **JobName**           | Job Name                                                                    |
-   | **MvId**              | Materialized View ID                                                        |
-   | **MvName**            | Materialized View Name                                                      |
-   | **MvDatabaseId**      | DB ID of the materialized view                                              |
-   | **MvDatabaseName**    | Name of the database to which the materialized view belongs                 |
-   | **Status**            | Task status                                                                 |
-   | **ErrorMsg**          | Task failure information                                                   |
-   | **CreateTime**        | Task creation time                                                          |
-   | **StartTime**         | Task start running time                                                     |
-   | **FinishTime**        | Task End Run Time                                                           |
-   | **DurationMs**        | Task runtime                                                                |
-   | **TaskContext**       | Task running parameters                                                     |
-   | **RefreshMode**       | Refresh mode                                                                |
-   | **NeedRefreshPartitions** | The partition information that needs to be refreshed for this task       |
-   | **CompletedPartitions** | The partition information that has been refreshed for this task          |
-   | **Progress**          | Task running progress                                                       |
+   | Field Name | Description |
+   |------------|-------------|
+   | **TaskId** | Unique ID of the refresh task. Each materialized view refresh creates a new task record. |
+   | **JobId** | ID of the job that generated this task. It corresponds to `jobs("type"="mv").Id`. |
+   | **JobName** | Name of the job that generated this task. It corresponds to `mv_infos("database"="...").JobName` and `jobs("type"="mv").Name`. |
+   | **MvId** | ID of the materialized view refreshed by this task. |
+   | **MvName** | Name of the materialized view refreshed by this task. |
+   | **MvDatabaseId** | ID of the database that contains the materialized view. |
+   | **MvDatabaseName** | Name of the database that contains the materialized view. |
+   | **Status** | Task status. Possible values: `PENDING` means the task is waiting to run; `RUNNING` means the task is running; `SUCCESS` means the task finished successfully; `FAILED` means the task failed; `CANCELED` means the task was canceled. |
+   | **ErrorMsg** | Error message when `Status` is `FAILED` or `CANCELED`. Empty when the task succeeds. |
+   | **CreateTime** | Time when the task record was created. |
+   | **StartTime** | Time when the task started running. It can be `\N` if the task has not started. |
+   | **FinishTime** | Time when the task finished. It can be `\N` if the task is still pending or running. |
+   | **DurationMs** | Runtime in milliseconds, calculated as `FinishTime - StartTime`. It can be `\N` if the task has not finished. |
+   | **TaskContext** | JSON string describing how the task was triggered and what the user requested. Common fields include `triggerMode`, `partitions`, and `isComplete`. `triggerMode` values are `MANUAL`, `COMMIT`, and `SYSTEM`. |
+   | **RefreshMode** | Actual refresh scope decided by this task. Possible values: `COMPLETE` means all materialized view partitions were refreshed; `PARTIAL` means only some partitions were refreshed; `NOT_REFRESH` means no partition needed refreshing. |
+   | **NeedRefreshPartitions** | JSON array of materialized view partitions that needed refreshing in this task. Empty array means no partition needed refreshing. |
+   | **CompletedPartitions** | JSON array of partitions that were refreshed successfully. Compare it with `NeedRefreshPartitions` to see whether all required partitions completed. |
+   | **Progress** | Refresh progress in the format `percentage (completed/total)`, for example `100.00% (1/1)`. It can be `\N` when there is no partition to refresh. |
+   | **LastQueryId** | Query ID of the SQL statement executed by the refresh task. Use this ID to search FE or BE logs when troubleshooting task failures. It can be empty when no refresh SQL was executed. This field is supported since Doris 3.0.0. |
+
+### MV task enum fields
+
+The following enum fields are commonly used when checking materialized view refresh tasks:
+
+- `Status`: lifecycle state of the task.
+  - `PENDING`: the task has been created but has not started running. It is waiting for scheduling or resources.
+  - `RUNNING`: the task is currently running.
+  - `SUCCESS`: the task finished successfully.
+  - `FAILED`: the task failed. Check `ErrorMsg` first, and use `LastQueryId` to search logs if it is not empty.
+  - `CANCELED`: the task was canceled before it finished.
+- `TaskContext.triggerMode`: why this task was created.
+  - `MANUAL`: created by a manual refresh command, such as `REFRESH MATERIALIZED VIEW`.
+  - `COMMIT`: created because data changes on related base tables triggered refresh.
+  - `SYSTEM`: created by an internal system action, for example the initial build of a materialized view created with immediate build.
+- `TaskContext.isComplete`: whether the refresh request asks for a complete refresh.
+  - `true`: the request asks Doris to refresh all materialized view partitions.
+  - `false`: the request does not force complete refresh. Doris can decide the actual refresh scope based on partition freshness.
+- `RefreshMode`: actual refresh scope selected by the task after checking partitions.
+  - `COMPLETE`: all materialized view partitions that belong to the MV were selected for refresh.
+  - `PARTIAL`: only some materialized view partitions were selected for refresh.
+  - `NOT_REFRESH`: no partition needed refresh. In this case, `NeedRefreshPartitions` is usually empty and `Progress` can be `\N`.
+
+:::info Version
+
+`LastQueryId` is supported since Doris 3.0.0. It is not available in Doris 2.1.x.
+
+:::
 
 
 ## Examples
 
-View tasks for all materialized views
+View the latest refresh task of a materialized view.
 
 ```sql
-select * from tasks("type"="mv");
+select *
+from tasks("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"
+order by CreateTime desc
+limit 1\G
 ```
 ```text
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| TaskId          | JobId | JobName          | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | Status  | ErrorMsg | CreateTime          | StartTime           | FinishTime          | DurationMs | TaskContext                                                 | RefreshMode | NeedRefreshPartitions                         | CompletedPartitions                           | Progress      | LastQueryId                       |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| 509478985247053 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 233        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 71897c47d0d94fd2-9ca52a0e6eb3bff5 |
-| 509486915704885 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 227        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 9bf5ff69d4cc4c78-b50505436c8410c4 |
-| 509487197275880 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 191        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 5b3b4525b6774b5b-89b070042cdcbcd5 |
-| 509478131194211 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 156        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 6d0a0782819b446e-b9da5d5de513ce00 |
-| 509486057129101 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:18 | 213        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | f1303483e3db43e7-aa424acc32dc39ca |
-| 509486143784554 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 151        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 8d29b11ac41f4fe0-9d7c86372707310b |
-| 488317385772600 | 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | SUCCESS |          | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 1          | {"triggerMode":"MANUAL","partitions":[],"isComplete":true}  | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-| 437156301250803 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 | 236985     | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | COMPLETE    | ["p_20210101_MAXVALUE","p_20200101_20210101"] | ["p_20210101_MAXVALUE","p_20200101_20210101"] | 100.00% (2/2) | 7965b4ddce8a4480-8884e9701679c1c4 |
-| 439689059641969 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 35         | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
+*************************** 1. row ***************************
+               TaskId: 437156301250803
+                JobId: 19508
+              JobName: inner_mtmv_19494
+                 MvId: 19494
+               MvName: mv1
+         MvDatabaseId: 16016
+       MvDatabaseName: test
+               Status: SUCCESS
+             ErrorMsg:
+           CreateTime: 2025-01-07 22:13:48
+            StartTime: 2025-01-07 22:13:48
+           FinishTime: 2025-01-07 22:17:45
+           DurationMs: 236985
+          TaskContext: {"triggerMode":"MANUAL","partitions":[],"isComplete":false}
+          RefreshMode: COMPLETE
+NeedRefreshPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+  CompletedPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+             Progress: 100.00% (2/2)
+          LastQueryId: 7965b4ddce8a4480-8884e9701679c1c4
 ```
+
+In this result:
+
+- `TaskId` identifies this refresh execution. It is different for every refresh.
+- `JobId` and `JobName` identify the MV refresh job. The job can be queried with `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`.
+- `MvId`, `MvName`, `MvDatabaseId`, and `MvDatabaseName` identify the materialized view refreshed by the task.
+- `Status` is `SUCCESS`, so the task finished successfully. If it is `FAILED`, check `ErrorMsg` first.
+- `CreateTime`, `StartTime`, `FinishTime`, and `DurationMs` show when the task was created, when it started, when it finished, and how long it ran.
+- `TaskContext` shows this task was manually triggered. `partitions: []` means the user did not specify a partition list in the refresh command.
+- `RefreshMode` is `COMPLETE`, so this task refreshed all partitions that the materialized view had to refresh.
+- `NeedRefreshPartitions` lists two partitions that needed refreshing, and `CompletedPartitions` lists the same two partitions, so all required partitions completed.
+- `Progress` is `100.00% (2/2)`, which also means two of two required partitions completed.
+- `LastQueryId` is the query ID of the refresh SQL. Use it to search Doris logs when the task fails or runs slowly.
+
+:::info Note
+
+The number of stored and displayed task records is controlled by the FE configuration item `max_persistence_task_count`. The default value is 100. When the number of task records exceeds this limit, older task records are discarded. If the value is less than 1, task records are not persisted. Restart FE after changing this configuration.
+
+:::
 
 View tasks for all insert tasks
 
@@ -100,4 +159,3 @@ select * from tasks("type"="insert");
 | 79133848479750 | 78533940810334 | insert_tab_job | 78533940810334_79133848479750 | SUCCESS |          | 2025-01-17 14:42:54 | 2025-01-17 14:42:54 | 2025-01-17 14:42:54 |             |               | root |
 +----------------+----------------+----------------+-------------------------------+---------+----------+---------------------+---------------------+---------------------+-------------+---------------+------+
 ```
-

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/table-valued-functions/jobs.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/table-valued-functions/jobs.md
@@ -48,34 +48,78 @@ JOBS(
     
     | 字段名              | 描述                                 |
     |---------------------|--------------------------------------|
-    | Id                  | job id                               |
-    | Name                | job 名称                              |
-    | MvId                | 物化视图 id                           |
-    | MvName              | 物化视图名称                         |
-    | MvDatabaseId        | 物化视图所属 db id                    |
-    | MvDatabaseName      | 物化视图所属 db 名称                   |
-    | ExecuteType         | 执行类型                             |
-    | RecurringStrategy   | 循环策略                             |
-    | Status              | job 状态                              |
-    | CreateTime          | task 创建时间                         |
+    | Id                  | job ID。对于 MV job，该字段对应 `tasks("type"="mv").JobId`。 |
+    | Name                | job 名称。对于 MV job，该字段对应 `mv_infos("database"="...").JobName` 和 `tasks("type"="mv").JobName`。 |
+    | MvId                | 该 job 维护的物化视图 ID。 |
+    | MvName              | 该 job 维护的物化视图名称。 |
+    | MvDatabaseId        | 物化视图所属数据库 ID。 |
+    | MvDatabaseName      | 物化视图所属数据库名称。 |
+    | ExecuteType         | job 执行类型。MV job 可取值为 `MANUAL` 和 `RECURRING`。`MANUAL` 表示刷新 task 由手动刷新、提交触发或系统内部事件触发；`RECURRING` 表示按周期调度刷新。 |
+    | RecurringStrategy   | 根据 `ExecuteType` 生成的调度描述。`MANUAL TRIGGER` 表示该 job 不按定时器自动运行；`EVERY ... STARTS ... [ENDS ...]` 表示周期调度。 |
+    | Status              | job 状态。可取值：`PENDING` 表示等待调度；`RUNNING` 表示 job 可生成 task；`PAUSED` 表示 job 已暂停且可恢复；`STOPPED` 表示 job 已停止且不可恢复；`FINISHED` 表示 job 已结束。 |
+    | CreateTime          | job 创建时间。 |
+
+### MV job 枚举字段说明
+
+查看物化视图刷新 job 时，下面这些枚举字段最常用：
+
+- `ExecuteType`：job 创建刷新 task 的方式。
+  - `MANUAL`：job 不按自己的定时器运行。只有手动刷新、提交触发刷新或系统触发刷新时，才会创建 task。
+  - `RECURRING`：job 按调度周期运行，会周期性创建刷新 task。
+- `RecurringStrategy`：根据 `ExecuteType` 生成的可读调度规则。
+  - `MANUAL TRIGGER`：job 不按周期调度。`ExecuteType` 为 `MANUAL` 时通常显示这个值。
+  - `EVERY <interval> <unit> STARTS <time> [ENDS <time>]`：job 按周期调度。例如 `EVERY 10 MINUTE STARTS 2025-01-17 14:42:53`。
+- `Status`：job 自身当前状态。
+  - `PENDING`：job 正在等待调度。
+  - `RUNNING`：job 处于运行状态，可以创建刷新 task。
+  - `PAUSED`：job 已暂停。恢复前不会创建新的刷新 task。
+  - `STOPPED`：job 已停止，不能恢复。
+  - `FINISHED`：job 已结束。对于长期存在的物化视图刷新 job 不常见，但通用 job 框架中可能出现。
+
+对于物化视图，一个物化视图对应一个刷新 job，一个刷新 job 可以创建多个刷新 task。可以用 `jobs("type"="mv").Name` 关联 `mv_infos("database"="...").JobName` 和 `tasks("type"="mv").JobName`。
 
 
 ## 示例
 
-查看所有物化视图的 job
+查看某个物化视图的刷新 job。
 
 ```sql
-select * from jobs("type"="mv");
+select *
+from jobs("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"\G
 ```
 ```text
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| Id    | Name             | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | ExecuteType | RecurringStrategy | Status  | CreateTime          |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 12:26:06 |
-| 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-07 22:13:31 |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
+*************************** 1. row ***************************
+               Id: 19508
+             Name: inner_mtmv_19494
+             MvId: 19494
+           MvName: mv1
+     MvDatabaseId: 16016
+   MvDatabaseName: test
+      ExecuteType: MANUAL
+RecurringStrategy: MANUAL TRIGGER
+           Status: RUNNING
+       CreateTime: 2025-01-07 22:13:31
+```
+
+该结果中：
+
+- `Id` 是物化视图刷新 job ID，与 `tasks("type"="mv")` 中的 `JobId` 相同。
+- `Name` 是物化视图刷新 job 名称，与 `mv_infos("database"="test")` 和 `tasks("type"="mv")` 中的 `JobName` 相同。
+- `MvId` 和 `MvName` 标识该 job 维护的物化视图。
+- `MvDatabaseId` 和 `MvDatabaseName` 标识物化视图所属数据库。
+- `ExecuteType` 为 `MANUAL`，表示该 job 不按自身定时器运行。当物化视图被手动刷新、提交触发刷新或系统触发刷新时，才会生成刷新 task。
+- `RecurringStrategy` 为 `MANUAL TRIGGER`，与 `ExecuteType = MANUAL` 对应。如果是定时刷新的物化视图，该字段会显示为 `EVERY ... STARTS ...`。
+- `Status` 为 `RUNNING`，表示该 job 可以生成刷新 task。如果为 `PAUSED`，需要先恢复物化视图 job，才会继续产生新 task。
+- `CreateTime` 表示该物化视图刷新 job 的创建时间。
+
+查看该 job 生成的刷新 task：
+
+```sql
+select *
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc;
 ```
 
 查看所有 insert 任务的 job

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/table-valued-functions/mv_infos.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/table-valued-functions/mv_infos.md
@@ -26,44 +26,92 @@ MV_INFOS("database"="<database>")
 |-------------------------|---------|--------------------------------------------------------------------|
 | Id                      | BIGINT  | 物化视图 id                                                         |
 | Name                    | TEXT    | 物化视图 Name                                                       |
-| JobName                 | TEXT    | 物化视图对应的 job 名称                                               |
-| State                   | TEXT    | 物化视图状态                                                       |
-| SchemaChangeDetail      | TEXT    | 物化视图 State 变为 SchemaChange 的原因                                 |
-| RefreshState            | TEXT    | 物化视图刷新状态                                                   |
-| RefreshInfo             | TEXT    | 物化视图定义的刷新策略信息                                         |
+| JobName                 | TEXT    | 物化视图对应的刷新 job 名称，可用于查询 `jobs("type"="mv")` 和 `tasks("type"="mv")`。 |
+| State                   | TEXT    | 物化视图元数据状态。可取值：`INIT`、`NORMAL`、`SCHEMA_CHANGE`。 |
+| SchemaChangeDetail      | TEXT    | `State` 变为 `SCHEMA_CHANGE` 的原因。物化视图不处于 schema change 状态时通常为空。 |
+| RefreshState            | TEXT    | 最近一次刷新状态。可取值：`INIT`、`SUCCESS`、`FAIL`。 |
+| RefreshInfo             | TEXT    | 物化视图定义的刷新策略信息，包括构建方式、刷新方式和触发方式。 |
 | QuerySql                | TEXT    | 物化视图定义的查询语句                                             |
-| EnvInfo                 | TEXT    | 物化视图创建时的环境信息                                           |
 | MvProperties            | TEXT    | 物化视属性                                                         |
 | MvPartitionInfo         | TEXT    | 物化视图的分区信息                                                 |
-| SyncWithBaseTables      | BOOLEAN | 是否和 base 表数据同步，如需查看哪个分区不同步，请使用[SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS) |
+| SyncWithBaseTables      | BOOLEAN | 物化视图数据是否和基表数据同步。如需查看哪个分区不同步，请使用 [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS)。 |
+
+`RefreshInfo` 的展示格式为 `BUILD <BuildMode> REFRESH <RefreshMethod> ON <RefreshTrigger> [schedule]`。每一部分的含义见下面的枚举字段说明。
+
+### MV 信息枚举字段说明
+
+查看物化视图定义和健康状态时，下面这些枚举字段最常用：
+
+- `State`：物化视图元数据状态。
+  - `INIT`：物化视图已创建，但还没有进入正常可用的元数据状态。
+  - `NORMAL`：物化视图元数据正常。大多数情况下应该是这个状态。
+  - `SCHEMA_CHANGE`：基表或相关对象的 schema 变更影响了该物化视图。需要查看 `SchemaChangeDetail` 了解原因。此时物化视图通常仍可直接查询，但在刷新成功前可能不能用于透明改写。
+- `RefreshState`：最近一次刷新结果状态。
+  - `INIT`：还没有记录刷新结果。
+  - `SUCCESS`：最近一次刷新成功。
+  - `FAIL`：最近一次刷新失败。可以用 `JobName` 查询 `tasks("type"="mv")`，查看失败 task 的 `ErrorMsg`。
+- `RefreshInfo.BuildMode`：Doris 什么时候构建物化视图数据。
+  - `IMMEDIATE`：创建物化视图后立即构建。
+  - `DEFERRED`：创建时不立即构建，需要后续刷新后才有新鲜数据。
+- `RefreshInfo.RefreshMethod`：Doris 如何选择要刷新的数据。
+  - `COMPLETE`：总是全量刷新物化视图。
+  - `AUTO`：Doris 自动判断刷新全部分区还是只刷新变更分区。
+- `RefreshInfo.RefreshTrigger`：什么动作触发刷新 task。
+  - `MANUAL`：手动触发刷新。
+  - `COMMIT`：相关基表数据变更后触发刷新。
+  - `SCHEDULE`：按调度周期触发刷新。调度细节会出现在 `RefreshInfo` 的 `ON SCHEDULE` 后面。
+- `MvPartitionInfo.partitionType`：物化视图的分区方式。
+  - `FOLLOW_BASE_TABLE`：物化视图分区跟随基表分区列。
+  - `SELF_MANAGE`：物化视图自己管理分区。
+  - `EXPR`：物化视图使用表达式定义分区。
+- `SyncWithBaseTables`：物化视图数据是否和基表同步。
+  - `1` 或 `true`：已同步。
+  - `0` 或 `false`：未完全同步。对于分区物化视图，可以用 `SHOW PARTITIONS FROM <mv_name>` 查看分区级同步状态。
 
 
 ## 示例
 
-查看 test 下的所有物化视图
+查看 `test` 数据库下名为 `mv1` 的物化视图。
 
 ```sql
-select * from mv_infos("database"="test");
+select *
+from mv_infos("database"="test")
+where Name = "mv1"\G
 ```
 ```text
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name                     | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                                                                                         | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1                      | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`                                                                      | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-| 21788 | test_tablet_type_mtmv_mv | inner_mtmv_21788 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`test_tablet_type_mtmv_table`.`k2`, `internal`.`test`.`test_tablet_type_mtmv_table`.`k3` from `internal`.`test`.`test_tablet_type_mtmv_table` | {}                                                        | MTMVPartitionInfo{partitionType=SELF_MANAGE}                                                              |                  0 |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
+*************************** 1. row ***************************
+                Id: 19494
+              Name: mv1
+           JobName: inner_mtmv_19494
+             State: NORMAL
+SchemaChangeDetail:
+      RefreshState: SUCCESS
+       RefreshInfo: BUILD DEFERRED REFRESH AUTO ON MANUAL
+          QuerySql: SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`
+      MvProperties: {partition_sync_limit=100, partition_sync_time_unit=YEAR}
+   MvPartitionInfo: MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'}
+SyncWithBaseTables: 1
 ```
 
-查看 test 下的物化视图名称为 mv1 的物化视图
+该结果中：
+
+- `Id` 和 `Name` 标识该物化视图。
+- `JobName` 是该物化视图的刷新 job 名称。可以通过该字段继续查询 job 或刷新 task，例如 `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`。
+- `State` 为 `NORMAL`，表示物化视图元数据状态正常。`INIT` 表示物化视图刚创建或初始化中；`SCHEMA_CHANGE` 表示基表 schema 变更影响了该物化视图，此时需要查看 `SchemaChangeDetail`。
+- `SchemaChangeDetail` 为空，因为当前 `State` 不是 `SCHEMA_CHANGE`。
+- `RefreshState` 为 `SUCCESS`，表示最近一次刷新成功。`INIT` 表示尚未记录成功刷新状态；`FAIL` 表示最近一次刷新失败，此时可使用 `JobName` 查询 `tasks("type"="mv")`，查看失败 task 的 `ErrorMsg`。
+- `RefreshInfo` 为 `BUILD DEFERRED REFRESH AUTO ON MANUAL`。`BUILD DEFERRED` 表示创建物化视图时不立即构建；`REFRESH AUTO` 表示 Doris 自动判断刷新全部分区还是部分分区；`ON MANUAL` 表示刷新由手动触发，而不是定时触发。
+- `QuerySql` 是物化视图定义的查询 SQL。
+- `MvProperties` 展示物化视图属性。本例中，分区同步由 `partition_sync_limit=100` 和 `partition_sync_time_unit=YEAR` 控制。
+- `MvPartitionInfo` 展示物化视图分区方式。`FOLLOW_BASE_TABLE` 表示跟随基表分区列；`SELF_MANAGE` 表示物化视图自己管理分区；`EXPR` 表示基于表达式定义分区。
+- `SyncWithBaseTables` 为 `1`，表示物化视图数据和基表数据同步。`0` 表示不完全同步。对于分区物化视图，可使用 `SHOW PARTITIONS FROM <mv_name>` 查看分区级同步状态。
+
+查看该物化视图最近一次刷新 task：
 
 ```sql
-select * from mv_infos("database"="test") where Name = "mv1";
+select *
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc
+limit 1;
 ```
-```text
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                    | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1  | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user` | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-```
-    

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/table-valued-functions/tasks.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/table-valued-functions/tasks.md
@@ -47,48 +47,107 @@ TASKS(
 
   | 字段名                | 描述                           |
   |-----------------------|--------------------------------|
-  | **TaskId**            | task id                        |
-  | **JobId**             | job id                         |
-  | **JobName**           | job 名称                        |
-  | **MvId**              | 物化视图 id                     |
-  | **MvName**            | 物化视图名称                    |
-  | **MvDatabaseId**      | 物化视图所属 db id              |
-  | **MvDatabaseName**    | 物化视图所属 db 名称            |
-  | **Status**            | task 状态                       |
-  | **ErrorMsg**          | task 失败信息                   |
-  | **CreateTime**        | task 创建时间                   |
-  | **StartTime**         | task 开始运行时间               |
-  | **FinishTime**        | task 结束运行时间               |
-  | **DurationMs**        | task 运行时间                   |
-  | **TaskContext**       | task 运行参数                   |
-  | **RefreshMode**       | 刷新模式                        |
-  | **NeedRefreshPartitions** | 本次 task 需要刷新的分区信息   |
-  | **CompletedPartitions** | 本次 task 刷新完成的分区信息   |
-  | **Progress**          | task 运行进度                   |
+  | **TaskId**            | 刷新任务的唯一 ID。每次物化视图刷新都会生成一条新的 task 记录。 |
+  | **JobId**             | 生成该 task 的 job ID，对应 `jobs("type"="mv").Id`。 |
+  | **JobName**           | 生成该 task 的 job 名称，对应 `mv_infos("database"="...").JobName` 和 `jobs("type"="mv").Name`。 |
+  | **MvId**              | 该 task 刷新的物化视图 ID。 |
+  | **MvName**            | 该 task 刷新的物化视图名称。 |
+  | **MvDatabaseId**      | 物化视图所属数据库 ID。 |
+  | **MvDatabaseName**    | 物化视图所属数据库名称。 |
+  | **Status**            | task 状态。可取值：`PENDING` 表示等待运行；`RUNNING` 表示正在运行；`SUCCESS` 表示运行成功；`FAILED` 表示运行失败；`CANCELED` 表示已取消。 |
+  | **ErrorMsg**          | 当 `Status` 为 `FAILED` 或 `CANCELED` 时记录错误信息；运行成功时通常为空。 |
+  | **CreateTime**        | task 记录创建时间。 |
+  | **StartTime**         | task 开始运行时间。如果 task 尚未开始，可能为 `\N`。 |
+  | **FinishTime**        | task 结束时间。如果 task 仍在等待或运行，可能为 `\N`。 |
+  | **DurationMs**        | task 运行耗时，单位毫秒，按 `FinishTime - StartTime` 计算。如果 task 尚未结束，可能为 `\N`。 |
+  | **TaskContext**       | task 触发方式和用户刷新参数的 JSON 字符串。常见字段包括 `triggerMode`、`partitions` 和 `isComplete`。`triggerMode` 可取值为 `MANUAL`、`COMMIT`、`SYSTEM`。 |
+  | **RefreshMode**       | 该 task 实际执行的刷新范围。可取值：`COMPLETE` 表示刷新全部物化视图分区；`PARTIAL` 表示只刷新部分分区；`NOT_REFRESH` 表示没有分区需要刷新。 |
+  | **NeedRefreshPartitions** | JSON 数组，记录本次 task 需要刷新的物化视图分区。空数组表示没有分区需要刷新。 |
+  | **CompletedPartitions** | JSON 数组，记录本次 task 已成功刷新的分区。可与 `NeedRefreshPartitions` 对比判断是否全部完成。 |
+  | **Progress**          | task 刷新进度，格式为 `百分比 (已完成分区数/需刷新分区数)`，例如 `100.00% (1/1)`。没有分区需要刷新时可能为 `\N`。 |
+  | **LastQueryId**       | 刷新 task 执行 SQL 的 query ID。排查 task 失败或耗时时，可用该 ID 搜索 FE 或 BE 日志。没有执行刷新 SQL 时可能为空。该字段从 Doris 3.0.0 开始支持。 |
+
+### MV task 枚举字段说明
+
+查看物化视图刷新 task 时，下面这些枚举字段最常用：
+
+- `Status`：task 生命周期状态。
+  - `PENDING`：task 已创建，但还没有开始执行，正在等待调度或资源。
+  - `RUNNING`：task 正在执行。
+  - `SUCCESS`：task 执行成功。
+  - `FAILED`：task 执行失败。优先查看 `ErrorMsg`；如果 `LastQueryId` 不为空，可以用它搜索日志。
+  - `CANCELED`：task 在完成前被取消。
+- `TaskContext.triggerMode`：该 task 是因为什么原因创建的。
+  - `MANUAL`：由手动刷新命令创建，例如 `REFRESH MATERIALIZED VIEW`。
+  - `COMMIT`：由相关基表数据变更触发创建。
+  - `SYSTEM`：由系统内部动作创建，例如创建物化视图时的初始构建。
+- `TaskContext.isComplete`：刷新请求是否要求全量刷新。
+  - `true`：请求 Doris 刷新全部物化视图分区。
+  - `false`：请求不强制全量刷新，Doris 可以根据分区新鲜度判断实际刷新范围。
+- `RefreshMode`：task 检查分区后选择的实际刷新范围。
+  - `COMPLETE`：选择刷新该物化视图的全部分区。
+  - `PARTIAL`：只选择刷新部分物化视图分区。
+  - `NOT_REFRESH`：没有分区需要刷新。此时 `NeedRefreshPartitions` 通常为空，`Progress` 可能为 `\N`。
+
+:::info 版本说明
+
+`LastQueryId` 从 Doris 3.0.0 开始支持，Doris 2.1.x 没有该字段。
+
+:::
 
 
 ## 示例
 
-查看所有物化视图的 tasks
+查看某个物化视图最近一次刷新 task。
 
 ```sql
-select * from tasks("type"="mv");
+select *
+from tasks("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"
+order by CreateTime desc
+limit 1\G
 ```
 ```text
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| TaskId          | JobId | JobName          | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | Status  | ErrorMsg | CreateTime          | StartTime           | FinishTime          | DurationMs | TaskContext                                                 | RefreshMode | NeedRefreshPartitions                         | CompletedPartitions                           | Progress      | LastQueryId                       |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| 509478985247053 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 233        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 71897c47d0d94fd2-9ca52a0e6eb3bff5 |
-| 509486915704885 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 227        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 9bf5ff69d4cc4c78-b50505436c8410c4 |
-| 509487197275880 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 191        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 5b3b4525b6774b5b-89b070042cdcbcd5 |
-| 509478131194211 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 156        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 6d0a0782819b446e-b9da5d5de513ce00 |
-| 509486057129101 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:18 | 213        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | f1303483e3db43e7-aa424acc32dc39ca |
-| 509486143784554 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 151        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 8d29b11ac41f4fe0-9d7c86372707310b |
-| 488317385772600 | 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | SUCCESS |          | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 1          | {"triggerMode":"MANUAL","partitions":[],"isComplete":true}  | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-| 437156301250803 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 | 236985     | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | COMPLETE    | ["p_20210101_MAXVALUE","p_20200101_20210101"] | ["p_20210101_MAXVALUE","p_20200101_20210101"] | 100.00% (2/2) | 7965b4ddce8a4480-8884e9701679c1c4 |
-| 439689059641969 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 35         | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
+*************************** 1. row ***************************
+               TaskId: 437156301250803
+                JobId: 19508
+              JobName: inner_mtmv_19494
+                 MvId: 19494
+               MvName: mv1
+         MvDatabaseId: 16016
+       MvDatabaseName: test
+               Status: SUCCESS
+             ErrorMsg:
+           CreateTime: 2025-01-07 22:13:48
+            StartTime: 2025-01-07 22:13:48
+           FinishTime: 2025-01-07 22:17:45
+           DurationMs: 236985
+          TaskContext: {"triggerMode":"MANUAL","partitions":[],"isComplete":false}
+          RefreshMode: COMPLETE
+NeedRefreshPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+  CompletedPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+             Progress: 100.00% (2/2)
+          LastQueryId: 7965b4ddce8a4480-8884e9701679c1c4
 ```
+
+该结果中：
+
+- `TaskId` 表示这次刷新执行的唯一 ID。每次刷新都会生成不同的 task。
+- `JobId` 和 `JobName` 标识该 task 所属的物化视图刷新 job。可以通过 `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";` 查询 job。
+- `MvId`、`MvName`、`MvDatabaseId`、`MvDatabaseName` 标识该 task 刷新的物化视图。
+- `Status` 为 `SUCCESS`，表示 task 执行成功。如果为 `FAILED`，优先查看 `ErrorMsg`。
+- `CreateTime`、`StartTime`、`FinishTime`、`DurationMs` 分别表示 task 创建时间、开始运行时间、结束时间和运行耗时。
+- `TaskContext` 表示该 task 是手动触发的。`partitions: []` 表示刷新命令没有指定分区列表。
+- `RefreshMode` 为 `COMPLETE`，表示本次 task 刷新了该物化视图需要刷新的全部分区。
+- `NeedRefreshPartitions` 列出本次需要刷新的两个分区，`CompletedPartitions` 列出同样两个分区，说明需要刷新的分区都已完成。
+- `Progress` 为 `100.00% (2/2)`，也表示两个需要刷新的分区都已完成。
+- `LastQueryId` 是刷新 SQL 的 query ID。排查 task 失败或耗时时，可以用该 ID 搜索 Doris 日志。
+
+:::info 备注
+
+task 记录默认保存和展示数量由 FE 配置项 `max_persistence_task_count` 控制，默认值为 100。超过该数量时，旧 task 记录会被丢弃。如果该值小于 1，则不持久化 task 记录。修改该配置后需要重启 FE 生效。
+
+:::
 
 查看所有 insert 任务的 tasks
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-valued-functions/jobs.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-valued-functions/jobs.md
@@ -18,64 +18,117 @@ JOBS(
 )
 ```
 
-## 必填参数 (Required Parameters)
-| 字段名          | 描述                                                            |
+## 参数
+| 参数          | 描述                                                            |
 |--------------|---------------------------------------------------------------|
 | **`<type>`** | 任务的类型：<br/> `insert`：insert into 类型的任务。 <br/> `mv`：物化视图类型的任务。 |
 
 
 ## 返回值
 
+该表函数返回 0 行或多行结果。函数本身不返回 NULL；当对应元数据不可用时，部分字段可能为空或 `NULL`。
+
 - **`jobs("type"="insert")`** insert 类型的 job 返回值
 
-  | 字段名             | 描述                           |
-      |--------------------|--------------------------------|
-  | Id                 | job id                        |
-  | Name               | job 名称                       |
-  | Definer            | job 定义者                     |
-  | ExecuteType        | 执行类型                       |
-  | RecurringStrategy  | 循环策略                       |
-  | Status             | job 状态                       |
-  | ExecuteSql         | 执行 SQL                       |
-  | CreateTime         | job 创建时间                   |
-  | SucceedTaskCount   | 成功任务数量                   |
-  | FailedTaskCount    | 失败任务数量                   |
-  | CanceledTaskCount  | 取消任务数量                   |
-  | Comment            | job 注释                       |
+    | 参数          | 描述                           |
+    |--------------------|--------------------------------|
+    | Id                 | job id                        |
+    | Name               | job 名称                       |
+    | Definer            | job 定义者                     |
+    | ExecuteType        | 执行类型                       |
+    | RecurringStrategy  | 循环策略                       |
+    | Status             | job 状态                       |
+    | ExecuteSql         | 执行 SQL                       |
+    | CreateTime         | job 创建时间                   |
+    | SucceedTaskCount   | 成功任务数量                   |
+    | FailedTaskCount    | 失败任务数量                   |
+    | CanceledTaskCount  | 取消任务数量                   |
+    | Comment            | job 注释                       |
 
 
 - **`jobs("type"="mv")`** MV 类型的 job 返回值
 
-  | 字段名              | 描述                                 |
-      |---------------------|--------------------------------------|
-  | Id                  | job id                               |
-  | Name                | job 名称                              |
-  | MvId                | 物化视图 id                           |
-  | MvName              | 物化视图名称                         |
-  | MvDatabaseId        | 物化视图所属 db id                    |
-  | MvDatabaseName      | 物化视图所属 db 名称                   |
-  | ExecuteType         | 执行类型                             |
-  | RecurringStrategy   | 循环策略                             |
-  | Status              | job 状态                              |
-  | CreateTime          | task 创建时间                         |
+    | 参数          | 描述                                 |
+    |---------------------|--------------------------------------|
+    | Id                  | job ID。对于 MV job，该字段对应 `tasks("type"="mv").JobId`。 |
+    | Name                | job 名称。对于 MV job，该字段对应 `mv_infos("database"="...").JobName` 和 `tasks("type"="mv").JobName`。 |
+    | MvId                | 该 job 维护的物化视图 ID。 |
+    | MvName              | 该 job 维护的物化视图名称。 |
+    | MvDatabaseId        | 物化视图所属数据库 ID。 |
+    | MvDatabaseName      | 物化视图所属数据库名称。 |
+    | ExecuteType         | job 执行类型。MV job 可取值为 `MANUAL` 和 `RECURRING`。`MANUAL` 表示刷新 task 由手动刷新、提交触发或系统内部事件触发；`RECURRING` 表示按周期调度刷新。 |
+    | RecurringStrategy   | 根据 `ExecuteType` 生成的调度描述。`MANUAL TRIGGER` 表示该 job 不按定时器自动运行；`EVERY ... STARTS ... [ENDS ...]` 表示周期调度。 |
+    | Status              | job 状态。可取值：`PENDING` 表示等待调度；`RUNNING` 表示 job 可生成 task；`PAUSED` 表示 job 已暂停且可恢复；`STOPPED` 表示 job 已停止且不可恢复；`FINISHED` 表示 job 已结束。 |
+    | CreateTime          | job 创建时间。 |
+
+### MV job 枚举字段说明
+
+查看物化视图刷新 job 时，下面这些枚举字段最常用：
+
+- `ExecuteType`：job 创建刷新 task 的方式。
+  - `MANUAL`：job 不按自己的定时器运行。只有手动刷新、提交触发刷新或系统触发刷新时，才会创建 task。
+  - `RECURRING`：job 按调度周期运行，会周期性创建刷新 task。
+- `RecurringStrategy`：根据 `ExecuteType` 生成的可读调度规则。
+  - `MANUAL TRIGGER`：job 不按周期调度。`ExecuteType` 为 `MANUAL` 时通常显示这个值。
+  - `EVERY <interval> <unit> STARTS <time> [ENDS <time>]`：job 按周期调度。例如 `EVERY 10 MINUTE STARTS 2025-01-17 14:42:53`。
+- `Status`：job 自身当前状态。
+  - `PENDING`：job 正在等待调度。
+  - `RUNNING`：job 处于运行状态，可以创建刷新 task。
+  - `PAUSED`：job 已暂停。恢复前不会创建新的刷新 task。
+  - `STOPPED`：job 已停止，不能恢复。
+  - `FINISHED`：job 已结束。对于长期存在的物化视图刷新 job 不常见，但通用 job 框架中可能出现。
+
+对于物化视图，一个物化视图对应一个刷新 job，一个刷新 job 可以创建多个刷新 task。可以用 `jobs("type"="mv").Name` 关联 `mv_infos("database"="...").JobName` 和 `tasks("type"="mv").JobName`。
 
 
 ## 示例
 
-查看所有物化视图的 job
+查看某个物化视图的刷新 job。
 
 ```sql
-select * from jobs("type"="mv");
+select *
+from jobs("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"\G
 ```
 ```text
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| Id    | Name             | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | ExecuteType | RecurringStrategy | Status  | CreateTime          |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 12:26:06 |
-| 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-07 22:13:31 |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
+*************************** 1. row ***************************
+               Id: 19508
+             Name: inner_mtmv_19494
+             MvId: 19494
+           MvName: mv1
+     MvDatabaseId: 16016
+   MvDatabaseName: test
+      ExecuteType: MANUAL
+RecurringStrategy: MANUAL TRIGGER
+           Status: RUNNING
+       CreateTime: 2025-01-07 22:13:31
+```
+
+该结果中：
+
+- `Id` 是物化视图刷新 job ID，与 `tasks("type"="mv")` 中的 `JobId` 相同。
+- `Name` 是物化视图刷新 job 名称，与 `mv_infos("database"="test")` 和 `tasks("type"="mv")` 中的 `JobName` 相同。
+- `MvId` 和 `MvName` 标识该 job 维护的物化视图。
+- `MvDatabaseId` 和 `MvDatabaseName` 标识物化视图所属数据库。
+- `ExecuteType` 为 `MANUAL`，表示该 job 不按自身定时器运行。当物化视图被手动刷新、提交触发刷新或系统触发刷新时，才会生成刷新 task。
+- `RecurringStrategy` 为 `MANUAL TRIGGER`，与 `ExecuteType = MANUAL` 对应。如果是定时刷新的物化视图，该字段会显示为 `EVERY ... STARTS ...`。
+- `Status` 为 `RUNNING`，表示该 job 可以生成刷新 task。如果为 `PAUSED`，需要先恢复物化视图 job，才会继续产生新 task。
+- `CreateTime` 表示该物化视图刷新 job 的创建时间。
+
+查看该 job 生成的刷新 task：
+
+```sql
+select TaskId, JobName, MvName, Status, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc;
+```
+```text
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+---------------------+---------------------+
 ```
 
 查看所有 insert 任务的 job

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-valued-functions/mv_infos.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-valued-functions/mv_infos.md
@@ -16,54 +16,116 @@
 MV_INFOS("database"="<database>")
 ```
 
-## 必填参数 (Required Parameters)
-**`<database>`**
-> 指定需要查询的集群数据库名
+## 参数
 
+| 参数              | 描述 |
+|-------------------|------|
+| **`<database>`** | 字符串，必填。指定需要查询异步物化视图元数据的数据库名。 |
 
 ## 返回值
+
+该表函数返回 0 行或多行异步物化视图信息。函数本身不返回 NULL；当对应元数据不可用时，部分字段可能为空或 `NULL`。
+
 | 字段名称                | 类型    | 说明                                                               |
 |-------------------------|---------|--------------------------------------------------------------------|
 | Id                      | BIGINT  | 物化视图 id                                                         |
 | Name                    | TEXT    | 物化视图 Name                                                       |
-| JobName                 | TEXT    | 物化视图对应的 job 名称                                               |
-| State                   | TEXT    | 物化视图状态                                                       |
-| SchemaChangeDetail      | TEXT    | 物化视图 State 变为 SchemaChange 的原因                                 |
-| RefreshState            | TEXT    | 物化视图刷新状态                                                   |
-| RefreshInfo             | TEXT    | 物化视图定义的刷新策略信息                                         |
+| JobName                 | TEXT    | 物化视图对应的刷新 job 名称，可用于查询 `jobs("type"="mv")` 和 `tasks("type"="mv")`。 |
+| State                   | TEXT    | 物化视图元数据状态。可取值：`INIT`、`NORMAL`、`SCHEMA_CHANGE`。 |
+| SchemaChangeDetail      | TEXT    | `State` 变为 `SCHEMA_CHANGE` 的原因。物化视图不处于 schema change 状态时通常为空。 |
+| RefreshState            | TEXT    | 最近一次刷新状态。可取值：`INIT`、`SUCCESS`、`FAIL`。 |
+| RefreshInfo             | TEXT    | 物化视图定义的刷新策略信息，包括构建方式、刷新方式和触发方式。 |
 | QuerySql                | TEXT    | 物化视图定义的查询语句                                             |
 | EnvInfo                 | TEXT    | 物化视图创建时的环境信息                                           |
 | MvProperties            | TEXT    | 物化视属性                                                         |
 | MvPartitionInfo         | TEXT    | 物化视图的分区信息                                                 |
-| SyncWithBaseTables      | BOOLEAN | 是否和 base 表数据同步，如需查看哪个分区不同步，请使用[SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS) |
+| SyncWithBaseTables      | BOOLEAN | 物化视图数据是否和基表数据同步。如需查看哪个分区不同步，请使用 [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS)。 |
+
+`RefreshInfo` 的展示格式为 `BUILD <BuildMode> REFRESH <RefreshMethod> ON <RefreshTrigger> [schedule]`。每一部分的含义见下面的枚举字段说明。
+
+### MV 信息枚举字段说明
+
+查看物化视图定义和健康状态时，下面这些枚举字段最常用：
+
+- `State`：物化视图元数据状态。
+  - `INIT`：物化视图已创建，但还没有进入正常可用的元数据状态。
+  - `NORMAL`：物化视图元数据正常。大多数情况下应该是这个状态。
+  - `SCHEMA_CHANGE`：基表或相关对象的 schema 变更影响了该物化视图。需要查看 `SchemaChangeDetail` 了解原因。此时物化视图通常仍可直接查询，但在刷新成功前可能不能用于透明改写。
+- `RefreshState`：最近一次刷新结果状态。
+  - `INIT`：还没有记录刷新结果。
+  - `SUCCESS`：最近一次刷新成功。
+  - `FAIL`：最近一次刷新失败。可以用 `JobName` 查询 `tasks("type"="mv")`，查看失败 task 的 `ErrorMsg`。
+- `RefreshInfo.BuildMode`：Doris 什么时候构建物化视图数据。
+  - `IMMEDIATE`：创建物化视图后立即构建。
+  - `DEFERRED`：创建时不立即构建，需要后续刷新后才有新鲜数据。
+- `RefreshInfo.RefreshMethod`：Doris 如何选择要刷新的数据。
+  - `COMPLETE`：总是全量刷新物化视图。
+  - `AUTO`：Doris 自动判断刷新全部分区还是只刷新变更分区。
+- `RefreshInfo.RefreshTrigger`：什么动作触发刷新 task。
+  - `MANUAL`：手动触发刷新。
+  - `COMMIT`：相关基表数据变更后触发刷新。
+  - `SCHEDULE`：按调度周期触发刷新。调度细节会出现在 `RefreshInfo` 的 `ON SCHEDULE` 后面。
+- `MvPartitionInfo.partitionType`：物化视图的分区方式。
+  - `FOLLOW_BASE_TABLE`：物化视图分区跟随基表分区列。
+  - `SELF_MANAGE`：物化视图自己管理分区。
+  - `EXPR`：物化视图使用表达式定义分区。
+- `SyncWithBaseTables`：物化视图数据是否和基表同步。
+  - `1` 或 `true`：已同步。
+  - `0` 或 `false`：未完全同步。对于分区物化视图，可以用 `SHOW PARTITIONS FROM <mv_name>` 查看分区级同步状态。
 
 
 ## 示例
 
-查看 test 下的所有物化视图
+查看 `test` 数据库下名为 `mv1` 的物化视图。
 
 ```sql
-select * from mv_infos("database"="test");
+select *
+from mv_infos("database"="test")
+where Name = "mv1"\G
 ```
 ```text
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name                     | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                                                                                         | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1                      | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`                                                                      | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-| 21788 | test_tablet_type_mtmv_mv | inner_mtmv_21788 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`test_tablet_type_mtmv_table`.`k2`, `internal`.`test`.`test_tablet_type_mtmv_table`.`k3` from `internal`.`test`.`test_tablet_type_mtmv_table` | {}                                                        | MTMVPartitionInfo{partitionType=SELF_MANAGE}                                                              |                  0 |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
+*************************** 1. row ***************************
+                Id: 19494
+              Name: mv1
+           JobName: inner_mtmv_19494
+             State: NORMAL
+SchemaChangeDetail:
+      RefreshState: SUCCESS
+       RefreshInfo: BUILD DEFERRED REFRESH AUTO ON MANUAL
+          QuerySql: SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`
+           EnvInfo: EnvInfo{ctlId='0', dbId='16813'}
+      MvProperties: {partition_sync_limit=100, partition_sync_time_unit=YEAR}
+   MvPartitionInfo: MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'}
+SyncWithBaseTables: 1
 ```
 
-查看 test 下的物化视图名称为 mv1 的物化视图
+该结果中：
+
+- `Id` 和 `Name` 标识该物化视图。
+- `JobName` 是该物化视图的刷新 job 名称。可以通过该字段继续查询 job 或刷新 task，例如 `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`。
+- `State` 为 `NORMAL`，表示物化视图元数据状态正常。`INIT` 表示物化视图刚创建或初始化中；`SCHEMA_CHANGE` 表示基表 schema 变更影响了该物化视图，此时需要查看 `SchemaChangeDetail`。
+- `SchemaChangeDetail` 为空，因为当前 `State` 不是 `SCHEMA_CHANGE`。
+- `RefreshState` 为 `SUCCESS`，表示最近一次刷新成功。`INIT` 表示尚未记录成功刷新状态；`FAIL` 表示最近一次刷新失败，此时可使用 `JobName` 查询 `tasks("type"="mv")`，查看失败 task 的 `ErrorMsg`。
+- `RefreshInfo` 为 `BUILD DEFERRED REFRESH AUTO ON MANUAL`。`BUILD DEFERRED` 表示创建物化视图时不立即构建；`REFRESH AUTO` 表示 Doris 自动判断刷新全部分区还是部分分区；`ON MANUAL` 表示刷新由手动触发，而不是定时触发。
+- `QuerySql` 是物化视图定义的查询 SQL。
+- `EnvInfo` 记录物化视图创建时的环境信息。
+- `MvProperties` 展示物化视图属性。本例中，分区同步由 `partition_sync_limit=100` 和 `partition_sync_time_unit=YEAR` 控制。
+- `MvPartitionInfo` 展示物化视图分区方式。`FOLLOW_BASE_TABLE` 表示跟随基表分区列；`SELF_MANAGE` 表示物化视图自己管理分区；`EXPR` 表示基于表达式定义分区。
+- `SyncWithBaseTables` 为 `1`，表示物化视图数据和基表数据同步。`0` 表示不完全同步。对于分区物化视图，可使用 `SHOW PARTITIONS FROM <mv_name>` 查看分区级同步状态。
+
+查看该物化视图最近一次刷新 task：
 
 ```sql
-select * from mv_infos("database"="test") where Name = "mv1";
+select TaskId, JobName, MvName, Status, ErrorMsg, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc
+limit 1;
 ```
 ```text
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                    | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1  | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user` | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | ErrorMsg | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
 ```
-    

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-valued-functions/mv_infos.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-valued-functions/mv_infos.md
@@ -68,7 +68,13 @@ MV_INFOS("database"="<database>")
 - `MvPartitionInfo.partitionType`：物化视图的分区方式。
   - `FOLLOW_BASE_TABLE`：物化视图分区跟随基表分区列。
   - `SELF_MANAGE`：物化视图自己管理分区。
-  - `EXPR`：物化视图使用表达式定义分区。
+
+:::info 版本说明
+
+Doris 2.1.x 的 `MvPartitionInfo.partitionType` 支持 `FOLLOW_BASE_TABLE` 和 `SELF_MANAGE`。`EXPR` 分区类型从 Doris 3.0.0 开始支持。
+
+:::
+
 - `SyncWithBaseTables`：物化视图数据是否和基表同步。
   - `1` 或 `true`：已同步。
   - `0` 或 `false`：未完全同步。对于分区物化视图，可以用 `SHOW PARTITIONS FROM <mv_name>` 查看分区级同步状态。
@@ -110,7 +116,7 @@ SyncWithBaseTables: 1
 - `QuerySql` 是物化视图定义的查询 SQL。
 - `EnvInfo` 记录物化视图创建时的环境信息。
 - `MvProperties` 展示物化视图属性。本例中，分区同步由 `partition_sync_limit=100` 和 `partition_sync_time_unit=YEAR` 控制。
-- `MvPartitionInfo` 展示物化视图分区方式。`FOLLOW_BASE_TABLE` 表示跟随基表分区列；`SELF_MANAGE` 表示物化视图自己管理分区；`EXPR` 表示基于表达式定义分区。
+- `MvPartitionInfo` 展示物化视图分区方式。在 Doris 2.1.x 中，`FOLLOW_BASE_TABLE` 表示跟随基表分区列，`SELF_MANAGE` 表示物化视图自己管理分区。`EXPR` 分区类型从 Doris 3.0.0 开始支持。
 - `SyncWithBaseTables` 为 `1`，表示物化视图数据和基表数据同步。`0` 表示不完全同步。对于分区物化视图，可使用 `SHOW PARTITIONS FROM <mv_name>` 查看分区级同步状态。
 
 查看该物化视图最近一次刷新 task：

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-valued-functions/tasks.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-valued-functions/tasks.md
@@ -17,18 +17,20 @@ TASKS(
 )
 ```
 
-## 必填参数 (Required Parameters)
-| 字段名          | 描述                                                            |
+## 参数
+| 参数          | 描述                                                            |
 |--------------|---------------------------------------------------------------|
 | **`<type>`** | 任务的类型：<br/> `insert`：insert into 类型的任务。 <br/> `mv`：物化视图类型的任务。 |
 
 
 ## 返回值
 
+该表函数返回 0 行或多行结果。函数本身不返回 NULL；当对应 task 元数据不可用时，部分字段可能为空、`NULL` 或 `\N`。
+
 - **`tasks("type"="insert")`** insert 类型的 tasks 返回值
 
-  | 字段名       | 描述                      |
-    |--------------|---------------------------|
+  | 参数          | 描述                      |
+  |--------------|---------------------------|
   | **TaskId**   | task id                   |
   | **JobId**    | job id                    |
   | **JobName**  | job 名称                   |
@@ -45,50 +47,106 @@ TASKS(
 
 - **`tasks("type"="mv")`** MV 类型的 tasks 返回值
 
-  | 字段名                | 描述                           |
-    |-----------------------|--------------------------------|
-  | **TaskId**            | task id                        |
-  | **JobId**             | job id                         |
-  | **JobName**           | job 名称                        |
-  | **MvId**              | 物化视图 id                     |
-  | **MvName**            | 物化视图名称                    |
-  | **MvDatabaseId**      | 物化视图所属 db id              |
-  | **MvDatabaseName**    | 物化视图所属 db 名称            |
-  | **Status**            | task 状态                       |
-  | **ErrorMsg**          | task 失败信息                   |
-  | **CreateTime**        | task 创建时间                   |
-  | **StartTime**         | task 开始运行时间               |
-  | **FinishTime**        | task 结束运行时间               |
-  | **DurationMs**        | task 运行时间                   |
-  | **TaskContext**       | task 运行参数                   |
-  | **RefreshMode**       | 刷新模式                        |
-  | **NeedRefreshPartitions** | 本次 task 需要刷新的分区信息   |
-  | **CompletedPartitions** | 本次 task 刷新完成的分区信息   |
-  | **Progress**          | task 运行进度                   |
+  | 参数          | 描述                           |
+  |-----------------------|--------------------------------|
+  | **TaskId**            | 刷新任务的唯一 ID。每次物化视图刷新都会生成一条新的 task 记录。 |
+  | **JobId**             | 生成该 task 的 job ID，对应 `jobs("type"="mv").Id`。 |
+  | **JobName**           | 生成该 task 的 job 名称，对应 `mv_infos("database"="...").JobName` 和 `jobs("type"="mv").Name`。 |
+  | **MvId**              | 该 task 刷新的物化视图 ID。 |
+  | **MvName**            | 该 task 刷新的物化视图名称。 |
+  | **MvDatabaseId**      | 物化视图所属数据库 ID。 |
+  | **MvDatabaseName**    | 物化视图所属数据库名称。 |
+  | **Status**            | task 状态。可取值：`PENDING` 表示等待运行；`RUNNING` 表示正在运行；`SUCCESS` 表示运行成功；`FAILED` 表示运行失败；`CANCELED` 表示已取消。 |
+  | **ErrorMsg**          | 当 `Status` 为 `FAILED` 或 `CANCELED` 时记录错误信息；运行成功时通常为空。 |
+  | **CreateTime**        | task 记录创建时间。 |
+  | **StartTime**         | task 开始运行时间。如果 task 尚未开始，可能为 `\N`。 |
+  | **FinishTime**        | task 结束时间。如果 task 仍在等待或运行，可能为 `\N`。 |
+  | **DurationMs**        | task 运行耗时，单位毫秒，按 `FinishTime - StartTime` 计算。如果 task 尚未结束，可能为 `\N`。 |
+  | **TaskContext**       | task 触发方式和用户刷新参数的 JSON 字符串。常见字段包括 `triggerMode`、`partitions` 和 `isComplete`。`triggerMode` 可取值为 `MANUAL`、`COMMIT`、`SYSTEM`。 |
+  | **RefreshMode**       | 该 task 实际执行的刷新范围。可取值：`COMPLETE` 表示刷新全部物化视图分区；`PARTIAL` 表示只刷新部分分区；`NOT_REFRESH` 表示没有分区需要刷新。 |
+  | **NeedRefreshPartitions** | JSON 数组，记录本次 task 需要刷新的物化视图分区。空数组表示没有分区需要刷新。 |
+  | **CompletedPartitions** | JSON 数组，记录本次 task 已成功刷新的分区。可与 `NeedRefreshPartitions` 对比判断是否全部完成。 |
+  | **Progress**          | task 刷新进度，格式为 `百分比 (已完成分区数/需刷新分区数)`，例如 `100.00% (1/1)`。没有分区需要刷新时可能为 `\N`。 |
+
+### MV task 枚举字段说明
+
+查看物化视图刷新 task 时，下面这些枚举字段最常用：
+
+- `Status`：task 生命周期状态。
+  - `PENDING`：task 已创建，但还没有开始执行，正在等待调度或资源。
+  - `RUNNING`：task 正在执行。
+  - `SUCCESS`：task 执行成功。
+  - `FAILED`：task 执行失败。优先查看 `ErrorMsg`。在 Doris 2.1.x 中，可以结合 task 时间字段和物化视图名称搜索 FE 或 BE 日志。
+  - `CANCELED`：task 在完成前被取消。
+- `TaskContext.triggerMode`：该 task 是因为什么原因创建的。
+  - `MANUAL`：由手动刷新命令创建，例如 `REFRESH MATERIALIZED VIEW`。
+  - `COMMIT`：由相关基表数据变更触发创建。
+  - `SYSTEM`：由系统内部动作创建，例如创建物化视图时的初始构建。
+- `TaskContext.isComplete`：刷新请求是否要求全量刷新。
+  - `true`：请求 Doris 刷新全部物化视图分区。
+  - `false`：请求不强制全量刷新，Doris 可以根据分区新鲜度判断实际刷新范围。
+- `RefreshMode`：task 检查分区后选择的实际刷新范围。
+  - `COMPLETE`：选择刷新该物化视图的全部分区。
+  - `PARTIAL`：只选择刷新部分物化视图分区。
+  - `NOT_REFRESH`：没有分区需要刷新。此时 `NeedRefreshPartitions` 通常为空，`Progress` 可能为 `\N`。
+
+:::info 版本说明
+
+Doris 2.1.x 的 `tasks("type"="mv")` 不提供 `LastQueryId`。排查刷新失败时，可结合 `ErrorMsg`、`CreateTime`、`StartTime`、`FinishTime`、`MvDatabaseName` 和 `MvName` 定位相关 FE 或 BE 日志。
+
+:::
 
 
 ## 示例
 
-查看所有物化视图的 tasks
+查看某个物化视图最近一次刷新 task。
 
 ```sql
-select * from tasks("type"="mv");
+select *
+from tasks("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"
+order by CreateTime desc
+limit 1\G
 ```
 ```text
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| TaskId          | JobId | JobName          | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | Status  | ErrorMsg | CreateTime          | StartTime           | FinishTime          | DurationMs | TaskContext                                                 | RefreshMode | NeedRefreshPartitions                         | CompletedPartitions                           | Progress      | LastQueryId                       |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| 509478985247053 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 233        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 71897c47d0d94fd2-9ca52a0e6eb3bff5 |
-| 509486915704885 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 227        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 9bf5ff69d4cc4c78-b50505436c8410c4 |
-| 509487197275880 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 191        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 5b3b4525b6774b5b-89b070042cdcbcd5 |
-| 509478131194211 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 156        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 6d0a0782819b446e-b9da5d5de513ce00 |
-| 509486057129101 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:18 | 213        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | f1303483e3db43e7-aa424acc32dc39ca |
-| 509486143784554 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 151        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 8d29b11ac41f4fe0-9d7c86372707310b |
-| 488317385772600 | 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | SUCCESS |          | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 1          | {"triggerMode":"MANUAL","partitions":[],"isComplete":true}  | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-| 437156301250803 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 | 236985     | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | COMPLETE    | ["p_20210101_MAXVALUE","p_20200101_20210101"] | ["p_20210101_MAXVALUE","p_20200101_20210101"] | 100.00% (2/2) | 7965b4ddce8a4480-8884e9701679c1c4 |
-| 439689059641969 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 35         | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
+*************************** 1. row ***************************
+               TaskId: 437156301250803
+                JobId: 19508
+              JobName: inner_mtmv_19494
+                 MvId: 19494
+               MvName: mv1
+         MvDatabaseId: 16016
+       MvDatabaseName: test
+               Status: SUCCESS
+             ErrorMsg:
+           CreateTime: 2025-01-07 22:13:48
+            StartTime: 2025-01-07 22:13:48
+           FinishTime: 2025-01-07 22:17:45
+           DurationMs: 236985
+          TaskContext: {"triggerMode":"MANUAL","partitions":[],"isComplete":false}
+          RefreshMode: COMPLETE
+NeedRefreshPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+  CompletedPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+             Progress: 100.00% (2/2)
 ```
+
+该结果中：
+
+- `TaskId` 表示这次刷新执行的唯一 ID。每次刷新都会生成不同的 task。
+- `JobId` 和 `JobName` 标识该 task 所属的物化视图刷新 job。可以通过 `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";` 查询 job。
+- `MvId`、`MvName`、`MvDatabaseId`、`MvDatabaseName` 标识该 task 刷新的物化视图。
+- `Status` 为 `SUCCESS`，表示 task 执行成功。如果为 `FAILED`，优先查看 `ErrorMsg`。
+- `CreateTime`、`StartTime`、`FinishTime`、`DurationMs` 分别表示 task 创建时间、开始运行时间、结束时间和运行耗时。
+- `TaskContext` 表示该 task 是手动触发的。`partitions: []` 表示刷新命令没有指定分区列表。
+- `RefreshMode` 为 `COMPLETE`，表示本次 task 刷新了该物化视图需要刷新的全部分区。
+- `NeedRefreshPartitions` 列出本次需要刷新的两个分区，`CompletedPartitions` 列出同样两个分区，说明需要刷新的分区都已完成。
+- `Progress` 为 `100.00% (2/2)`，也表示两个需要刷新的分区都已完成。
+
+:::info 备注
+
+task 记录默认保存和展示数量由 FE 配置项 `max_persistence_task_count` 控制，默认值为 100。超过该数量时，旧 task 记录会被丢弃。如果该值小于 1，则不持久化 task 记录。修改该配置后需要重启 FE 生效。
+
+:::
 
 查看所有 insert 任务的 tasks
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/table-valued-functions/jobs.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/table-valued-functions/jobs.md
@@ -18,64 +18,117 @@ JOBS(
 )
 ```
 
-## 必填参数 (Required Parameters)
-| 字段名          | 描述                                                            |
+## 参数
+| 参数          | 描述                                                            |
 |--------------|---------------------------------------------------------------|
 | **`<type>`** | 任务的类型：<br/> `insert`：insert into 类型的任务。 <br/> `mv`：物化视图类型的任务。 |
 
 
 ## 返回值
 
+该表函数返回 0 行或多行结果。函数本身不返回 NULL；当对应元数据不可用时，部分字段可能为空或 `NULL`。
+
 - **`jobs("type"="insert")`** insert 类型的 job 返回值
 
-  | 字段名             | 描述                           |
-      |--------------------|--------------------------------|
-  | Id                 | job id                        |
-  | Name               | job 名称                       |
-  | Definer            | job 定义者                     |
-  | ExecuteType        | 执行类型                       |
-  | RecurringStrategy  | 循环策略                       |
-  | Status             | job 状态                       |
-  | ExecuteSql         | 执行 SQL                       |
-  | CreateTime         | job 创建时间                   |
-  | SucceedTaskCount   | 成功任务数量                   |
-  | FailedTaskCount    | 失败任务数量                   |
-  | CanceledTaskCount  | 取消任务数量                   |
-  | Comment            | job 注释                       |
+    | 参数          | 描述                           |
+    |--------------------|--------------------------------|
+    | Id                 | job id                        |
+    | Name               | job 名称                       |
+    | Definer            | job 定义者                     |
+    | ExecuteType        | 执行类型                       |
+    | RecurringStrategy  | 循环策略                       |
+    | Status             | job 状态                       |
+    | ExecuteSql         | 执行 SQL                       |
+    | CreateTime         | job 创建时间                   |
+    | SucceedTaskCount   | 成功任务数量                   |
+    | FailedTaskCount    | 失败任务数量                   |
+    | CanceledTaskCount  | 取消任务数量                   |
+    | Comment            | job 注释                       |
 
 
 - **`jobs("type"="mv")`** MV 类型的 job 返回值
 
-  | 字段名              | 描述                                 |
-      |---------------------|--------------------------------------|
-  | Id                  | job id                               |
-  | Name                | job 名称                              |
-  | MvId                | 物化视图 id                           |
-  | MvName              | 物化视图名称                         |
-  | MvDatabaseId        | 物化视图所属 db id                    |
-  | MvDatabaseName      | 物化视图所属 db 名称                   |
-  | ExecuteType         | 执行类型                             |
-  | RecurringStrategy   | 循环策略                             |
-  | Status              | job 状态                              |
-  | CreateTime          | task 创建时间                         |
+    | 参数          | 描述                                 |
+    |---------------------|--------------------------------------|
+    | Id                  | job ID。对于 MV job，该字段对应 `tasks("type"="mv").JobId`。 |
+    | Name                | job 名称。对于 MV job，该字段对应 `mv_infos("database"="...").JobName` 和 `tasks("type"="mv").JobName`。 |
+    | MvId                | 该 job 维护的物化视图 ID。 |
+    | MvName              | 该 job 维护的物化视图名称。 |
+    | MvDatabaseId        | 物化视图所属数据库 ID。 |
+    | MvDatabaseName      | 物化视图所属数据库名称。 |
+    | ExecuteType         | job 执行类型。MV job 可取值为 `MANUAL` 和 `RECURRING`。`MANUAL` 表示刷新 task 由手动刷新、提交触发或系统内部事件触发；`RECURRING` 表示按周期调度刷新。 |
+    | RecurringStrategy   | 根据 `ExecuteType` 生成的调度描述。`MANUAL TRIGGER` 表示该 job 不按定时器自动运行；`EVERY ... STARTS ... [ENDS ...]` 表示周期调度。 |
+    | Status              | job 状态。可取值：`PENDING` 表示等待调度；`RUNNING` 表示 job 可生成 task；`PAUSED` 表示 job 已暂停且可恢复；`STOPPED` 表示 job 已停止且不可恢复；`FINISHED` 表示 job 已结束。 |
+    | CreateTime          | job 创建时间。 |
+
+### MV job 枚举字段说明
+
+查看物化视图刷新 job 时，下面这些枚举字段最常用：
+
+- `ExecuteType`：job 创建刷新 task 的方式。
+  - `MANUAL`：job 不按自己的定时器运行。只有手动刷新、提交触发刷新或系统触发刷新时，才会创建 task。
+  - `RECURRING`：job 按调度周期运行，会周期性创建刷新 task。
+- `RecurringStrategy`：根据 `ExecuteType` 生成的可读调度规则。
+  - `MANUAL TRIGGER`：job 不按周期调度。`ExecuteType` 为 `MANUAL` 时通常显示这个值。
+  - `EVERY <interval> <unit> STARTS <time> [ENDS <time>]`：job 按周期调度。例如 `EVERY 10 MINUTE STARTS 2025-01-17 14:42:53`。
+- `Status`：job 自身当前状态。
+  - `PENDING`：job 正在等待调度。
+  - `RUNNING`：job 处于运行状态，可以创建刷新 task。
+  - `PAUSED`：job 已暂停。恢复前不会创建新的刷新 task。
+  - `STOPPED`：job 已停止，不能恢复。
+  - `FINISHED`：job 已结束。对于长期存在的物化视图刷新 job 不常见，但通用 job 框架中可能出现。
+
+对于物化视图，一个物化视图对应一个刷新 job，一个刷新 job 可以创建多个刷新 task。可以用 `jobs("type"="mv").Name` 关联 `mv_infos("database"="...").JobName` 和 `tasks("type"="mv").JobName`。
 
 
 ## 示例
 
-查看所有物化视图的 job
+查看某个物化视图的刷新 job。
 
 ```sql
-select * from jobs("type"="mv");
+select *
+from jobs("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"\G
 ```
 ```text
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| Id    | Name             | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | ExecuteType | RecurringStrategy | Status  | CreateTime          |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 12:26:06 |
-| 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-07 22:13:31 |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
+*************************** 1. row ***************************
+               Id: 19508
+             Name: inner_mtmv_19494
+             MvId: 19494
+           MvName: mv1
+     MvDatabaseId: 16016
+   MvDatabaseName: test
+      ExecuteType: MANUAL
+RecurringStrategy: MANUAL TRIGGER
+           Status: RUNNING
+       CreateTime: 2025-01-07 22:13:31
+```
+
+该结果中：
+
+- `Id` 是物化视图刷新 job ID，与 `tasks("type"="mv")` 中的 `JobId` 相同。
+- `Name` 是物化视图刷新 job 名称，与 `mv_infos("database"="test")` 和 `tasks("type"="mv")` 中的 `JobName` 相同。
+- `MvId` 和 `MvName` 标识该 job 维护的物化视图。
+- `MvDatabaseId` 和 `MvDatabaseName` 标识物化视图所属数据库。
+- `ExecuteType` 为 `MANUAL`，表示该 job 不按自身定时器运行。当物化视图被手动刷新、提交触发刷新或系统触发刷新时，才会生成刷新 task。
+- `RecurringStrategy` 为 `MANUAL TRIGGER`，与 `ExecuteType = MANUAL` 对应。如果是定时刷新的物化视图，该字段会显示为 `EVERY ... STARTS ...`。
+- `Status` 为 `RUNNING`，表示该 job 可以生成刷新 task。如果为 `PAUSED`，需要先恢复物化视图 job，才会继续产生新 task。
+- `CreateTime` 表示该物化视图刷新 job 的创建时间。
+
+查看该 job 生成的刷新 task：
+
+```sql
+select TaskId, JobName, MvName, Status, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc;
+```
+```text
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+---------------------+---------------------+
 ```
 
 查看所有 insert 任务的 job

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/table-valued-functions/mv_infos.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/table-valued-functions/mv_infos.md
@@ -16,54 +16,116 @@
 MV_INFOS("database"="<database>")
 ```
 
-## 必填参数 (Required Parameters)
-**`<database>`**
-> 指定需要查询的集群数据库名
+## 参数
 
+| 参数              | 描述 |
+|-------------------|------|
+| **`<database>`** | 字符串，必填。指定需要查询异步物化视图元数据的数据库名。 |
 
 ## 返回值
+
+该表函数返回 0 行或多行异步物化视图信息。函数本身不返回 NULL；当对应元数据不可用时，部分字段可能为空或 `NULL`。
+
 | 字段名称                | 类型    | 说明                                                               |
 |-------------------------|---------|--------------------------------------------------------------------|
 | Id                      | BIGINT  | 物化视图 id                                                         |
 | Name                    | TEXT    | 物化视图 Name                                                       |
-| JobName                 | TEXT    | 物化视图对应的 job 名称                                               |
-| State                   | TEXT    | 物化视图状态                                                       |
-| SchemaChangeDetail      | TEXT    | 物化视图 State 变为 SchemaChange 的原因                                 |
-| RefreshState            | TEXT    | 物化视图刷新状态                                                   |
-| RefreshInfo             | TEXT    | 物化视图定义的刷新策略信息                                         |
+| JobName                 | TEXT    | 物化视图对应的刷新 job 名称，可用于查询 `jobs("type"="mv")` 和 `tasks("type"="mv")`。 |
+| State                   | TEXT    | 物化视图元数据状态。可取值：`INIT`、`NORMAL`、`SCHEMA_CHANGE`。 |
+| SchemaChangeDetail      | TEXT    | `State` 变为 `SCHEMA_CHANGE` 的原因。物化视图不处于 schema change 状态时通常为空。 |
+| RefreshState            | TEXT    | 最近一次刷新状态。可取值：`INIT`、`SUCCESS`、`FAIL`。 |
+| RefreshInfo             | TEXT    | 物化视图定义的刷新策略信息，包括构建方式、刷新方式和触发方式。 |
 | QuerySql                | TEXT    | 物化视图定义的查询语句                                             |
 | EnvInfo                 | TEXT    | 物化视图创建时的环境信息                                           |
 | MvProperties            | TEXT    | 物化视属性                                                         |
 | MvPartitionInfo         | TEXT    | 物化视图的分区信息                                                 |
-| SyncWithBaseTables      | BOOLEAN | 是否和 base 表数据同步，如需查看哪个分区不同步，请使用[SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS) |
+| SyncWithBaseTables      | BOOLEAN | 物化视图数据是否和基表数据同步。如需查看哪个分区不同步，请使用 [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS)。 |
+
+`RefreshInfo` 的展示格式为 `BUILD <BuildMode> REFRESH <RefreshMethod> ON <RefreshTrigger> [schedule]`。每一部分的含义见下面的枚举字段说明。
+
+### MV 信息枚举字段说明
+
+查看物化视图定义和健康状态时，下面这些枚举字段最常用：
+
+- `State`：物化视图元数据状态。
+  - `INIT`：物化视图已创建，但还没有进入正常可用的元数据状态。
+  - `NORMAL`：物化视图元数据正常。大多数情况下应该是这个状态。
+  - `SCHEMA_CHANGE`：基表或相关对象的 schema 变更影响了该物化视图。需要查看 `SchemaChangeDetail` 了解原因。此时物化视图通常仍可直接查询，但在刷新成功前可能不能用于透明改写。
+- `RefreshState`：最近一次刷新结果状态。
+  - `INIT`：还没有记录刷新结果。
+  - `SUCCESS`：最近一次刷新成功。
+  - `FAIL`：最近一次刷新失败。可以用 `JobName` 查询 `tasks("type"="mv")`，查看失败 task 的 `ErrorMsg`。
+- `RefreshInfo.BuildMode`：Doris 什么时候构建物化视图数据。
+  - `IMMEDIATE`：创建物化视图后立即构建。
+  - `DEFERRED`：创建时不立即构建，需要后续刷新后才有新鲜数据。
+- `RefreshInfo.RefreshMethod`：Doris 如何选择要刷新的数据。
+  - `COMPLETE`：总是全量刷新物化视图。
+  - `AUTO`：Doris 自动判断刷新全部分区还是只刷新变更分区。
+- `RefreshInfo.RefreshTrigger`：什么动作触发刷新 task。
+  - `MANUAL`：手动触发刷新。
+  - `COMMIT`：相关基表数据变更后触发刷新。
+  - `SCHEDULE`：按调度周期触发刷新。调度细节会出现在 `RefreshInfo` 的 `ON SCHEDULE` 后面。
+- `MvPartitionInfo.partitionType`：物化视图的分区方式。
+  - `FOLLOW_BASE_TABLE`：物化视图分区跟随基表分区列。
+  - `SELF_MANAGE`：物化视图自己管理分区。
+  - `EXPR`：物化视图使用表达式定义分区。
+- `SyncWithBaseTables`：物化视图数据是否和基表同步。
+  - `1` 或 `true`：已同步。
+  - `0` 或 `false`：未完全同步。对于分区物化视图，可以用 `SHOW PARTITIONS FROM <mv_name>` 查看分区级同步状态。
 
 
 ## 示例
 
-查看 test 下的所有物化视图
+查看 `test` 数据库下名为 `mv1` 的物化视图。
 
 ```sql
-select * from mv_infos("database"="test");
+select *
+from mv_infos("database"="test")
+where Name = "mv1"\G
 ```
 ```text
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name                     | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                                                                                         | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1                      | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`                                                                      | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-| 21788 | test_tablet_type_mtmv_mv | inner_mtmv_21788 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`test_tablet_type_mtmv_table`.`k2`, `internal`.`test`.`test_tablet_type_mtmv_table`.`k3` from `internal`.`test`.`test_tablet_type_mtmv_table` | {}                                                        | MTMVPartitionInfo{partitionType=SELF_MANAGE}                                                              |                  0 |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
+*************************** 1. row ***************************
+                Id: 19494
+              Name: mv1
+           JobName: inner_mtmv_19494
+             State: NORMAL
+SchemaChangeDetail:
+      RefreshState: SUCCESS
+       RefreshInfo: BUILD DEFERRED REFRESH AUTO ON MANUAL
+          QuerySql: SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`
+           EnvInfo: EnvInfo{ctlId='0', dbId='16813'}
+      MvProperties: {partition_sync_limit=100, partition_sync_time_unit=YEAR}
+   MvPartitionInfo: MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'}
+SyncWithBaseTables: 1
 ```
 
-查看 test 下的物化视图名称为 mv1 的物化视图
+该结果中：
+
+- `Id` 和 `Name` 标识该物化视图。
+- `JobName` 是该物化视图的刷新 job 名称。可以通过该字段继续查询 job 或刷新 task，例如 `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`。
+- `State` 为 `NORMAL`，表示物化视图元数据状态正常。`INIT` 表示物化视图刚创建或初始化中；`SCHEMA_CHANGE` 表示基表 schema 变更影响了该物化视图，此时需要查看 `SchemaChangeDetail`。
+- `SchemaChangeDetail` 为空，因为当前 `State` 不是 `SCHEMA_CHANGE`。
+- `RefreshState` 为 `SUCCESS`，表示最近一次刷新成功。`INIT` 表示尚未记录成功刷新状态；`FAIL` 表示最近一次刷新失败，此时可使用 `JobName` 查询 `tasks("type"="mv")`，查看失败 task 的 `ErrorMsg`。
+- `RefreshInfo` 为 `BUILD DEFERRED REFRESH AUTO ON MANUAL`。`BUILD DEFERRED` 表示创建物化视图时不立即构建；`REFRESH AUTO` 表示 Doris 自动判断刷新全部分区还是部分分区；`ON MANUAL` 表示刷新由手动触发，而不是定时触发。
+- `QuerySql` 是物化视图定义的查询 SQL。
+- `EnvInfo` 记录物化视图创建时的环境信息。
+- `MvProperties` 展示物化视图属性。本例中，分区同步由 `partition_sync_limit=100` 和 `partition_sync_time_unit=YEAR` 控制。
+- `MvPartitionInfo` 展示物化视图分区方式。`FOLLOW_BASE_TABLE` 表示跟随基表分区列；`SELF_MANAGE` 表示物化视图自己管理分区；`EXPR` 表示基于表达式定义分区。
+- `SyncWithBaseTables` 为 `1`，表示物化视图数据和基表数据同步。`0` 表示不完全同步。对于分区物化视图，可使用 `SHOW PARTITIONS FROM <mv_name>` 查看分区级同步状态。
+
+查看该物化视图最近一次刷新 task：
 
 ```sql
-select * from mv_infos("database"="test") where Name = "mv1";
+select TaskId, JobName, MvName, Status, ErrorMsg, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc
+limit 1;
 ```
 ```text
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                    | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1  | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user` | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | ErrorMsg | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
 ```
-    

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/table-valued-functions/tasks.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/table-valued-functions/tasks.md
@@ -17,18 +17,20 @@ TASKS(
 )
 ```
 
-## 必填参数 (Required Parameters)
-| 字段名          | 描述                                                            |
+## 参数
+| 参数          | 描述                                                            |
 |--------------|---------------------------------------------------------------|
 | **`<type>`** | 任务的类型：<br/> `insert`：insert into 类型的任务。 <br/> `mv`：物化视图类型的任务。 |
 
 
 ## 返回值
 
+该表函数返回 0 行或多行结果。函数本身不返回 NULL；当对应 task 元数据不可用时，部分字段可能为空、`NULL` 或 `\N`。
+
 - **`tasks("type"="insert")`** insert 类型的 tasks 返回值
 
-  | 字段名       | 描述                      |
-    |--------------|---------------------------|
+  | 参数          | 描述                      |
+  |--------------|---------------------------|
   | **TaskId**   | task id                   |
   | **JobId**    | job id                    |
   | **JobName**  | job 名称                   |
@@ -45,50 +47,109 @@ TASKS(
 
 - **`tasks("type"="mv")`** MV 类型的 tasks 返回值
 
-  | 字段名                | 描述                           |
-    |-----------------------|--------------------------------|
-  | **TaskId**            | task id                        |
-  | **JobId**             | job id                         |
-  | **JobName**           | job 名称                        |
-  | **MvId**              | 物化视图 id                     |
-  | **MvName**            | 物化视图名称                    |
-  | **MvDatabaseId**      | 物化视图所属 db id              |
-  | **MvDatabaseName**    | 物化视图所属 db 名称            |
-  | **Status**            | task 状态                       |
-  | **ErrorMsg**          | task 失败信息                   |
-  | **CreateTime**        | task 创建时间                   |
-  | **StartTime**         | task 开始运行时间               |
-  | **FinishTime**        | task 结束运行时间               |
-  | **DurationMs**        | task 运行时间                   |
-  | **TaskContext**       | task 运行参数                   |
-  | **RefreshMode**       | 刷新模式                        |
-  | **NeedRefreshPartitions** | 本次 task 需要刷新的分区信息   |
-  | **CompletedPartitions** | 本次 task 刷新完成的分区信息   |
-  | **Progress**          | task 运行进度                   |
+  | 参数          | 描述                           |
+  |-----------------------|--------------------------------|
+  | **TaskId**            | 刷新任务的唯一 ID。每次物化视图刷新都会生成一条新的 task 记录。 |
+  | **JobId**             | 生成该 task 的 job ID，对应 `jobs("type"="mv").Id`。 |
+  | **JobName**           | 生成该 task 的 job 名称，对应 `mv_infos("database"="...").JobName` 和 `jobs("type"="mv").Name`。 |
+  | **MvId**              | 该 task 刷新的物化视图 ID。 |
+  | **MvName**            | 该 task 刷新的物化视图名称。 |
+  | **MvDatabaseId**      | 物化视图所属数据库 ID。 |
+  | **MvDatabaseName**    | 物化视图所属数据库名称。 |
+  | **Status**            | task 状态。可取值：`PENDING` 表示等待运行；`RUNNING` 表示正在运行；`SUCCESS` 表示运行成功；`FAILED` 表示运行失败；`CANCELED` 表示已取消。 |
+  | **ErrorMsg**          | 当 `Status` 为 `FAILED` 或 `CANCELED` 时记录错误信息；运行成功时通常为空。 |
+  | **CreateTime**        | task 记录创建时间。 |
+  | **StartTime**         | task 开始运行时间。如果 task 尚未开始，可能为 `\N`。 |
+  | **FinishTime**        | task 结束时间。如果 task 仍在等待或运行，可能为 `\N`。 |
+  | **DurationMs**        | task 运行耗时，单位毫秒，按 `FinishTime - StartTime` 计算。如果 task 尚未结束，可能为 `\N`。 |
+  | **TaskContext**       | task 触发方式和用户刷新参数的 JSON 字符串。常见字段包括 `triggerMode`、`partitions` 和 `isComplete`。`triggerMode` 可取值为 `MANUAL`、`COMMIT`、`SYSTEM`。 |
+  | **RefreshMode**       | 该 task 实际执行的刷新范围。可取值：`COMPLETE` 表示刷新全部物化视图分区；`PARTIAL` 表示只刷新部分分区；`NOT_REFRESH` 表示没有分区需要刷新。 |
+  | **NeedRefreshPartitions** | JSON 数组，记录本次 task 需要刷新的物化视图分区。空数组表示没有分区需要刷新。 |
+  | **CompletedPartitions** | JSON 数组，记录本次 task 已成功刷新的分区。可与 `NeedRefreshPartitions` 对比判断是否全部完成。 |
+  | **Progress**          | task 刷新进度，格式为 `百分比 (已完成分区数/需刷新分区数)`，例如 `100.00% (1/1)`。没有分区需要刷新时可能为 `\N`。 |
+  | **LastQueryId**       | 刷新 task 执行 SQL 的 query ID。排查 task 失败或耗时时，可用该 ID 搜索 FE 或 BE 日志。没有执行刷新 SQL 时可能为空。该字段从 Doris 3.0.0 开始支持。 |
+
+### MV task 枚举字段说明
+
+查看物化视图刷新 task 时，下面这些枚举字段最常用：
+
+- `Status`：task 生命周期状态。
+  - `PENDING`：task 已创建，但还没有开始执行，正在等待调度或资源。
+  - `RUNNING`：task 正在执行。
+  - `SUCCESS`：task 执行成功。
+  - `FAILED`：task 执行失败。优先查看 `ErrorMsg`；如果 `LastQueryId` 不为空，可以用它搜索日志。
+  - `CANCELED`：task 在完成前被取消。
+- `TaskContext.triggerMode`：该 task 是因为什么原因创建的。
+  - `MANUAL`：由手动刷新命令创建，例如 `REFRESH MATERIALIZED VIEW`。
+  - `COMMIT`：由相关基表数据变更触发创建。
+  - `SYSTEM`：由系统内部动作创建，例如创建物化视图时的初始构建。
+- `TaskContext.isComplete`：刷新请求是否要求全量刷新。
+  - `true`：请求 Doris 刷新全部物化视图分区。
+  - `false`：请求不强制全量刷新，Doris 可以根据分区新鲜度判断实际刷新范围。
+- `RefreshMode`：task 检查分区后选择的实际刷新范围。
+  - `COMPLETE`：选择刷新该物化视图的全部分区。
+  - `PARTIAL`：只选择刷新部分物化视图分区。
+  - `NOT_REFRESH`：没有分区需要刷新。此时 `NeedRefreshPartitions` 通常为空，`Progress` 可能为 `\N`。
+
+:::info 版本说明
+
+`LastQueryId` 从 Doris 3.0.0 开始支持，Doris 2.1.x 没有该字段。
+
+:::
 
 
 ## 示例
 
-查看所有物化视图的 tasks
+查看某个物化视图最近一次刷新 task。
 
 ```sql
-select * from tasks("type"="mv");
+select *
+from tasks("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"
+order by CreateTime desc
+limit 1\G
 ```
 ```text
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| TaskId          | JobId | JobName          | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | Status  | ErrorMsg | CreateTime          | StartTime           | FinishTime          | DurationMs | TaskContext                                                 | RefreshMode | NeedRefreshPartitions                         | CompletedPartitions                           | Progress      | LastQueryId                       |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| 509478985247053 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 233        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 71897c47d0d94fd2-9ca52a0e6eb3bff5 |
-| 509486915704885 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 227        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 9bf5ff69d4cc4c78-b50505436c8410c4 |
-| 509487197275880 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 191        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 5b3b4525b6774b5b-89b070042cdcbcd5 |
-| 509478131194211 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 156        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 6d0a0782819b446e-b9da5d5de513ce00 |
-| 509486057129101 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:18 | 213        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | f1303483e3db43e7-aa424acc32dc39ca |
-| 509486143784554 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 151        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 8d29b11ac41f4fe0-9d7c86372707310b |
-| 488317385772600 | 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | SUCCESS |          | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 1          | {"triggerMode":"MANUAL","partitions":[],"isComplete":true}  | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-| 437156301250803 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 | 236985     | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | COMPLETE    | ["p_20210101_MAXVALUE","p_20200101_20210101"] | ["p_20210101_MAXVALUE","p_20200101_20210101"] | 100.00% (2/2) | 7965b4ddce8a4480-8884e9701679c1c4 |
-| 439689059641969 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 35         | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
+*************************** 1. row ***************************
+               TaskId: 437156301250803
+                JobId: 19508
+              JobName: inner_mtmv_19494
+                 MvId: 19494
+               MvName: mv1
+         MvDatabaseId: 16016
+       MvDatabaseName: test
+               Status: SUCCESS
+             ErrorMsg:
+           CreateTime: 2025-01-07 22:13:48
+            StartTime: 2025-01-07 22:13:48
+           FinishTime: 2025-01-07 22:17:45
+           DurationMs: 236985
+          TaskContext: {"triggerMode":"MANUAL","partitions":[],"isComplete":false}
+          RefreshMode: COMPLETE
+NeedRefreshPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+  CompletedPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+             Progress: 100.00% (2/2)
+          LastQueryId: 7965b4ddce8a4480-8884e9701679c1c4
 ```
+
+该结果中：
+
+- `TaskId` 表示这次刷新执行的唯一 ID。每次刷新都会生成不同的 task。
+- `JobId` 和 `JobName` 标识该 task 所属的物化视图刷新 job。可以通过 `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";` 查询 job。
+- `MvId`、`MvName`、`MvDatabaseId`、`MvDatabaseName` 标识该 task 刷新的物化视图。
+- `Status` 为 `SUCCESS`，表示 task 执行成功。如果为 `FAILED`，优先查看 `ErrorMsg`。
+- `CreateTime`、`StartTime`、`FinishTime`、`DurationMs` 分别表示 task 创建时间、开始运行时间、结束时间和运行耗时。
+- `TaskContext` 表示该 task 是手动触发的。`partitions: []` 表示刷新命令没有指定分区列表。
+- `RefreshMode` 为 `COMPLETE`，表示本次 task 刷新了该物化视图需要刷新的全部分区。
+- `NeedRefreshPartitions` 列出本次需要刷新的两个分区，`CompletedPartitions` 列出同样两个分区，说明需要刷新的分区都已完成。
+- `Progress` 为 `100.00% (2/2)`，也表示两个需要刷新的分区都已完成。
+- `LastQueryId` 是刷新 SQL 的 query ID。排查 task 失败或耗时时，可以用该 ID 搜索 Doris 日志。
+
+:::info 备注
+
+task 记录默认保存和展示数量由 FE 配置项 `max_persistence_task_count` 控制，默认值为 100。超过该数量时，旧 task 记录会被丢弃。如果该值小于 1，则不持久化 task 记录。修改该配置后需要重启 FE 生效。
+
+:::
 
 查看所有 insert 任务的 tasks
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/table-valued-functions/jobs.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/table-valued-functions/jobs.md
@@ -18,17 +18,19 @@ JOBS(
 )
 ```
 
-## 必填参数 (Required Parameters)
-| 字段名          | 描述                                                            |
+## 参数
+| 参数          | 描述                                                            |
 |--------------|---------------------------------------------------------------|
 | **`<type>`** | 任务的类型：<br/> `insert`：insert into 类型的任务。 <br/> `mv`：物化视图类型的任务。 |
 
 
 ## 返回值
 
+该表函数返回 0 行或多行结果。函数本身不返回 NULL；当对应元数据不可用时，部分字段可能为空或 `NULL`。
+
 - **`jobs("type"="insert")`** insert 类型的 job 返回值
-    
-    | 字段名             | 描述                           |
+
+    | 参数          | 描述                           |
     |--------------------|--------------------------------|
     | Id                 | job id                        |
     | Name               | job 名称                       |
@@ -45,37 +47,88 @@ JOBS(
 
 
 - **`jobs("type"="mv")`** MV 类型的 job 返回值
-    
-    | 字段名              | 描述                                 |
+
+    | 参数          | 描述                                 |
     |---------------------|--------------------------------------|
-    | Id                  | job id                               |
-    | Name                | job 名称                              |
-    | MvId                | 物化视图 id                           |
-    | MvName              | 物化视图名称                         |
-    | MvDatabaseId        | 物化视图所属 db id                    |
-    | MvDatabaseName      | 物化视图所属 db 名称                   |
-    | ExecuteType         | 执行类型                             |
-    | RecurringStrategy   | 循环策略                             |
-    | Status              | job 状态                              |
-    | CreateTime          | task 创建时间                         |
+    | Id                  | job ID。对于 MV job，该字段对应 `tasks("type"="mv").JobId`。 |
+    | Name                | job 名称。对于 MV job，该字段对应 `mv_infos("database"="...").JobName` 和 `tasks("type"="mv").JobName`。 |
+    | MvId                | 该 job 维护的物化视图 ID。 |
+    | MvName              | 该 job 维护的物化视图名称。 |
+    | MvDatabaseId        | 物化视图所属数据库 ID。 |
+    | MvDatabaseName      | 物化视图所属数据库名称。 |
+    | ExecuteType         | job 执行类型。MV job 可取值为 `MANUAL` 和 `RECURRING`。`MANUAL` 表示刷新 task 由手动刷新、提交触发或系统内部事件触发；`RECURRING` 表示按周期调度刷新。 |
+    | RecurringStrategy   | 根据 `ExecuteType` 生成的调度描述。`MANUAL TRIGGER` 表示该 job 不按定时器自动运行；`EVERY ... STARTS ... [ENDS ...]` 表示周期调度。 |
+    | Status              | job 状态。可取值：`PENDING` 表示等待调度；`RUNNING` 表示 job 可生成 task；`PAUSED` 表示 job 已暂停且可恢复；`STOPPED` 表示 job 已停止且不可恢复；`FINISHED` 表示 job 已结束。 |
+    | CreateTime          | job 创建时间。 |
+
+### MV job 枚举字段说明
+
+查看物化视图刷新 job 时，下面这些枚举字段最常用：
+
+- `ExecuteType`：job 创建刷新 task 的方式。
+  - `MANUAL`：job 不按自己的定时器运行。只有手动刷新、提交触发刷新或系统触发刷新时，才会创建 task。
+  - `RECURRING`：job 按调度周期运行，会周期性创建刷新 task。
+- `RecurringStrategy`：根据 `ExecuteType` 生成的可读调度规则。
+  - `MANUAL TRIGGER`：job 不按周期调度。`ExecuteType` 为 `MANUAL` 时通常显示这个值。
+  - `EVERY <interval> <unit> STARTS <time> [ENDS <time>]`：job 按周期调度。例如 `EVERY 10 MINUTE STARTS 2025-01-17 14:42:53`。
+- `Status`：job 自身当前状态。
+  - `PENDING`：job 正在等待调度。
+  - `RUNNING`：job 处于运行状态，可以创建刷新 task。
+  - `PAUSED`：job 已暂停。恢复前不会创建新的刷新 task。
+  - `STOPPED`：job 已停止，不能恢复。
+  - `FINISHED`：job 已结束。对于长期存在的物化视图刷新 job 不常见，但通用 job 框架中可能出现。
+
+对于物化视图，一个物化视图对应一个刷新 job，一个刷新 job 可以创建多个刷新 task。可以用 `jobs("type"="mv").Name` 关联 `mv_infos("database"="...").JobName` 和 `tasks("type"="mv").JobName`。
 
 
 ## 示例
 
-查看所有物化视图的 job
+查看某个物化视图的刷新 job。
 
 ```sql
-select * from jobs("type"="mv");
+select *
+from jobs("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"\G
 ```
 ```text
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| Id    | Name             | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | ExecuteType | RecurringStrategy | Status  | CreateTime          |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 12:26:06 |
-| 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-07 22:13:31 |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
+*************************** 1. row ***************************
+               Id: 19508
+             Name: inner_mtmv_19494
+             MvId: 19494
+           MvName: mv1
+     MvDatabaseId: 16016
+   MvDatabaseName: test
+      ExecuteType: MANUAL
+RecurringStrategy: MANUAL TRIGGER
+           Status: RUNNING
+       CreateTime: 2025-01-07 22:13:31
+```
+
+该结果中：
+
+- `Id` 是物化视图刷新 job ID，与 `tasks("type"="mv")` 中的 `JobId` 相同。
+- `Name` 是物化视图刷新 job 名称，与 `mv_infos("database"="test")` 和 `tasks("type"="mv")` 中的 `JobName` 相同。
+- `MvId` 和 `MvName` 标识该 job 维护的物化视图。
+- `MvDatabaseId` 和 `MvDatabaseName` 标识物化视图所属数据库。
+- `ExecuteType` 为 `MANUAL`，表示该 job 不按自身定时器运行。当物化视图被手动刷新、提交触发刷新或系统触发刷新时，才会生成刷新 task。
+- `RecurringStrategy` 为 `MANUAL TRIGGER`，与 `ExecuteType = MANUAL` 对应。如果是定时刷新的物化视图，该字段会显示为 `EVERY ... STARTS ...`。
+- `Status` 为 `RUNNING`，表示该 job 可以生成刷新 task。如果为 `PAUSED`，需要先恢复物化视图 job，才会继续产生新 task。
+- `CreateTime` 表示该物化视图刷新 job 的创建时间。
+
+查看该 job 生成的刷新 task：
+
+```sql
+select TaskId, JobName, MvName, Status, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc;
+```
+```text
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+---------------------+---------------------+
 ```
 
 查看所有 insert 任务的 job

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/table-valued-functions/mv_infos.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/table-valued-functions/mv_infos.md
@@ -16,54 +16,116 @@
 MV_INFOS("database"="<database>")
 ```
 
-## 必填参数 (Required Parameters)
-**`<database>`**
-> 指定需要查询的集群数据库名
+## 参数
 
+| 参数              | 描述 |
+|-------------------|------|
+| **`<database>`** | 字符串，必填。指定需要查询异步物化视图元数据的数据库名。 |
 
 ## 返回值
+
+该表函数返回 0 行或多行异步物化视图信息。函数本身不返回 NULL；当对应元数据不可用时，部分字段可能为空或 `NULL`。
+
 | 字段名称                | 类型    | 说明                                                               |
 |-------------------------|---------|--------------------------------------------------------------------|
 | Id                      | BIGINT  | 物化视图 id                                                         |
 | Name                    | TEXT    | 物化视图 Name                                                       |
-| JobName                 | TEXT    | 物化视图对应的 job 名称                                               |
-| State                   | TEXT    | 物化视图状态                                                       |
-| SchemaChangeDetail      | TEXT    | 物化视图 State 变为 SchemaChange 的原因                                 |
-| RefreshState            | TEXT    | 物化视图刷新状态                                                   |
-| RefreshInfo             | TEXT    | 物化视图定义的刷新策略信息                                         |
+| JobName                 | TEXT    | 物化视图对应的刷新 job 名称，可用于查询 `jobs("type"="mv")` 和 `tasks("type"="mv")`。 |
+| State                   | TEXT    | 物化视图元数据状态。可取值：`INIT`、`NORMAL`、`SCHEMA_CHANGE`。 |
+| SchemaChangeDetail      | TEXT    | `State` 变为 `SCHEMA_CHANGE` 的原因。物化视图不处于 schema change 状态时通常为空。 |
+| RefreshState            | TEXT    | 最近一次刷新状态。可取值：`INIT`、`SUCCESS`、`FAIL`。 |
+| RefreshInfo             | TEXT    | 物化视图定义的刷新策略信息，包括构建方式、刷新方式和触发方式。 |
 | QuerySql                | TEXT    | 物化视图定义的查询语句                                             |
 | EnvInfo                 | TEXT    | 物化视图创建时的环境信息                                           |
 | MvProperties            | TEXT    | 物化视属性                                                         |
 | MvPartitionInfo         | TEXT    | 物化视图的分区信息                                                 |
-| SyncWithBaseTables      | BOOLEAN | 是否和 base 表数据同步，如需查看哪个分区不同步，请使用[SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS) |
+| SyncWithBaseTables      | BOOLEAN | 物化视图数据是否和基表数据同步。如需查看哪个分区不同步，请使用 [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS)。 |
+
+`RefreshInfo` 的展示格式为 `BUILD <BuildMode> REFRESH <RefreshMethod> ON <RefreshTrigger> [schedule]`。每一部分的含义见下面的枚举字段说明。
+
+### MV 信息枚举字段说明
+
+查看物化视图定义和健康状态时，下面这些枚举字段最常用：
+
+- `State`：物化视图元数据状态。
+  - `INIT`：物化视图已创建，但还没有进入正常可用的元数据状态。
+  - `NORMAL`：物化视图元数据正常。大多数情况下应该是这个状态。
+  - `SCHEMA_CHANGE`：基表或相关对象的 schema 变更影响了该物化视图。需要查看 `SchemaChangeDetail` 了解原因。此时物化视图通常仍可直接查询，但在刷新成功前可能不能用于透明改写。
+- `RefreshState`：最近一次刷新结果状态。
+  - `INIT`：还没有记录刷新结果。
+  - `SUCCESS`：最近一次刷新成功。
+  - `FAIL`：最近一次刷新失败。可以用 `JobName` 查询 `tasks("type"="mv")`，查看失败 task 的 `ErrorMsg`。
+- `RefreshInfo.BuildMode`：Doris 什么时候构建物化视图数据。
+  - `IMMEDIATE`：创建物化视图后立即构建。
+  - `DEFERRED`：创建时不立即构建，需要后续刷新后才有新鲜数据。
+- `RefreshInfo.RefreshMethod`：Doris 如何选择要刷新的数据。
+  - `COMPLETE`：总是全量刷新物化视图。
+  - `AUTO`：Doris 自动判断刷新全部分区还是只刷新变更分区。
+- `RefreshInfo.RefreshTrigger`：什么动作触发刷新 task。
+  - `MANUAL`：手动触发刷新。
+  - `COMMIT`：相关基表数据变更后触发刷新。
+  - `SCHEDULE`：按调度周期触发刷新。调度细节会出现在 `RefreshInfo` 的 `ON SCHEDULE` 后面。
+- `MvPartitionInfo.partitionType`：物化视图的分区方式。
+  - `FOLLOW_BASE_TABLE`：物化视图分区跟随基表分区列。
+  - `SELF_MANAGE`：物化视图自己管理分区。
+  - `EXPR`：物化视图使用表达式定义分区。
+- `SyncWithBaseTables`：物化视图数据是否和基表同步。
+  - `1` 或 `true`：已同步。
+  - `0` 或 `false`：未完全同步。对于分区物化视图，可以用 `SHOW PARTITIONS FROM <mv_name>` 查看分区级同步状态。
 
 
 ## 示例
 
-查看 test 下的所有物化视图
+查看 `test` 数据库下名为 `mv1` 的物化视图。
 
 ```sql
-select * from mv_infos("database"="test");
+select *
+from mv_infos("database"="test")
+where Name = "mv1"\G
 ```
 ```text
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name                     | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                                                                                         | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1                      | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`                                                                      | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-| 21788 | test_tablet_type_mtmv_mv | inner_mtmv_21788 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`test_tablet_type_mtmv_table`.`k2`, `internal`.`test`.`test_tablet_type_mtmv_table`.`k3` from `internal`.`test`.`test_tablet_type_mtmv_table` | {}                                                        | MTMVPartitionInfo{partitionType=SELF_MANAGE}                                                              |                  0 |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
+*************************** 1. row ***************************
+                Id: 19494
+              Name: mv1
+           JobName: inner_mtmv_19494
+             State: NORMAL
+SchemaChangeDetail:
+      RefreshState: SUCCESS
+       RefreshInfo: BUILD DEFERRED REFRESH AUTO ON MANUAL
+          QuerySql: SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`
+           EnvInfo: EnvInfo{ctlId='0', dbId='16813'}
+      MvProperties: {partition_sync_limit=100, partition_sync_time_unit=YEAR}
+   MvPartitionInfo: MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'}
+SyncWithBaseTables: 1
 ```
 
-查看 test 下的物化视图名称为 mv1 的物化视图
+该结果中：
+
+- `Id` 和 `Name` 标识该物化视图。
+- `JobName` 是该物化视图的刷新 job 名称。可以通过该字段继续查询 job 或刷新 task，例如 `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`。
+- `State` 为 `NORMAL`，表示物化视图元数据状态正常。`INIT` 表示物化视图刚创建或初始化中；`SCHEMA_CHANGE` 表示基表 schema 变更影响了该物化视图，此时需要查看 `SchemaChangeDetail`。
+- `SchemaChangeDetail` 为空，因为当前 `State` 不是 `SCHEMA_CHANGE`。
+- `RefreshState` 为 `SUCCESS`，表示最近一次刷新成功。`INIT` 表示尚未记录成功刷新状态；`FAIL` 表示最近一次刷新失败，此时可使用 `JobName` 查询 `tasks("type"="mv")`，查看失败 task 的 `ErrorMsg`。
+- `RefreshInfo` 为 `BUILD DEFERRED REFRESH AUTO ON MANUAL`。`BUILD DEFERRED` 表示创建物化视图时不立即构建；`REFRESH AUTO` 表示 Doris 自动判断刷新全部分区还是部分分区；`ON MANUAL` 表示刷新由手动触发，而不是定时触发。
+- `QuerySql` 是物化视图定义的查询 SQL。
+- `EnvInfo` 记录物化视图创建时的环境信息。
+- `MvProperties` 展示物化视图属性。本例中，分区同步由 `partition_sync_limit=100` 和 `partition_sync_time_unit=YEAR` 控制。
+- `MvPartitionInfo` 展示物化视图分区方式。`FOLLOW_BASE_TABLE` 表示跟随基表分区列；`SELF_MANAGE` 表示物化视图自己管理分区；`EXPR` 表示基于表达式定义分区。
+- `SyncWithBaseTables` 为 `1`，表示物化视图数据和基表数据同步。`0` 表示不完全同步。对于分区物化视图，可使用 `SHOW PARTITIONS FROM <mv_name>` 查看分区级同步状态。
+
+查看该物化视图最近一次刷新 task：
 
 ```sql
-select * from mv_infos("database"="test") where Name = "mv1";
+select TaskId, JobName, MvName, Status, ErrorMsg, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc
+limit 1;
 ```
 ```text
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                    | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1  | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user` | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | ErrorMsg | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
 ```
-    

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/table-valued-functions/tasks.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/table-valued-functions/tasks.md
@@ -17,17 +17,19 @@ TASKS(
 )
 ```
 
-## 必填参数 (Required Parameters)
-| 字段名          | 描述                                                            |
+## 参数
+| 参数          | 描述                                                            |
 |--------------|---------------------------------------------------------------|
 | **`<type>`** | 任务的类型：<br/> `insert`：insert into 类型的任务。 <br/> `mv`：物化视图类型的任务。 |
 
 
 ## 返回值
 
+该表函数返回 0 行或多行结果。函数本身不返回 NULL；当对应 task 元数据不可用时，部分字段可能为空、`NULL` 或 `\N`。
+
 - **`tasks("type"="insert")`** insert 类型的 tasks 返回值
 
-  | 字段名       | 描述                      |
+  | 参数          | 描述                      |
   |--------------|---------------------------|
   | **TaskId**   | task id                   |
   | **JobId**    | job id                    |
@@ -45,50 +47,109 @@ TASKS(
 
 - **`tasks("type"="mv")`** MV 类型的 tasks 返回值
 
-  | 字段名                | 描述                           |
+  | 参数          | 描述                           |
   |-----------------------|--------------------------------|
-  | **TaskId**            | task id                        |
-  | **JobId**             | job id                         |
-  | **JobName**           | job 名称                        |
-  | **MvId**              | 物化视图 id                     |
-  | **MvName**            | 物化视图名称                    |
-  | **MvDatabaseId**      | 物化视图所属 db id              |
-  | **MvDatabaseName**    | 物化视图所属 db 名称            |
-  | **Status**            | task 状态                       |
-  | **ErrorMsg**          | task 失败信息                   |
-  | **CreateTime**        | task 创建时间                   |
-  | **StartTime**         | task 开始运行时间               |
-  | **FinishTime**        | task 结束运行时间               |
-  | **DurationMs**        | task 运行时间                   |
-  | **TaskContext**       | task 运行参数                   |
-  | **RefreshMode**       | 刷新模式                        |
-  | **NeedRefreshPartitions** | 本次 task 需要刷新的分区信息   |
-  | **CompletedPartitions** | 本次 task 刷新完成的分区信息   |
-  | **Progress**          | task 运行进度                   |
+  | **TaskId**            | 刷新任务的唯一 ID。每次物化视图刷新都会生成一条新的 task 记录。 |
+  | **JobId**             | 生成该 task 的 job ID，对应 `jobs("type"="mv").Id`。 |
+  | **JobName**           | 生成该 task 的 job 名称，对应 `mv_infos("database"="...").JobName` 和 `jobs("type"="mv").Name`。 |
+  | **MvId**              | 该 task 刷新的物化视图 ID。 |
+  | **MvName**            | 该 task 刷新的物化视图名称。 |
+  | **MvDatabaseId**      | 物化视图所属数据库 ID。 |
+  | **MvDatabaseName**    | 物化视图所属数据库名称。 |
+  | **Status**            | task 状态。可取值：`PENDING` 表示等待运行；`RUNNING` 表示正在运行；`SUCCESS` 表示运行成功；`FAILED` 表示运行失败；`CANCELED` 表示已取消。 |
+  | **ErrorMsg**          | 当 `Status` 为 `FAILED` 或 `CANCELED` 时记录错误信息；运行成功时通常为空。 |
+  | **CreateTime**        | task 记录创建时间。 |
+  | **StartTime**         | task 开始运行时间。如果 task 尚未开始，可能为 `\N`。 |
+  | **FinishTime**        | task 结束时间。如果 task 仍在等待或运行，可能为 `\N`。 |
+  | **DurationMs**        | task 运行耗时，单位毫秒，按 `FinishTime - StartTime` 计算。如果 task 尚未结束，可能为 `\N`。 |
+  | **TaskContext**       | task 触发方式和用户刷新参数的 JSON 字符串。常见字段包括 `triggerMode`、`partitions` 和 `isComplete`。`triggerMode` 可取值为 `MANUAL`、`COMMIT`、`SYSTEM`。 |
+  | **RefreshMode**       | 该 task 实际执行的刷新范围。可取值：`COMPLETE` 表示刷新全部物化视图分区；`PARTIAL` 表示只刷新部分分区；`NOT_REFRESH` 表示没有分区需要刷新。 |
+  | **NeedRefreshPartitions** | JSON 数组，记录本次 task 需要刷新的物化视图分区。空数组表示没有分区需要刷新。 |
+  | **CompletedPartitions** | JSON 数组，记录本次 task 已成功刷新的分区。可与 `NeedRefreshPartitions` 对比判断是否全部完成。 |
+  | **Progress**          | task 刷新进度，格式为 `百分比 (已完成分区数/需刷新分区数)`，例如 `100.00% (1/1)`。没有分区需要刷新时可能为 `\N`。 |
+  | **LastQueryId**       | 刷新 task 执行 SQL 的 query ID。排查 task 失败或耗时时，可用该 ID 搜索 FE 或 BE 日志。没有执行刷新 SQL 时可能为空。该字段从 Doris 3.0.0 开始支持。 |
+
+### MV task 枚举字段说明
+
+查看物化视图刷新 task 时，下面这些枚举字段最常用：
+
+- `Status`：task 生命周期状态。
+  - `PENDING`：task 已创建，但还没有开始执行，正在等待调度或资源。
+  - `RUNNING`：task 正在执行。
+  - `SUCCESS`：task 执行成功。
+  - `FAILED`：task 执行失败。优先查看 `ErrorMsg`；如果 `LastQueryId` 不为空，可以用它搜索日志。
+  - `CANCELED`：task 在完成前被取消。
+- `TaskContext.triggerMode`：该 task 是因为什么原因创建的。
+  - `MANUAL`：由手动刷新命令创建，例如 `REFRESH MATERIALIZED VIEW`。
+  - `COMMIT`：由相关基表数据变更触发创建。
+  - `SYSTEM`：由系统内部动作创建，例如创建物化视图时的初始构建。
+- `TaskContext.isComplete`：刷新请求是否要求全量刷新。
+  - `true`：请求 Doris 刷新全部物化视图分区。
+  - `false`：请求不强制全量刷新，Doris 可以根据分区新鲜度判断实际刷新范围。
+- `RefreshMode`：task 检查分区后选择的实际刷新范围。
+  - `COMPLETE`：选择刷新该物化视图的全部分区。
+  - `PARTIAL`：只选择刷新部分物化视图分区。
+  - `NOT_REFRESH`：没有分区需要刷新。此时 `NeedRefreshPartitions` 通常为空，`Progress` 可能为 `\N`。
+
+:::info 版本说明
+
+`LastQueryId` 从 Doris 3.0.0 开始支持，Doris 2.1.x 没有该字段。
+
+:::
 
 
 ## 示例
 
-查看所有物化视图的 tasks
+查看某个物化视图最近一次刷新 task。
 
 ```sql
-select * from tasks("type"="mv");
+select *
+from tasks("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"
+order by CreateTime desc
+limit 1\G
 ```
 ```text
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| TaskId          | JobId | JobName          | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | Status  | ErrorMsg | CreateTime          | StartTime           | FinishTime          | DurationMs | TaskContext                                                 | RefreshMode | NeedRefreshPartitions                         | CompletedPartitions                           | Progress      | LastQueryId                       |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| 509478985247053 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 233        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 71897c47d0d94fd2-9ca52a0e6eb3bff5 |
-| 509486915704885 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 227        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 9bf5ff69d4cc4c78-b50505436c8410c4 |
-| 509487197275880 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 191        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 5b3b4525b6774b5b-89b070042cdcbcd5 |
-| 509478131194211 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 156        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 6d0a0782819b446e-b9da5d5de513ce00 |
-| 509486057129101 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:18 | 213        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | f1303483e3db43e7-aa424acc32dc39ca |
-| 509486143784554 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 151        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 8d29b11ac41f4fe0-9d7c86372707310b |
-| 488317385772600 | 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | SUCCESS |          | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 1          | {"triggerMode":"MANUAL","partitions":[],"isComplete":true}  | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-| 437156301250803 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 | 236985     | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | COMPLETE    | ["p_20210101_MAXVALUE","p_20200101_20210101"] | ["p_20210101_MAXVALUE","p_20200101_20210101"] | 100.00% (2/2) | 7965b4ddce8a4480-8884e9701679c1c4 |
-| 439689059641969 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 35         | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
+*************************** 1. row ***************************
+               TaskId: 437156301250803
+                JobId: 19508
+              JobName: inner_mtmv_19494
+                 MvId: 19494
+               MvName: mv1
+         MvDatabaseId: 16016
+       MvDatabaseName: test
+               Status: SUCCESS
+             ErrorMsg:
+           CreateTime: 2025-01-07 22:13:48
+            StartTime: 2025-01-07 22:13:48
+           FinishTime: 2025-01-07 22:17:45
+           DurationMs: 236985
+          TaskContext: {"triggerMode":"MANUAL","partitions":[],"isComplete":false}
+          RefreshMode: COMPLETE
+NeedRefreshPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+  CompletedPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+             Progress: 100.00% (2/2)
+          LastQueryId: 7965b4ddce8a4480-8884e9701679c1c4
 ```
+
+该结果中：
+
+- `TaskId` 表示这次刷新执行的唯一 ID。每次刷新都会生成不同的 task。
+- `JobId` 和 `JobName` 标识该 task 所属的物化视图刷新 job。可以通过 `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";` 查询 job。
+- `MvId`、`MvName`、`MvDatabaseId`、`MvDatabaseName` 标识该 task 刷新的物化视图。
+- `Status` 为 `SUCCESS`，表示 task 执行成功。如果为 `FAILED`，优先查看 `ErrorMsg`。
+- `CreateTime`、`StartTime`、`FinishTime`、`DurationMs` 分别表示 task 创建时间、开始运行时间、结束时间和运行耗时。
+- `TaskContext` 表示该 task 是手动触发的。`partitions: []` 表示刷新命令没有指定分区列表。
+- `RefreshMode` 为 `COMPLETE`，表示本次 task 刷新了该物化视图需要刷新的全部分区。
+- `NeedRefreshPartitions` 列出本次需要刷新的两个分区，`CompletedPartitions` 列出同样两个分区，说明需要刷新的分区都已完成。
+- `Progress` 为 `100.00% (2/2)`，也表示两个需要刷新的分区都已完成。
+- `LastQueryId` 是刷新 SQL 的 query ID。排查 task 失败或耗时时，可以用该 ID 搜索 Doris 日志。
+
+:::info 备注
+
+task 记录默认保存和展示数量由 FE 配置项 `max_persistence_task_count` 控制，默认值为 100。超过该数量时，旧 task 记录会被丢弃。如果该值小于 1，则不持久化 task 记录。修改该配置后需要重启 FE 生效。
+
+:::
 
 查看所有 insert 任务的 tasks
 ```sql

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/table-valued-functions/jobs.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/table-valued-functions/jobs.md
@@ -18,8 +18,8 @@ JOBS(
 )
 ```
 
-## Required Parameters
-| Field         | Description                                                                                   |
+## Parameters
+| Parameter     | Description                                                                                   |
 |---------------|-----------------------------------------------------------------------------------------------|
 | **`<type>`**  | The type of the job: <br/> `insert`: Insert into type job. <br/> `mv`: Materialized view job. |
 
@@ -27,56 +27,109 @@ JOBS(
 
 ## Return Value
 
+This table function returns zero or more rows. The function itself does not return NULL. Individual fields can be empty or `NULL` when the corresponding metadata is unavailable.
+
 -  **`jobs("type"="insert")`** Job return value of type insert
 
-   | Field              | Description                |
-       |--------------------|----------------------------|
-   | Id                 | Job ID                     |
-   | Name               | Job name                   |
-   | Definer            | Job definer                |
-   | ExecuteType        | Execution type             |
-   | RecurringStrategy  | Recurring strategy         |
-   | Status             | Job status                 |
-   | ExecuteSql         | Execution SQL              |
-   | CreateTime         | Job creation time          |
-   | SucceedTaskCount   | Number of successful tasks |
-   | FailedTaskCount    | Number of failed tasks     |
-   | CanceledTaskCount  | Number of canceled tasks   |
-   | Comment            | Job comment                |
+    | Parameter     | Description                |
+    |--------------------|----------------------------|
+    | Id                 | Job ID                     |
+    | Name               | Job name                   |
+    | Definer            | Job definer                |
+    | ExecuteType        | Execution type             |
+    | RecurringStrategy  | Recurring strategy         |
+    | Status             | Job status                 |
+    | ExecuteSql         | Execution SQL              |
+    | CreateTime         | Job creation time          |
+    | SucceedTaskCount   | Number of successful tasks |
+    | FailedTaskCount    | Number of failed tasks     |
+    | CanceledTaskCount  | Number of canceled tasks   |
+    | Comment            | Job comment                |
 
 
 - **`jobs("type"="mv")`** MV type job return value
 
-  | Field                | Description                                                 |
-      |----------------------|-------------------------------------------------------------|
-  | Id                   | job ID                                                      |
-  | Name                 | job name                                                    |
-  | MvId                 | Materialized View ID                                        |
-  | MvName               | Materialized View Name                                      |
-  | MvDatabaseId         | DB ID of the materialized view                              |
-  | MvDatabaseName       | Name of the database to which the materialized view belongs |
-  | ExecuteType          | Execution type                                              |
-  | RecurringStrategy    | Loop strategy                                               |
-  | Status               | Job status                                                  |
-  | CreateTime           | Task creation time                                          |
+    | Parameter     | Description                                                 |
+    |----------------------|-------------------------------------------------------------|
+    | Id                   | Job ID. For MV jobs, it corresponds to `tasks("type"="mv").JobId`. |
+    | Name                 | Job name. For MV jobs, it corresponds to `mv_infos("database"="...").JobName` and `tasks("type"="mv").JobName`. |
+    | MvId                 | ID of the materialized view maintained by this job. |
+    | MvName               | Name of the materialized view maintained by this job. |
+    | MvDatabaseId         | ID of the database that contains the materialized view. |
+    | MvDatabaseName       | Name of the database that contains the materialized view. |
+    | ExecuteType          | Job execution type. For MV jobs, possible values are `MANUAL` and `RECURRING`. `MANUAL` means refresh tasks are triggered manually, by commit, or by internal events. `RECURRING` means refresh tasks are scheduled periodically. |
+    | RecurringStrategy    | Scheduling description derived from `ExecuteType`. `MANUAL TRIGGER` means the job does not run on a timer. `EVERY ... STARTS ... [ENDS ...]` means the job runs periodically. |
+    | Status               | Job status. Possible values: `PENDING` means the job is waiting for scheduling; `RUNNING` means the job can produce tasks; `PAUSED` means the job is paused and can be resumed; `STOPPED` means the job has been stopped and cannot be resumed; `FINISHED` means the job has finished. |
+    | CreateTime           | Time when the job was created. |
+
+### MV job enum fields
+
+The following enum fields are commonly used when checking materialized view refresh jobs:
+
+- `ExecuteType`: how the job creates refresh tasks.
+  - `MANUAL`: the job does not run on its own timer. A task is created only when a refresh is triggered manually, by commit, or by the system.
+  - `RECURRING`: the job runs on a schedule and periodically creates refresh tasks.
+- `RecurringStrategy`: human-readable scheduling rule generated from `ExecuteType`.
+  - `MANUAL TRIGGER`: the job is not scheduled periodically. This is the usual value when `ExecuteType` is `MANUAL`.
+  - `EVERY <interval> <unit> STARTS <time> [ENDS <time>]`: the job is scheduled periodically. For example, `EVERY 10 MINUTE STARTS 2025-01-17 14:42:53`.
+- `Status`: current state of the job itself.
+  - `PENDING`: the job is waiting to be scheduled.
+  - `RUNNING`: the job is active and can create refresh tasks.
+  - `PAUSED`: the job is paused. It will not create new refresh tasks until it is resumed.
+  - `STOPPED`: the job has been stopped and cannot be resumed.
+  - `FINISHED`: the job has finished. This is uncommon for long-lived MV refresh jobs, but it can appear in the generic job framework.
+
+For materialized views, one materialized view has one refresh job, and one refresh job can create many refresh tasks. Use `jobs("type"="mv").Name` to connect the job to `mv_infos("database"="...").JobName` and `tasks("type"="mv").JobName`.
 
 
 ## Examples
 
-View jobs in all materialized views
+View the refresh job of a materialized view.
 
 ```sql
-select * from jobs("type"="mv");
+select *
+from jobs("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"\G
 ```
 ```text
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| Id    | Name             | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | ExecuteType | RecurringStrategy | Status  | CreateTime          |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 12:26:06 |
-| 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-07 22:13:31 |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
+*************************** 1. row ***************************
+               Id: 19508
+             Name: inner_mtmv_19494
+             MvId: 19494
+           MvName: mv1
+     MvDatabaseId: 16016
+   MvDatabaseName: test
+      ExecuteType: MANUAL
+RecurringStrategy: MANUAL TRIGGER
+           Status: RUNNING
+       CreateTime: 2025-01-07 22:13:31
+```
+
+In this result:
+
+- `Id` is the MV refresh job ID. It is the same value as `JobId` in `tasks("type"="mv")`.
+- `Name` is the MV refresh job name. It is the same value as `JobName` in `mv_infos("database"="test")` and `tasks("type"="mv")`.
+- `MvId` and `MvName` identify the materialized view maintained by this job.
+- `MvDatabaseId` and `MvDatabaseName` identify the database that contains the materialized view.
+- `ExecuteType` is `MANUAL`, so this job does not run by its own timer. A refresh task is created when the materialized view is manually refreshed, refreshed on commit, or triggered by the system.
+- `RecurringStrategy` is `MANUAL TRIGGER`, which matches `ExecuteType = MANUAL`. For a scheduled materialized view, this field is displayed as `EVERY ... STARTS ...`.
+- `Status` is `RUNNING`, so the job can generate refresh tasks. If it is `PAUSED`, resume the materialized view job before expecting new tasks.
+- `CreateTime` is the time when this MV refresh job was created.
+
+To view the tasks generated by this job, use the job name:
+
+```sql
+select TaskId, JobName, MvName, Status, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc;
+```
+```text
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+---------------------+---------------------+
 ```
 
 View all insert jobs

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/table-valued-functions/mv_infos.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/table-valued-functions/mv_infos.md
@@ -15,53 +15,115 @@ Table function, generating temporary tables for asynchronous materialized views,
 MV_INFOS("database"="<database>")
 ```
 
-## Required Parameters
-**`<database>`**
-> Specify the cluster database name to be queried
+## Parameters
 
+| Parameter        | Description |
+|------------------|-------------|
+| **`<database>`** | Required. String type. Name of the database whose asynchronous materialized view metadata you want to query. |
 
 ## Return Value
+
+This table function returns zero or more rows describing asynchronous materialized views. The function itself does not return NULL. Individual fields can be empty or `NULL` when the corresponding metadata is unavailable.
 
 | Field                  | Type    | Description                                                         |
 |------------------------|---------|---------------------------------------------------------------------|
 | Id                     | BIGINT  | Materialized view ID                                                |
 | Name                   | TEXT    | Materialized view name                                              |
-| JobName                | TEXT    | Job name corresponding to the materialized view                      |
-| State                  | TEXT    | State of the materialized view                                       |
-| SchemaChangeDetail     | TEXT    | Reason for the state change to SchemaChange                         |
-| RefreshState           | TEXT    | Refresh state of the materialized view                               |
-| RefreshInfo            | TEXT    | Refresh strategy information defined for the materialized view       |
+| JobName                | TEXT    | Name of the refresh job corresponding to the materialized view. It can be used to query `jobs("type"="mv")` and `tasks("type"="mv")`. |
+| State                  | TEXT    | Metadata state of the materialized view. Possible values: `INIT`, `NORMAL`, and `SCHEMA_CHANGE`. |
+| SchemaChangeDetail     | TEXT    | Reason why `State` becomes `SCHEMA_CHANGE`. Empty when the materialized view is not in schema change state. |
+| RefreshState           | TEXT    | State of the latest refresh. Possible values: `INIT`, `SUCCESS`, and `FAIL`. |
+| RefreshInfo            | TEXT    | Refresh strategy defined for the materialized view, including build mode, refresh method, and trigger mode. |
 | QuerySql               | TEXT    | SQL query defined for the materialized view                          |
 | EnvInfo                | TEXT    | Environment information when the materialized view was created       |
 | MvProperties           | TEXT    | Materialized view properties                                         |
 | MvPartitionInfo        | TEXT    | Partition information of the materialized view                       |
-| SyncWithBaseTables     | BOOLEAN | Whether the data is synchronized with the base table. To check which partition is not synchronized, use [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS) |
+| SyncWithBaseTables     | BOOLEAN | Whether the data of the materialized view is synchronized with its base tables. To check which partition is not synchronized, use [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS). |
+
+`RefreshInfo` is displayed as `BUILD <BuildMode> REFRESH <RefreshMethod> ON <RefreshTrigger> [schedule]`. The meaning of each part is described in the enum section below.
+
+### MV info enum fields
+
+The following enum fields are commonly used when checking materialized view definitions and health:
+
+- `State`: metadata state of the materialized view.
+  - `INIT`: the materialized view has been created but has not reached normal usable metadata state yet.
+  - `NORMAL`: the materialized view metadata is normal. This is the expected state in most cases.
+  - `SCHEMA_CHANGE`: a schema change on a base table or related object affected this materialized view. Check `SchemaChangeDetail` for the reason. The materialized view can usually be queried directly, but it may not be available for transparent rewrite until it is refreshed successfully.
+- `RefreshState`: result state of the latest refresh.
+  - `INIT`: no refresh result has been recorded yet.
+  - `SUCCESS`: the latest refresh finished successfully.
+  - `FAIL`: the latest refresh failed. Use `JobName` to query `tasks("type"="mv")` and check the failed task's `ErrorMsg`.
+- `RefreshInfo.BuildMode`: when Doris builds the materialized view data.
+  - `IMMEDIATE`: build the materialized view immediately after creation.
+  - `DEFERRED`: do not build it at creation time. The materialized view needs a later refresh before it has fresh data.
+- `RefreshInfo.RefreshMethod`: how Doris chooses data to refresh.
+  - `COMPLETE`: always refresh the materialized view completely.
+  - `AUTO`: Doris decides whether to refresh all partitions or only changed partitions.
+- `RefreshInfo.RefreshTrigger`: what triggers refresh tasks.
+  - `MANUAL`: refresh is triggered manually.
+  - `COMMIT`: refresh is triggered by data changes on related base tables.
+  - `SCHEDULE`: refresh is triggered by a schedule. The schedule details appear after `ON SCHEDULE` in `RefreshInfo`.
+- `MvPartitionInfo.partitionType`: how the materialized view is partitioned.
+  - `FOLLOW_BASE_TABLE`: materialized view partitions follow a base table partition column.
+  - `SELF_MANAGE`: the materialized view manages its own partitions.
+  - `EXPR`: materialized view partitions are defined by an expression.
+- `SyncWithBaseTables`: whether materialized view data is synchronized with base tables.
+  - `1` or `true`: synchronized.
+  - `0` or `false`: not fully synchronized. For partitioned materialized views, use `SHOW PARTITIONS FROM <mv_name>` to check partition-level synchronization.
 
 ## Examples
 
-View all materialized views under test
+View a materialized view under database `test`.
 
 ```sql
-select * from mv_infos("database"="test");
+select *
+from mv_infos("database"="test")
+where Name = "mv1"\G
 ```
 ```text
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name                     | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                                                                                         | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1                      | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`                                                                      | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-| 21788 | test_tablet_type_mtmv_mv | inner_mtmv_21788 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`test_tablet_type_mtmv_table`.`k2`, `internal`.`test`.`test_tablet_type_mtmv_table`.`k3` from `internal`.`test`.`test_tablet_type_mtmv_table` | {}                                                        | MTMVPartitionInfo{partitionType=SELF_MANAGE}                                                              |                  0 |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
+*************************** 1. row ***************************
+                Id: 19494
+              Name: mv1
+           JobName: inner_mtmv_19494
+             State: NORMAL
+SchemaChangeDetail:
+      RefreshState: SUCCESS
+       RefreshInfo: BUILD DEFERRED REFRESH AUTO ON MANUAL
+          QuerySql: SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`
+           EnvInfo: EnvInfo{ctlId='0', dbId='16813'}
+      MvProperties: {partition_sync_limit=100, partition_sync_time_unit=YEAR}
+   MvPartitionInfo: MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'}
+SyncWithBaseTables: 1
 ```
 
-View the materialized view named mv1 under test
+In this result:
+
+- `Id` and `Name` identify the materialized view.
+- `JobName` is the refresh job name for this materialized view. Use it to query the job or refresh tasks, for example `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`.
+- `State` is `NORMAL`, which means the materialized view metadata is normal. `INIT` means the materialized view has just been created or initialized. `SCHEMA_CHANGE` means a schema change on a base table affected this materialized view; in this state, check `SchemaChangeDetail`.
+- `SchemaChangeDetail` is empty because `State` is not `SCHEMA_CHANGE`.
+- `RefreshState` is `SUCCESS`, which means the latest refresh succeeded. `INIT` means no successful refresh state has been recorded yet. `FAIL` means the latest refresh failed; query `tasks("type"="mv")` with `JobName` to find the failed task and its `ErrorMsg`.
+- `RefreshInfo` is `BUILD DEFERRED REFRESH AUTO ON MANUAL`. `BUILD DEFERRED` means the materialized view was not built immediately at creation time. `REFRESH AUTO` means Doris decides whether to refresh all partitions or only changed partitions. `ON MANUAL` means refresh is triggered manually rather than by a schedule.
+- `QuerySql` is the query definition of the materialized view.
+- `EnvInfo` records the environment information when the materialized view was created.
+- `MvProperties` shows the properties of the materialized view. In this example, partition synchronization is limited by `partition_sync_limit=100` and `partition_sync_time_unit=YEAR`.
+- `MvPartitionInfo` shows how the materialized view is partitioned. `FOLLOW_BASE_TABLE` means the materialized view follows a base table partition column. `SELF_MANAGE` means the materialized view manages its own partitions. `EXPR` means the materialized view uses an expression-based partition definition.
+- `SyncWithBaseTables` is `1`, which means the materialized view data is synchronized with its base tables. `0` means it is not fully synchronized. For partitioned materialized views, use `SHOW PARTITIONS FROM <mv_name>` to check partition-level synchronization.
+
+To view the latest refresh task of this materialized view:
 
 ```sql
-select * from mv_infos("database"="test") where Name = "mv1";
+select TaskId, JobName, MvName, Status, ErrorMsg, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc
+limit 1;
 ```
 ```text
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                    | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1  | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user` | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | ErrorMsg | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/table-valued-functions/mv_infos.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/table-valued-functions/mv_infos.md
@@ -67,7 +67,13 @@ The following enum fields are commonly used when checking materialized view defi
 - `MvPartitionInfo.partitionType`: how the materialized view is partitioned.
   - `FOLLOW_BASE_TABLE`: materialized view partitions follow a base table partition column.
   - `SELF_MANAGE`: the materialized view manages its own partitions.
-  - `EXPR`: materialized view partitions are defined by an expression.
+
+:::info Version
+
+Doris 2.1.x supports `FOLLOW_BASE_TABLE` and `SELF_MANAGE` for `MvPartitionInfo.partitionType`. The `EXPR` partition type is supported since Doris 3.0.0.
+
+:::
+
 - `SyncWithBaseTables`: whether materialized view data is synchronized with base tables.
   - `1` or `true`: synchronized.
   - `0` or `false`: not fully synchronized. For partitioned materialized views, use `SHOW PARTITIONS FROM <mv_name>` to check partition-level synchronization.
@@ -108,7 +114,7 @@ In this result:
 - `QuerySql` is the query definition of the materialized view.
 - `EnvInfo` records the environment information when the materialized view was created.
 - `MvProperties` shows the properties of the materialized view. In this example, partition synchronization is limited by `partition_sync_limit=100` and `partition_sync_time_unit=YEAR`.
-- `MvPartitionInfo` shows how the materialized view is partitioned. `FOLLOW_BASE_TABLE` means the materialized view follows a base table partition column. `SELF_MANAGE` means the materialized view manages its own partitions. `EXPR` means the materialized view uses an expression-based partition definition.
+- `MvPartitionInfo` shows how the materialized view is partitioned. In Doris 2.1.x, `FOLLOW_BASE_TABLE` means the materialized view follows a base table partition column, and `SELF_MANAGE` means the materialized view manages its own partitions. The `EXPR` partition type is supported since Doris 3.0.0.
 - `SyncWithBaseTables` is `1`, which means the materialized view data is synchronized with its base tables. `0` means it is not fully synchronized. For partitioned materialized views, use `SHOW PARTITIONS FROM <mv_name>` to check partition-level synchronization.
 
 To view the latest refresh task of this materialized view:

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/table-valued-functions/tasks.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/table-valued-functions/tasks.md
@@ -17,18 +17,20 @@ TASKS(
 )
 ```
 
-## Required Parameters
-| Field         | Description                                                                                       |
+## Parameters
+| Parameter     | Description                                                                                       |
 |---------------|---------------------------------------------------------------------------------------------------|
 | **`<type>`**  | Type of the task: <br/> `insert`: insert into type task. <br/> `mv`: materialized view type task. |
 
 
 ## Return Value
 
+This table function returns zero or more rows. The function itself does not return NULL. Individual fields can be empty, `NULL`, or `\N` when the corresponding task metadata is unavailable.
+
 -  **`tasks("type"="insert")`** tasks return value of type insert
 
    | Field Name   | Description                        |
-      |--------------|------------------------------------|
+   |--------------|------------------------------------|
    | **TaskId**   | Task id                            |
    | **JobId**    | Job id                             |
    | **JobName**  | Job name                           |
@@ -41,52 +43,108 @@ TASKS(
    | **LoadStatistic**| Load statistics                |
    | **User**     | User                               |
 
--  **`tasks("type"="mv")`** Tasks return value of type MV
+-  **`tasks("type"="mv")`** tasks return value of type MV
 
-   | Field Name            | Description                                                                 |
-      |-----------------------|-----------------------------------------------------------------------------|
-   | **TaskId**            | Task id                                                                     |
-   | **JobId**             | Job id                                                                      |
-   | **JobName**           | Job Name                                                                    |
-   | **MvId**              | Materialized View ID                                                        |
-   | **MvName**            | Materialized View Name                                                      |
-   | **MvDatabaseId**      | DB ID of the materialized view                                              |
-   | **MvDatabaseName**    | Name of the database to which the materialized view belongs                 |
-   | **Status**            | Task status                                                                 |
-   | **ErrorMsg**          | Task failure information                                                   |
-   | **CreateTime**        | Task creation time                                                          |
-   | **StartTime**         | Task start running time                                                     |
-   | **FinishTime**        | Task End Run Time                                                           |
-   | **DurationMs**        | Task runtime                                                                |
-   | **TaskContext**       | Task running parameters                                                     |
-   | **RefreshMode**       | Refresh mode                                                                |
-   | **NeedRefreshPartitions** | The partition information that needs to be refreshed for this task       |
-   | **CompletedPartitions** | The partition information that has been refreshed for this task          |
-   | **Progress**          | Task running progress                                                       |
+   | Field Name | Description |
+   |------------|-------------|
+   | **TaskId** | Unique ID of the refresh task. Each materialized view refresh creates a new task record. |
+   | **JobId** | ID of the job that generated this task. It corresponds to `jobs("type"="mv").Id`. |
+   | **JobName** | Name of the job that generated this task. It corresponds to `mv_infos("database"="...").JobName` and `jobs("type"="mv").Name`. |
+   | **MvId** | ID of the materialized view refreshed by this task. |
+   | **MvName** | Name of the materialized view refreshed by this task. |
+   | **MvDatabaseId** | ID of the database that contains the materialized view. |
+   | **MvDatabaseName** | Name of the database that contains the materialized view. |
+   | **Status** | Task status. Possible values: `PENDING` means the task is waiting to run; `RUNNING` means the task is running; `SUCCESS` means the task finished successfully; `FAILED` means the task failed; `CANCELED` means the task was canceled. |
+   | **ErrorMsg** | Error message when `Status` is `FAILED` or `CANCELED`. Empty when the task succeeds. |
+   | **CreateTime** | Time when the task record was created. |
+   | **StartTime** | Time when the task started running. It can be `\N` if the task has not started. |
+   | **FinishTime** | Time when the task finished. It can be `\N` if the task is still pending or running. |
+   | **DurationMs** | Runtime in milliseconds, calculated as `FinishTime - StartTime`. It can be `\N` if the task has not finished. |
+   | **TaskContext** | JSON string describing how the task was triggered and what the user requested. Common fields include `triggerMode`, `partitions`, and `isComplete`. `triggerMode` values are `MANUAL`, `COMMIT`, and `SYSTEM`. |
+   | **RefreshMode** | Actual refresh scope decided by this task. Possible values: `COMPLETE` means all materialized view partitions were refreshed; `PARTIAL` means only some partitions were refreshed; `NOT_REFRESH` means no partition needed refreshing. |
+   | **NeedRefreshPartitions** | JSON array of materialized view partitions that needed refreshing in this task. Empty array means no partition needed refreshing. |
+   | **CompletedPartitions** | JSON array of partitions that were refreshed successfully. Compare it with `NeedRefreshPartitions` to see whether all required partitions completed. |
+   | **Progress** | Refresh progress in the format `percentage (completed/total)`, for example `100.00% (1/1)`. It can be `\N` when there is no partition to refresh. |
+
+### MV task enum fields
+
+The following enum fields are commonly used when checking materialized view refresh tasks:
+
+- `Status`: lifecycle state of the task.
+  - `PENDING`: the task has been created but has not started running. It is waiting for scheduling or resources.
+  - `RUNNING`: the task is currently running.
+  - `SUCCESS`: the task finished successfully.
+  - `FAILED`: the task failed. Check `ErrorMsg` first. In Doris 2.1.x, use the task time fields and materialized view name to search FE or BE logs for more details.
+  - `CANCELED`: the task was canceled before it finished.
+- `TaskContext.triggerMode`: why this task was created.
+  - `MANUAL`: created by a manual refresh command, such as `REFRESH MATERIALIZED VIEW`.
+  - `COMMIT`: created because data changes on related base tables triggered refresh.
+  - `SYSTEM`: created by an internal system action, for example the initial build of a materialized view created with immediate build.
+- `TaskContext.isComplete`: whether the refresh request asks for a complete refresh.
+  - `true`: the request asks Doris to refresh all materialized view partitions.
+  - `false`: the request does not force complete refresh. Doris can decide the actual refresh scope based on partition freshness.
+- `RefreshMode`: actual refresh scope selected by the task after checking partitions.
+  - `COMPLETE`: all materialized view partitions that belong to the MV were selected for refresh.
+  - `PARTIAL`: only some materialized view partitions were selected for refresh.
+  - `NOT_REFRESH`: no partition needed refresh. In this case, `NeedRefreshPartitions` is usually empty and `Progress` can be `\N`.
+
+:::info Version
+
+Doris 2.1.x does not provide `LastQueryId` in `tasks("type"="mv")`. To troubleshoot refresh failures, use `ErrorMsg`, `CreateTime`, `StartTime`, `FinishTime`, `MvDatabaseName`, and `MvName` to locate related FE or BE logs.
+
+:::
 
 
 ## Examples
 
-View tasks for all materialized views
+View the latest refresh task of a materialized view.
 
 ```sql
-select * from tasks("type"="mv");
+select *
+from tasks("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"
+order by CreateTime desc
+limit 1\G
 ```
 ```text
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| TaskId          | JobId | JobName          | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | Status  | ErrorMsg | CreateTime          | StartTime           | FinishTime          | DurationMs | TaskContext                                                 | RefreshMode | NeedRefreshPartitions                         | CompletedPartitions                           | Progress      | LastQueryId                       |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| 509478985247053 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 233        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 71897c47d0d94fd2-9ca52a0e6eb3bff5 |
-| 509486915704885 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 227        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 9bf5ff69d4cc4c78-b50505436c8410c4 |
-| 509487197275880 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 191        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 5b3b4525b6774b5b-89b070042cdcbcd5 |
-| 509478131194211 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 156        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 6d0a0782819b446e-b9da5d5de513ce00 |
-| 509486057129101 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:18 | 213        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | f1303483e3db43e7-aa424acc32dc39ca |
-| 509486143784554 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 151        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 8d29b11ac41f4fe0-9d7c86372707310b |
-| 488317385772600 | 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | SUCCESS |          | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 1          | {"triggerMode":"MANUAL","partitions":[],"isComplete":true}  | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-| 437156301250803 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 | 236985     | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | COMPLETE    | ["p_20210101_MAXVALUE","p_20200101_20210101"] | ["p_20210101_MAXVALUE","p_20200101_20210101"] | 100.00% (2/2) | 7965b4ddce8a4480-8884e9701679c1c4 |
-| 439689059641969 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 35         | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
+*************************** 1. row ***************************
+               TaskId: 437156301250803
+                JobId: 19508
+              JobName: inner_mtmv_19494
+                 MvId: 19494
+               MvName: mv1
+         MvDatabaseId: 16016
+       MvDatabaseName: test
+               Status: SUCCESS
+             ErrorMsg:
+           CreateTime: 2025-01-07 22:13:48
+            StartTime: 2025-01-07 22:13:48
+           FinishTime: 2025-01-07 22:17:45
+           DurationMs: 236985
+          TaskContext: {"triggerMode":"MANUAL","partitions":[],"isComplete":false}
+          RefreshMode: COMPLETE
+NeedRefreshPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+  CompletedPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+             Progress: 100.00% (2/2)
 ```
+
+In this result:
+
+- `TaskId` identifies this refresh execution. It is different for every refresh.
+- `JobId` and `JobName` identify the MV refresh job. The job can be queried with `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`.
+- `MvId`, `MvName`, `MvDatabaseId`, and `MvDatabaseName` identify the materialized view refreshed by the task.
+- `Status` is `SUCCESS`, so the task finished successfully. If it is `FAILED`, check `ErrorMsg` first.
+- `CreateTime`, `StartTime`, `FinishTime`, and `DurationMs` show when the task was created, when it started, when it finished, and how long it ran.
+- `TaskContext` shows this task was manually triggered. `partitions: []` means the user did not specify a partition list in the refresh command.
+- `RefreshMode` is `COMPLETE`, so this task refreshed all partitions that the materialized view had to refresh.
+- `NeedRefreshPartitions` lists two partitions that needed refreshing, and `CompletedPartitions` lists the same two partitions, so all required partitions completed.
+- `Progress` is `100.00% (2/2)`, which also means two of two required partitions completed.
+
+:::info Note
+
+The number of stored and displayed task records is controlled by the FE configuration item `max_persistence_task_count`. The default value is 100. When the number of task records exceeds this limit, older task records are discarded. If the value is less than 1, task records are not persisted. Restart FE after changing this configuration.
+
+:::
 
 View tasks for all insert tasks
 
@@ -100,4 +158,3 @@ select * from tasks("type"="insert");
 | 79133848479750 | 78533940810334 | insert_tab_job | 78533940810334_79133848479750 | SUCCESS |          | 2025-01-17 14:42:54 | 2025-01-17 14:42:54 | 2025-01-17 14:42:54 |             |               | root |
 +----------------+----------------+----------------+-------------------------------+---------+----------+---------------------+---------------------+---------------------+-------------+---------------+------+
 ```
-

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/table-valued-functions/jobs.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/table-valued-functions/jobs.md
@@ -18,8 +18,8 @@ JOBS(
 )
 ```
 
-## Required Parameters
-| Field         | Description                                                                                   |
+## Parameters
+| Parameter     | Description                                                                                   |
 |---------------|-----------------------------------------------------------------------------------------------|
 | **`<type>`**  | The type of the job: <br/> `insert`: Insert into type job. <br/> `mv`: Materialized view job. |
 
@@ -27,56 +27,109 @@ JOBS(
 
 ## Return Value
 
+This table function returns zero or more rows. The function itself does not return NULL. Individual fields can be empty or `NULL` when the corresponding metadata is unavailable.
+
 -  **`jobs("type"="insert")`** Job return value of type insert
 
-   | Field              | Description                |
-       |--------------------|----------------------------|
-   | Id                 | Job ID                     |
-   | Name               | Job name                   |
-   | Definer            | Job definer                |
-   | ExecuteType        | Execution type             |
-   | RecurringStrategy  | Recurring strategy         |
-   | Status             | Job status                 |
-   | ExecuteSql         | Execution SQL              |
-   | CreateTime         | Job creation time          |
-   | SucceedTaskCount   | Number of successful tasks |
-   | FailedTaskCount    | Number of failed tasks     |
-   | CanceledTaskCount  | Number of canceled tasks   |
-   | Comment            | Job comment                |
+    | Parameter     | Description                |
+    |--------------------|----------------------------|
+    | Id                 | Job ID                     |
+    | Name               | Job name                   |
+    | Definer            | Job definer                |
+    | ExecuteType        | Execution type             |
+    | RecurringStrategy  | Recurring strategy         |
+    | Status             | Job status                 |
+    | ExecuteSql         | Execution SQL              |
+    | CreateTime         | Job creation time          |
+    | SucceedTaskCount   | Number of successful tasks |
+    | FailedTaskCount    | Number of failed tasks     |
+    | CanceledTaskCount  | Number of canceled tasks   |
+    | Comment            | Job comment                |
 
 
 - **`jobs("type"="mv")`** MV type job return value
 
-  | Field                | Description                                                 |
-      |----------------------|-------------------------------------------------------------|
-  | Id                   | job ID                                                      |
-  | Name                 | job name                                                    |
-  | MvId                 | Materialized View ID                                        |
-  | MvName               | Materialized View Name                                      |
-  | MvDatabaseId         | DB ID of the materialized view                              |
-  | MvDatabaseName       | Name of the database to which the materialized view belongs |
-  | ExecuteType          | Execution type                                              |
-  | RecurringStrategy    | Loop strategy                                               |
-  | Status               | Job status                                                  |
-  | CreateTime           | Task creation time                                          |
+    | Parameter     | Description                                                 |
+    |----------------------|-------------------------------------------------------------|
+    | Id                   | Job ID. For MV jobs, it corresponds to `tasks("type"="mv").JobId`. |
+    | Name                 | Job name. For MV jobs, it corresponds to `mv_infos("database"="...").JobName` and `tasks("type"="mv").JobName`. |
+    | MvId                 | ID of the materialized view maintained by this job. |
+    | MvName               | Name of the materialized view maintained by this job. |
+    | MvDatabaseId         | ID of the database that contains the materialized view. |
+    | MvDatabaseName       | Name of the database that contains the materialized view. |
+    | ExecuteType          | Job execution type. For MV jobs, possible values are `MANUAL` and `RECURRING`. `MANUAL` means refresh tasks are triggered manually, by commit, or by internal events. `RECURRING` means refresh tasks are scheduled periodically. |
+    | RecurringStrategy    | Scheduling description derived from `ExecuteType`. `MANUAL TRIGGER` means the job does not run on a timer. `EVERY ... STARTS ... [ENDS ...]` means the job runs periodically. |
+    | Status               | Job status. Possible values: `PENDING` means the job is waiting for scheduling; `RUNNING` means the job can produce tasks; `PAUSED` means the job is paused and can be resumed; `STOPPED` means the job has been stopped and cannot be resumed; `FINISHED` means the job has finished. |
+    | CreateTime           | Time when the job was created. |
+
+### MV job enum fields
+
+The following enum fields are commonly used when checking materialized view refresh jobs:
+
+- `ExecuteType`: how the job creates refresh tasks.
+  - `MANUAL`: the job does not run on its own timer. A task is created only when a refresh is triggered manually, by commit, or by the system.
+  - `RECURRING`: the job runs on a schedule and periodically creates refresh tasks.
+- `RecurringStrategy`: human-readable scheduling rule generated from `ExecuteType`.
+  - `MANUAL TRIGGER`: the job is not scheduled periodically. This is the usual value when `ExecuteType` is `MANUAL`.
+  - `EVERY <interval> <unit> STARTS <time> [ENDS <time>]`: the job is scheduled periodically. For example, `EVERY 10 MINUTE STARTS 2025-01-17 14:42:53`.
+- `Status`: current state of the job itself.
+  - `PENDING`: the job is waiting to be scheduled.
+  - `RUNNING`: the job is active and can create refresh tasks.
+  - `PAUSED`: the job is paused. It will not create new refresh tasks until it is resumed.
+  - `STOPPED`: the job has been stopped and cannot be resumed.
+  - `FINISHED`: the job has finished. This is uncommon for long-lived MV refresh jobs, but it can appear in the generic job framework.
+
+For materialized views, one materialized view has one refresh job, and one refresh job can create many refresh tasks. Use `jobs("type"="mv").Name` to connect the job to `mv_infos("database"="...").JobName` and `tasks("type"="mv").JobName`.
 
 
 ## Examples
 
-View jobs in all materialized views
+View the refresh job of a materialized view.
 
 ```sql
-select * from jobs("type"="mv");
+select *
+from jobs("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"\G
 ```
 ```text
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| Id    | Name             | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | ExecuteType | RecurringStrategy | Status  | CreateTime          |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 12:26:06 |
-| 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-07 22:13:31 |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
+*************************** 1. row ***************************
+               Id: 19508
+             Name: inner_mtmv_19494
+             MvId: 19494
+           MvName: mv1
+     MvDatabaseId: 16016
+   MvDatabaseName: test
+      ExecuteType: MANUAL
+RecurringStrategy: MANUAL TRIGGER
+           Status: RUNNING
+       CreateTime: 2025-01-07 22:13:31
+```
+
+In this result:
+
+- `Id` is the MV refresh job ID. It is the same value as `JobId` in `tasks("type"="mv")`.
+- `Name` is the MV refresh job name. It is the same value as `JobName` in `mv_infos("database"="test")` and `tasks("type"="mv")`.
+- `MvId` and `MvName` identify the materialized view maintained by this job.
+- `MvDatabaseId` and `MvDatabaseName` identify the database that contains the materialized view.
+- `ExecuteType` is `MANUAL`, so this job does not run by its own timer. A refresh task is created when the materialized view is manually refreshed, refreshed on commit, or triggered by the system.
+- `RecurringStrategy` is `MANUAL TRIGGER`, which matches `ExecuteType = MANUAL`. For a scheduled materialized view, this field is displayed as `EVERY ... STARTS ...`.
+- `Status` is `RUNNING`, so the job can generate refresh tasks. If it is `PAUSED`, resume the materialized view job before expecting new tasks.
+- `CreateTime` is the time when this MV refresh job was created.
+
+To view the tasks generated by this job, use the job name:
+
+```sql
+select TaskId, JobName, MvName, Status, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc;
+```
+```text
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+---------------------+---------------------+
 ```
 
 View all insert jobs

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/table-valued-functions/mv_infos.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/table-valued-functions/mv_infos.md
@@ -15,53 +15,115 @@ Table function, generating temporary tables for asynchronous materialized views,
 MV_INFOS("database"="<database>")
 ```
 
-## Required Parameters
-**`<database>`**
-> Specify the cluster database name to be queried
+## Parameters
 
+| Parameter        | Description |
+|------------------|-------------|
+| **`<database>`** | Required. String type. Name of the database whose asynchronous materialized view metadata you want to query. |
 
 ## Return Value
+
+This table function returns zero or more rows describing asynchronous materialized views. The function itself does not return NULL. Individual fields can be empty or `NULL` when the corresponding metadata is unavailable.
 
 | Field                  | Type    | Description                                                         |
 |------------------------|---------|---------------------------------------------------------------------|
 | Id                     | BIGINT  | Materialized view ID                                                |
 | Name                   | TEXT    | Materialized view name                                              |
-| JobName                | TEXT    | Job name corresponding to the materialized view                      |
-| State                  | TEXT    | State of the materialized view                                       |
-| SchemaChangeDetail     | TEXT    | Reason for the state change to SchemaChange                         |
-| RefreshState           | TEXT    | Refresh state of the materialized view                               |
-| RefreshInfo            | TEXT    | Refresh strategy information defined for the materialized view       |
+| JobName                | TEXT    | Name of the refresh job corresponding to the materialized view. It can be used to query `jobs("type"="mv")` and `tasks("type"="mv")`. |
+| State                  | TEXT    | Metadata state of the materialized view. Possible values: `INIT`, `NORMAL`, and `SCHEMA_CHANGE`. |
+| SchemaChangeDetail     | TEXT    | Reason why `State` becomes `SCHEMA_CHANGE`. Empty when the materialized view is not in schema change state. |
+| RefreshState           | TEXT    | State of the latest refresh. Possible values: `INIT`, `SUCCESS`, and `FAIL`. |
+| RefreshInfo            | TEXT    | Refresh strategy defined for the materialized view, including build mode, refresh method, and trigger mode. |
 | QuerySql               | TEXT    | SQL query defined for the materialized view                          |
 | EnvInfo                | TEXT    | Environment information when the materialized view was created       |
 | MvProperties           | TEXT    | Materialized view properties                                         |
 | MvPartitionInfo        | TEXT    | Partition information of the materialized view                       |
-| SyncWithBaseTables     | BOOLEAN | Whether the data is synchronized with the base table. To check which partition is not synchronized, use [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS) |
+| SyncWithBaseTables     | BOOLEAN | Whether the data of the materialized view is synchronized with its base tables. To check which partition is not synchronized, use [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS). |
+
+`RefreshInfo` is displayed as `BUILD <BuildMode> REFRESH <RefreshMethod> ON <RefreshTrigger> [schedule]`. The meaning of each part is described in the enum section below.
+
+### MV info enum fields
+
+The following enum fields are commonly used when checking materialized view definitions and health:
+
+- `State`: metadata state of the materialized view.
+  - `INIT`: the materialized view has been created but has not reached normal usable metadata state yet.
+  - `NORMAL`: the materialized view metadata is normal. This is the expected state in most cases.
+  - `SCHEMA_CHANGE`: a schema change on a base table or related object affected this materialized view. Check `SchemaChangeDetail` for the reason. The materialized view can usually be queried directly, but it may not be available for transparent rewrite until it is refreshed successfully.
+- `RefreshState`: result state of the latest refresh.
+  - `INIT`: no refresh result has been recorded yet.
+  - `SUCCESS`: the latest refresh finished successfully.
+  - `FAIL`: the latest refresh failed. Use `JobName` to query `tasks("type"="mv")` and check the failed task's `ErrorMsg`.
+- `RefreshInfo.BuildMode`: when Doris builds the materialized view data.
+  - `IMMEDIATE`: build the materialized view immediately after creation.
+  - `DEFERRED`: do not build it at creation time. The materialized view needs a later refresh before it has fresh data.
+- `RefreshInfo.RefreshMethod`: how Doris chooses data to refresh.
+  - `COMPLETE`: always refresh the materialized view completely.
+  - `AUTO`: Doris decides whether to refresh all partitions or only changed partitions.
+- `RefreshInfo.RefreshTrigger`: what triggers refresh tasks.
+  - `MANUAL`: refresh is triggered manually.
+  - `COMMIT`: refresh is triggered by data changes on related base tables.
+  - `SCHEDULE`: refresh is triggered by a schedule. The schedule details appear after `ON SCHEDULE` in `RefreshInfo`.
+- `MvPartitionInfo.partitionType`: how the materialized view is partitioned.
+  - `FOLLOW_BASE_TABLE`: materialized view partitions follow a base table partition column.
+  - `SELF_MANAGE`: the materialized view manages its own partitions.
+  - `EXPR`: materialized view partitions are defined by an expression.
+- `SyncWithBaseTables`: whether materialized view data is synchronized with base tables.
+  - `1` or `true`: synchronized.
+  - `0` or `false`: not fully synchronized. For partitioned materialized views, use `SHOW PARTITIONS FROM <mv_name>` to check partition-level synchronization.
 
 ## Examples
 
-View all materialized views under test
+View a materialized view under database `test`.
 
 ```sql
-select * from mv_infos("database"="test");
+select *
+from mv_infos("database"="test")
+where Name = "mv1"\G
 ```
 ```text
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name                     | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                                                                                         | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1                      | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`                                                                      | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-| 21788 | test_tablet_type_mtmv_mv | inner_mtmv_21788 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`test_tablet_type_mtmv_table`.`k2`, `internal`.`test`.`test_tablet_type_mtmv_table`.`k3` from `internal`.`test`.`test_tablet_type_mtmv_table` | {}                                                        | MTMVPartitionInfo{partitionType=SELF_MANAGE}                                                              |                  0 |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
+*************************** 1. row ***************************
+                Id: 19494
+              Name: mv1
+           JobName: inner_mtmv_19494
+             State: NORMAL
+SchemaChangeDetail:
+      RefreshState: SUCCESS
+       RefreshInfo: BUILD DEFERRED REFRESH AUTO ON MANUAL
+          QuerySql: SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`
+           EnvInfo: EnvInfo{ctlId='0', dbId='16813'}
+      MvProperties: {partition_sync_limit=100, partition_sync_time_unit=YEAR}
+   MvPartitionInfo: MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'}
+SyncWithBaseTables: 1
 ```
 
-View the materialized view named mv1 under test
+In this result:
+
+- `Id` and `Name` identify the materialized view.
+- `JobName` is the refresh job name for this materialized view. Use it to query the job or refresh tasks, for example `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`.
+- `State` is `NORMAL`, which means the materialized view metadata is normal. `INIT` means the materialized view has just been created or initialized. `SCHEMA_CHANGE` means a schema change on a base table affected this materialized view; in this state, check `SchemaChangeDetail`.
+- `SchemaChangeDetail` is empty because `State` is not `SCHEMA_CHANGE`.
+- `RefreshState` is `SUCCESS`, which means the latest refresh succeeded. `INIT` means no successful refresh state has been recorded yet. `FAIL` means the latest refresh failed; query `tasks("type"="mv")` with `JobName` to find the failed task and its `ErrorMsg`.
+- `RefreshInfo` is `BUILD DEFERRED REFRESH AUTO ON MANUAL`. `BUILD DEFERRED` means the materialized view was not built immediately at creation time. `REFRESH AUTO` means Doris decides whether to refresh all partitions or only changed partitions. `ON MANUAL` means refresh is triggered manually rather than by a schedule.
+- `QuerySql` is the query definition of the materialized view.
+- `EnvInfo` records the environment information when the materialized view was created.
+- `MvProperties` shows the properties of the materialized view. In this example, partition synchronization is limited by `partition_sync_limit=100` and `partition_sync_time_unit=YEAR`.
+- `MvPartitionInfo` shows how the materialized view is partitioned. `FOLLOW_BASE_TABLE` means the materialized view follows a base table partition column. `SELF_MANAGE` means the materialized view manages its own partitions. `EXPR` means the materialized view uses an expression-based partition definition.
+- `SyncWithBaseTables` is `1`, which means the materialized view data is synchronized with its base tables. `0` means it is not fully synchronized. For partitioned materialized views, use `SHOW PARTITIONS FROM <mv_name>` to check partition-level synchronization.
+
+To view the latest refresh task of this materialized view:
 
 ```sql
-select * from mv_infos("database"="test") where Name = "mv1";
+select TaskId, JobName, MvName, Status, ErrorMsg, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc
+limit 1;
 ```
 ```text
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                    | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1  | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user` | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | ErrorMsg | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/table-valued-functions/tasks.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/table-valued-functions/tasks.md
@@ -17,18 +17,20 @@ TASKS(
 )
 ```
 
-## Required Parameters
-| Field         | Description                                                                                       |
+## Parameters
+| Parameter     | Description                                                                                       |
 |---------------|---------------------------------------------------------------------------------------------------|
 | **`<type>`**  | Type of the task: <br/> `insert`: insert into type task. <br/> `mv`: materialized view type task. |
 
 
 ## Return Value
 
+This table function returns zero or more rows. The function itself does not return NULL. Individual fields can be empty, `NULL`, or `\N` when the corresponding task metadata is unavailable.
+
 -  **`tasks("type"="insert")`** tasks return value of type insert
 
    | Field Name   | Description                        |
-      |--------------|------------------------------------|
+   |--------------|------------------------------------|
    | **TaskId**   | Task id                            |
    | **JobId**    | Job id                             |
    | **JobName**  | Job name                           |
@@ -41,52 +43,111 @@ TASKS(
    | **LoadStatistic**| Load statistics                |
    | **User**     | User                               |
 
--  **`tasks("type"="mv")`** Tasks return value of type MV
+-  **`tasks("type"="mv")`** tasks return value of type MV
 
-   | Field Name            | Description                                                                 |
-      |-----------------------|-----------------------------------------------------------------------------|
-   | **TaskId**            | Task id                                                                     |
-   | **JobId**             | Job id                                                                      |
-   | **JobName**           | Job Name                                                                    |
-   | **MvId**              | Materialized View ID                                                        |
-   | **MvName**            | Materialized View Name                                                      |
-   | **MvDatabaseId**      | DB ID of the materialized view                                              |
-   | **MvDatabaseName**    | Name of the database to which the materialized view belongs                 |
-   | **Status**            | Task status                                                                 |
-   | **ErrorMsg**          | Task failure information                                                   |
-   | **CreateTime**        | Task creation time                                                          |
-   | **StartTime**         | Task start running time                                                     |
-   | **FinishTime**        | Task End Run Time                                                           |
-   | **DurationMs**        | Task runtime                                                                |
-   | **TaskContext**       | Task running parameters                                                     |
-   | **RefreshMode**       | Refresh mode                                                                |
-   | **NeedRefreshPartitions** | The partition information that needs to be refreshed for this task       |
-   | **CompletedPartitions** | The partition information that has been refreshed for this task          |
-   | **Progress**          | Task running progress                                                       |
+   | Field Name | Description |
+   |------------|-------------|
+   | **TaskId** | Unique ID of the refresh task. Each materialized view refresh creates a new task record. |
+   | **JobId** | ID of the job that generated this task. It corresponds to `jobs("type"="mv").Id`. |
+   | **JobName** | Name of the job that generated this task. It corresponds to `mv_infos("database"="...").JobName` and `jobs("type"="mv").Name`. |
+   | **MvId** | ID of the materialized view refreshed by this task. |
+   | **MvName** | Name of the materialized view refreshed by this task. |
+   | **MvDatabaseId** | ID of the database that contains the materialized view. |
+   | **MvDatabaseName** | Name of the database that contains the materialized view. |
+   | **Status** | Task status. Possible values: `PENDING` means the task is waiting to run; `RUNNING` means the task is running; `SUCCESS` means the task finished successfully; `FAILED` means the task failed; `CANCELED` means the task was canceled. |
+   | **ErrorMsg** | Error message when `Status` is `FAILED` or `CANCELED`. Empty when the task succeeds. |
+   | **CreateTime** | Time when the task record was created. |
+   | **StartTime** | Time when the task started running. It can be `\N` if the task has not started. |
+   | **FinishTime** | Time when the task finished. It can be `\N` if the task is still pending or running. |
+   | **DurationMs** | Runtime in milliseconds, calculated as `FinishTime - StartTime`. It can be `\N` if the task has not finished. |
+   | **TaskContext** | JSON string describing how the task was triggered and what the user requested. Common fields include `triggerMode`, `partitions`, and `isComplete`. `triggerMode` values are `MANUAL`, `COMMIT`, and `SYSTEM`. |
+   | **RefreshMode** | Actual refresh scope decided by this task. Possible values: `COMPLETE` means all materialized view partitions were refreshed; `PARTIAL` means only some partitions were refreshed; `NOT_REFRESH` means no partition needed refreshing. |
+   | **NeedRefreshPartitions** | JSON array of materialized view partitions that needed refreshing in this task. Empty array means no partition needed refreshing. |
+   | **CompletedPartitions** | JSON array of partitions that were refreshed successfully. Compare it with `NeedRefreshPartitions` to see whether all required partitions completed. |
+   | **Progress** | Refresh progress in the format `percentage (completed/total)`, for example `100.00% (1/1)`. It can be `\N` when there is no partition to refresh. |
+   | **LastQueryId** | Query ID of the SQL statement executed by the refresh task. Use this ID to search FE or BE logs when troubleshooting task failures. It can be empty when no refresh SQL was executed. This field is supported since Doris 3.0.0. |
+
+### MV task enum fields
+
+The following enum fields are commonly used when checking materialized view refresh tasks:
+
+- `Status`: lifecycle state of the task.
+  - `PENDING`: the task has been created but has not started running. It is waiting for scheduling or resources.
+  - `RUNNING`: the task is currently running.
+  - `SUCCESS`: the task finished successfully.
+  - `FAILED`: the task failed. Check `ErrorMsg` first, and use `LastQueryId` to search logs if it is not empty.
+  - `CANCELED`: the task was canceled before it finished.
+- `TaskContext.triggerMode`: why this task was created.
+  - `MANUAL`: created by a manual refresh command, such as `REFRESH MATERIALIZED VIEW`.
+  - `COMMIT`: created because data changes on related base tables triggered refresh.
+  - `SYSTEM`: created by an internal system action, for example the initial build of a materialized view created with immediate build.
+- `TaskContext.isComplete`: whether the refresh request asks for a complete refresh.
+  - `true`: the request asks Doris to refresh all materialized view partitions.
+  - `false`: the request does not force complete refresh. Doris can decide the actual refresh scope based on partition freshness.
+- `RefreshMode`: actual refresh scope selected by the task after checking partitions.
+  - `COMPLETE`: all materialized view partitions that belong to the MV were selected for refresh.
+  - `PARTIAL`: only some materialized view partitions were selected for refresh.
+  - `NOT_REFRESH`: no partition needed refresh. In this case, `NeedRefreshPartitions` is usually empty and `Progress` can be `\N`.
+
+:::info Version
+
+`LastQueryId` is supported since Doris 3.0.0. It is not available in Doris 2.1.x.
+
+:::
 
 
 ## Examples
 
-View tasks for all materialized views
+View the latest refresh task of a materialized view.
 
 ```sql
-select * from tasks("type"="mv");
+select *
+from tasks("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"
+order by CreateTime desc
+limit 1\G
 ```
 ```text
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| TaskId          | JobId | JobName          | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | Status  | ErrorMsg | CreateTime          | StartTime           | FinishTime          | DurationMs | TaskContext                                                 | RefreshMode | NeedRefreshPartitions                         | CompletedPartitions                           | Progress      | LastQueryId                       |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| 509478985247053 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 233        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 71897c47d0d94fd2-9ca52a0e6eb3bff5 |
-| 509486915704885 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 227        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 9bf5ff69d4cc4c78-b50505436c8410c4 |
-| 509487197275880 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 191        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 5b3b4525b6774b5b-89b070042cdcbcd5 |
-| 509478131194211 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 156        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 6d0a0782819b446e-b9da5d5de513ce00 |
-| 509486057129101 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:18 | 213        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | f1303483e3db43e7-aa424acc32dc39ca |
-| 509486143784554 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 151        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 8d29b11ac41f4fe0-9d7c86372707310b |
-| 488317385772600 | 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | SUCCESS |          | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 1          | {"triggerMode":"MANUAL","partitions":[],"isComplete":true}  | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-| 437156301250803 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 | 236985     | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | COMPLETE    | ["p_20210101_MAXVALUE","p_20200101_20210101"] | ["p_20210101_MAXVALUE","p_20200101_20210101"] | 100.00% (2/2) | 7965b4ddce8a4480-8884e9701679c1c4 |
-| 439689059641969 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 35         | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
+*************************** 1. row ***************************
+               TaskId: 437156301250803
+                JobId: 19508
+              JobName: inner_mtmv_19494
+                 MvId: 19494
+               MvName: mv1
+         MvDatabaseId: 16016
+       MvDatabaseName: test
+               Status: SUCCESS
+             ErrorMsg:
+           CreateTime: 2025-01-07 22:13:48
+            StartTime: 2025-01-07 22:13:48
+           FinishTime: 2025-01-07 22:17:45
+           DurationMs: 236985
+          TaskContext: {"triggerMode":"MANUAL","partitions":[],"isComplete":false}
+          RefreshMode: COMPLETE
+NeedRefreshPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+  CompletedPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+             Progress: 100.00% (2/2)
+          LastQueryId: 7965b4ddce8a4480-8884e9701679c1c4
 ```
+
+In this result:
+
+- `TaskId` identifies this refresh execution. It is different for every refresh.
+- `JobId` and `JobName` identify the MV refresh job. The job can be queried with `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`.
+- `MvId`, `MvName`, `MvDatabaseId`, and `MvDatabaseName` identify the materialized view refreshed by the task.
+- `Status` is `SUCCESS`, so the task finished successfully. If it is `FAILED`, check `ErrorMsg` first.
+- `CreateTime`, `StartTime`, `FinishTime`, and `DurationMs` show when the task was created, when it started, when it finished, and how long it ran.
+- `TaskContext` shows this task was manually triggered. `partitions: []` means the user did not specify a partition list in the refresh command.
+- `RefreshMode` is `COMPLETE`, so this task refreshed all partitions that the materialized view had to refresh.
+- `NeedRefreshPartitions` lists two partitions that needed refreshing, and `CompletedPartitions` lists the same two partitions, so all required partitions completed.
+- `Progress` is `100.00% (2/2)`, which also means two of two required partitions completed.
+- `LastQueryId` is the query ID of the refresh SQL. Use it to search Doris logs when the task fails or runs slowly.
+
+:::info Note
+
+The number of stored and displayed task records is controlled by the FE configuration item `max_persistence_task_count`. The default value is 100. When the number of task records exceeds this limit, older task records are discarded. If the value is less than 1, task records are not persisted. Restart FE after changing this configuration.
+
+:::
 
 View tasks for all insert tasks
 
@@ -100,4 +161,3 @@ select * from tasks("type"="insert");
 | 79133848479750 | 78533940810334 | insert_tab_job | 78533940810334_79133848479750 | SUCCESS |          | 2025-01-17 14:42:54 | 2025-01-17 14:42:54 | 2025-01-17 14:42:54 |             |               | root |
 +----------------+----------------+----------------+-------------------------------+---------+----------+---------------------+---------------------+---------------------+-------------+---------------+------+
 ```
-

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/table-valued-functions/jobs.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/table-valued-functions/jobs.md
@@ -18,8 +18,8 @@ JOBS(
 )
 ```
 
-## Required Parameters
-| Field         | Description                                                                                   |
+## Parameters
+| Parameter     | Description                                                                                   |
 |---------------|-----------------------------------------------------------------------------------------------|
 | **`<type>`**  | The type of the job: <br/> `insert`: Insert into type job. <br/> `mv`: Materialized view job. |
 
@@ -27,9 +27,11 @@ JOBS(
 
 ## Return Value
 
+This table function returns zero or more rows. The function itself does not return NULL. Individual fields can be empty or `NULL` when the corresponding metadata is unavailable.
+
 -  **`jobs("type"="insert")`** Job return value of type insert
 
-    | Field              | Description                |
+    | Parameter     | Description                |
     |--------------------|----------------------------|
     | Id                 | Job ID                     |
     | Name               | Job name                   |
@@ -47,36 +49,87 @@ JOBS(
 
 - **`jobs("type"="mv")`** MV type job return value
 
-    | Field                | Description                                                 |
+    | Parameter     | Description                                                 |
     |----------------------|-------------------------------------------------------------|
-    | Id                   | job ID                                                      |
-    | Name                 | job name                                                    |
-    | MvId                 | Materialized View ID                                        |
-    | MvName               | Materialized View Name                                      |
-    | MvDatabaseId         | DB ID of the materialized view                              |
-    | MvDatabaseName       | Name of the database to which the materialized view belongs |
-    | ExecuteType          | Execution type                                              |
-    | RecurringStrategy    | Loop strategy                                               |
-    | Status               | Job status                                                  |
-    | CreateTime           | Task creation time                                          |
+    | Id                   | Job ID. For MV jobs, it corresponds to `tasks("type"="mv").JobId`. |
+    | Name                 | Job name. For MV jobs, it corresponds to `mv_infos("database"="...").JobName` and `tasks("type"="mv").JobName`. |
+    | MvId                 | ID of the materialized view maintained by this job. |
+    | MvName               | Name of the materialized view maintained by this job. |
+    | MvDatabaseId         | ID of the database that contains the materialized view. |
+    | MvDatabaseName       | Name of the database that contains the materialized view. |
+    | ExecuteType          | Job execution type. For MV jobs, possible values are `MANUAL` and `RECURRING`. `MANUAL` means refresh tasks are triggered manually, by commit, or by internal events. `RECURRING` means refresh tasks are scheduled periodically. |
+    | RecurringStrategy    | Scheduling description derived from `ExecuteType`. `MANUAL TRIGGER` means the job does not run on a timer. `EVERY ... STARTS ... [ENDS ...]` means the job runs periodically. |
+    | Status               | Job status. Possible values: `PENDING` means the job is waiting for scheduling; `RUNNING` means the job can produce tasks; `PAUSED` means the job is paused and can be resumed; `STOPPED` means the job has been stopped and cannot be resumed; `FINISHED` means the job has finished. |
+    | CreateTime           | Time when the job was created. |
+
+### MV job enum fields
+
+The following enum fields are commonly used when checking materialized view refresh jobs:
+
+- `ExecuteType`: how the job creates refresh tasks.
+  - `MANUAL`: the job does not run on its own timer. A task is created only when a refresh is triggered manually, by commit, or by the system.
+  - `RECURRING`: the job runs on a schedule and periodically creates refresh tasks.
+- `RecurringStrategy`: human-readable scheduling rule generated from `ExecuteType`.
+  - `MANUAL TRIGGER`: the job is not scheduled periodically. This is the usual value when `ExecuteType` is `MANUAL`.
+  - `EVERY <interval> <unit> STARTS <time> [ENDS <time>]`: the job is scheduled periodically. For example, `EVERY 10 MINUTE STARTS 2025-01-17 14:42:53`.
+- `Status`: current state of the job itself.
+  - `PENDING`: the job is waiting to be scheduled.
+  - `RUNNING`: the job is active and can create refresh tasks.
+  - `PAUSED`: the job is paused. It will not create new refresh tasks until it is resumed.
+  - `STOPPED`: the job has been stopped and cannot be resumed.
+  - `FINISHED`: the job has finished. This is uncommon for long-lived MV refresh jobs, but it can appear in the generic job framework.
+
+For materialized views, one materialized view has one refresh job, and one refresh job can create many refresh tasks. Use `jobs("type"="mv").Name` to connect the job to `mv_infos("database"="...").JobName` and `tasks("type"="mv").JobName`.
 
 
 ## Examples
 
-View jobs in all materialized views
+View the refresh job of a materialized view.
 
 ```sql
-select * from jobs("type"="mv");
+select *
+from jobs("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"\G
 ```
 ```text
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| Id    | Name             | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | ExecuteType | RecurringStrategy | Status  | CreateTime          |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
-| 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 18:19:10 |
-| 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-08 12:26:06 |
-| 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | MANUAL      | MANUAL TRIGGER    | RUNNING | 2025-01-07 22:13:31 |
-+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+-------------+-------------------+---------+---------------------+
+*************************** 1. row ***************************
+               Id: 19508
+             Name: inner_mtmv_19494
+             MvId: 19494
+           MvName: mv1
+     MvDatabaseId: 16016
+   MvDatabaseName: test
+      ExecuteType: MANUAL
+RecurringStrategy: MANUAL TRIGGER
+           Status: RUNNING
+       CreateTime: 2025-01-07 22:13:31
+```
+
+In this result:
+
+- `Id` is the MV refresh job ID. It is the same value as `JobId` in `tasks("type"="mv")`.
+- `Name` is the MV refresh job name. It is the same value as `JobName` in `mv_infos("database"="test")` and `tasks("type"="mv")`.
+- `MvId` and `MvName` identify the materialized view maintained by this job.
+- `MvDatabaseId` and `MvDatabaseName` identify the database that contains the materialized view.
+- `ExecuteType` is `MANUAL`, so this job does not run by its own timer. A refresh task is created when the materialized view is manually refreshed, refreshed on commit, or triggered by the system.
+- `RecurringStrategy` is `MANUAL TRIGGER`, which matches `ExecuteType = MANUAL`. For a scheduled materialized view, this field is displayed as `EVERY ... STARTS ...`.
+- `Status` is `RUNNING`, so the job can generate refresh tasks. If it is `PAUSED`, resume the materialized view job before expecting new tasks.
+- `CreateTime` is the time when this MV refresh job was created.
+
+To view the tasks generated by this job, use the job name:
+
+```sql
+select TaskId, JobName, MvName, Status, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc;
+```
+```text
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+---------------------+---------------------+
 ```
 
 View all insert jobs

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/table-valued-functions/mv_infos.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/table-valued-functions/mv_infos.md
@@ -15,53 +15,115 @@ Table function, generating temporary tables for asynchronous materialized views,
 MV_INFOS("database"="<database>")
 ```
 
-## Required Parameters
-**`<database>`**
-> Specify the cluster database name to be queried
+## Parameters
 
+| Parameter        | Description |
+|------------------|-------------|
+| **`<database>`** | Required. String type. Name of the database whose asynchronous materialized view metadata you want to query. |
 
 ## Return Value
+
+This table function returns zero or more rows describing asynchronous materialized views. The function itself does not return NULL. Individual fields can be empty or `NULL` when the corresponding metadata is unavailable.
 
 | Field                  | Type    | Description                                                         |
 |------------------------|---------|---------------------------------------------------------------------|
 | Id                     | BIGINT  | Materialized view ID                                                |
 | Name                   | TEXT    | Materialized view name                                              |
-| JobName                | TEXT    | Job name corresponding to the materialized view                      |
-| State                  | TEXT    | State of the materialized view                                       |
-| SchemaChangeDetail     | TEXT    | Reason for the state change to SchemaChange                         |
-| RefreshState           | TEXT    | Refresh state of the materialized view                               |
-| RefreshInfo            | TEXT    | Refresh strategy information defined for the materialized view       |
+| JobName                | TEXT    | Name of the refresh job corresponding to the materialized view. It can be used to query `jobs("type"="mv")` and `tasks("type"="mv")`. |
+| State                  | TEXT    | Metadata state of the materialized view. Possible values: `INIT`, `NORMAL`, and `SCHEMA_CHANGE`. |
+| SchemaChangeDetail     | TEXT    | Reason why `State` becomes `SCHEMA_CHANGE`. Empty when the materialized view is not in schema change state. |
+| RefreshState           | TEXT    | State of the latest refresh. Possible values: `INIT`, `SUCCESS`, and `FAIL`. |
+| RefreshInfo            | TEXT    | Refresh strategy defined for the materialized view, including build mode, refresh method, and trigger mode. |
 | QuerySql               | TEXT    | SQL query defined for the materialized view                          |
 | EnvInfo                | TEXT    | Environment information when the materialized view was created       |
 | MvProperties           | TEXT    | Materialized view properties                                         |
 | MvPartitionInfo        | TEXT    | Partition information of the materialized view                       |
-| SyncWithBaseTables     | BOOLEAN | Whether the data is synchronized with the base table. To check which partition is not synchronized, use [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS) |
+| SyncWithBaseTables     | BOOLEAN | Whether the data of the materialized view is synchronized with its base tables. To check which partition is not synchronized, use [SHOW PARTITIONS](../../sql-statements/table-and-view/table/SHOW-PARTITIONS). |
+
+`RefreshInfo` is displayed as `BUILD <BuildMode> REFRESH <RefreshMethod> ON <RefreshTrigger> [schedule]`. The meaning of each part is described in the enum section below.
+
+### MV info enum fields
+
+The following enum fields are commonly used when checking materialized view definitions and health:
+
+- `State`: metadata state of the materialized view.
+  - `INIT`: the materialized view has been created but has not reached normal usable metadata state yet.
+  - `NORMAL`: the materialized view metadata is normal. This is the expected state in most cases.
+  - `SCHEMA_CHANGE`: a schema change on a base table or related object affected this materialized view. Check `SchemaChangeDetail` for the reason. The materialized view can usually be queried directly, but it may not be available for transparent rewrite until it is refreshed successfully.
+- `RefreshState`: result state of the latest refresh.
+  - `INIT`: no refresh result has been recorded yet.
+  - `SUCCESS`: the latest refresh finished successfully.
+  - `FAIL`: the latest refresh failed. Use `JobName` to query `tasks("type"="mv")` and check the failed task's `ErrorMsg`.
+- `RefreshInfo.BuildMode`: when Doris builds the materialized view data.
+  - `IMMEDIATE`: build the materialized view immediately after creation.
+  - `DEFERRED`: do not build it at creation time. The materialized view needs a later refresh before it has fresh data.
+- `RefreshInfo.RefreshMethod`: how Doris chooses data to refresh.
+  - `COMPLETE`: always refresh the materialized view completely.
+  - `AUTO`: Doris decides whether to refresh all partitions or only changed partitions.
+- `RefreshInfo.RefreshTrigger`: what triggers refresh tasks.
+  - `MANUAL`: refresh is triggered manually.
+  - `COMMIT`: refresh is triggered by data changes on related base tables.
+  - `SCHEDULE`: refresh is triggered by a schedule. The schedule details appear after `ON SCHEDULE` in `RefreshInfo`.
+- `MvPartitionInfo.partitionType`: how the materialized view is partitioned.
+  - `FOLLOW_BASE_TABLE`: materialized view partitions follow a base table partition column.
+  - `SELF_MANAGE`: the materialized view manages its own partitions.
+  - `EXPR`: materialized view partitions are defined by an expression.
+- `SyncWithBaseTables`: whether materialized view data is synchronized with base tables.
+  - `1` or `true`: synchronized.
+  - `0` or `false`: not fully synchronized. For partitioned materialized views, use `SHOW PARTITIONS FROM <mv_name>` to check partition-level synchronization.
 
 ## Examples
 
-View all materialized views under test
+View a materialized view under database `test`.
 
 ```sql
-select * from mv_infos("database"="test");
+select *
+from mv_infos("database"="test")
+where Name = "mv1"\G
 ```
 ```text
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name                     | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                                                                                         | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1                      | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`                                                                      | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-| 21788 | test_tablet_type_mtmv_mv | inner_mtmv_21788 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`test_tablet_type_mtmv_table`.`k2`, `internal`.`test`.`test_tablet_type_mtmv_table`.`k3` from `internal`.`test`.`test_tablet_type_mtmv_table` | {}                                                        | MTMVPartitionInfo{partitionType=SELF_MANAGE}                                                              |                  0 |
-+-------+--------------------------+------------------+--------+--------------------+--------------+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
+*************************** 1. row ***************************
+                Id: 19494
+              Name: mv1
+           JobName: inner_mtmv_19494
+             State: NORMAL
+SchemaChangeDetail:
+      RefreshState: SUCCESS
+       RefreshInfo: BUILD DEFERRED REFRESH AUTO ON MANUAL
+          QuerySql: SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user`
+           EnvInfo: EnvInfo{ctlId='0', dbId='16813'}
+      MvProperties: {partition_sync_limit=100, partition_sync_time_unit=YEAR}
+   MvPartitionInfo: MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'}
+SyncWithBaseTables: 1
 ```
 
-View the materialized view named mv1 under test
+In this result:
+
+- `Id` and `Name` identify the materialized view.
+- `JobName` is the refresh job name for this materialized view. Use it to query the job or refresh tasks, for example `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`.
+- `State` is `NORMAL`, which means the materialized view metadata is normal. `INIT` means the materialized view has just been created or initialized. `SCHEMA_CHANGE` means a schema change on a base table affected this materialized view; in this state, check `SchemaChangeDetail`.
+- `SchemaChangeDetail` is empty because `State` is not `SCHEMA_CHANGE`.
+- `RefreshState` is `SUCCESS`, which means the latest refresh succeeded. `INIT` means no successful refresh state has been recorded yet. `FAIL` means the latest refresh failed; query `tasks("type"="mv")` with `JobName` to find the failed task and its `ErrorMsg`.
+- `RefreshInfo` is `BUILD DEFERRED REFRESH AUTO ON MANUAL`. `BUILD DEFERRED` means the materialized view was not built immediately at creation time. `REFRESH AUTO` means Doris decides whether to refresh all partitions or only changed partitions. `ON MANUAL` means refresh is triggered manually rather than by a schedule.
+- `QuerySql` is the query definition of the materialized view.
+- `EnvInfo` records the environment information when the materialized view was created.
+- `MvProperties` shows the properties of the materialized view. In this example, partition synchronization is limited by `partition_sync_limit=100` and `partition_sync_time_unit=YEAR`.
+- `MvPartitionInfo` shows how the materialized view is partitioned. `FOLLOW_BASE_TABLE` means the materialized view follows a base table partition column. `SELF_MANAGE` means the materialized view manages its own partitions. `EXPR` means the materialized view uses an expression-based partition definition.
+- `SyncWithBaseTables` is `1`, which means the materialized view data is synchronized with its base tables. `0` means it is not fully synchronized. For partitioned materialized views, use `SHOW PARTITIONS FROM <mv_name>` to check partition-level synchronization.
+
+To view the latest refresh task of this materialized view:
 
 ```sql
-select * from mv_infos("database"="test") where Name = "mv1";
+select TaskId, JobName, MvName, Status, ErrorMsg, CreateTime, FinishTime
+from tasks("type"="mv")
+where JobName = "inner_mtmv_19494"
+order by CreateTime desc
+limit 1;
 ```
 ```text
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| Id    | Name | JobName          | State  | SchemaChangeDetail | RefreshState | RefreshInfo                           | QuerySql                                                                                    | MvProperties                                              | MvPartitionInfo                                                                                           | SyncWithBaseTables |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
-| 19494 | mv1  | inner_mtmv_19494 | NORMAL |                    | SUCCESS      | BUILD DEFERRED REFRESH AUTO ON MANUAL | SELECT `internal`.`test`.`user`.`k2`, `internal`.`test`.`user`.`k3` FROM `internal`.`test`.`user` | {partition_sync_limit=100, partition_sync_time_unit=YEAR} | MTMVPartitionInfo{partitionType=FOLLOW_BASE_TABLE, relatedTable=user, relatedCol='k2', partitionCol='k2'} |                  1 |
-+-------+------+------------------+--------+--------------------+--------------+---------------------------------------+---------------------------------------------------------------------------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------------------+
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| TaskId          | JobName          | MvName | Status  | ErrorMsg | CreateTime          | FinishTime          |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
+| 437156301250803 | inner_mtmv_19494 | mv1    | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 |
++-----------------+------------------+--------+---------+----------+---------------------+---------------------+
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/table-valued-functions/tasks.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/table-valued-functions/tasks.md
@@ -17,13 +17,15 @@ TASKS(
 )
 ```
 
-## Required Parameters
-| Field         | Description                                                                                       |
+## Parameters
+| Parameter     | Description                                                                                       |
 |---------------|---------------------------------------------------------------------------------------------------|
 | **`<type>`**  | Type of the task: <br/> `insert`: insert into type task. <br/> `mv`: materialized view type task. |
 
 
 ## Return Value
+
+This table function returns zero or more rows. The function itself does not return NULL. Individual fields can be empty, `NULL`, or `\N` when the corresponding task metadata is unavailable.
 
 -  **`tasks("type"="insert")`** tasks return value of type insert
 
@@ -41,52 +43,111 @@ TASKS(
    | **LoadStatistic**| Load statistics                |
    | **User**     | User                               |
 
--  **`tasks("type"="mv")`** Tasks return value of type MV
+-  **`tasks("type"="mv")`** tasks return value of type MV
 
-   | Field Name            | Description                                                                 |
-   |-----------------------|-----------------------------------------------------------------------------|
-   | **TaskId**            | Task id                                                                     |
-   | **JobId**             | Job id                                                                      |
-   | **JobName**           | Job Name                                                                    |
-   | **MvId**              | Materialized View ID                                                        |
-   | **MvName**            | Materialized View Name                                                      |
-   | **MvDatabaseId**      | DB ID of the materialized view                                              |
-   | **MvDatabaseName**    | Name of the database to which the materialized view belongs                 |
-   | **Status**            | Task status                                                                 |
-   | **ErrorMsg**          | Task failure information                                                   |
-   | **CreateTime**        | Task creation time                                                          |
-   | **StartTime**         | Task start running time                                                     |
-   | **FinishTime**        | Task End Run Time                                                           |
-   | **DurationMs**        | Task runtime                                                                |
-   | **TaskContext**       | Task running parameters                                                     |
-   | **RefreshMode**       | Refresh mode                                                                |
-   | **NeedRefreshPartitions** | The partition information that needs to be refreshed for this task       |
-   | **CompletedPartitions** | The partition information that has been refreshed for this task          |
-   | **Progress**          | Task running progress                                                       |
+   | Field Name | Description |
+   |------------|-------------|
+   | **TaskId** | Unique ID of the refresh task. Each materialized view refresh creates a new task record. |
+   | **JobId** | ID of the job that generated this task. It corresponds to `jobs("type"="mv").Id`. |
+   | **JobName** | Name of the job that generated this task. It corresponds to `mv_infos("database"="...").JobName` and `jobs("type"="mv").Name`. |
+   | **MvId** | ID of the materialized view refreshed by this task. |
+   | **MvName** | Name of the materialized view refreshed by this task. |
+   | **MvDatabaseId** | ID of the database that contains the materialized view. |
+   | **MvDatabaseName** | Name of the database that contains the materialized view. |
+   | **Status** | Task status. Possible values: `PENDING` means the task is waiting to run; `RUNNING` means the task is running; `SUCCESS` means the task finished successfully; `FAILED` means the task failed; `CANCELED` means the task was canceled. |
+   | **ErrorMsg** | Error message when `Status` is `FAILED` or `CANCELED`. Empty when the task succeeds. |
+   | **CreateTime** | Time when the task record was created. |
+   | **StartTime** | Time when the task started running. It can be `\N` if the task has not started. |
+   | **FinishTime** | Time when the task finished. It can be `\N` if the task is still pending or running. |
+   | **DurationMs** | Runtime in milliseconds, calculated as `FinishTime - StartTime`. It can be `\N` if the task has not finished. |
+   | **TaskContext** | JSON string describing how the task was triggered and what the user requested. Common fields include `triggerMode`, `partitions`, and `isComplete`. `triggerMode` values are `MANUAL`, `COMMIT`, and `SYSTEM`. |
+   | **RefreshMode** | Actual refresh scope decided by this task. Possible values: `COMPLETE` means all materialized view partitions were refreshed; `PARTIAL` means only some partitions were refreshed; `NOT_REFRESH` means no partition needed refreshing. |
+   | **NeedRefreshPartitions** | JSON array of materialized view partitions that needed refreshing in this task. Empty array means no partition needed refreshing. |
+   | **CompletedPartitions** | JSON array of partitions that were refreshed successfully. Compare it with `NeedRefreshPartitions` to see whether all required partitions completed. |
+   | **Progress** | Refresh progress in the format `percentage (completed/total)`, for example `100.00% (1/1)`. It can be `\N` when there is no partition to refresh. |
+   | **LastQueryId** | Query ID of the SQL statement executed by the refresh task. Use this ID to search FE or BE logs when troubleshooting task failures. It can be empty when no refresh SQL was executed. This field is supported since Doris 3.0.0. |
+
+### MV task enum fields
+
+The following enum fields are commonly used when checking materialized view refresh tasks:
+
+- `Status`: lifecycle state of the task.
+  - `PENDING`: the task has been created but has not started running. It is waiting for scheduling or resources.
+  - `RUNNING`: the task is currently running.
+  - `SUCCESS`: the task finished successfully.
+  - `FAILED`: the task failed. Check `ErrorMsg` first, and use `LastQueryId` to search logs if it is not empty.
+  - `CANCELED`: the task was canceled before it finished.
+- `TaskContext.triggerMode`: why this task was created.
+  - `MANUAL`: created by a manual refresh command, such as `REFRESH MATERIALIZED VIEW`.
+  - `COMMIT`: created because data changes on related base tables triggered refresh.
+  - `SYSTEM`: created by an internal system action, for example the initial build of a materialized view created with immediate build.
+- `TaskContext.isComplete`: whether the refresh request asks for a complete refresh.
+  - `true`: the request asks Doris to refresh all materialized view partitions.
+  - `false`: the request does not force complete refresh. Doris can decide the actual refresh scope based on partition freshness.
+- `RefreshMode`: actual refresh scope selected by the task after checking partitions.
+  - `COMPLETE`: all materialized view partitions that belong to the MV were selected for refresh.
+  - `PARTIAL`: only some materialized view partitions were selected for refresh.
+  - `NOT_REFRESH`: no partition needed refresh. In this case, `NeedRefreshPartitions` is usually empty and `Progress` can be `\N`.
+
+:::info Version
+
+`LastQueryId` is supported since Doris 3.0.0. It is not available in Doris 2.1.x.
+
+:::
 
 
 ## Examples
 
-View tasks for all materialized views
+View the latest refresh task of a materialized view.
 
 ```sql
-select * from tasks("type"="mv");
+select *
+from tasks("type"="mv")
+where MvDatabaseName = "test" and MvName = "mv1"
+order by CreateTime desc
+limit 1\G
 ```
 ```text
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| TaskId          | JobId | JobName          | MvId  | MvName                   | MvDatabaseId | MvDatabaseName                                         | Status  | ErrorMsg | CreateTime          | StartTime           | FinishTime          | DurationMs | TaskContext                                                 | RefreshMode | NeedRefreshPartitions                         | CompletedPartitions                           | Progress      | LastQueryId                       |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
-| 509478985247053 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 233        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 71897c47d0d94fd2-9ca52a0e6eb3bff5 |
-| 509486915704885 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 227        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 9bf5ff69d4cc4c78-b50505436c8410c4 |
-| 509487197275880 | 23369 | inner_mtmv_23363 | 23363 | range_date_up_union_mv1  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 191        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 5b3b4525b6774b5b-89b070042cdcbcd5 |
-| 509478131194211 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 2025-01-08 18:19:10 | 156        | {"triggerMode":"SYSTEM","isComplete":false}                 | COMPLETE    | ["p_20231001_20231101"]                       | ["p_20231001_20231101"]                       | 100.00% (1/1) | 6d0a0782819b446e-b9da5d5de513ce00 |
-| 509486057129101 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:17 | 2025-01-08 18:19:17 | 2025-01-08 18:19:18 | 213        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | f1303483e3db43e7-aa424acc32dc39ca |
-| 509486143784554 | 23377 | inner_mtmv_23371 | 23371 | range_date_up_union_mv2  | 21805        | regression_test_nereids_rules_p0_mv_create_part_and_up | SUCCESS |          | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 2025-01-08 18:19:18 | 151        | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | PARTIAL     | ["p_20231101_20231201"]                       | ["p_20231101_20231201"]                       | 100.00% (1/1) | 8d29b11ac41f4fe0-9d7c86372707310b |
-| 488317385772600 | 21794 | inner_mtmv_21788 | 21788 | test_tablet_type_mtmv_mv | 16016        | zd                                                     | SUCCESS |          | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 2025-01-08 12:26:29 | 1          | {"triggerMode":"MANUAL","partitions":[],"isComplete":true}  | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-| 437156301250803 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:13:48 | 2025-01-07 22:13:48 | 2025-01-07 22:17:45 | 236985     | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | COMPLETE    | ["p_20210101_MAXVALUE","p_20200101_20210101"] | ["p_20210101_MAXVALUE","p_20200101_20210101"] | 100.00% (2/2) | 7965b4ddce8a4480-8884e9701679c1c4 |
-| 439689059641969 | 19508 | inner_mtmv_19494 | 19494 | mv1                      | 16016        | zd                                                     | SUCCESS |          | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 2025-01-07 22:55:59 | 35         | {"triggerMode":"MANUAL","partitions":[],"isComplete":false} | NOT_REFRESH | []                                            | \N                                            | \N            |                                   |
-+-----------------+-------+------------------+-------+--------------------------+--------------+--------------------------------------------------------+---------+----------+---------------------+---------------------+---------------------+------------+-------------------------------------------------------------+-------------+-----------------------------------------------+-----------------------------------------------+---------------+-----------------------------------+
+*************************** 1. row ***************************
+               TaskId: 437156301250803
+                JobId: 19508
+              JobName: inner_mtmv_19494
+                 MvId: 19494
+               MvName: mv1
+         MvDatabaseId: 16016
+       MvDatabaseName: test
+               Status: SUCCESS
+             ErrorMsg:
+           CreateTime: 2025-01-07 22:13:48
+            StartTime: 2025-01-07 22:13:48
+           FinishTime: 2025-01-07 22:17:45
+           DurationMs: 236985
+          TaskContext: {"triggerMode":"MANUAL","partitions":[],"isComplete":false}
+          RefreshMode: COMPLETE
+NeedRefreshPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+  CompletedPartitions: ["p_20210101_MAXVALUE","p_20200101_20210101"]
+             Progress: 100.00% (2/2)
+          LastQueryId: 7965b4ddce8a4480-8884e9701679c1c4
 ```
+
+In this result:
+
+- `TaskId` identifies this refresh execution. It is different for every refresh.
+- `JobId` and `JobName` identify the MV refresh job. The job can be queried with `select * from jobs("type"="mv") where Name = "inner_mtmv_19494";`.
+- `MvId`, `MvName`, `MvDatabaseId`, and `MvDatabaseName` identify the materialized view refreshed by the task.
+- `Status` is `SUCCESS`, so the task finished successfully. If it is `FAILED`, check `ErrorMsg` first.
+- `CreateTime`, `StartTime`, `FinishTime`, and `DurationMs` show when the task was created, when it started, when it finished, and how long it ran.
+- `TaskContext` shows this task was manually triggered. `partitions: []` means the user did not specify a partition list in the refresh command.
+- `RefreshMode` is `COMPLETE`, so this task refreshed all partitions that the materialized view had to refresh.
+- `NeedRefreshPartitions` lists two partitions that needed refreshing, and `CompletedPartitions` lists the same two partitions, so all required partitions completed.
+- `Progress` is `100.00% (2/2)`, which also means two of two required partitions completed.
+- `LastQueryId` is the query ID of the refresh SQL. Use it to search Doris logs when the task fails or runs slowly.
+
+:::info Note
+
+The number of stored and displayed task records is controlled by the FE configuration item `max_persistence_task_count`. The default value is 100. When the number of task records exceeds this limit, older task records are discarded. If the value is less than 1, task records are not persisted. Restart FE after changing this configuration.
+
+:::
 
 View tasks for all insert tasks
 
@@ -100,4 +161,3 @@ select * from tasks("type"="insert");
 | 79133848479750 | 78533940810334 | insert_tab_job | 78533940810334_79133848479750 | SUCCESS |          | 2025-01-17 14:42:54 | 2025-01-17 14:42:54 | 2025-01-17 14:42:54 |             |               | root |
 +----------------+----------------+----------------+-------------------------------+---------+----------+---------------------+---------------------+---------------------+-------------+---------------+------+
 ```
-


### PR DESCRIPTION
## Versions

- [x] dev
- [x] 4.x
- [x] 3.x
- [x] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [ ] Japanese candidate translation needed
  - Japanese docs are report-only in the docs governance check and require human review before merging a candidate translation, so they are not included in this PR.

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
  - Docs-only change; no site build or runtime test cases were run.
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

## Summary

- Updated materialized-view related `jobs`, `tasks`, and `mv_infos` table-valued function docs across current/dev, 4.x, 3.x, and 2.1 in English and Chinese.
- Added clearer MV job/task/info field descriptions, enum explanations, and example outputs.
- Documented the Doris 2.1.x `tasks("type"="mv")` limitation: `LastQueryId` is not available in 2.1.x.
- Clarified the Doris 2.1.x `mv_infos` partition info limitation: partitioned async materialized views are supported in 2.1.x, but `MvPartitionInfo.partitionType = EXPR` is supported since Doris 3.0.0; 2.1.x supports `FOLLOW_BASE_TABLE` and `SELF_MANAGE`.
- Kept `EnvInfo` in versioned `mv_infos` docs because these versioned pages still expose it.

## Validation

- `git diff --check`: passed
- `yarn docs:links:changed`: no findings
- `yarn docs:sql-functions:changed`: no findings
- `yarn docs:i18n-sync:changed`: non-blocking notices/warnings only; current docs are already updated in this PR and Japanese remains report-only.
- `yarn docs:lint:changed`: exit 0; reports non-blocking SEO/i18n warnings for existing versioned-title/description patterns and report-only Japanese candidates.
- Checked Apache Doris source: `2.1.0-release` has partitioned MTMV syntax/code/tests, while `MTMVPartitionInfo.MTMVPartitionType.EXPR` appears in `branch-3.0` and later.