### PR TITLE
[chore] remove check-legacy-docs from required status checks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -53,7 +53,6 @@ github:
           - check-md-links
           - check-file-sizes
           - Build docs-next
-          - check-legacy-docs
   features:
     issues: true
 


### PR DESCRIPTION
The check-legacy-docs workflow guards edits to the legacy `docs/` and `i18n/zh-CN/docusaurus-plugin-content-docs/current/` trees, which are being retired (dev moved to the docs-next plugin and the legacy plugin runs with `includeCurrentVersion: false`). Drop it from the required status checks on master *first*, so the follow-up PR that deletes the workflow file does not leave every PR blocked waiting for a check that no longer runs.
