### PR TITLE
[doc] add SeaweedFS storage doc

### DIFF
--- a/docs-next/lakehouse/storages/seaweedfs.md
+++ b/docs-next/lakehouse/storages/seaweedfs.md
@@ -1,0 +1,69 @@
+---
+{
+    "title": "SeaweedFS | Storages",
+    "language": "en",
+    "description": "This document describes the parameters required to access SeaweedFS, which apply to the following scenarios:",
+    "sidebar_label": "SeaweedFS"
+}
+---
+
+# SeaweedFS
+
+This document describes the parameters required to access [SeaweedFS](https://seaweedfs.com/), which apply to the following scenarios:
+
+- Catalog properties
+- Table Valued Function properties
+- Broker Load properties
+- Export properties
+- Outfile properties
+
+**Doris uses the S3 Client to access SeaweedFS through the S3-compatible protocol.** This page covers SeaweedFS S3 (normal) buckets. For Iceberg tables stored in SeaweedFS S3 Table Buckets (REST Catalog + S3 served from the same `weed` process), see [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md).
+
+## Quick start with `weed mini`
+
+`weed mini` brings up a SeaweedFS S3 endpoint in a single process, seeding credentials and a pre-created bucket from environment variables:
+
+```bash
+AWS_ACCESS_KEY_ID=admin \
+AWS_SECRET_ACCESS_KEY=secret \
+S3_BUCKET=my-bucket \
+weed mini -dir=/data
+```
+
+The S3 endpoint is then reachable at `http://localhost:8333` with `my-bucket` already created and `admin` / `secret` as valid credentials. See [Quick Start with `weed mini`](https://github.com/seaweedfs/seaweedfs/wiki/Quick-Start-with-weed-mini) for Docker, custom ports, multiple buckets, and reverse-proxy options.
+
+## Parameter Overview
+
+SeaweedFS is accessed via the S3-compatible protocol, so it uses the same `s3.*` properties as AWS S3.
+
+| Property Name                   | Description                                                                                          | Default | Required |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------- | ------- | -------- |
+| s3.endpoint                     | SeaweedFS S3 gateway endpoint, for example `http://seaweedfs.example.com:8333`                        |         | Yes      |
+| s3.access_key                   | Access key configured in the SeaweedFS S3 IAM config                                                  |         | Yes      |
+| s3.secret_key                   | Secret key paired with `s3.access_key`                                                                |         | Yes      |
+| s3.region                       | Region. SeaweedFS does not validate the value but the AWS S3 SDK requires one, e.g. `us-east-1`       |         | Yes      |
+| s3.use_path_style               | Set to `true`. SeaweedFS serves objects under `http://<endpoint>/<bucket>/<key>`                       | FALSE   | No       |
+| s3.connection.maximum           | Maximum number of connections to the SeaweedFS S3 gateway                                              | 50      | No       |
+| s3.connection.request.timeout   | Request timeout in milliseconds                                                                        | 3000    | No       |
+| s3.connection.timeout           | Connection establishment timeout in milliseconds                                                       | 1000    | No       |
+
+### Using path-style access
+
+SeaweedFS uses path-style addressing (`http://<endpoint>/<bucket>/<key>`) and does not provision per-bucket DNS subdomains, so set `s3.use_path_style = true` for every connection.
+
+## Example Configuration
+
+```properties
+"s3.access_key" = "your-access-key",
+"s3.secret_key" = "your-secret-key",
+"s3.endpoint" = "http://seaweedfs.example.com:8333",
+"s3.region" = "us-east-1",
+"s3.use_path_style" = "true"
+```
+
+## Usage Recommendations
+
+* Set `s3.use_path_style = true`. SeaweedFS does not use per-bucket DNS subdomains.
+* `s3.region` is required by the AWS S3 SDK but ignored by SeaweedFS — any non-empty value works.
+* For HTTPS, terminate TLS at a reverse proxy and start `weed` with `-s3.externalUrl=https://<proxy>` so S3 signature verification works.
+* For Iceberg tables in SeaweedFS S3 Table Buckets, see [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md).

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-next/current/lakehouse/storages/seaweedfs.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-next/current/lakehouse/storages/seaweedfs.md
@@ -1,0 +1,69 @@
+---
+{
+    "title": "SeaweedFS | Storages",
+    "language": "zh-CN",
+    "description": "本文档介绍访问 SeaweedFS 所需的参数，这些参数适用于以下场景：",
+    "sidebar_label": "SeaweedFS"
+}
+---
+
+# SeaweedFS
+
+本文档介绍访问 [SeaweedFS](https://seaweedfs.com/) 所需的参数，这些参数适用于以下场景：
+
+- Catalog 属性
+- Table Valued Function 属性
+- Broker Load 属性
+- Export 属性
+- Outfile 属性
+
+**Doris 使用 S3 Client，通过 S3 兼容协议访问 SeaweedFS。** 本文针对 SeaweedFS S3（普通）Bucket 的使用场景。如需将 Iceberg 表存储在 SeaweedFS 的 S3 Table Bucket 中（由同一 `weed` 进程同时提供 REST Catalog 与 S3），请参见 [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md)。
+
+## 使用 `weed mini` 快速启动
+
+`weed mini` 会在单一进程内启动 SeaweedFS S3 服务，并通过环境变量注入凭证及预创建 Bucket：
+
+```bash
+AWS_ACCESS_KEY_ID=admin \
+AWS_SECRET_ACCESS_KEY=secret \
+S3_BUCKET=my-bucket \
+weed mini -dir=/data
+```
+
+启动后 S3 服务可通过 `http://localhost:8333` 访问，`my-bucket` 已创建，凭证为 `admin` / `secret`。Docker、自定义端口、多桶、反向代理等更多用法请参见 [Quick Start with `weed mini`](https://github.com/seaweedfs/seaweedfs/wiki/Quick-Start-with-weed-mini)。
+
+## 参数总览
+
+由于 SeaweedFS 通过 S3 兼容协议访问，所以使用与 AWS S3 相同的 `s3.*` 参数。
+
+| 属性名称                          | 描述                                                                                       | 默认值 | 是否必须 |
+| --------------------------------- | ------------------------------------------------------------------------------------------ | ------ | -------- |
+| s3.endpoint                       | SeaweedFS S3 网关地址，例如 `http://seaweedfs.example.com:8333`                              |        | 是       |
+| s3.access_key                     | 在 SeaweedFS S3 IAM 配置中创建的 Access Key                                                  |        | 是       |
+| s3.secret_key                     | 与 `s3.access_key` 配对使用的 Secret Key                                                     |        | 是       |
+| s3.region                         | 区域。SeaweedFS 不会校验取值，但 AWS S3 SDK 要求必须设置，例如 `us-east-1`                    |        | 是       |
+| s3.use_path_style                 | 建议设置为 `true`。SeaweedFS 通过 `http://<endpoint>/<bucket>/<key>` 形式提供对象访问         | FALSE  | 否       |
+| s3.connection.maximum             | 与 SeaweedFS S3 网关之间的最大连接数                                                          | 50     | 否       |
+| s3.connection.request.timeout     | 请求超时时间，单位为毫秒                                                                       | 3000   | 否       |
+| s3.connection.timeout             | 建立连接的超时时间，单位为毫秒                                                                 | 1000   | 否       |
+
+### 使用 Path-style 访问
+
+SeaweedFS 使用 path-style 地址（`http://<endpoint>/<bucket>/<key>`），不为每个 bucket 分配独立的 DNS 子域名，因此请将 `s3.use_path_style` 设置为 `true`。
+
+## 示例配置
+
+```properties
+"s3.access_key" = "your-access-key",
+"s3.secret_key" = "your-secret-key",
+"s3.endpoint" = "http://seaweedfs.example.com:8333",
+"s3.region" = "us-east-1",
+"s3.use_path_style" = "true"
+```
+
+## 使用建议
+
+* 将 `s3.use_path_style` 设置为 `true`，SeaweedFS 不使用 per-bucket DNS 子域名。
+* `s3.region` 是 AWS S3 SDK 的必填项，SeaweedFS 本身不会校验该值，填入任意非空字符串即可。
+* 如需 HTTPS，可在反向代理上终止 TLS，并使用 `-s3.externalUrl=https://<proxy>` 启动 `weed`，以便 S3 签名校验通过。
+* 如需将 Iceberg 表存储在 SeaweedFS 的 S3 Table Bucket 中，详见 [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md)。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/lakehouse/storages/seaweedfs.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/lakehouse/storages/seaweedfs.md
@@ -1,0 +1,69 @@
+---
+{
+    "title": "SeaweedFS | Storages",
+    "language": "zh-CN",
+    "description": "本文档介绍访问 SeaweedFS 所需的参数，这些参数适用于以下场景：",
+    "sidebar_label": "SeaweedFS"
+}
+---
+
+# SeaweedFS
+
+本文档介绍访问 [SeaweedFS](https://seaweedfs.com/) 所需的参数，这些参数适用于以下场景：
+
+- Catalog 属性
+- Table Valued Function 属性
+- Broker Load 属性
+- Export 属性
+- Outfile 属性
+
+**Doris 使用 S3 Client，通过 S3 兼容协议访问 SeaweedFS。** 本文针对 SeaweedFS S3（普通）Bucket 的使用场景。如需将 Iceberg 表存储在 SeaweedFS 的 S3 Table Bucket 中（由同一 `weed` 进程同时提供 REST Catalog 与 S3），请参见 [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md)。
+
+## 使用 `weed mini` 快速启动
+
+`weed mini` 会在单一进程内启动 SeaweedFS S3 服务，并通过环境变量注入凭证及预创建 Bucket：
+
+```bash
+AWS_ACCESS_KEY_ID=admin \
+AWS_SECRET_ACCESS_KEY=secret \
+S3_BUCKET=my-bucket \
+weed mini -dir=/data
+```
+
+启动后 S3 服务可通过 `http://localhost:8333` 访问，`my-bucket` 已创建，凭证为 `admin` / `secret`。Docker、自定义端口、多桶、反向代理等更多用法请参见 [Quick Start with `weed mini`](https://github.com/seaweedfs/seaweedfs/wiki/Quick-Start-with-weed-mini)。
+
+## 参数总览
+
+由于 SeaweedFS 通过 S3 兼容协议访问，所以使用与 AWS S3 相同的 `s3.*` 参数。
+
+| 属性名称                          | 描述                                                                                       | 默认值 | 是否必须 |
+| --------------------------------- | ------------------------------------------------------------------------------------------ | ------ | -------- |
+| s3.endpoint                       | SeaweedFS S3 网关地址，例如 `http://seaweedfs.example.com:8333`                              |        | 是       |
+| s3.access_key                     | 在 SeaweedFS S3 IAM 配置中创建的 Access Key                                                  |        | 是       |
+| s3.secret_key                     | 与 `s3.access_key` 配对使用的 Secret Key                                                     |        | 是       |
+| s3.region                         | 区域。SeaweedFS 不会校验取值，但 AWS S3 SDK 要求必须设置，例如 `us-east-1`                    |        | 是       |
+| s3.use_path_style                 | 建议设置为 `true`。SeaweedFS 通过 `http://<endpoint>/<bucket>/<key>` 形式提供对象访问         | FALSE  | 否       |
+| s3.connection.maximum             | 与 SeaweedFS S3 网关之间的最大连接数                                                          | 50     | 否       |
+| s3.connection.request.timeout     | 请求超时时间，单位为毫秒                                                                       | 3000   | 否       |
+| s3.connection.timeout             | 建立连接的超时时间，单位为毫秒                                                                 | 1000   | 否       |
+
+### 使用 Path-style 访问
+
+SeaweedFS 使用 path-style 地址（`http://<endpoint>/<bucket>/<key>`），不为每个 bucket 分配独立的 DNS 子域名，因此请将 `s3.use_path_style` 设置为 `true`。
+
+## 示例配置
+
+```properties
+"s3.access_key" = "your-access-key",
+"s3.secret_key" = "your-secret-key",
+"s3.endpoint" = "http://seaweedfs.example.com:8333",
+"s3.region" = "us-east-1",
+"s3.use_path_style" = "true"
+```
+
+## 使用建议
+
+* 将 `s3.use_path_style` 设置为 `true`，SeaweedFS 不使用 per-bucket DNS 子域名。
+* `s3.region` 是 AWS S3 SDK 的必填项，SeaweedFS 本身不会校验该值，填入任意非空字符串即可。
+* 如需 HTTPS，可在反向代理上终止 TLS，并使用 `-s3.externalUrl=https://<proxy>` 启动 `weed`，以便 S3 签名校验通过。
+* 如需将 Iceberg 表存储在 SeaweedFS 的 S3 Table Bucket 中，详见 [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md)。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/storages/seaweedfs.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/storages/seaweedfs.md
@@ -1,0 +1,69 @@
+---
+{
+    "title": "SeaweedFS | Storages",
+    "language": "zh-CN",
+    "description": "本文档介绍访问 SeaweedFS 所需的参数，这些参数适用于以下场景：",
+    "sidebar_label": "SeaweedFS"
+}
+---
+
+# SeaweedFS
+
+本文档介绍访问 [SeaweedFS](https://seaweedfs.com/) 所需的参数，这些参数适用于以下场景：
+
+- Catalog 属性
+- Table Valued Function 属性
+- Broker Load 属性
+- Export 属性
+- Outfile 属性
+
+**Doris 使用 S3 Client，通过 S3 兼容协议访问 SeaweedFS。** 本文针对 SeaweedFS S3（普通）Bucket 的使用场景。如需将 Iceberg 表存储在 SeaweedFS 的 S3 Table Bucket 中（由同一 `weed` 进程同时提供 REST Catalog 与 S3），请参见 [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md)。
+
+## 使用 `weed mini` 快速启动
+
+`weed mini` 会在单一进程内启动 SeaweedFS S3 服务，并通过环境变量注入凭证及预创建 Bucket：
+
+```bash
+AWS_ACCESS_KEY_ID=admin \
+AWS_SECRET_ACCESS_KEY=secret \
+S3_BUCKET=my-bucket \
+weed mini -dir=/data
+```
+
+启动后 S3 服务可通过 `http://localhost:8333` 访问，`my-bucket` 已创建，凭证为 `admin` / `secret`。Docker、自定义端口、多桶、反向代理等更多用法请参见 [Quick Start with `weed mini`](https://github.com/seaweedfs/seaweedfs/wiki/Quick-Start-with-weed-mini)。
+
+## 参数总览
+
+由于 SeaweedFS 通过 S3 兼容协议访问，所以使用与 AWS S3 相同的 `s3.*` 参数。
+
+| 属性名称                          | 描述                                                                                       | 默认值 | 是否必须 |
+| --------------------------------- | ------------------------------------------------------------------------------------------ | ------ | -------- |
+| s3.endpoint                       | SeaweedFS S3 网关地址，例如 `http://seaweedfs.example.com:8333`                              |        | 是       |
+| s3.access_key                     | 在 SeaweedFS S3 IAM 配置中创建的 Access Key                                                  |        | 是       |
+| s3.secret_key                     | 与 `s3.access_key` 配对使用的 Secret Key                                                     |        | 是       |
+| s3.region                         | 区域。SeaweedFS 不会校验取值，但 AWS S3 SDK 要求必须设置，例如 `us-east-1`                    |        | 是       |
+| s3.use_path_style                 | 建议设置为 `true`。SeaweedFS 通过 `http://<endpoint>/<bucket>/<key>` 形式提供对象访问         | FALSE  | 否       |
+| s3.connection.maximum             | 与 SeaweedFS S3 网关之间的最大连接数                                                          | 50     | 否       |
+| s3.connection.request.timeout     | 请求超时时间，单位为毫秒                                                                       | 3000   | 否       |
+| s3.connection.timeout             | 建立连接的超时时间，单位为毫秒                                                                 | 1000   | 否       |
+
+### 使用 Path-style 访问
+
+SeaweedFS 使用 path-style 地址（`http://<endpoint>/<bucket>/<key>`），不为每个 bucket 分配独立的 DNS 子域名，因此请将 `s3.use_path_style` 设置为 `true`。
+
+## 示例配置
+
+```properties
+"s3.access_key" = "your-access-key",
+"s3.secret_key" = "your-secret-key",
+"s3.endpoint" = "http://seaweedfs.example.com:8333",
+"s3.region" = "us-east-1",
+"s3.use_path_style" = "true"
+```
+
+## 使用建议
+
+* 将 `s3.use_path_style` 设置为 `true`，SeaweedFS 不使用 per-bucket DNS 子域名。
+* `s3.region` 是 AWS S3 SDK 的必填项，SeaweedFS 本身不会校验该值，填入任意非空字符串即可。
+* 如需 HTTPS，可在反向代理上终止 TLS，并使用 `-s3.externalUrl=https://<proxy>` 启动 `weed`，以便 S3 签名校验通过。
+* 如需将 Iceberg 表存储在 SeaweedFS 的 S3 Table Bucket 中，详见 [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md)。

--- a/sidebars-next.ts
+++ b/sidebars-next.ts
@@ -695,6 +695,7 @@ const sidebars: SidebarsConfig = {
                         'lakehouse/storages/tencent-cos',
                         'lakehouse/storages/huawei-obs',
                         'lakehouse/storages/baidu-bos',
+                        'lakehouse/storages/seaweedfs',
                         'lakehouse/storages/minio',
                         'lakehouse/storages/juicefs',
                         'lakehouse/storages/ozone',

--- a/versioned_docs/version-3.x/lakehouse/storages/seaweedfs.md
+++ b/versioned_docs/version-3.x/lakehouse/storages/seaweedfs.md
@@ -1,0 +1,69 @@
+---
+{
+    "title": "SeaweedFS | Storages",
+    "language": "en",
+    "description": "This document describes the parameters required to access SeaweedFS, which apply to the following scenarios:",
+    "sidebar_label": "SeaweedFS"
+}
+---
+
+# SeaweedFS
+
+This document describes the parameters required to access [SeaweedFS](https://seaweedfs.com/), which apply to the following scenarios:
+
+- Catalog properties
+- Table Valued Function properties
+- Broker Load properties
+- Export properties
+- Outfile properties
+
+**Doris uses the S3 Client to access SeaweedFS through the S3-compatible protocol.** This page covers SeaweedFS S3 (normal) buckets. For Iceberg tables stored in SeaweedFS S3 Table Buckets (REST Catalog + S3 served from the same `weed` process), see [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md).
+
+## Quick start with `weed mini`
+
+`weed mini` brings up a SeaweedFS S3 endpoint in a single process, seeding credentials and a pre-created bucket from environment variables:
+
+```bash
+AWS_ACCESS_KEY_ID=admin \
+AWS_SECRET_ACCESS_KEY=secret \
+S3_BUCKET=my-bucket \
+weed mini -dir=/data
+```
+
+The S3 endpoint is then reachable at `http://localhost:8333` with `my-bucket` already created and `admin` / `secret` as valid credentials. See [Quick Start with `weed mini`](https://github.com/seaweedfs/seaweedfs/wiki/Quick-Start-with-weed-mini) for Docker, custom ports, multiple buckets, and reverse-proxy options.
+
+## Parameter Overview
+
+SeaweedFS is accessed via the S3-compatible protocol, so it uses the same `s3.*` properties as AWS S3.
+
+| Property Name                   | Description                                                                                          | Default | Required |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------- | ------- | -------- |
+| s3.endpoint                     | SeaweedFS S3 gateway endpoint, for example `http://seaweedfs.example.com:8333`                        |         | Yes      |
+| s3.access_key                   | Access key configured in the SeaweedFS S3 IAM config                                                  |         | Yes      |
+| s3.secret_key                   | Secret key paired with `s3.access_key`                                                                |         | Yes      |
+| s3.region                       | Region. SeaweedFS does not validate the value but the AWS S3 SDK requires one, e.g. `us-east-1`       |         | Yes      |
+| s3.use_path_style               | Set to `true`. SeaweedFS serves objects under `http://<endpoint>/<bucket>/<key>`                       | FALSE   | No       |
+| s3.connection.maximum           | Maximum number of connections to the SeaweedFS S3 gateway                                              | 50      | No       |
+| s3.connection.request.timeout   | Request timeout in milliseconds                                                                        | 3000    | No       |
+| s3.connection.timeout           | Connection establishment timeout in milliseconds                                                       | 1000    | No       |
+
+### Using path-style access
+
+SeaweedFS uses path-style addressing (`http://<endpoint>/<bucket>/<key>`) and does not provision per-bucket DNS subdomains, so set `s3.use_path_style = true` for every connection.
+
+## Example Configuration
+
+```properties
+"s3.access_key" = "your-access-key",
+"s3.secret_key" = "your-secret-key",
+"s3.endpoint" = "http://seaweedfs.example.com:8333",
+"s3.region" = "us-east-1",
+"s3.use_path_style" = "true"
+```
+
+## Usage Recommendations
+
+* Set `s3.use_path_style = true`. SeaweedFS does not use per-bucket DNS subdomains.
+* `s3.region` is required by the AWS S3 SDK but ignored by SeaweedFS — any non-empty value works.
+* For HTTPS, terminate TLS at a reverse proxy and start `weed` with `-s3.externalUrl=https://<proxy>` so S3 signature verification works.
+* For Iceberg tables in SeaweedFS S3 Table Buckets, see [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md).

--- a/versioned_docs/version-4.x/lakehouse/storages/seaweedfs.md
+++ b/versioned_docs/version-4.x/lakehouse/storages/seaweedfs.md
@@ -1,0 +1,69 @@
+---
+{
+    "title": "SeaweedFS | Storages",
+    "language": "en",
+    "description": "This document describes the parameters required to access SeaweedFS, which apply to the following scenarios:",
+    "sidebar_label": "SeaweedFS"
+}
+---
+
+# SeaweedFS
+
+This document describes the parameters required to access [SeaweedFS](https://seaweedfs.com/), which apply to the following scenarios:
+
+- Catalog properties
+- Table Valued Function properties
+- Broker Load properties
+- Export properties
+- Outfile properties
+
+**Doris uses the S3 Client to access SeaweedFS through the S3-compatible protocol.** This page covers SeaweedFS S3 (normal) buckets. For Iceberg tables stored in SeaweedFS S3 Table Buckets (REST Catalog + S3 served from the same `weed` process), see [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md).
+
+## Quick start with `weed mini`
+
+`weed mini` brings up a SeaweedFS S3 endpoint in a single process, seeding credentials and a pre-created bucket from environment variables:
+
+```bash
+AWS_ACCESS_KEY_ID=admin \
+AWS_SECRET_ACCESS_KEY=secret \
+S3_BUCKET=my-bucket \
+weed mini -dir=/data
+```
+
+The S3 endpoint is then reachable at `http://localhost:8333` with `my-bucket` already created and `admin` / `secret` as valid credentials. See [Quick Start with `weed mini`](https://github.com/seaweedfs/seaweedfs/wiki/Quick-Start-with-weed-mini) for Docker, custom ports, multiple buckets, and reverse-proxy options.
+
+## Parameter Overview
+
+SeaweedFS is accessed via the S3-compatible protocol, so it uses the same `s3.*` properties as AWS S3.
+
+| Property Name                   | Description                                                                                          | Default | Required |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------- | ------- | -------- |
+| s3.endpoint                     | SeaweedFS S3 gateway endpoint, for example `http://seaweedfs.example.com:8333`                        |         | Yes      |
+| s3.access_key                   | Access key configured in the SeaweedFS S3 IAM config                                                  |         | Yes      |
+| s3.secret_key                   | Secret key paired with `s3.access_key`                                                                |         | Yes      |
+| s3.region                       | Region. SeaweedFS does not validate the value but the AWS S3 SDK requires one, e.g. `us-east-1`       |         | Yes      |
+| s3.use_path_style               | Set to `true`. SeaweedFS serves objects under `http://<endpoint>/<bucket>/<key>`                       | FALSE   | No       |
+| s3.connection.maximum           | Maximum number of connections to the SeaweedFS S3 gateway                                              | 50      | No       |
+| s3.connection.request.timeout   | Request timeout in milliseconds                                                                        | 3000    | No       |
+| s3.connection.timeout           | Connection establishment timeout in milliseconds                                                       | 1000    | No       |
+
+### Using path-style access
+
+SeaweedFS uses path-style addressing (`http://<endpoint>/<bucket>/<key>`) and does not provision per-bucket DNS subdomains, so set `s3.use_path_style = true` for every connection.
+
+## Example Configuration
+
+```properties
+"s3.access_key" = "your-access-key",
+"s3.secret_key" = "your-secret-key",
+"s3.endpoint" = "http://seaweedfs.example.com:8333",
+"s3.region" = "us-east-1",
+"s3.use_path_style" = "true"
+```
+
+## Usage Recommendations
+
+* Set `s3.use_path_style = true`. SeaweedFS does not use per-bucket DNS subdomains.
+* `s3.region` is required by the AWS S3 SDK but ignored by SeaweedFS — any non-empty value works.
+* For HTTPS, terminate TLS at a reverse proxy and start `weed` with `-s3.externalUrl=https://<proxy>` so S3 signature verification works.
+* For Iceberg tables in SeaweedFS S3 Table Buckets, see [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md).

--- a/versioned_sidebars/version-3.x-sidebars.json
+++ b/versioned_sidebars/version-3.x-sidebars.json
@@ -500,6 +500,7 @@
                                 "lakehouse/storages/tencent-cos",
                                 "lakehouse/storages/huawei-obs",
                                 "lakehouse/storages/baidu-bos",
+                                "lakehouse/storages/seaweedfs",
                                 "lakehouse/storages/minio"
                             ]
                         },

--- a/versioned_sidebars/version-4.x-sidebars.json
+++ b/versioned_sidebars/version-4.x-sidebars.json
@@ -482,6 +482,7 @@
                                 "lakehouse/storages/tencent-cos",
                                 "lakehouse/storages/huawei-obs",
                                 "lakehouse/storages/baidu-bos",
+                                "lakehouse/storages/seaweedfs",
                                 "lakehouse/storages/minio",
                                 "lakehouse/storages/juicefs",
                                 "lakehouse/storages/ozone"


### PR DESCRIPTION
## Versions

- [x] dev
- [x] 4.x
- [x] 3.x
- [ ] 2.1

## Languages

- [x] Chinese
- [x] English

## Summary

Adds a Storages page for [SeaweedFS](https://github.com/seaweedfs/seaweedfs), mirroring the structure of the existing [MinIO storage page](https://doris.apache.org/docs/4.x/lakehouse/storages/minio).

This page covers SeaweedFS **S3 (normal) buckets** — the `s3.*` properties Doris uses to access a SeaweedFS S3 gateway in the Catalog / TVF / Broker Load / Export / Outfile scenarios. The other way to store on SeaweedFS — Iceberg tables in **S3 Table Buckets** with the embedded REST Catalog — is already covered by the [Integration with SeaweedFS](https://doris.apache.org/docs/4.x/lakehouse/best-practices/doris-seaweedfs) best-practices page added in #3607, which this page links to.

Includes a one-paragraph `weed mini` quick start (single-process master + volume + filer + S3, with credentials and a pre-created bucket seeded from env vars) and a note on path-style addressing (`s3.use_path_style = true`).

## Files

- 3 English pages: `docs-next/`, `versioned_docs/version-3.x`, `versioned_docs/version-4.x`
- 3 Chinese pages: corresponding `i18n/zh-CN/...` paths
- 3 sidebars: `sidebars-next.ts`, `versioned_sidebars/version-{3,4}.x-sidebars.json` — `seaweedfs` slotted under `Lakehouse > Storages`, above `minio`.

I'm the maintainer of SeaweedFS, so I can keep this page in sync with future upstream changes.