### PR TITLE
[fix] stop search results from leaking across doc versions

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -362,7 +362,7 @@ const config = {
                 searchBarShortcutHint: true,
                 searchResultLimits: 100,
                 searchContextByPaths: ['docs-next', 'docs'],
-                useAllContextsWithNoSearchContext: true,
+                useAllContextsWithNoSearchContext: false,
             },
         ],
     ],


### PR DESCRIPTION
Disable useAllContextsWithNoSearchContext so the root search-index.json no longer aggregates docs-next + every versioned docs/* bucket. When runtime context detection misses (e.g. on no-context pages or transient SPA state) the worker now falls back to a docs-free root index instead of returning v4.x results on /docs-next pages.
