### PR TITLE
[fix] unify column name in unique data model doc

### DIFF
--- a/docs/table-design/data-model/unique.md
+++ b/docs/table-design/data-model/unique.md
@@ -87,12 +87,12 @@ Before Doris 2.1, merge-on-read was enabled by default. Starting from 2.1, you m
 CREATE TABLE IF NOT EXISTS example_tbl_unique
 (
     user_id         LARGEINT        NOT NULL,
-    username        VARCHAR(50)     NOT NULL,
+    user_name       VARCHAR(50)     NOT NULL,
     city            VARCHAR(20),
     age             SMALLINT,
     sex             TINYINT
 )
-UNIQUE KEY(user_id, username)
+UNIQUE KEY(user_id, user_name)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10
 PROPERTIES (
     "enable_unique_key_merge_on_write" = "false"
@@ -122,14 +122,14 @@ INSERT INTO example_tbl_unique VALUES
 
 -- Query the updated data
 SELECT * FROM example_tbl_unique;
-+---------+----------+------+------+------+
-| user_id | username | city | age  | sex  |
-+---------+----------+------+------+------+
-| 101     | Tom      | BJ   |   27 |    1 |
-| 102     | Jason    | SH   |   28 |    1 |
-| 104     | Olivia   | SZ   |   22 |    2 |
-| 103     | Juice    | SH   |   20 |    2 |
-+---------+----------+------+------+------+
++---------+-----------+------+------+------+
+| user_id | user_name | city | age  | sex  |
++---------+-----------+------+------+------+
+| 101     | Tom       | BJ   |   27 |    1 |
+| 102     | Jason     | SH   |   28 |    1 |
+| 104     | Olivia    | SZ   |   22 |    2 |
+| 103     | Juice     | SH   |   20 |    2 |
++---------+-----------+------+------+------+
 ```
 
 ## Notes

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/data-model/unique.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/data-model/unique.md
@@ -87,12 +87,12 @@ PROPERTIES (
 CREATE TABLE IF NOT EXISTS example_tbl_unique
 (
     user_id         LARGEINT        NOT NULL,
-    username        VARCHAR(50)     NOT NULL,
+    user_name       VARCHAR(50)     NOT NULL,
     city            VARCHAR(20),
     age             SMALLINT,
     sex             TINYINT
 )
-UNIQUE KEY(user_id, username)
+UNIQUE KEY(user_id, user_name)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10
 PROPERTIES (
     "enable_unique_key_merge_on_write" = "false"
@@ -122,14 +122,14 @@ INSERT INTO example_tbl_unique VALUES
 
 -- 查询更新后的数据
 SELECT * FROM example_tbl_unique;
-+---------+----------+------+------+------+
-| user_id | username | city | age  | sex  |
-+---------+----------+------+------+------+
-| 101     | Tom      | BJ   |   27 |    1 |
-| 102     | Jason    | SH   |   28 |    1 |
-| 104     | Olivia   | SZ   |   22 |    2 |
-| 103     | Juice    | SH   |   20 |    2 |
-+---------+----------+------+------+------+
++---------+-----------+------+------+------+
+| user_id | user_name | city | age  | sex  |
++---------+-----------+------+------+------+
+| 101     | Tom       | BJ   |   27 |    1 |
+| 102     | Jason     | SH   |   28 |    1 |
+| 104     | Olivia    | SZ   |   22 |    2 |
+| 103     | Juice     | SH   |   20 |    2 |
++---------+-----------+------+------+------+
 ```
 
 ## 注意事项

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/table-design/data-model/unique.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/table-design/data-model/unique.md
@@ -66,12 +66,12 @@ PROPERTIES (
 CREATE TABLE IF NOT EXISTS example_tbl_unique
 (
     user_id         LARGEINT        NOT NULL,
-    username        VARCHAR(50)     NOT NULL,
+    user_name       VARCHAR(50)     NOT NULL,
     city            VARCHAR(20),
     age             SMALLINT,
     sex             TINYINT
 )
-UNIQUE KEY(user_id, username)
+UNIQUE KEY(user_id, user_name)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10
 PROPERTIES (
     "enable_unique_key_merge_on_write" = "false"
@@ -101,14 +101,14 @@ INSERT INTO example_tbl_unique VALUES
 
 -- check updated data
 SELECT * FROM example_tbl_unique;
-+---------+----------+------+------+------+
-| user_id | username | city | age  | sex  |
-+---------+----------+------+------+------+
-| 101     | Tom      | BJ   |   27 |    1 |
-| 102     | Jason    | SH   |   28 |    1 |
-| 104     | Olivia   | SZ   |   22 |    2 |
-| 103     | Juice    | SH   |   20 |    2 |
-+---------+----------+------+------+------+
++---------+-----------+------+------+------+
+| user_id | user_name | city | age  | sex  |
++---------+-----------+------+------+------+
+| 101     | Tom       | BJ   |   27 |    1 |
+| 102     | Jason     | SH   |   28 |    1 |
+| 104     | Olivia    | SZ   |   22 |    2 |
+| 103     | Juice     | SH   |   20 |    2 |
++---------+-----------+------+------+------+
 ```
 
 ## 注意事项

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/table-design/data-model/unique.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/table-design/data-model/unique.md
@@ -66,12 +66,12 @@ PROPERTIES (
 CREATE TABLE IF NOT EXISTS example_tbl_unique
 (
     user_id         LARGEINT        NOT NULL,
-    username        VARCHAR(50)     NOT NULL,
+    user_name       VARCHAR(50)     NOT NULL,
     city            VARCHAR(20),
     age             SMALLINT,
     sex             TINYINT
 )
-UNIQUE KEY(user_id, username)
+UNIQUE KEY(user_id, user_name)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10
 PROPERTIES (
     "enable_unique_key_merge_on_write" = "false"
@@ -101,14 +101,14 @@ INSERT INTO example_tbl_unique VALUES
 
 -- check updated data
 SELECT * FROM example_tbl_unique;
-+---------+----------+------+------+------+
-| user_id | username | city | age  | sex  |
-+---------+----------+------+------+------+
-| 101     | Tom      | BJ   |   27 |    1 |
-| 102     | Jason    | SH   |   28 |    1 |
-| 104     | Olivia   | SZ   |   22 |    2 |
-| 103     | Juice    | SH   |   20 |    2 |
-+---------+----------+------+------+------+
++---------+-----------+------+------+------+
+| user_id | user_name | city | age  | sex  |
++---------+-----------+------+------+------+
+| 101     | Tom       | BJ   |   27 |    1 |
+| 102     | Jason     | SH   |   28 |    1 |
+| 104     | Olivia    | SZ   |   22 |    2 |
+| 103     | Juice     | SH   |   20 |    2 |
++---------+-----------+------+------+------+
 ```
 
 ## 注意事项

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/table-design/data-model/unique.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/table-design/data-model/unique.md
@@ -87,12 +87,12 @@ PROPERTIES (
 CREATE TABLE IF NOT EXISTS example_tbl_unique
 (
     user_id         LARGEINT        NOT NULL,
-    username        VARCHAR(50)     NOT NULL,
+    user_name       VARCHAR(50)     NOT NULL,
     city            VARCHAR(20),
     age             SMALLINT,
     sex             TINYINT
 )
-UNIQUE KEY(user_id, username)
+UNIQUE KEY(user_id, user_name)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10
 PROPERTIES (
     "enable_unique_key_merge_on_write" = "false"
@@ -122,14 +122,14 @@ INSERT INTO example_tbl_unique VALUES
 
 -- 查询更新后的数据
 SELECT * FROM example_tbl_unique;
-+---------+----------+------+------+------+
-| user_id | username | city | age  | sex  |
-+---------+----------+------+------+------+
-| 101     | Tom      | BJ   |   27 |    1 |
-| 102     | Jason    | SH   |   28 |    1 |
-| 104     | Olivia   | SZ   |   22 |    2 |
-| 103     | Juice    | SH   |   20 |    2 |
-+---------+----------+------+------+------+
++---------+-----------+------+------+------+
+| user_id | user_name | city | age  | sex  |
++---------+-----------+------+------+------+
+| 101     | Tom       | BJ   |   27 |    1 |
+| 102     | Jason     | SH   |   28 |    1 |
+| 104     | Olivia    | SZ   |   22 |    2 |
+| 103     | Juice     | SH   |   20 |    2 |
++---------+-----------+------+------+------+
 ```
 
 ## 注意事项

--- a/versioned_docs/version-2.0/table-design/data-model/unique.md
+++ b/versioned_docs/version-2.0/table-design/data-model/unique.md
@@ -69,12 +69,12 @@ When creating a table, the `UNIQUE KEY` keyword can be used to specify a Unique 
 CREATE TABLE IF NOT EXISTS example_tbl_unique
 (
     user_id         LARGEINT        NOT NULL,
-    username        VARCHAR(50)     NOT NULL,
+    user_name       VARCHAR(50)     NOT NULL,
     city            VARCHAR(20),
     age             SMALLINT,
     sex             TINYINT
 )
-UNIQUE KEY(user_id, username)
+UNIQUE KEY(user_id, user_name)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10
 PROPERTIES (
     "enable_unique_key_merge_on_write" = "false"
@@ -104,14 +104,14 @@ INSERT INTO example_tbl_unique VALUES
 
 -- check updated data
 SELECT * FROM example_tbl_unique;
-+---------+----------+------+------+------+
-| user_id | username | city | age  | sex  |
-+---------+----------+------+------+------+
-| 101     | Tom      | BJ   |   27 |    1 |
-| 102     | Jason    | SH   |   28 |    1 |
-| 104     | Olivia   | SZ   |   22 |    2 |
-| 103     | Juice    | SH   |   20 |    2 |
-+---------+----------+------+------+------+
++---------+-----------+------+------+------+
+| user_id | user_name | city | age  | sex  |
++---------+-----------+------+------+------+
+| 101     | Tom       | BJ   |   27 |    1 |
+| 102     | Jason     | SH   |   28 |    1 |
+| 104     | Olivia    | SZ   |   22 |    2 |
+| 103     | Juice     | SH   |   20 |    2 |
++---------+-----------+------+------+------+
 ```
 
 ## Notes

--- a/versioned_docs/version-2.0/table-design/data-model/unique.md
+++ b/versioned_docs/version-2.0/table-design/data-model/unique.md
@@ -69,12 +69,12 @@ When creating a table, the `UNIQUE KEY` keyword can be used to specify a Unique 
 CREATE TABLE IF NOT EXISTS example_tbl_unique
 (
     user_id         LARGEINT        NOT NULL,
-    user_name       VARCHAR(50)     NOT NULL,
+    username        VARCHAR(50)     NOT NULL,
     city            VARCHAR(20),
     age             SMALLINT,
     sex             TINYINT
 )
-UNIQUE KEY(user_id, user_name)
+UNIQUE KEY(user_id, username)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10
 PROPERTIES (
     "enable_unique_key_merge_on_write" = "false"
@@ -104,14 +104,14 @@ INSERT INTO example_tbl_unique VALUES
 
 -- check updated data
 SELECT * FROM example_tbl_unique;
-+---------+-----------+------+------+------+
-| user_id | user_name | city | age  | sex  |
-+---------+-----------+------+------+------+
-| 101     | Tom       | BJ   |   27 |    1 |
-| 102     | Jason     | SH   |   28 |    1 |
-| 104     | Olivia    | SZ   |   22 |    2 |
-| 103     | Juice     | SH   |   20 |    2 |
-+---------+-----------+------+------+------+
++---------+----------+------+------+------+
+| user_id | username | city | age  | sex  |
++---------+----------+------+------+------+
+| 101     | Tom      | BJ   |   27 |    1 |
+| 102     | Jason    | SH   |   28 |    1 |
+| 104     | Olivia   | SZ   |   22 |    2 |
+| 103     | Juice    | SH   |   20 |    2 |
++---------+----------+------+------+------+
 ```
 
 ## Notes

--- a/versioned_docs/version-2.1/table-design/data-model/unique.md
+++ b/versioned_docs/version-2.1/table-design/data-model/unique.md
@@ -70,12 +70,12 @@ When creating a table, the `UNIQUE KEY` keyword can be used to specify a Unique 
 CREATE TABLE IF NOT EXISTS example_tbl_unique
 (
     user_id         LARGEINT        NOT NULL,
-    username        VARCHAR(50)     NOT NULL,
+    user_name       VARCHAR(50)     NOT NULL,
     city            VARCHAR(20),
     age             SMALLINT,
     sex             TINYINT
 )
-UNIQUE KEY(user_id, username)
+UNIQUE KEY(user_id, user_name)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10
 PROPERTIES (
     "enable_unique_key_merge_on_write" = "false"
@@ -105,14 +105,14 @@ INSERT INTO example_tbl_unique VALUES
 
 -- check updated data
 SELECT * FROM example_tbl_unique;
-+---------+----------+------+------+------+
-| user_id | username | city | age  | sex  |
-+---------+----------+------+------+------+
-| 101     | Tom      | BJ   |   27 |    1 |
-| 102     | Jason    | SH   |   28 |    1 |
-| 104     | Olivia   | SZ   |   22 |    2 |
-| 103     | Juice    | SH   |   20 |    2 |
-+---------+----------+------+------+------+
++---------+-----------+------+------+------+
+| user_id | user_name | city | age  | sex  |
++---------+-----------+------+------+------+
+| 101     | Tom       | BJ   |   27 |    1 |
+| 102     | Jason     | SH   |   28 |    1 |
+| 104     | Olivia    | SZ   |   22 |    2 |
+| 103     | Juice     | SH   |   20 |    2 |
++---------+-----------+------+------+------+
 ```
 
 ## Notes

--- a/versioned_docs/version-3.x/table-design/data-model/unique.md
+++ b/versioned_docs/version-3.x/table-design/data-model/unique.md
@@ -70,12 +70,12 @@ When creating a table, the `UNIQUE KEY` keyword can be used to specify a Unique 
 CREATE TABLE IF NOT EXISTS example_tbl_unique
 (
     user_id         LARGEINT        NOT NULL,
-    username        VARCHAR(50)     NOT NULL,
+    user_name       VARCHAR(50)     NOT NULL,
     city            VARCHAR(20),
     age             SMALLINT,
     sex             TINYINT
 )
-UNIQUE KEY(user_id, username)
+UNIQUE KEY(user_id, user_name)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10
 PROPERTIES (
     "enable_unique_key_merge_on_write" = "false"
@@ -105,14 +105,14 @@ INSERT INTO example_tbl_unique VALUES
 
 -- check updated data
 SELECT * FROM example_tbl_unique;
-+---------+----------+------+------+------+
-| user_id | username | city | age  | sex  |
-+---------+----------+------+------+------+
-| 101     | Tom      | BJ   |   27 |    1 |
-| 102     | Jason    | SH   |   28 |    1 |
-| 104     | Olivia   | SZ   |   22 |    2 |
-| 103     | Juice    | SH   |   20 |    2 |
-+---------+----------+------+------+------+
++---------+-----------+------+------+------+
+| user_id | user_name | city | age  | sex  |
++---------+-----------+------+------+------+
+| 101     | Tom       | BJ   |   27 |    1 |
+| 102     | Jason     | SH   |   28 |    1 |
+| 104     | Olivia    | SZ   |   22 |    2 |
+| 103     | Juice     | SH   |   20 |    2 |
++---------+-----------+------+------+------+
 ```
 
 ## Notes

--- a/versioned_docs/version-4.x/table-design/data-model/unique.md
+++ b/versioned_docs/version-4.x/table-design/data-model/unique.md
@@ -87,12 +87,12 @@ Before Doris 2.1, merge-on-read was enabled by default. Starting from 2.1, you m
 CREATE TABLE IF NOT EXISTS example_tbl_unique
 (
     user_id         LARGEINT        NOT NULL,
-    username        VARCHAR(50)     NOT NULL,
+    user_name       VARCHAR(50)     NOT NULL,
     city            VARCHAR(20),
     age             SMALLINT,
     sex             TINYINT
 )
-UNIQUE KEY(user_id, username)
+UNIQUE KEY(user_id, user_name)
 DISTRIBUTED BY HASH(user_id) BUCKETS 10
 PROPERTIES (
     "enable_unique_key_merge_on_write" = "false"
@@ -122,14 +122,14 @@ INSERT INTO example_tbl_unique VALUES
 
 -- Query the updated data
 SELECT * FROM example_tbl_unique;
-+---------+----------+------+------+------+
-| user_id | username | city | age  | sex  |
-+---------+----------+------+------+------+
-| 101     | Tom      | BJ   |   27 |    1 |
-| 102     | Jason    | SH   |   28 |    1 |
-| 104     | Olivia   | SZ   |   22 |    2 |
-| 103     | Juice    | SH   |   20 |    2 |
-+---------+----------+------+------+------+
++---------+-----------+------+------+------+
+| user_id | user_name | city | age  | sex  |
++---------+-----------+------+------+------+
+| 101     | Tom       | BJ   |   27 |    1 |
+| 102     | Jason     | SH   |   28 |    1 |
+| 104     | Olivia    | SZ   |   22 |    2 |
+| 103     | Juice     | SH   |   20 |    2 |
++---------+-----------+------+------+------+
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary

In the Unique data model doc (`table-design/data-model/unique.md`), the table `example_tbl_unique` is defined with column `user_name` in the merge-on-write example, but `username` in the merge-on-read example and its `SELECT *` result table — an internal inconsistency for what is meant to be the same table.

The diagram embedded in the doc uses `user_name`, so the merge-on-read `CREATE TABLE` / `UNIQUE KEY` and the result-table column are unified to `user_name` (the ASCII result table is widened to keep alignment).

Applied across all affected versions: EN (next + 2.0/2.1/3.x/4.x) and Chinese (next + 2.1/3.x/4.x).

Note: the Chinese 2.0 doc uses a different, older doc structure that is internally consistent on `username`; it is left unchanged here.

## Test plan

- [x] Verified all 9 files had the same user_name vs username inconsistency
- [x] Verified the result-table ASCII borders stay aligned after widening the column
- [x] Confirmed no `username` remains in the 9 changed files