### PR TITLE
[fix] reword garbled return-value sentences in ipv4_string_to_num docs

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
@@ -9,7 +9,7 @@
 ## ipv4_string_to_num_or_default
 
 ## Description
-Takes a string containing an IPv4 address in A.B.C.D format (dot-separated decimal numbers). Returns a BIGINT number representing the corresponding the numeric value of the address in network byte order (big endian) IPv4 address.
+Takes a string containing an IPv4 address in A.B.C.D format (dot-separated decimal numbers). Returns a BIGINT representing the numeric value of the corresponding IPv4 address in network byte order (big endian).
 
 ## Syntax
 ```sql
@@ -23,7 +23,7 @@ IPV4_STRING_TO_NUM_OR_DEFAULT(<ipv4_string>)
 Return Type: BIGINT
 
 Return Value Meaning:
-- Returns the the numeric value of the address in network byte order (big endian) integer representation of the corresponding IPv4 address
+- Returns the numeric value of the corresponding IPv4 address, as a network byte order (big endian) integer
 - Returns `0` for invalid IPv4 strings or `NULL` input
 
 ### Usage Notes
@@ -33,7 +33,7 @@ Return Value Meaning:
 
 ## Examples
 
-Convert IPv4 text `192.168.0.1` to the corresponding the numeric value of the address in network byte order (big endian) integer.
+Convert IPv4 text `192.168.0.1` to the corresponding numeric value as a network byte order (big endian) integer.
 ```sql
 select ipv4_string_to_num_or_default('192.168.0.1');
 +----------------------------------------------+

--- a/docs/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num.md
@@ -9,7 +9,7 @@
 ## ipv4_string_to_num
 
 ## Description
-Takes a string containing an IPv4 address in A.B.C.D format (dot-separated decimal numbers). Returns the the numeric value of the address in network byte order (big endian) integer corresponding IPv4 address.
+Takes a string containing an IPv4 address in A.B.C.D format (dot-separated decimal numbers). Returns the numeric value of the corresponding IPv4 address in network byte order (big endian).
 
 ## Syntax
 ```sql
@@ -23,7 +23,7 @@ IPV4_STRING_TO_NUM(<ipv4_string>)
 Return Type: BIGINT
 
 Return Value Meaning:
-- Returns the the numeric value of the address in network byte order (big endian) integer representation of the corresponding IPv4 address
+- Returns the numeric value of the corresponding IPv4 address, as a network byte order (big endian) integer
 - Throws an exception for invalid IPv4 strings or `NULL` input
 
 ### Usage Notes
@@ -33,7 +33,7 @@ Return Value Meaning:
 
 ## Examples
 
-Convert IPv4 text `192.168.0.1` to the corresponding the the numeric value of the address in network byte order (big endian) integer.
+Convert IPv4 text `192.168.0.1` to the corresponding numeric value as a network byte order (big endian) integer.
 ```sql
 select ipv4_string_to_num('192.168.0.1');
 +-----------------------------------+

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
@@ -9,7 +9,7 @@
 ## ipv4_string_to_num_or_default
 
 ## Description
-Takes a string containing an IPv4 address in A.B.C.D format (dot-separated decimal numbers). Returns a BIGINT number representing the corresponding the numeric value of the address in network byte order (big endian) IPv4 address.
+Takes a string containing an IPv4 address in A.B.C.D format (dot-separated decimal numbers). Returns a BIGINT representing the numeric value of the corresponding IPv4 address in network byte order (big endian).
 
 ## Syntax
 ```sql
@@ -23,7 +23,7 @@ IPV4_STRING_TO_NUM_OR_DEFAULT(<ipv4_string>)
 Return Type: BIGINT
 
 Return Value Meaning:
-- Returns the the numeric value of the address in network byte order (big endian) integer representation of the corresponding IPv4 address
+- Returns the numeric value of the corresponding IPv4 address, as a network byte order (big endian) integer
 - Returns `0` for invalid IPv4 strings or `NULL` input
 
 ### Usage Notes
@@ -33,7 +33,7 @@ Return Value Meaning:
 
 ## Examples
 
-Convert IPv4 text `192.168.0.1` to the corresponding the numeric value of the address in network byte order (big endian) integer.
+Convert IPv4 text `192.168.0.1` to the corresponding numeric value as a network byte order (big endian) integer.
 ```sql
 select ipv4_string_to_num_or_default('192.168.0.1');
 +----------------------------------------------+

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num.md
@@ -9,7 +9,7 @@
 ## ipv4_string_to_num
 
 ## Description
-Takes a string containing an IPv4 address in A.B.C.D format (dot-separated decimal numbers). Returns the the numeric value of the address in network byte order (big endian) integer corresponding IPv4 address.
+Takes a string containing an IPv4 address in A.B.C.D format (dot-separated decimal numbers). Returns the numeric value of the corresponding IPv4 address in network byte order (big endian).
 
 ## Syntax
 ```sql
@@ -23,7 +23,7 @@ IPV4_STRING_TO_NUM(<ipv4_string>)
 Return Type: BIGINT
 
 Return Value Meaning:
-- Returns the the numeric value of the address in network byte order (big endian) integer representation of the corresponding IPv4 address
+- Returns the numeric value of the corresponding IPv4 address, as a network byte order (big endian) integer
 - Throws an exception for invalid IPv4 strings or `NULL` input
 
 ### Usage Notes
@@ -33,7 +33,7 @@ Return Value Meaning:
 
 ## Examples
 
-Convert IPv4 text `192.168.0.1` to the corresponding the the numeric value of the address in network byte order (big endian) integer.
+Convert IPv4 text `192.168.0.1` to the corresponding numeric value as a network byte order (big endian) integer.
 ```sql
 select ipv4_string_to_num('192.168.0.1');
 +-----------------------------------+


### PR DESCRIPTION
## Summary

The `ipv4_string_to_num` and `ipv4_string_to_num_or_default` function docs had garbled, ungrammatical sentences in their Description, Return Value, and Examples sections — including a doubled "the the" and a broken clause ("...integer corresponding IPv4 address").

Reworded the three sentences in each doc for clarity, e.g.:
- before: "Returns the the numeric value of the address in network byte order (big endian) integer corresponding IPv4 address."
- after: "Returns the numeric value of the corresponding IPv4 address in network byte order (big endian)."

Affected versions: English `docs/` (next) and `versioned_docs/version-4.x` only — the Chinese versions and English 2.1/3.x were already fine.

## Test plan

- [x] Verified only these 2 docs (in next + 4.x) contained the garbled text
- [x] Confirmed no "the the" / "corresponding the numeric" garble remains