### PR TITLE
[fix] correct BE runtime log file name in be-log doc

### DIFF
--- a/docs/admin-manual/log-management/be-log.md
+++ b/docs/admin-manual/log-management/be-log.md
@@ -163,7 +163,7 @@ Meaning of each prefix:
 
 | Prefix | Corresponding log |
 | --- | --- |
-| `RuntimeLogger` | Logs from `be.log` |
+| `RuntimeLogger` | Logs from `be.INFO` |
 
 > Support for `jni.log` prefixes will be added in a future release.
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/log-management/be-log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/log-management/be-log.md
@@ -163,7 +163,7 @@ RuntimeLogger I20240624 00:36:46.326643 1460958 olap_server.cpp:424] try to star
 
 | 前缀 | 对应日志 |
 | --- | --- |
-| `RuntimeLogger` | 对应 `be.log` 中的日志 |
+| `RuntimeLogger` | 对应 `be.INFO` 中的日志 |
 
 > 后续版本将增加对 `jni.log` 的前缀支持。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/log-management/be-log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/log-management/be-log.md
@@ -163,7 +163,7 @@ RuntimeLogger I20240624 00:36:46.326643 1460958 olap_server.cpp:424] try to star
 
 | 前缀 | 对应日志 |
 | --- | --- |
-| `RuntimeLogger` | 对应 `be.log` 中的日志 |
+| `RuntimeLogger` | 对应 `be.INFO` 中的日志 |
 
 > 后续版本将增加对 `jni.log` 的前缀支持。
 

--- a/versioned_docs/version-2.1/admin-manual/log-management/be-log.md
+++ b/versioned_docs/version-2.1/admin-manual/log-management/be-log.md
@@ -127,7 +127,7 @@ RuntimeLogger I20240624 00:36:46.326643 1460958 olap_server.cpp:424] try to star
 
 The meanings of different prefixes are as follows:
 
-- `RuntimeLogger`: corresponds to the logs in `be.log`.
+- `RuntimeLogger`: corresponds to the logs in `be.INFO`.
 
 > Support for `jni.log` will be added in future versions.
 

--- a/versioned_docs/version-4.x/admin-manual/log-management/be-log.md
+++ b/versioned_docs/version-4.x/admin-manual/log-management/be-log.md
@@ -163,7 +163,7 @@ Meaning of each prefix:
 
 | Prefix | Corresponding log |
 | --- | --- |
-| `RuntimeLogger` | Logs from `be.log` |
+| `RuntimeLogger` | Logs from `be.INFO` |
 
 > Support for `jni.log` prefixes will be added in a future release.
 


### PR DESCRIPTION
## Summary

In the BE log doc (`admin-manual/log-management/be-log.md`), the log-prefix table mapped the `RuntimeLogger` prefix to "logs from `be.log`". The BE has no `be.log` file — its main runtime log is `be.INFO`, as listed in the same doc's log-categories table (`be.INFO`, `be.WARNING`, `be.out`, `jni.log`, `be.gc.log`).

Corrected `be.log` → `be.INFO` across all affected versions: EN (next + 2.1/4.x) and Chinese (next + 4.x).

## Test plan

- [x] Verified the doc's own log-categories table lists `be.INFO` (and no `be.log`)
- [x] Verified each `be.log` occurrence is the `RuntimeLogger` prefix row