### PR TITLE
[fix] restore correct content for compaction-run BE HTTP API doc

### DIFF
--- a/docs/admin-manual/open-api/be-http/compaction-run.md
+++ b/docs/admin-manual/open-api/be-http/compaction-run.md
@@ -1,151 +1,115 @@
 ---
 {
-    "title": "Disk Capacity Management | Be Http",
+    "title": "Manually Trigger Compaction",
     "language": "en",
-    "description": "This document mainly introduces system parameters and processing strategies related to disk storage capacity.",
-    "sidebar_label": "Disk Capacity Management"
+    "description": "POST /api/compaction/run?tableid={int}&compacttype=full Note that tableid=xxx will take effect only when compacttype=full is specified."
 }
 ---
 
-# Disk Capacity Management
+# Manually Trigger Compaction
 
-This document mainly introduces system parameters and processing strategies related to disk storage capacity. 
+## Request
 
-If Doris' data disk capacity is not controlled, the process will hang because the disk is full. Therefore, we monitor the disk usage and remaining capacity, and control various operations in the Doris system by setting different warning levels, and try to avoid the situation where the disk is full. 
+`POST /api/compaction/run?tablet_id={int}&compact_type={enum}`
+`POST /api/compaction/run?table_id={int}&compact_type=full` Note that table_id=xxx will take effect only when compact_type=full is specified.
+`GET /api/compaction/run_status?tablet_id={int}`
 
-## Glossary
 
-* Data Dir: Data directory, each data directory specified in the `storage_root_path` of the BE configuration file `be.conf`. Usually a data directory corresponds to a disk, so the following **disk** also refers to a data directory. 
+## Description
 
-## Basic Principles
+Used to manually trigger the comparison and show status.
 
-BE will report disk usage to FE on a regular basis (every minute). FE records these statistical values and restricts various operation requests based on these statistical values. 
+## Query parameters
 
-Two thresholds, **High Watermark** and **Flood Stage**, are set in FE. Flood Stage is higher than High Watermark. When the disk usage is higher than High Watermark, Doris will restrict the execution of certain operations (such as replica balancing, etc.). If it is higher than Flood Stage, certain operations (such as load data) will be prohibited. 
+* `tablet_id`
+    - ID of the tablet
 
-At the same time, a **Flood Stage** is also set on the BE. Taking into account that FE cannot fully detect the disk usage on BE in a timely manner, and cannot control certain BE operations (such as Compaction). Therefore, Flood Stage on the BE is used for the BE to actively refuse and stop certain operations to achieve the purpose of self-protection. 
+* `table_id`
+    - ID of table. Note that table_id=xxx will take effect only when compact_type=full is specified, and only one tablet_id and table_id can be specified, and cannot be specified at the same time. After specifying table_id, full_compaction will be automatically executed for all tablets under this table.
 
-## FE Parameter
+* `compact_type`
+    - The value is `base` or `cumulative` or `full`. For usage scenarios of full_compaction, please refer to [Data Recovery](../../trouble-shooting/repairing-data).
 
-**High Watermark:**
+## Request body
 
-```
-storage_high_watermark_usage_percent: default value is 85 (85%).
-storage_min_left_capacity_bytes: default value is 2GB.
-```
+None
 
-When disk capacity **more than** `storage_high_watermark_usage_percent`, **or** disk free capacity **less than** `storage_min_left_capacity_bytes`, the disk will no longer be used as the destination path for the following operations:
+## Response
 
-* Tablet Balance
-* Colocation Relocation
-* Decommission
+### Trigger Compaction
 
-**Flood Stage:**
-
-```
-storage_flood_stage_usage_percent: default value is 95 (95%).
-storage_flood_stage_left_capacity_bytes: default value is 1GB.
-```
-
-When disk capacity **more than** `storage_flood_stage_usage_percent`, **or** disk free capacity **less than** `storage_flood_stage_left_capacity_bytes`, the disk will no longer be used as the destination path for the following operations:
-    
-* Tablet Balance
-* Colocation Relocation
-* Replica make up
-* Restore
-* Load/Insert
-
-## BE Parameter
-
-**Flood Stage:**
+If the tablet does not exist, an error in JSON format is returned:
 
 ```
-capacity_used_percent_flood_stage: default value is 95 (95%).
-capacity_min_left_bytes_flood_stage: default value is 1GB.
+{
+    "status": "Fail",
+    "msg": "Tablet not found"
+}
 ```
 
-When disk capacity **more than** `storage_flood_stage_usage_percent`, **and** disk free capacity **less than** `storage_flood_stage_left_capacity_bytes`, the following operations on this disk will be prohibited:
+If the tablet exists and the tablet is not running, JSON format is returned:
 
-* Base/Cumulative Compaction
-* Data load
-* Clone Task (Usually occurs when the replica is repaired or balanced.)
-* Push Task (Occurs during the Loading phase of Hadoop import, and the file is downloaded. )
-* Alter Task (Schema Change or Rollup Task.)
-* Download Task (The Downloading phase of the recovery operation.)
-    
-## Disk Capacity Release
+```
+{
+    "status": "Fail",
+    "msg": "fail to execute compaction, error = -2000"
+}
+```
 
-When the disk capacity is higher than High Watermark or even Flood Stage, many operations will be prohibited. At this time, you can try to reduce the disk usage and restore the system in the following ways. 
+If the tablet exists and the tablet is running, JSON format is returned:
 
-* Delete table or partition 
+```
+{
+    "status": "Success",
+    "msg": "compaction task is successfully triggered."
+}
+```
 
-    By deleting tables or partitions, you can quickly reduce the disk space usage and restore the cluster. 
-    **Note: Only the `DROP` operation can achieve the purpose of quickly reducing the disk space usage, the `DELETE` operation cannot.**
+Explanation of results:
 
-    ```
-    DROP TABLE tbl;
-    ALTER TABLE tbl DROP PARTITION p1;
-    ```
-    
-* BE expansion
+* status: Trigger task status, when it is successfully triggered, it is Success; when for some reason (for example, the appropriate version is not obtained), it returns Fail.
+* msg: Give specific success or failure information.
 
-    After backend expansion, data tablets will be automatically balanced to BE nodes with lower disk usage. The expansion operation will make the cluster reach a balanced state in a few hours or days depending on the amount of data and the number of nodes. 
-    
-* Modify replica of a table or partition 
+### Show Status
 
-    You can reduce the number of replica of a table or partition. For example, the default 3 replica can be reduced to 2 replica. Although this method reduces the reliability of the data, it can quickly reduce the disk usage rate and restore the cluster to normal.
-    This method is usually used in emergency recovery systems. Please restore the number of copies to 3 after reducing the disk usage rate by expanding or deleting data after recovery.  
-    Modifying the replica operation takes effect instantly, and the backends will automatically and asynchronously delete the redundant replica. 
-    
-    ```
-    ALTER TABLE tbl MODIFY PARTITION p1 SET("replication_num" = "2");
-    ```
-    
-* Delete unnecessary files 
+If the tablet does not exist, an error in JSON format is returned:
+```
+{
+    "status": "Fail",
+    "msg": "Tablet not found"
+}
+```
+If the tablet exists and the tablet is not running, JSON format is returned:
 
-    When the BE has crashed because the disk is full and cannot be started (this phenomenon may occur due to untimely detection of FE or BE), you need to delete some temporary files in the data directory to ensure that the BE process can start.
-    Files in the following directories can be deleted directly: 
+```
+{
+    "status" : "Success",
+    "run_status" : false,
+    "msg" : "this tablet_id is not running",
+    "tablet_id" : 11308,
+    "schema_hash" : 700967178,
+    "compact_type" : ""
+}
+```
 
-    * log/: Log files in the log directory. 
-    * snapshot/: Snapshot files in the snapshot directory. 
-    * trash/ Trash files in the trash directory. 
+If the tablet exists and the tablet is running, JSON format is returned:
+```
+{
+    "status" : "Success",
+    "run_status" : true,
+    "msg" : "this tablet_id is running",
+    "tablet_id" : 11308,
+    "schema_hash" : 700967178,
+    "compact_type" : "cumulative"
+}
+```
 
-    **This operation will affect [Restore data from BE Recycle Bin](../../open-api/be-http/tablet-restore).**
+Explanation of results:
 
-    If the BE can still be started, you can use `ADMIN CLEAN TRASH ON(BackendHost:BackendHeartBeatPort);` to actively clean up temporary files. **all trash files** and expired snapshot files will be cleaned up, **This will affect the operation of restoring data from the trash bin**.
+* run_status: Get the current manual compaction task execution status.
 
+### Examples
 
-    If you do not manually execute `ADMIN CLEAN TRASH`, the system will still automatically execute the cleanup within a few minutes to tens of minutes.There are two situations as follows: 
-    * If the disk usage does not reach 90% of the **Flood Stage**, expired trash files and expired snapshot files will be cleaned up. At this time, some recent files will be retained without affecting the recovery of data. 
-    * If the disk usage has reached 90% of the **Flood Stage**, **all trash files** and expired snapshot files will be cleaned up, **This will affect the operation of restoring data from the trash bin**.
-
-    The time interval for automatic execution can be changed by `max_garbage_sweep_interval` and `min_garbage_sweep_interval` in the configuration items. 
-
-    When the recovery fails due to lack of trash files, the following results may be returned: 
-
-    ```
-    {"status": "Fail","msg": "can find tablet path in trash"}
-    ```
-
-* Delete data file (dangerous!!!)
-
-    When none of the above operations can free up capacity, you need to delete data files to free up space. The data file is in the `data/` directory of the specified data directory. To delete a tablet, you must first ensure that at least one replica of the tablet is normal, otherwise **deleting the only replica will result in data loss**. 
-    
-    Suppose we want to delete the tablet with id 12345: 
-    
-    * Find the directory corresponding to Tablet, usually under `data/shard_id/tablet_id/`. like: 
-
-        ```data/0/12345/```
-        
-    * Record the tablet id and schema hash. The schema hash is the name of the next-level directory of the previous step. The following is 352781111: 
-
-        ```data/0/12345/352781111```
-
-    * Delete the data directory: 
-
-        ```rm -rf data/0/12345/```
-
-    * Delete tablet metadata (refer to [Tablet metadata management tool](../../trouble-shooting/tablet-meta-tool)）
-
-        ```./lib/meta_tool --operation=delete_header --root_path=/path/to/root_path --tablet_id=12345 --schema_hash= 352781111```
-
+```
+curl -X POST "http://127.0.0.1:8040/api/compaction/run?tablet_id=10015&compact_type=cumulative"
+```

--- a/versioned_docs/version-4.x/admin-manual/open-api/be-http/compaction-run.md
+++ b/versioned_docs/version-4.x/admin-manual/open-api/be-http/compaction-run.md
@@ -1,151 +1,115 @@
 ---
 {
-    "title": "Disk Capacity Management | Be Http",
+    "title": "Manually Trigger Compaction",
     "language": "en",
-    "description": "This document mainly introduces system parameters and processing strategies related to disk storage capacity.",
-    "sidebar_label": "Disk Capacity Management"
+    "description": "POST /api/compaction/run?tableid={int}&compacttype=full Note that tableid=xxx will take effect only when compacttype=full is specified."
 }
 ---
 
-# Disk Capacity Management
+# Manually Trigger Compaction
 
-This document mainly introduces system parameters and processing strategies related to disk storage capacity. 
+## Request
 
-If Doris' data disk capacity is not controlled, the process will hang because the disk is full. Therefore, we monitor the disk usage and remaining capacity, and control various operations in the Doris system by setting different warning levels, and try to avoid the situation where the disk is full. 
+`POST /api/compaction/run?tablet_id={int}&compact_type={enum}`
+`POST /api/compaction/run?table_id={int}&compact_type=full` Note that table_id=xxx will take effect only when compact_type=full is specified.
+`GET /api/compaction/run_status?tablet_id={int}`
 
-## Glossary
 
-* Data Dir: Data directory, each data directory specified in the `storage_root_path` of the BE configuration file `be.conf`. Usually a data directory corresponds to a disk, so the following **disk** also refers to a data directory. 
+## Description
 
-## Basic Principles
+Used to manually trigger the comparison and show status.
 
-BE will report disk usage to FE on a regular basis (every minute). FE records these statistical values and restricts various operation requests based on these statistical values. 
+## Query parameters
 
-Two thresholds, **High Watermark** and **Flood Stage**, are set in FE. Flood Stage is higher than High Watermark. When the disk usage is higher than High Watermark, Doris will restrict the execution of certain operations (such as replica balancing, etc.). If it is higher than Flood Stage, certain operations (such as load data) will be prohibited. 
+* `tablet_id`
+    - ID of the tablet
 
-At the same time, a **Flood Stage** is also set on the BE. Taking into account that FE cannot fully detect the disk usage on BE in a timely manner, and cannot control certain BE operations (such as Compaction). Therefore, Flood Stage on the BE is used for the BE to actively refuse and stop certain operations to achieve the purpose of self-protection. 
+* `table_id`
+    - ID of table. Note that table_id=xxx will take effect only when compact_type=full is specified, and only one tablet_id and table_id can be specified, and cannot be specified at the same time. After specifying table_id, full_compaction will be automatically executed for all tablets under this table.
 
-## FE Parameter
+* `compact_type`
+    - The value is `base` or `cumulative` or `full`. For usage scenarios of full_compaction, please refer to [Data Recovery](../../trouble-shooting/repairing-data).
 
-**High Watermark:**
+## Request body
 
-```
-storage_high_watermark_usage_percent: default value is 85 (85%).
-storage_min_left_capacity_bytes: default value is 2GB.
-```
+None
 
-When disk capacity **more than** `storage_high_watermark_usage_percent`, **or** disk free capacity **less than** `storage_min_left_capacity_bytes`, the disk will no longer be used as the destination path for the following operations:
+## Response
 
-* Tablet Balance
-* Colocation Relocation
-* Decommission
+### Trigger Compaction
 
-**Flood Stage:**
-
-```
-storage_flood_stage_usage_percent: default value is 95 (95%).
-storage_flood_stage_left_capacity_bytes: default value is 1GB.
-```
-
-When disk capacity **more than** `storage_flood_stage_usage_percent`, **or** disk free capacity **less than** `storage_flood_stage_left_capacity_bytes`, the disk will no longer be used as the destination path for the following operations:
-    
-* Tablet Balance
-* Colocation Relocation
-* Replica make up
-* Restore
-* Load/Insert
-
-## BE Parameter
-
-**Flood Stage:**
+If the tablet does not exist, an error in JSON format is returned:
 
 ```
-capacity_used_percent_flood_stage: default value is 95 (95%).
-capacity_min_left_bytes_flood_stage: default value is 1GB.
+{
+    "status": "Fail",
+    "msg": "Tablet not found"
+}
 ```
 
-When disk capacity **more than** `storage_flood_stage_usage_percent`, **and** disk free capacity **less than** `storage_flood_stage_left_capacity_bytes`, the following operations on this disk will be prohibited:
+If the tablet exists and the tablet is not running, JSON format is returned:
 
-* Base/Cumulative Compaction
-* Data load
-* Clone Task (Usually occurs when the replica is repaired or balanced.)
-* Push Task (Occurs during the Loading phase of Hadoop import, and the file is downloaded. )
-* Alter Task (Schema Change or Rollup Task.)
-* Download Task (The Downloading phase of the recovery operation.)
-    
-## Disk Capacity Release
+```
+{
+    "status": "Fail",
+    "msg": "fail to execute compaction, error = -2000"
+}
+```
 
-When the disk capacity is higher than High Watermark or even Flood Stage, many operations will be prohibited. At this time, you can try to reduce the disk usage and restore the system in the following ways. 
+If the tablet exists and the tablet is running, JSON format is returned:
 
-* Delete table or partition 
+```
+{
+    "status": "Success",
+    "msg": "compaction task is successfully triggered."
+}
+```
 
-    By deleting tables or partitions, you can quickly reduce the disk space usage and restore the cluster. 
-    **Note: Only the `DROP` operation can achieve the purpose of quickly reducing the disk space usage, the `DELETE` operation cannot.**
+Explanation of results:
 
-    ```
-    DROP TABLE tbl;
-    ALTER TABLE tbl DROP PARTITION p1;
-    ```
-    
-* BE expansion
+* status: Trigger task status, when it is successfully triggered, it is Success; when for some reason (for example, the appropriate version is not obtained), it returns Fail.
+* msg: Give specific success or failure information.
 
-    After backend expansion, data tablets will be automatically balanced to BE nodes with lower disk usage. The expansion operation will make the cluster reach a balanced state in a few hours or days depending on the amount of data and the number of nodes. 
-    
-* Modify replica of a table or partition 
+### Show Status
 
-    You can reduce the number of replica of a table or partition. For example, the default 3 replica can be reduced to 2 replica. Although this method reduces the reliability of the data, it can quickly reduce the disk usage rate and restore the cluster to normal.
-    This method is usually used in emergency recovery systems. Please restore the number of copies to 3 after reducing the disk usage rate by expanding or deleting data after recovery.  
-    Modifying the replica operation takes effect instantly, and the backends will automatically and asynchronously delete the redundant replica. 
-    
-    ```
-    ALTER TABLE tbl MODIFY PARTITION p1 SET("replication_num" = "2");
-    ```
-    
-* Delete unnecessary files 
+If the tablet does not exist, an error in JSON format is returned:
+```
+{
+    "status": "Fail",
+    "msg": "Tablet not found"
+}
+```
+If the tablet exists and the tablet is not running, JSON format is returned:
 
-    When the BE has crashed because the disk is full and cannot be started (this phenomenon may occur due to untimely detection of FE or BE), you need to delete some temporary files in the data directory to ensure that the BE process can start.
-    Files in the following directories can be deleted directly: 
+```
+{
+    "status" : "Success",
+    "run_status" : false,
+    "msg" : "this tablet_id is not running",
+    "tablet_id" : 11308,
+    "schema_hash" : 700967178,
+    "compact_type" : ""
+}
+```
 
-    * log/: Log files in the log directory. 
-    * snapshot/: Snapshot files in the snapshot directory. 
-    * trash/ Trash files in the trash directory. 
+If the tablet exists and the tablet is running, JSON format is returned:
+```
+{
+    "status" : "Success",
+    "run_status" : true,
+    "msg" : "this tablet_id is running",
+    "tablet_id" : 11308,
+    "schema_hash" : 700967178,
+    "compact_type" : "cumulative"
+}
+```
 
-    **This operation will affect [Restore data from BE Recycle Bin](../../open-api/be-http/tablet-restore).**
+Explanation of results:
 
-    If the BE can still be started, you can use `ADMIN CLEAN TRASH ON(BackendHost:BackendHeartBeatPort);` to actively clean up temporary files. **all trash files** and expired snapshot files will be cleaned up, **This will affect the operation of restoring data from the trash bin**.
+* run_status: Get the current manual compaction task execution status.
 
+### Examples
 
-    If you do not manually execute `ADMIN CLEAN TRASH`, the system will still automatically execute the cleanup within a few minutes to tens of minutes.There are two situations as follows: 
-    * If the disk usage does not reach 90% of the **Flood Stage**, expired trash files and expired snapshot files will be cleaned up. At this time, some recent files will be retained without affecting the recovery of data. 
-    * If the disk usage has reached 90% of the **Flood Stage**, **all trash files** and expired snapshot files will be cleaned up, **This will affect the operation of restoring data from the trash bin**.
-
-    The time interval for automatic execution can be changed by `max_garbage_sweep_interval` and `min_garbage_sweep_interval` in the configuration items. 
-
-    When the recovery fails due to lack of trash files, the following results may be returned: 
-
-    ```
-    {"status": "Fail","msg": "can find tablet path in trash"}
-    ```
-
-* Delete data file (dangerous!!!)
-
-    When none of the above operations can free up capacity, you need to delete data files to free up space. The data file is in the `data/` directory of the specified data directory. To delete a tablet, you must first ensure that at least one replica of the tablet is normal, otherwise **deleting the only replica will result in data loss**. 
-    
-    Suppose we want to delete the tablet with id 12345: 
-    
-    * Find the directory corresponding to Tablet, usually under `data/shard_id/tablet_id/`. like: 
-
-        ```data/0/12345/```
-        
-    * Record the tablet id and schema hash. The schema hash is the name of the next-level directory of the previous step. The following is 352781111: 
-
-        ```data/0/12345/352781111```
-
-    * Delete the data directory: 
-
-        ```rm -rf data/0/12345/```
-
-    * Delete tablet metadata (refer to [Tablet metadata management tool](../../trouble-shooting/tablet-meta-tool)）
-
-        ```./lib/meta_tool --operation=delete_header --root_path=/path/to/root_path --tablet_id=12345 --schema_hash= 352781111```
-
+```
+curl -X POST "http://127.0.0.1:8040/api/compaction/run?tablet_id=10015&compact_type=cumulative"
+```


### PR DESCRIPTION
## Summary

The `admin-manual/open-api/be-http/compaction-run.md` doc in the **English next and 4.x** versions had been overwritten with a verbatim copy of the **Disk Capacity Management** doc — wrong `title`/`sidebar_label`/frontmatter and a body entirely about disk capacity, with nothing about the compaction API.

Restored the correct **"Manually Trigger Compaction"** content (documenting the `POST /api/compaction/run` BE HTTP API) from the `version-3.x` doc, which is identical to `version-2.1` and consistent with the Chinese versions.

Scope: only English `docs/` (next) and `versioned_docs/version-4.x` were affected. English 2.0/2.1/3.x and all Chinese versions were already correct and are untouched.

This also resolves a secondary inconsistency in the wrongly-placed content (BE Parameter section mixed `capacity_*_flood_stage` and `storage_flood_stage_*` parameter names) — that content is removed entirely by the restore.

## Test plan

- [x] Confirmed EN 2.1/3.x and all ZH `compaction-run.md` already have the correct compaction API content
- [x] Confirmed EN next and 4.x were byte-identical copies of the disk-capacity doc
- [x] Restored content matches the `/api/compaction/run` API documented in the other versions