### PR TITLE
[fix] correct restore_reset_index_id example value in CCR config doc

### DIFF
--- a/docs/admin-manual/data-admin/ccr/config.md
+++ b/docs/admin-manual/data-admin/ccr/config.md
@@ -59,7 +59,7 @@ This document is for operators and developers who use Doris **CCR (Cross-Cluster
 Configure in `fe.conf`, for example:
 
 ```shell
-restore_reset_index_id = true
+restore_reset_index_id = false
 ```
 
 | Name | Description | Default value | Version |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/data-admin/ccr/config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/data-admin/ccr/config.md
@@ -59,7 +59,7 @@
 在 `fe.conf` 中配置，例如：
 
 ```shell
-restore_reset_index_id = true
+restore_reset_index_id = false
 ```
 
 | 名称 | 说明 | 默认值 | 版本 |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr/config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr/config.md
@@ -10,7 +10,7 @@
 
 ## FE 配置
 
-在 fe.conf 中配置，例如 `restore_reset_index_id = true`。
+在 fe.conf 中配置，例如 `restore_reset_index_id = false`。
 
 | **名称**|**说明**|**默认值**| **版本** |
 |---|---|---|---|

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/data-admin/ccr/config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/data-admin/ccr/config.md
@@ -10,7 +10,7 @@
 
 ## FE 配置
 
-在 fe.conf 中配置，例如 `restore_reset_index_id = true`。
+在 fe.conf 中配置，例如 `restore_reset_index_id = false`。
 
 | **名称**|**说明**|**默认值**| **版本** |
 |---|---|---|---|

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/data-admin/ccr/config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/data-admin/ccr/config.md
@@ -59,7 +59,7 @@
 在 `fe.conf` 中配置，例如：
 
 ```shell
-restore_reset_index_id = true
+restore_reset_index_id = false
 ```
 
 | 名称 | 说明 | 默认值 | 版本 |

--- a/versioned_docs/version-2.1/admin-manual/data-admin/ccr/config.md
+++ b/versioned_docs/version-2.1/admin-manual/data-admin/ccr/config.md
@@ -10,7 +10,7 @@ This document provides the configurations that need to be adjusted or paid atten
 
 ## FE Configuration
 
-Configured in `fe.conf`, for example, `restore_reset_index_id = true`.
+Configured in `fe.conf`, for example, `restore_reset_index_id = false`.
 
 | **Name**|**Description**|**Default Value**| **Version** |
 |---|---|---|---|

--- a/versioned_docs/version-3.x/admin-manual/data-admin/ccr/config.md
+++ b/versioned_docs/version-3.x/admin-manual/data-admin/ccr/config.md
@@ -10,7 +10,7 @@ This document provides the configurations that need to be adjusted or paid atten
 
 ## FE Configuration
 
-Configured in `fe.conf`, for example, `restore_reset_index_id = true`.
+Configured in `fe.conf`, for example, `restore_reset_index_id = false`.
 
 | **Name**|**Description**|**Default Value**| **Version** |
 |---|---|---|---|

--- a/versioned_docs/version-4.x/admin-manual/data-admin/ccr/config.md
+++ b/versioned_docs/version-4.x/admin-manual/data-admin/ccr/config.md
@@ -59,7 +59,7 @@ This document is for operators and developers who use Doris **CCR (Cross-Cluster
 Configure in `fe.conf`, for example:
 
 ```shell
-restore_reset_index_id = true
+restore_reset_index_id = false
 ```
 
 | Name | Description | Default value | Version |


### PR DESCRIPTION
## Summary

In the CCR config doc (`admin-manual/data-admin/ccr/config.md`), the "FE Configuration" example showed:

```
restore_reset_index_id = true
```

This contradicts the rest of the same doc — the parameter reference table and the "Common Tuning Combinations" table both say `restore_reset_index_id` should be `false` for synced tables with inverted/bitmap indexes. The FE default is also `false` (verified against `Config.java`: `public static boolean restore_reset_index_id = false`). No scenario in the doc recommends `true`.

Changed the example value to `false`. Applied across all affected versions: EN (next + 2.1/3.x/4.x) and Chinese (next + 2.1/3.x/4.x).

## Test plan

- [x] Verified the FE default `restore_reset_index_id = false` against `apache/doris` `Config.java`
- [x] Confirmed the parameter table and tuning table in the same doc both say `false`