### PR TITLE
[fix] correct malformed query string in be-http meta API example

### DIFF
--- a/docs/admin-manual/open-api/be-http/meta.md
+++ b/docs/admin-manual/open-api/be-http/meta.md
@@ -49,7 +49,7 @@ None
 
 
     ```
-    curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
+    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
     ```
 

--- a/docs/admin-manual/open-api/be-http/meta.md
+++ b/docs/admin-manual/open-api/be-http/meta.md
@@ -32,24 +32,24 @@ None
 
 ## Response
 
-    ```
-    {
-        "table_id": 148107,
-        "partition_id": 148104,
-        "tablet_id": 148193,
-        "schema_hash": 2090621954,
-        "shard_id": 38,
-        "creation_time": 1673253868,
-        "cumulative_layer_point": -1,
-        "tablet_state": "PB_RUNNING",
-        ...
-    }
-    ```
+```
+{
+    "table_id": 148107,
+    "partition_id": 148104,
+    "tablet_id": 148193,
+    "schema_hash": 2090621954,
+    "shard_id": 38,
+    "creation_time": 1673253868,
+    "cumulative_layer_point": -1,
+    "tablet_state": "PB_RUNNING",
+    ...
+}
+```
 ## Examples
 
 
-    ```
-    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
+```
+curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
-    ```
+```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/open-api/be-http/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/open-api/be-http/meta.md
@@ -47,7 +47,7 @@
 
 
     ```shell
-    curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
+    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/open-api/be-http/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/open-api/be-http/meta.md
@@ -30,24 +30,24 @@
 
 ## 响应
 
-    ```json
-    {
-        "table_id": 148107,
-        "partition_id": 148104,
-        "tablet_id": 148193,
-        "schema_hash": 2090621954,
-        "shard_id": 38,
-        "creation_time": 1673253868,
-        "cumulative_layer_point": -1,
-        "tablet_state": "PB_RUNNING",
-        ...
-    }
-    ```
+```json
+{
+    "table_id": 148107,
+    "partition_id": 148104,
+    "tablet_id": 148193,
+    "schema_hash": 2090621954,
+    "shard_id": 38,
+    "creation_time": 1673253868,
+    "cumulative_layer_point": -1,
+    "tablet_state": "PB_RUNNING",
+    ...
+}
+```
 ## 示例
 
 
-    ```shell
-    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
+```shell
+curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
-    ```
+```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/open-api/be-http/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/open-api/be-http/meta.md
@@ -47,7 +47,7 @@
 
 
     ```shell
-    curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
+    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/open-api/be-http/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/open-api/be-http/meta.md
@@ -30,24 +30,24 @@
 
 ## Response
 
-    ```json
-    {
-        "table_id": 148107,
-        "partition_id": 148104,
-        "tablet_id": 148193,
-        "schema_hash": 2090621954,
-        "shard_id": 38,
-        "creation_time": 1673253868,
-        "cumulative_layer_point": -1,
-        "tablet_state": "PB_RUNNING",
-        ...
-    }
-    ```
+```json
+{
+    "table_id": 148107,
+    "partition_id": 148104,
+    "tablet_id": 148193,
+    "schema_hash": 2090621954,
+    "shard_id": 38,
+    "creation_time": 1673253868,
+    "cumulative_layer_point": -1,
+    "tablet_state": "PB_RUNNING",
+    ...
+}
+```
 ## Examples
 
 
-    ```shell
-    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
+```shell
+curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
-    ```
+```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/open-api/be-http/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/open-api/be-http/meta.md
@@ -47,7 +47,7 @@
 
 
     ```shell
-    curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
+    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/open-api/be-http/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/open-api/be-http/meta.md
@@ -30,24 +30,24 @@
 
 ## Response
 
-    ```json
-    {
-        "table_id": 148107,
-        "partition_id": 148104,
-        "tablet_id": 148193,
-        "schema_hash": 2090621954,
-        "shard_id": 38,
-        "creation_time": 1673253868,
-        "cumulative_layer_point": -1,
-        "tablet_state": "PB_RUNNING",
-        ...
-    }
-    ```
+```json
+{
+    "table_id": 148107,
+    "partition_id": 148104,
+    "tablet_id": 148193,
+    "schema_hash": 2090621954,
+    "shard_id": 38,
+    "creation_time": 1673253868,
+    "cumulative_layer_point": -1,
+    "tablet_state": "PB_RUNNING",
+    ...
+}
+```
 ## Examples
 
 
-    ```shell
-    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
+```shell
+curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
-    ```
+```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/open-api/be-http/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/open-api/be-http/meta.md
@@ -47,7 +47,7 @@
 
 
     ```shell
-    curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
+    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
     ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/open-api/be-http/meta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/open-api/be-http/meta.md
@@ -30,24 +30,24 @@
 
 ## 响应
 
-    ```json
-    {
-        "table_id": 148107,
-        "partition_id": 148104,
-        "tablet_id": 148193,
-        "schema_hash": 2090621954,
-        "shard_id": 38,
-        "creation_time": 1673253868,
-        "cumulative_layer_point": -1,
-        "tablet_state": "PB_RUNNING",
-        ...
-    }
-    ```
+```json
+{
+    "table_id": 148107,
+    "partition_id": 148104,
+    "tablet_id": 148193,
+    "schema_hash": 2090621954,
+    "shard_id": 38,
+    "creation_time": 1673253868,
+    "cumulative_layer_point": -1,
+    "tablet_state": "PB_RUNNING",
+    ...
+}
+```
 ## 示例
 
 
-    ```shell
-    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
+```shell
+curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
-    ```
+```
 

--- a/versioned_docs/version-2.1/admin-manual/open-api/be-http/meta.md
+++ b/versioned_docs/version-2.1/admin-manual/open-api/be-http/meta.md
@@ -49,7 +49,7 @@ None
 
 
     ```
-    curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
+    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
     ```
 

--- a/versioned_docs/version-2.1/admin-manual/open-api/be-http/meta.md
+++ b/versioned_docs/version-2.1/admin-manual/open-api/be-http/meta.md
@@ -32,24 +32,24 @@ None
 
 ## Response
 
-    ```
-    {
-        "table_id": 148107,
-        "partition_id": 148104,
-        "tablet_id": 148193,
-        "schema_hash": 2090621954,
-        "shard_id": 38,
-        "creation_time": 1673253868,
-        "cumulative_layer_point": -1,
-        "tablet_state": "PB_RUNNING",
-        ...
-    }
-    ```
+```
+{
+    "table_id": 148107,
+    "partition_id": 148104,
+    "tablet_id": 148193,
+    "schema_hash": 2090621954,
+    "shard_id": 38,
+    "creation_time": 1673253868,
+    "cumulative_layer_point": -1,
+    "tablet_state": "PB_RUNNING",
+    ...
+}
+```
 ## Examples
 
 
-    ```
-    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
+```
+curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
-    ```
+```
 

--- a/versioned_docs/version-3.x/admin-manual/open-api/be-http/meta.md
+++ b/versioned_docs/version-3.x/admin-manual/open-api/be-http/meta.md
@@ -49,7 +49,7 @@ None
 
 
     ```
-    curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
+    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
     ```
 

--- a/versioned_docs/version-3.x/admin-manual/open-api/be-http/meta.md
+++ b/versioned_docs/version-3.x/admin-manual/open-api/be-http/meta.md
@@ -32,24 +32,24 @@ None
 
 ## Response
 
-    ```
-    {
-        "table_id": 148107,
-        "partition_id": 148104,
-        "tablet_id": 148193,
-        "schema_hash": 2090621954,
-        "shard_id": 38,
-        "creation_time": 1673253868,
-        "cumulative_layer_point": -1,
-        "tablet_state": "PB_RUNNING",
-        ...
-    }
-    ```
+```
+{
+    "table_id": 148107,
+    "partition_id": 148104,
+    "tablet_id": 148193,
+    "schema_hash": 2090621954,
+    "shard_id": 38,
+    "creation_time": 1673253868,
+    "cumulative_layer_point": -1,
+    "tablet_state": "PB_RUNNING",
+    ...
+}
+```
 ## Examples
 
 
-    ```
-    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
+```
+curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
-    ```
+```
 

--- a/versioned_docs/version-4.x/admin-manual/open-api/be-http/meta.md
+++ b/versioned_docs/version-4.x/admin-manual/open-api/be-http/meta.md
@@ -49,7 +49,7 @@ None
 
 
     ```
-    curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
+    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
     ```
 

--- a/versioned_docs/version-4.x/admin-manual/open-api/be-http/meta.md
+++ b/versioned_docs/version-4.x/admin-manual/open-api/be-http/meta.md
@@ -32,24 +32,24 @@ None
 
 ## Response
 
-    ```
-    {
-        "table_id": 148107,
-        "partition_id": 148104,
-        "tablet_id": 148193,
-        "schema_hash": 2090621954,
-        "shard_id": 38,
-        "creation_time": 1673253868,
-        "cumulative_layer_point": -1,
-        "tablet_state": "PB_RUNNING",
-        ...
-    }
-    ```
+```
+{
+    "table_id": 148107,
+    "partition_id": 148104,
+    "tablet_id": 148193,
+    "schema_hash": 2090621954,
+    "shard_id": 38,
+    "creation_time": 1673253868,
+    "cumulative_layer_point": -1,
+    "tablet_state": "PB_RUNNING",
+    ...
+}
+```
 ## Examples
 
 
-    ```
-    curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
+```
+curl "http://127.0.0.1:8040/api/meta/header/148193?byte_to_base64=true"
 
-    ```
+```
 


### PR DESCRIPTION
## Summary

In the be-http "View Meta" API doc (`admin-manual/open-api/be-http/meta.md`), the curl example joined the query parameter with `&` directly after the path segment:

```
curl "http://127.0.0.1:8040/api/meta/header/148193&byte_to_base64=true"
```

Per the request spec in the same doc — `GET /api/meta/header/{tablet_id}?byte_to_base64={bool}` — the query string must start with `?`. Corrected `148193&byte_to_base64=true` to `148193?byte_to_base64=true`.

Applied across all affected versions: EN (next + 2.1/3.x/4.x) and Chinese (next + 2.1/3.x/4.x).

## Test plan

- [x] Verified against the request spec line in the same doc