### PR TITLE
[fix] replace full-width comma placeholder in be-http metrics example

### DIFF
--- a/docs/admin-manual/open-api/be-http/metrics.md
+++ b/docs/admin-manual/open-api/be-http/metrics.md
@@ -37,7 +37,7 @@ None
     doris_be__max_network_send_bytes_rate LONG 16232
     doris_be_process_thread_num LONG 1120
     doris_be_process_fd_num_used LONG 336
-    ，，，
+    ...
 
     ```
 ## Examples

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/open-api/be-http/metrics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/open-api/be-http/metrics.md
@@ -37,7 +37,7 @@ prometheus 监控采集接口
     doris_be__max_network_send_bytes_rate LONG 16232
     doris_be_process_thread_num LONG 1120
     doris_be_process_fd_num_used LONG 336
-    ，，，
+    ...
 
     ```
 ## 示例

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/open-api/be-http/metrics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/open-api/be-http/metrics.md
@@ -37,7 +37,7 @@ prometheus 监控采集接口
     doris_be__max_network_send_bytes_rate LONG 16232
     doris_be_process_thread_num LONG 1120
     doris_be_process_fd_num_used LONG 336
-    ，，，
+    ...
 
     ```
 ## Examples

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/open-api/be-http/metrics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/open-api/be-http/metrics.md
@@ -37,7 +37,7 @@ prometheus 监控采集接口
     doris_be__max_network_send_bytes_rate LONG 16232
     doris_be_process_thread_num LONG 1120
     doris_be_process_fd_num_used LONG 336
-    ，，，
+    ...
 
     ```
 ## Examples

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/open-api/be-http/metrics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/open-api/be-http/metrics.md
@@ -37,7 +37,7 @@ prometheus 监控采集接口
     doris_be__max_network_send_bytes_rate LONG 16232
     doris_be_process_thread_num LONG 1120
     doris_be_process_fd_num_used LONG 336
-    ，，，
+    ...
 
     ```
 ## 示例

--- a/versioned_docs/version-2.1/admin-manual/open-api/be-http/metrics.md
+++ b/versioned_docs/version-2.1/admin-manual/open-api/be-http/metrics.md
@@ -37,7 +37,7 @@ None
     doris_be__max_network_send_bytes_rate LONG 16232
     doris_be_process_thread_num LONG 1120
     doris_be_process_fd_num_used LONG 336
-    ，，，
+    ...
 
     ```
 ## Examples

--- a/versioned_docs/version-3.x/admin-manual/open-api/be-http/metrics.md
+++ b/versioned_docs/version-3.x/admin-manual/open-api/be-http/metrics.md
@@ -37,7 +37,7 @@ None
     doris_be__max_network_send_bytes_rate LONG 16232
     doris_be_process_thread_num LONG 1120
     doris_be_process_fd_num_used LONG 336
-    ，，，
+    ...
 
     ```
 ## Examples

--- a/versioned_docs/version-4.x/admin-manual/open-api/be-http/metrics.md
+++ b/versioned_docs/version-4.x/admin-manual/open-api/be-http/metrics.md
@@ -37,7 +37,7 @@ None
     doris_be__max_network_send_bytes_rate LONG 16232
     doris_be_process_thread_num LONG 1120
     doris_be_process_fd_num_used LONG 336
-    ，，，
+    ...
 
     ```
 ## Examples


### PR DESCRIPTION
## Summary

In the be-http metrics API doc (`admin-manual/open-api/be-http/metrics.md`), the Response example used three full-width Chinese commas (`，，，`) as an "omitted lines" placeholder. Replaced with a standard `...` ellipsis.

Applied across all affected versions: EN (next + 2.1/3.x/4.x) and Chinese (next + 2.1/3.x/4.x).

## Test plan

- [x] Confirmed the `，，，` is an omission placeholder in the Response code block