### PR TITLE
Change workload group property from min_cpu_percent to cpu_share

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/workload-management/workload-group.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/workload-management/workload-group.md
@@ -262,7 +262,7 @@ SELECT * FROM information_schema.workload_groups WHERE name = 'g1';
 ### 修改 Workload Group
 
 ```sql
-ALTER WORKLOAD GROUP g1 PROPERTIES('min_cpu_percent' = '2048');
+ALTER WORKLOAD GROUP g1 PROPERTIES('cpu_share' = '2048');
 
 SELECT cpu_share FROM information_schema.workload_groups WHERE name = 'g1';
 +-----------+


### PR DESCRIPTION
## Versions 

- [ ] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [ ] Chinese
- [ ] English
- [ ] Japanese candidate translation needed

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
- [ ] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync
