### PR TITLE
[fix] remove corrupted column row from parameters system-table doc

### DIFF
--- a/docs/admin-manual/system-tables/information_schema/parameters.md
+++ b/docs/admin-manual/system-tables/information_schema/parameters.md
@@ -35,4 +35,3 @@ This table is solely for compatibility with MySQL behavior and is always empty.
 | COLLATION_NAME         | varchar(64)  |             |
 | DTD_IDENTIFIER         | varchar(64)  |             |
 | ROUTINE_TYPE           | varchar(64)  |             |
-| DATA_TYPEDTD_IDENDS    | varchar(64)  |             |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/system-tables/information_schema/parameters.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/system-tables/information_schema/parameters.md
@@ -35,4 +35,3 @@
 | COLLATION_NAME         | varchar(64)  |      |
 | DTD_IDENTIFIER         | varchar(64)  |      |
 | ROUTINE_TYPE           | varchar(64)  |      |
-| DATA_TYPEDTD_IDENDS    | varchar(64)  |      |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/system-tables/information_schema/parameters.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/system-tables/information_schema/parameters.md
@@ -35,4 +35,3 @@
 | COLLATION_NAME         | varchar(64)  |      |
 | DTD_IDENTIFIER         | varchar(64)  |      |
 | ROUTINE_TYPE           | varchar(64)  |      |
-| DATA_TYPEDTD_IDENDS    | varchar(64)  |      |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/system-tables/information_schema/parameters.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/system-tables/information_schema/parameters.md
@@ -35,4 +35,3 @@
 | COLLATION_NAME         | varchar(64)  |      |
 | DTD_IDENTIFIER         | varchar(64)  |      |
 | ROUTINE_TYPE           | varchar(64)  |      |
-| DATA_TYPEDTD_IDENDS    | varchar(64)  |      |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/system-tables/information_schema/parameters.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/system-tables/information_schema/parameters.md
@@ -35,4 +35,3 @@
 | COLLATION_NAME         | varchar(64)  |      |
 | DTD_IDENTIFIER         | varchar(64)  |      |
 | ROUTINE_TYPE           | varchar(64)  |      |
-| DATA_TYPEDTD_IDENDS    | varchar(64)  |      |

--- a/versioned_docs/version-2.1/admin-manual/system-tables/information_schema/parameters.md
+++ b/versioned_docs/version-2.1/admin-manual/system-tables/information_schema/parameters.md
@@ -35,4 +35,3 @@ This table is solely for compatibility with MySQL behavior and is always empty.
 | COLLATION_NAME         | varchar(64)  |             |
 | DTD_IDENTIFIER         | varchar(64)  |             |
 | ROUTINE_TYPE           | varchar(64)  |             |
-| DATA_TYPEDTD_IDENDS    | varchar(64)  |             |

--- a/versioned_docs/version-3.x/admin-manual/system-tables/information_schema/parameters.md
+++ b/versioned_docs/version-3.x/admin-manual/system-tables/information_schema/parameters.md
@@ -35,4 +35,3 @@ This table is solely for compatibility with MySQL behavior and is always empty.
 | COLLATION_NAME         | varchar(64)  |             |
 | DTD_IDENTIFIER         | varchar(64)  |             |
 | ROUTINE_TYPE           | varchar(64)  |             |
-| DATA_TYPEDTD_IDENDS    | varchar(64)  |             |

--- a/versioned_docs/version-4.x/admin-manual/system-tables/information_schema/parameters.md
+++ b/versioned_docs/version-4.x/admin-manual/system-tables/information_schema/parameters.md
@@ -35,4 +35,3 @@ This table is solely for compatibility with MySQL behavior and is always empty.
 | COLLATION_NAME         | varchar(64)  |             |
 | DTD_IDENTIFIER         | varchar(64)  |             |
 | ROUTINE_TYPE           | varchar(64)  |             |
-| DATA_TYPEDTD_IDENDS    | varchar(64)  |             |


### PR DESCRIPTION
## Summary

The `parameters` system-table doc (`admin-manual/system-tables/information_schema/parameters.md`) listed a garbage column row `DATA_TYPEDTD_IDENDS` after the legitimate last column `ROUTINE_TYPE`.

`DATA_TYPEDTD_IDENDS` is not a valid `information_schema.parameters` column — it is a mangled artifact. Both `DATA_TYPE` and `DTD_IDENTIFIER` (which it appears to be a corrupted concatenation of) already appear as their own correct rows in the table, so this is a redundant garbage row, not a missing column.

Removed the corrupted row across all versions: EN (next + 2.1/3.x/4.x) and Chinese (next + 2.1/3.x/4.x).

## Test plan

- [x] Confirmed `DATA_TYPE` and `DTD_IDENTIFIER` already exist as separate correct rows
- [x] Confirmed the garbage row sits after `ROUTINE_TYPE`, the standard last column

## Note

The doc is also missing the standard MySQL `PARAMETERS` column `CHARACTER_MAXIMUM_LENGTH` — a separate completeness gap, not addressed in this PR.