### PR TITLE
[fix] correct rebalance-type FE config key in managing-compute-cluster doc

### DIFF
--- a/docs/compute-storage-decoupled/managing-compute-cluster.md
+++ b/docs/compute-storage-decoupled/managing-compute-cluster.md
@@ -221,7 +221,7 @@ The following example describes the three strategy types using a scale-out scena
 Set the global default value in the FE configuration file (`fe.conf`):
 
 ```
-cloud_default_rebalance_type = "async_warmup"
+cloud_warm_up_for_rebalance_type = "async_warmup"
 ```
 
 ##### Compute Group-Level Configuration
@@ -264,7 +264,7 @@ After renaming, user permissions and default compute group settings associated w
 
 - **View**:
     ```sql
-    ADMIN SHOW FRONTEND CONFIG LIKE "cloud_default_rebalance_type";
+    ADMIN SHOW FRONTEND CONFIG LIKE "cloud_warm_up_for_rebalance_type";
     ```
 - **Modify** (takes effect without restarting FE):
     ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/managing-compute-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/compute-storage-decoupled/managing-compute-cluster.md
@@ -221,7 +221,7 @@ Cloud Rebalance 是 Doris 存算分离架构下的负载均衡机制。当计算
 通过 FE 配置文件（`fe.conf`）设置全局默认值：
 
 ```
-cloud_default_rebalance_type = "async_warmup"
+cloud_warm_up_for_rebalance_type = "async_warmup"
 ```
 
 ##### 计算组级别配置
@@ -264,7 +264,7 @@ ALTER SYSTEM RENAME COMPUTE GROUP <old_name> <new_name>;
 
 - **查看**：
     ```sql
-    ADMIN SHOW FRONTEND CONFIG LIKE "cloud_default_rebalance_type";
+    ADMIN SHOW FRONTEND CONFIG LIKE "cloud_warm_up_for_rebalance_type";
     ```
 - **修改**（修改后无需重启 FE 即可生效）：
     ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/compute-storage-decoupled/managing-compute-cluster.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/compute-storage-decoupled/managing-compute-cluster.md
@@ -221,7 +221,7 @@ Cloud Rebalance 是 Doris 存算分离架构下的负载均衡机制。当计算
 通过 FE 配置文件（`fe.conf`）设置全局默认值：
 
 ```
-cloud_default_rebalance_type = "async_warmup"
+cloud_warm_up_for_rebalance_type = "async_warmup"
 ```
 
 ##### 计算组级别配置
@@ -264,7 +264,7 @@ ALTER SYSTEM RENAME COMPUTE GROUP <old_name> <new_name>;
 
 - **查看**：
     ```sql
-    ADMIN SHOW FRONTEND CONFIG LIKE "cloud_default_rebalance_type";
+    ADMIN SHOW FRONTEND CONFIG LIKE "cloud_warm_up_for_rebalance_type";
     ```
 - **修改**（修改后无需重启 FE 即可生效）：
     ```sql

--- a/versioned_docs/version-4.x/compute-storage-decoupled/managing-compute-cluster.md
+++ b/versioned_docs/version-4.x/compute-storage-decoupled/managing-compute-cluster.md
@@ -221,7 +221,7 @@ The following example describes the three strategy types using a scale-out scena
 Set the global default value in the FE configuration file (`fe.conf`):
 
 ```
-cloud_default_rebalance_type = "async_warmup"
+cloud_warm_up_for_rebalance_type = "async_warmup"
 ```
 
 ##### Compute Group-Level Configuration
@@ -264,7 +264,7 @@ After renaming, user permissions and default compute group settings associated w
 
 - **View**:
     ```sql
-    ADMIN SHOW FRONTEND CONFIG LIKE "cloud_default_rebalance_type";
+    ADMIN SHOW FRONTEND CONFIG LIKE "cloud_warm_up_for_rebalance_type";
     ```
 - **Modify** (takes effect without restarting FE):
     ```sql


### PR DESCRIPTION
## Summary

The `managing-compute-cluster` doc referenced an FE config `cloud_default_rebalance_type` in two places — the `fe.conf` example and the `ADMIN SHOW FRONTEND CONFIG` example — but no such config exists in Doris.

The real config is `cloud_warm_up_for_rebalance_type` (default `async_warmup`), verified against the apache/doris FE source: it is defined in `Config.java` and used in `BalanceTypeEnum.java`, `ComputeGroup.java`, `CloudTabletRebalancer.java`, and the cloud regression tests. The `ADMIN SET FRONTEND CONFIG` example in the same doc already used the correct key — only the other two references were wrong.

Corrected `cloud_default_rebalance_type` → `cloud_warm_up_for_rebalance_type` across all affected versions (EN next/4.x, ZH next/4.x; the feature does not exist in 3.x).

## Test plan

- [x] Verified against apache/doris `Config.java`: `cloud_warm_up_for_rebalance_type` exists, `cloud_default_rebalance_type` does not (zero matches repo-wide)
- [x] Confirmed the `ADMIN SET` example and the cloud regression tests use `cloud_warm_up_for_rebalance_type`