### PR TITLE
[fix] let Ask Me modal close after the first question

### DIFF
--- a/static/js/custom-script.js
+++ b/static/js/custom-script.js
@@ -31,10 +31,16 @@
         'padding-bottom:2rem !important;' +
         '--modal-y-offset:0 !important;' +
         '}' +
+        // Do NOT add `display:flex !important` here — Kapa already sets
+        // `display:flex; flex-direction:column` inline via Mantine's `sx`
+        // prop, and overriding with `!important` would also override the
+        // `display:none` Mantine's transition writes inline when the modal
+        // is keep-mounted and closed (which happens after the first
+        // question). That kept the modal visible after onClose fired,
+        // making X / Esc / overlay-click all silently fail on the second
+        // attempt.
         '.mantine-Modal-content{' +
         'max-height:calc(100vh - 80px - 2rem) !important;' +
-        'display:flex !important;' +
-        'flex-direction:column !important;' +
         '}' +
         '.mantine-Modal-body{' +
         'flex:1 1 auto !important;' +


### PR DESCRIPTION
After the first question the Kapa widget flips its Mantine modal to `keepMounted: true`, and Mantine then hides a closed keep-mounted modal by writing `style="display: none"` inline on the content section. Our `.mantine-Modal-content { display: flex !important; flex-direction: column !important }` overrides won that cascade and pinned the modal visible even after onClose fired. From there every subsequent X / Esc / overlay click hit `useDisclosure.close()` with state already `false` and silently became a no-op. Drop those two declarations — Kapa already sets `display: flex; flex-direction: column` inline via Mantine `sx`, so the flex layout still applies and Mantine transition can now hide the modal correctly.
