### PR TITLE
[fix] correct typos / wrong descriptions / stray markdown in SQL data-type and aggregate-function docs

### DIFF
--- a/docs/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
+++ b/docs/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
@@ -310,8 +310,7 @@ mysql> SELECT cast('[1,                 2]' as json);
 ```
 
 ### Key Differences and Notes:
-- CAST(string AS JSON): Used to parse strings that conform to JSON syntax.
-- CAST(string AS JSON): For Number types, it will only parse Int8, Int16, Int32, Int64, Int128, and Double types, not Decimal type.
+- CAST(string AS JSON): Used to parse strings that conform to JSON syntax. For Number types, it will only parse Int8, Int16, Int32, Int64, Int128, and Double types, not Decimal type.
 - Unlike most other JSON implementations, Doris's JSONB type supports up to Int128 precision. Numbers exceeding Int128 precision may overflow.
 - If the input number string is 12.34, it will be parsed as a Double; if there's no decimal point, it will be parsed as an integer (if the size exceeds Int128 range, it will be converted to Double but with precision loss)
 

--- a/docs/sql-manual/basic-element/sql-data-types/string-type/STRING.md
+++ b/docs/sql-manual/basic-element/sql-data-types/string-type/STRING.md
@@ -2,13 +2,12 @@
 {
     "title": "STRING",
     "language": "en",
-    "description": "STRING (M) A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),"
+    "description": "A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),"
 }
 ---
 
 ## STRING
 ### Description
-STRING (M)
 A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),and the length of the String type is also limited by the configuration string_type_length_soft_limit_bytes(a soft limit of string type length) of be. the String type can only be used in the value column, not in the key column and the partition and bucket columns
 
 Note: Variable length strings are stored in UTF-8 encoding, so usually English characters occupies 1 byte, and Chinese characters occupies 3 bytes.

--- a/docs/sql-manual/basic-element/variables.md
+++ b/docs/sql-manual/basic-element/variables.md
@@ -109,7 +109,7 @@ User-defined variables are a mechanism for temporarily storing data within a ses
     | allow_partition_column_nullable                            | true                                  | true                                  | 0       |
     | analyze_timeout                                           | 43200                                 | 43200                                 | 0       |
     | version                                                      | 5.7.99                                | 5.7.99                                | 0       |
-    | version_comment                                                | Doris version doris0.0.0--de61c5823 | Doris version doris-0.0--de61c5823 | 0       |
+    | version_comment                                                | Doris version doris-0.0.0--de61c58223 | Doris version doris-0.0.0--de61c58223 | 0       |
     | wait_full_block_schedule_times                                 | 2                                     | 2                                     | 0       |
     | wait_timeout                                               | 28800                                 | 28800                                 | 0       |
     | workload_group                                                 |                                       |                                       | 0       |

--- a/docs/sql-manual/sql-functions/aggregate-functions/ai-agg.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/ai-agg.md
@@ -107,7 +107,7 @@ INSERT INTO product_reviews VALUES
 
 Using AI_AGG to summarize and evaluate:
 ```sql
-SET default_ai_resoure = 'ai_resource_name';
+SET default_ai_resource = 'ai_resource_name';
 SELECT
     product_id,
     AI_AGG(

--- a/docs/sql-manual/sql-functions/aggregate-functions/array-agg.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/array-agg.md
@@ -67,6 +67,3 @@ select array_agg(c2) from test_doris_array_agg where c1 is null;
 | []            |
 +---------------+
 ```
-|    1 | ["a","b"]       |
-
-

--- a/docs/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
@@ -28,8 +28,6 @@ Returns a value of Bitmap type. If there is no valid data in the group, returns 
 
 ## Example
 
-## Example
-
 ```sql
 -- setup
 CREATE TABLE user_tags (

--- a/docs/sql-manual/sql-functions/aggregate-functions/bool-or.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/bool-or.md
@@ -28,7 +28,7 @@ BOOL_OR(<expr>)
 
 ## Return Value
 
-The return value is BOOLEAN. It returns TRUE when all non-NULL values exist, otherwise it returns FALSE.
+The return value is BOOLEAN. It returns TRUE when at least one non-NULL value is TRUE, otherwise it returns FALSE.
 
 If all values of the expression are NULL or the expression is empty, the function returns NULL.
 

--- a/docs/sql-manual/sql-functions/aggregate-functions/covar-samp.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/covar-samp.md
@@ -74,7 +74,3 @@ select id, covar_samp(x, y) from baseall group by id;
 |    5 |             NULL |
 +------+------------------+
 ```
-|    4 |             NULL |
-|    5 |             NULL |
-+------+------------------+
-```

--- a/docs/sql-manual/sql-functions/aggregate-functions/histogram.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/histogram.md
@@ -126,8 +126,8 @@ Query result description:
 Field description:
 - num_buckets: The number of buckets
 - buckets: All buckets
-    - lower: Upper bound of the bucket
-    - upper: Lower bound of the bucket
+    - lower: Lower bound of the bucket
+    - upper: Upper bound of the bucket
     - count: The number of elements contained in the bucket
     - pre_sum: The total number of elements in the front bucket
     - ndv: The number of different values in the bucket

--- a/docs/sql-manual/sql-functions/aggregate-functions/percentile_reservoir.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/percentile_reservoir.md
@@ -76,14 +76,14 @@ FROM sales_data;
 ```
 
 ```sql
-select percentile(sale_price, NULL) from sales_data;
+select percentile_reservoir(sale_price, NULL) from sales_data;
 ```
 
 If all input values are NULL, returns NULL.
 
 ```text
 +------------------------------+
-| percentile(sale_price, NULL) |
+| percentile_reservoir(sale_price, NULL) |
 +------------------------------+
 |                         NULL |
 +------------------------------+

--- a/versioned_docs/version-2.1/sql-manual/basic-element/sql-data-types/string-type/STRING.md
+++ b/versioned_docs/version-2.1/sql-manual/basic-element/sql-data-types/string-type/STRING.md
@@ -2,13 +2,12 @@
 {
     "title": "STRING",
     "language": "en",
-    "description": "STRING (M) A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),"
+    "description": "A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),"
 }
 ---
 
 ## STRING
 ### Description
-STRING (M)
 A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),and the length of the String type is also limited by the configuration string_type_length_soft_limit_bytes(a soft limit of string type length) of be. the String type can only be used in the value column, not in the key column and the partition and bucket columns
 
 Note: Variable length strings are stored in UTF-8 encoding, so usually English characters occupies 1 byte, and Chinese characters occupies 3 bytes.

--- a/versioned_docs/version-2.1/sql-manual/basic-element/variables.md
+++ b/versioned_docs/version-2.1/sql-manual/basic-element/variables.md
@@ -109,7 +109,7 @@ User-defined variables are a mechanism for temporarily storing data within a ses
     | allow_partition_column_nullable                            | true                                  | true                                  | 0       |
     | analyze_timeout                                           | 43200                                 | 43200                                 | 0       |
     | version                                                      | 5.7.99                                | 5.7.99                                | 0       |
-    | version_comment                                                | Doris version doris0.0.0--de61c5823 | Doris version doris-0.0--de61c5823 | 0       |
+    | version_comment                                                | Doris version doris-0.0.0--de61c58223 | Doris version doris-0.0.0--de61c58223 | 0       |
     | wait_full_block_schedule_times                                 | 2                                     | 2                                     | 0       |
     | wait_timeout                                               | 28800                                 | 28800                                 | 0       |
     | workload_group                                                 |                                       |                                       | 0       |

--- a/versioned_docs/version-3.x/sql-manual/basic-element/sql-data-types/string-type/STRING.md
+++ b/versioned_docs/version-3.x/sql-manual/basic-element/sql-data-types/string-type/STRING.md
@@ -2,13 +2,12 @@
 {
     "title": "STRING",
     "language": "en",
-    "description": "STRING (M) A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),"
+    "description": "A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),"
 }
 ---
 
 ## STRING
 ### Description
-STRING (M)
 A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),and the length of the String type is also limited by the configuration string_type_length_soft_limit_bytes(a soft limit of string type length) of be. the String type can only be used in the value column, not in the key column and the partition and bucket columns
 
 Note: Variable length strings are stored in UTF-8 encoding, so usually English characters occupies 1 byte, and Chinese characters occupies 3 bytes.

--- a/versioned_docs/version-3.x/sql-manual/basic-element/variables.md
+++ b/versioned_docs/version-3.x/sql-manual/basic-element/variables.md
@@ -109,7 +109,7 @@ User-defined variables are a mechanism for temporarily storing data within a ses
     | allow_partition_column_nullable                            | true                                  | true                                  | 0       |
     | analyze_timeout                                           | 43200                                 | 43200                                 | 0       |
     | version                                                      | 5.7.99                                | 5.7.99                                | 0       |
-    | version_comment                                                | Doris version doris0.0.0--de61c5823 | Doris version doris-0.0--de61c5823 | 0       |
+    | version_comment                                                | Doris version doris-0.0.0--de61c58223 | Doris version doris-0.0.0--de61c58223 | 0       |
     | wait_full_block_schedule_times                                 | 2                                     | 2                                     | 0       |
     | wait_timeout                                               | 28800                                 | 28800                                 | 0       |
     | workload_group                                                 |                                       |                                       | 0       |

--- a/versioned_docs/version-4.x/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
+++ b/versioned_docs/version-4.x/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
@@ -310,8 +310,7 @@ mysql> SELECT cast('[1,                 2]' as json);
 ```
 
 ### Key Differences and Notes:
-- CAST(string AS JSON): Used to parse strings that conform to JSON syntax.
-- CAST(string AS JSON): For Number types, it will only parse Int8, Int16, Int32, Int64, Int128, and Double types, not Decimal type.
+- CAST(string AS JSON): Used to parse strings that conform to JSON syntax. For Number types, it will only parse Int8, Int16, Int32, Int64, Int128, and Double types, not Decimal type.
 - Unlike most other JSON implementations, Doris's JSONB type supports up to Int128 precision. Numbers exceeding Int128 precision may overflow.
 - If the input number string is 12.34, it will be parsed as a Double; if there's no decimal point, it will be parsed as an integer (if the size exceeds Int128 range, it will be converted to Double but with precision loss)
 

--- a/versioned_docs/version-4.x/sql-manual/basic-element/sql-data-types/string-type/STRING.md
+++ b/versioned_docs/version-4.x/sql-manual/basic-element/sql-data-types/string-type/STRING.md
@@ -2,13 +2,12 @@
 {
     "title": "STRING",
     "language": "en",
-    "description": "STRING (M) A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),"
+    "description": "A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),"
 }
 ---
 
 ## STRING
 ### Description
-STRING (M)
 A variable length string. Default support is 1048576 bytes (1M), adjustable up to 2147483643 bytes (2G),and the length of the String type is also limited by the configuration string_type_length_soft_limit_bytes(a soft limit of string type length) of be. the String type can only be used in the value column, not in the key column and the partition and bucket columns
 
 Note: Variable length strings are stored in UTF-8 encoding, so usually English characters occupies 1 byte, and Chinese characters occupies 3 bytes.

--- a/versioned_docs/version-4.x/sql-manual/basic-element/variables.md
+++ b/versioned_docs/version-4.x/sql-manual/basic-element/variables.md
@@ -109,7 +109,7 @@ User-defined variables are a mechanism for temporarily storing data within a ses
     | allow_partition_column_nullable                            | true                                  | true                                  | 0       |
     | analyze_timeout                                           | 43200                                 | 43200                                 | 0       |
     | version                                                      | 5.7.99                                | 5.7.99                                | 0       |
-    | version_comment                                                | Doris version doris0.0.0--de61c5823 | Doris version doris-0.0--de61c5823 | 0       |
+    | version_comment                                                | Doris version doris-0.0.0--de61c58223 | Doris version doris-0.0.0--de61c58223 | 0       |
     | wait_full_block_schedule_times                                 | 2                                     | 2                                     | 0       |
     | wait_timeout                                               | 28800                                 | 28800                                 | 0       |
     | workload_group                                                 |                                       |                                       | 0       |

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/ai-agg.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/ai-agg.md
@@ -107,7 +107,7 @@ INSERT INTO product_reviews VALUES
 
 Using AI_AGG to summarize and evaluate:
 ```sql
-SET default_ai_resoure = 'ai_resource_name';
+SET default_ai_resource = 'ai_resource_name';
 SELECT
     product_id,
     AI_AGG(

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/array-agg.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/array-agg.md
@@ -67,6 +67,3 @@ select array_agg(c2) from test_doris_array_agg where c1 is null;
 | []            |
 +---------------+
 ```
-|    1 | ["a","b"]       |
-
-

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
@@ -28,8 +28,6 @@ Returns a value of Bitmap type. If there is no valid data in the group, returns 
 
 ## Example
 
-## Example
-
 ```sql
 -- setup
 CREATE TABLE user_tags (

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/bool-or.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/bool-or.md
@@ -28,7 +28,7 @@ BOOL_OR(<expr>)
 
 ## Return Value
 
-The return value is BOOLEAN. It returns TRUE when all non-NULL values exist, otherwise it returns FALSE.
+The return value is BOOLEAN. It returns TRUE when at least one non-NULL value is TRUE, otherwise it returns FALSE.
 
 If all values of the expression are NULL or the expression is empty, the function returns NULL.
 

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/covar-samp.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/covar-samp.md
@@ -74,7 +74,3 @@ select id, covar_samp(x, y) from baseall group by id;
 |    5 |             NULL |
 +------+------------------+
 ```
-|    4 |             NULL |
-|    5 |             NULL |
-+------+------------------+
-```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/histogram.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/histogram.md
@@ -126,8 +126,8 @@ Query result description:
 Field description:
 - num_buckets: The number of buckets
 - buckets: All buckets
-    - lower: Upper bound of the bucket
-    - upper: Lower bound of the bucket
+    - lower: Lower bound of the bucket
+    - upper: Upper bound of the bucket
     - count: The number of elements contained in the bucket
     - pre_sum: The total number of elements in the front bucket
     - ndv: The number of different values in the bucket

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/percentile_reservoir.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/percentile_reservoir.md
@@ -76,14 +76,14 @@ FROM sales_data;
 ```
 
 ```sql
-select percentile(sale_price, NULL) from sales_data;
+select percentile_reservoir(sale_price, NULL) from sales_data;
 ```
 
 If all input values are NULL, returns NULL.
 
 ```text
 +------------------------------+
-| percentile(sale_price, NULL) |
+| percentile_reservoir(sale_price, NULL) |
 +------------------------------+
 |                         NULL |
 +------------------------------+


### PR DESCRIPTION
## Summary

Fixes ten small documentation issues across `sql-manual/basic-element/` and `sql-manual/sql-functions/aggregate-functions/`. Each item below is independent.

- **STRING.md** — drop the spurious `STRING (M)` from the type description (both the frontmatter description and the body). STRING does not take a length parameter.
- **variables.md** — the `version_comment` row showed different values in the Value vs Default_Value columns (`doris0.0.0--de61c5823` vs `doris-0.0--de61c5823`). Both columns now use the canonical `doris-0.0.0--de61c58223` form already used in the zh-CN translation.
- **ai-agg.md** — typo `default_ai_resoure` → `default_ai_resource`.
- **array-agg.md** — remove a stray `|    1 | ["a","b"]       |` table row that sat outside the closing code fence and rendered as literal text.
- **bitmap-intersect.md** — collapse two consecutive `## Example` headings into one.
- **bool-or.md** — the Return Value paragraph said "TRUE when all non-NULL values exist", which is the logical AND semantics. Corrected to "TRUE when at least one non-NULL value is TRUE".
- **covar-samp.md** — remove an orphan duplicated result-table block plus an extra closing code fence that appeared after the legitimate one.
- **histogram.md** — the `lower` and `upper` bucket field descriptions were swapped (`lower: Upper bound`, `upper: Lower bound`). Corrected.
- **JSON.md** — two consecutive bullets both began with `CAST(string AS JSON):`. Merged into one bullet that keeps the content of both.
- **percentile_reservoir.md** — the third example's query and result header used `percentile(...)` instead of `percentile_reservoir(...)` (looked like copy-paste from `percentile.md`).

## Test plan

- [ ] CI doc build passes
- [ ] Spot-check the affected pages render as expected (STRING.md description, variables.md `version_comment` row, single `## Example` in bitmap-intersect, clean result tables in array-agg / covar-samp, corrected bucket field descriptions in histogram, merged bullet in JSON.md, `percentile_reservoir` in the third example)