### PR TITLE
[doc] add MySQL/PostgreSQL data source pages to legacy sidebars.ts

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -315,6 +315,8 @@ const sidebars: SidebarsConfig = {
                         'data-operate/import/data-source/snowflake',
                         'data-operate/import/data-source/bigquery',
                         'data-operate/import/data-source/redshift',
+                        'data-operate/import/data-source/mysql',
+                        'data-operate/import/data-source/postgresql',
                         'data-operate/import/data-source/migrate-data-from-other-olap',
                         'data-operate/import/data-source/migrate-data-from-other-oltp',
                     ],


### PR DESCRIPTION
## Summary

Follow-up to #3704. That PR added the restored `data-source/mysql.md` and `data-source/postgresql.md` to `versioned_sidebars/version-4.x-sidebars.json`, but missed `sidebars.ts` (the legacy plugin sidebar that was re-introduced after #3645). As a result, the two pages exist as routes but are not visible in the Data Source sidebar under the legacy `docs/` tree.

This PR adds the two entries to `sidebars.ts` so they appear alongside the other data sources.

## Test plan

- [ ] Build the site and confirm **MySQL** and **PostgreSQL** entries show up under **Data Loading → Data Source** in the sidebar