### PR TITLE
[fix](doc) correct defaults and example outputs that disagreed with the engine

### DIFF
--- a/docs/connection-integration/data-integration/doris-streamloader.md
+++ b/docs/connection-integration/data-integration/doris-streamloader.md
@@ -248,7 +248,7 @@ Load Result: {
 
     **To import multiple files, use the `source_file` approach.**
 
-2. **`workers`**: The default value is the number of CPU cores. On machines with many cores (such as 96), this produces too much concurrency. Lower the value. **A common recommendation is `8`**.
+2. **`workers`**: The default value is `0`, which enables automatic mode (the tool computes a value from the import size, `disk_throughput`, and `streamload_throughput`, typically yielding 1, 2, 4, or 8). You can also set it manually — for high-performance clusters you may increase it, but **no more than 10 is recommended**. **A common manual value is `8`**.
 
 3. **`max_byte_per_task`**: A larger value reduces the number of import versions. However, if you encounter a `body exceed max size` error and do not want to adjust `streaming_load_max_mb` (which requires restarting the BE), or if you encounter the `-238 TOO MANY SEGMENT` error, you can lower this value temporarily. **The default usually works.**
 

--- a/docs/connection-integration/data-integration/flink-doris-connector.md
+++ b/docs/connection-integration/data-integration/flink-doris-connector.md
@@ -802,7 +802,7 @@ After the Flink cluster is started, you can run the corresponding command accord
 | doris.request.tablet.size   | 1             | N        | The number of Doris Tablets corresponding to one Partition. The smaller this value is set, the more Partitions will be generated, increasing parallelism on the Flink side, but also placing more pressure on Doris. |
 | doris.batch.size            | 4064          | N        | The maximum number of rows read from BE at a time. Increasing this value can reduce the number of connections established between Flink and Doris, thereby reducing the additional time overhead caused by network latency. |
 | doris.exec.mem.limit        | 8192mb        | N        | Memory limit for a single query. The default is 8GB, in bytes.                                                                                         |
-| source.use-flight-sql       | FALSE         | N        | Whether to use Arrow Flight SQL for reading                                                                                                            |
+| source.use-flight-sql       | TRUE          | N        | Whether to use Arrow Flight SQL for reading                                                                                                            |
 | source.flight-sql-port      | -             | N        | When using Arrow Flight SQL for reading, the FE's `arrow_flight_sql_port`                                                                              |
 
 **DataStream-Specific Configuration**

--- a/docs/data-operate/import/file-format/json.md
+++ b/docs/data-operate/import/file-format/json.md
@@ -189,7 +189,7 @@ The following table lists the support for JSON-related parameters across the dif
 
 - **Purpose**: Specifies whether to read JSON data line by line.
 - **Type**: Boolean.
-- **Default**: false.
+- **Default**: true if `strip_outer_array` is not set; specifying `strip_outer_array=true` causes it to default to false. (Broker Load and Routine Load always force `read_json_by_line=true`.)
 - **Examples**:
 
     ```json

--- a/docs/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
+++ b/docs/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
@@ -152,7 +152,7 @@ mysql> SELECT DISTINCT j FROM test_jsonb_groupby;
    +------+----------+
    ```
 
-   This is because the first `123` is of type `BIGINT`, while the second `123` is of type `TINYINT`, resulting in different binary representations. You can verify their types with the following query:
+   This is because the first `123` is stored internally as a 64-bit integer (`json_type` reports `bigint`), while the second `123` is stored as a narrow integer (`json_type` reports `int` for all sub-`bigint` integer widths), resulting in different binary representations. You can verify their types with the following query:
    ```sql
    mysql> SELECT j, json_type(j, '$') FROM test_jsonb;
    +------+------------------+

--- a/docs/sql-manual/sql-functions/scalar-functions/binary-functions/to-base64-binary.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/binary-functions/to-base64-binary.md
@@ -27,7 +27,7 @@ Returns VARCHAR type, representing the Base64 encoded string.
 
 Special cases:
 - If input is NULL, returns NULL
-- If input is an empty string, returns an empty string
+- If input is an empty VARBINARY (zero bytes), returns an empty string
 
 ## Examples
 

--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
@@ -32,7 +32,7 @@ $type$ represents the unit of period
 | -- | -- |
 | `date_or_time_expr` | A valid date expression, supporting input of date/datetime/timestamptz types. For specific formats, please refer to [timestamptz conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/timestamptz-conversion), [datetime conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/datetime-conversion) and [date conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/date-conversion) |
 | `period` | Specifies the number of units each period consists of, of `INT` type. The starting time point is 0001-01-01T00:00:00 |
-| `type` | Can be: YEAR, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND |
+| `type` | Can be: YEAR, QUARTER, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND |
 
 ## Return Value
 

--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-add.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-add.md
@@ -92,5 +92,5 @@ SELECT MINUTES_ADD(NULL, 10), MINUTES_ADD('2023-07-13 22:28:18', NULL) AS result
 
 -- Calculation result exceeds datetime range, throws error
 SELECT MINUTES_ADD('9999-12-31 23:59:59', 2) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minutes_add of 9999-12-31 23:59:59, 2 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minute_add of 9999-12-31 23:59:59, 2 out of range
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-sub.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-sub.md
@@ -92,5 +92,5 @@ SELECT MINUTES_SUB(NULL, 10), MINUTES_SUB('2023-07-13 22:28:18', NULL) AS result
 
 -- Calculation result exceeds datetime range, throws error
 SELECT MINUTES_SUB('0000-01-01 00:00:00', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minutes_add of 0000-01-01 00:00:00, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minute_add of 0000-01-01 00:00:00, -1 out of range
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/months-add.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/months-add.md
@@ -95,8 +95,8 @@ SELECT MONTHS_ADD(NULL, 5), MONTHS_ADD('2023-07-13', NULL) AS result;
 
 -- Calculation result exceeds date range
 SELECT MONTHS_ADD('9999-12-31', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 9999-12-31, 1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 9999-12-31, 1 out of range
 
 SELECT MONTHS_ADD('0000-01-01', -1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 0000-01-01, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 0000-01-01, -1 out of range
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/months-sub.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/months-sub.md
@@ -95,8 +95,8 @@ SELECT MONTHS_SUB('2025-10-10 11:22:33.123+07:00', 1);
 
 --- Calculation result exceeds date range
 mysql> SELECT MONTHS_SUB('0000-01-01', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 0000-01-01, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 0000-01-01, -1 out of range
 
 mysql> SELECT MONTHS_SUB('9999-12-31', -1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 9999-12-31, 1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 9999-12-31, 1 out of range
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/previous-day.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/previous-day.md
@@ -1,13 +1,14 @@
 ---
 {
     "title": "PREVIOUS_DAY",
-    "language": "en"
+    "language": "en",
+    "description": "Returns the first date matching the target day of the week before the specified date."
 }
 ---
 
 ## Description
 
-The PREVIOUS_DAY function returns the first date that matches the target day of the week before the specified date. For example, `PREVIOUS_DAY('2020-01-31', 'MONDAY')` represents the first Monday before 2020-01-31. This function supports DATE, DATETIME, and TIMESTAMPTZ types, and ignores the time part of the input (calculating based on the date part only).
+The PREVIOUS_DAY function returns the first date that matches the target day of the week before the specified date. For example, `PREVIOUS_DAY('2020-01-31', 'MONDAY')` represents the first Monday before 2020-01-31. This function accepts DATE and DATETIME inputs, ignoring any time portion (calculation is based on the date part only).
 
 ## Syntax
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/data-integration/doris-streamloader.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/data-integration/doris-streamloader.md
@@ -248,7 +248,7 @@ Load Result: {
 
     **如需导入多个文件，推荐使用 `source_file` 方式。**
 
-2. **`workers`**：默认值为 CPU 核数。在 CPU 核数较多的场景（如 96 核）会产生过多并发，需要降低该值，**一般推荐设置为 `8`**。
+2. **`workers`**：默认值为 `0`，即自动模式（工具会根据导入数据大小、`disk_throughput` 与 `streamload_throughput` 自动推算，常见结果为 1、2、4 或 8）。也可手动设置，性能好的集群可适当调大，**最好不超过 10**。**一般手动设置为 `8`**。
 
 3. **`max_byte_per_task`**：可设置较大值以减少导入版本数。但如遇到 `body exceed max size` 错误且不想调整 `streaming_load_max_mb`（需重启 BE），或遇到 `-238 TOO MANY SEGMENT` 错误，可临时调小该值。**一般使用默认即可。**
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/data-integration/flink-doris-connector.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/data-integration/flink-doris-connector.md
@@ -802,7 +802,7 @@ Flink Doris Connector 集成了 [Flink CDC](https://nightlies.apache.org/flink/f
 | doris.request.tablet.size   | 1             | N        | 一个 Partition 对应的 Doris Tablet 个数。此数值设置越小，则会生成越多的 Partition，从而提升 Flink 侧的并行度，但同时会对 Doris 造成更大的压力。         |
 | doris.batch.size            | 4064          | N        | 一次从 BE 读取数据的最大行数。增大此数值可减少 Flink 与 Doris 之间建立连接的次数，从而减轻网络延迟所带来的额外时间开销。                               |
 | doris.exec.mem.limit        | 8192mb        | N        | 单个查询的内存限制。默认为 8GB，单位为字节                                                                                                             |
-| source.use-flight-sql       | FALSE         | N        | 是否使用 Arrow Flight SQL 读取                                                                                                                         |
+| source.use-flight-sql       | TRUE          | N        | 是否使用 Arrow Flight SQL 读取                                                                                                                         |
 | source.flight-sql-port      | -             | N        | 使用 Arrow Flight SQL 读取时，FE 的 `arrow_flight_sql_port`                                                                                            |
 
 **DataStream 专有配置项**

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
@@ -32,7 +32,7 @@ $type$ 代表的是周期单位
 | -- | -- |
 | `date_or_time_expr` | 参数是合法的日期表达式，支持输入 date/datetime/timestamptz 类型，具体格式请查看 [timestamptz的转换](../../../../sql-manual/basic-element/sql-data-types/conversion/timestamptz-conversion), [datetime 的转换](../../../../../current/sql-manual/basic-element/sql-data-types/conversion/datetime-conversion) 和 [date 的转换](../../../../../current/sql-manual/basic-element/sql-data-types/conversion/date-conversion) |
 | `period` | 参数是指定每个周期有多少个单位组成,为 `INT` 类型，开始的时间起点为 0001-01-01T00:00:00 |
-| `type` | 参数可以是：YEAR, MONTH, WEEK,DAY, HOUR, MINUTE, SECOND |
+| `type` | 参数可以是：YEAR, QUARTER, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND |
 
 ## 返回值
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-add.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-add.md
@@ -91,5 +91,5 @@ SELECT MINUTES_ADD(NULL, 10), MINUTES_ADD('2023-07-13 22:28:18', NULL) AS result
 
 --- 计算结果超出日期时间范围，报错
 SELECT MINUTES_ADD('9999-12-31 23:59:59', 2) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minutes_add of 9999-12-31 23:59:59, 2 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minute_add of 9999-12-31 23:59:59, 2 out of range
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-sub.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-sub.md
@@ -95,5 +95,5 @@ SELECT MINUTES_SUB(NULL, 10), MINUTES_SUB('2023-07-13 22:28:18', NULL) AS result
 
 --- 计算结果超出日期时间范围，报错
 SELECT MINUTES_SUB('0000-01-01 00:00:00', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minutes_add of 0000-01-01 00:00:00, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minute_add of 0000-01-01 00:00:00, -1 out of range
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/months-add.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/months-add.md
@@ -95,8 +95,8 @@ SELECT MONTHS_ADD('2025-10-10 11:22:33.123+07:00', 1);
 
 --- 计算结果超出日期范围
 mysql> SELECT MONTHS_ADD('9999-12-31', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 9999-12-31, 1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 9999-12-31, 1 out of range
 
 mysql> SELECT MONTHS_ADD('0000-01-01',- 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 0000-01-01, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 0000-01-01, -1 out of range
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/months-sub.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/months-sub.md
@@ -96,8 +96,8 @@ SELECT MONTHS_SUB('2025-10-10 11:22:33.123+07:00', 1);
 
 --- 计算结果超出日期范围
 mysql> SELECT MONTHS_SUB('0000-01-01', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 0000-01-01, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 0000-01-01, -1 out of range
 
 mysql> SELECT MONTHS_SUB('9999-12-31', -1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 9999-12-31, 1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 9999-12-31, 1 out of range
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
@@ -20,7 +20,7 @@
 | -- | -- |
 | `datetime` | 参数是合法的日期表达式 |
 | `period` | 参数是指定每个周期有多少个单位组成，开始的时间起点为 0001-01-01T00:00:00 |
-| `type` | 参数可以是：YEAR, MONTH, DAY, HOUR, MINUTE, SECOND |
+| `type` | 参数可以是：YEAR, QUARTER, MONTH, DAY, HOUR, MINUTE, SECOND |
 
 :::tip 
 QUARTER 支持从 3.0.8 和 3.1.0 版本开始。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/data-integration/doris-streamloader.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/data-integration/doris-streamloader.md
@@ -248,7 +248,7 @@ Load Result: {
 
     **如需导入多个文件，推荐使用 `source_file` 方式。**
 
-2. **`workers`**：默认值为 CPU 核数。在 CPU 核数较多的场景（如 96 核）会产生过多并发，需要降低该值，**一般推荐设置为 `8`**。
+2. **`workers`**：默认值为 `0`，即自动模式（工具会根据导入数据大小、`disk_throughput` 与 `streamload_throughput` 自动推算，常见结果为 1、2、4 或 8）。也可手动设置，性能好的集群可适当调大，**最好不超过 10**。**一般手动设置为 `8`**。
 
 3. **`max_byte_per_task`**：可设置较大值以减少导入版本数。但如遇到 `body exceed max size` 错误且不想调整 `streaming_load_max_mb`（需重启 BE），或遇到 `-238 TOO MANY SEGMENT` 错误，可临时调小该值。**一般使用默认即可。**
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/data-integration/flink-doris-connector.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/data-integration/flink-doris-connector.md
@@ -802,7 +802,7 @@ Flink Doris Connector 集成了 [Flink CDC](https://nightlies.apache.org/flink/f
 | doris.request.tablet.size   | 1             | N        | 一个 Partition 对应的 Doris Tablet 个数。此数值设置越小，则会生成越多的 Partition，从而提升 Flink 侧的并行度，但同时会对 Doris 造成更大的压力。         |
 | doris.batch.size            | 4064          | N        | 一次从 BE 读取数据的最大行数。增大此数值可减少 Flink 与 Doris 之间建立连接的次数，从而减轻网络延迟所带来的额外时间开销。                               |
 | doris.exec.mem.limit        | 8192mb        | N        | 单个查询的内存限制。默认为 8GB，单位为字节                                                                                                             |
-| source.use-flight-sql       | FALSE         | N        | 是否使用 Arrow Flight SQL 读取                                                                                                                         |
+| source.use-flight-sql       | TRUE          | N        | 是否使用 Arrow Flight SQL 读取                                                                                                                         |
 | source.flight-sql-port      | -             | N        | 使用 Arrow Flight SQL 读取时，FE 的 `arrow_flight_sql_port`                                                                                            |
 
 **DataStream 专有配置项**

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
@@ -32,7 +32,7 @@ $type$ 代表的是周期单位
 | -- | -- |
 | `date_or_time_expr` | 参数是合法的日期表达式，支持输入 date/datetime/timestamptz 类型，具体格式请查看 [timestamptz的转换](../../../../sql-manual/basic-element/sql-data-types/conversion/timestamptz-conversion), [datetime 的转换](../../../../../current/sql-manual/basic-element/sql-data-types/conversion/datetime-conversion) 和 [date 的转换](../../../../../current/sql-manual/basic-element/sql-data-types/conversion/date-conversion) |
 | `period` | 参数是指定每个周期有多少个单位组成,为 `INT` 类型，开始的时间起点为 0001-01-01T00:00:00 |
-| `type` | 参数可以是：YEAR, MONTH, WEEK,DAY, HOUR, MINUTE, SECOND |
+| `type` | 参数可以是：YEAR, QUARTER, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND |
 
 ## 返回值
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-add.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-add.md
@@ -91,5 +91,5 @@ SELECT MINUTES_ADD(NULL, 10), MINUTES_ADD('2023-07-13 22:28:18', NULL) AS result
 
 --- 计算结果超出日期时间范围，报错
 SELECT MINUTES_ADD('9999-12-31 23:59:59', 2) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minutes_add of 9999-12-31 23:59:59, 2 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minute_add of 9999-12-31 23:59:59, 2 out of range
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-sub.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-sub.md
@@ -95,5 +95,5 @@ SELECT MINUTES_SUB(NULL, 10), MINUTES_SUB('2023-07-13 22:28:18', NULL) AS result
 
 --- 计算结果超出日期时间范围，报错
 SELECT MINUTES_SUB('0000-01-01 00:00:00', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minutes_add of 0000-01-01 00:00:00, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minute_add of 0000-01-01 00:00:00, -1 out of range
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/months-add.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/months-add.md
@@ -95,8 +95,8 @@ SELECT MONTHS_ADD('2025-10-10 11:22:33.123+07:00', 1);
 
 --- 计算结果超出日期范围
 mysql> SELECT MONTHS_ADD('9999-12-31', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 9999-12-31, 1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 9999-12-31, 1 out of range
 
 mysql> SELECT MONTHS_ADD('0000-01-01',- 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 0000-01-01, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 0000-01-01, -1 out of range
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/months-sub.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/months-sub.md
@@ -96,8 +96,8 @@ SELECT MONTHS_SUB('2025-10-10 11:22:33.123+07:00', 1);
 
 --- 计算结果超出日期范围
 mysql> SELECT MONTHS_SUB('0000-01-01', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 0000-01-01, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 0000-01-01, -1 out of range
 
 mysql> SELECT MONTHS_SUB('9999-12-31', -1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 9999-12-31, 1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 9999-12-31, 1 out of range
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
@@ -20,7 +20,7 @@
 | -- | -- |
 | `datetime` | The argument is a valid date expression |
 | `period` | The argument specifies how many units make up each period, with the start time being 0001-01-01T00:00:00 |
-| `type` | The argument can be: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND|
+| `type` | The argument can be: YEAR, QUARTER, MONTH, DAY, HOUR, MINUTE, SECOND|
 
 :::tip 
 QUARTER is supported since version 3.0.8 and 3.1.0.

--- a/versioned_docs/version-4.x/connection-integration/data-integration/doris-streamloader.md
+++ b/versioned_docs/version-4.x/connection-integration/data-integration/doris-streamloader.md
@@ -248,7 +248,7 @@ Load Result: {
 
     **To import multiple files, use the `source_file` approach.**
 
-2. **`workers`**: The default value is the number of CPU cores. On machines with many cores (such as 96), this produces too much concurrency. Lower the value. **A common recommendation is `8`**.
+2. **`workers`**: The default value is `0`, which enables automatic mode (the tool computes a value from the import size, `disk_throughput`, and `streamload_throughput`, typically yielding 1, 2, 4, or 8). You can also set it manually — for high-performance clusters you may increase it, but **no more than 10 is recommended**. **A common manual value is `8`**.
 
 3. **`max_byte_per_task`**: A larger value reduces the number of import versions. However, if you encounter a `body exceed max size` error and do not want to adjust `streaming_load_max_mb` (which requires restarting the BE), or if you encounter the `-238 TOO MANY SEGMENT` error, you can lower this value temporarily. **The default usually works.**
 

--- a/versioned_docs/version-4.x/connection-integration/data-integration/flink-doris-connector.md
+++ b/versioned_docs/version-4.x/connection-integration/data-integration/flink-doris-connector.md
@@ -802,7 +802,7 @@ After the Flink cluster is started, you can run the corresponding command accord
 | doris.request.tablet.size   | 1             | N        | The number of Doris Tablets corresponding to one Partition. The smaller this value is set, the more Partitions will be generated, increasing parallelism on the Flink side, but also placing more pressure on Doris. |
 | doris.batch.size            | 4064          | N        | The maximum number of rows read from BE at a time. Increasing this value can reduce the number of connections established between Flink and Doris, thereby reducing the additional time overhead caused by network latency. |
 | doris.exec.mem.limit        | 8192mb        | N        | Memory limit for a single query. The default is 8GB, in bytes.                                                                                         |
-| source.use-flight-sql       | FALSE         | N        | Whether to use Arrow Flight SQL for reading                                                                                                            |
+| source.use-flight-sql       | TRUE          | N        | Whether to use Arrow Flight SQL for reading                                                                                                            |
 | source.flight-sql-port      | -             | N        | When using Arrow Flight SQL for reading, the FE's `arrow_flight_sql_port`                                                                              |
 
 **DataStream-Specific Configuration**

--- a/versioned_docs/version-4.x/data-operate/import/file-format/json.md
+++ b/versioned_docs/version-4.x/data-operate/import/file-format/json.md
@@ -189,7 +189,7 @@ The following table lists the support for JSON-related parameters across the dif
 
 - **Purpose**: Specifies whether to read JSON data line by line.
 - **Type**: Boolean.
-- **Default**: false.
+- **Default**: true if `strip_outer_array` is not set; specifying `strip_outer_array=true` causes it to default to false. (Broker Load and Routine Load always force `read_json_by_line=true`.)
 - **Examples**:
 
     ```json

--- a/versioned_docs/version-4.x/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
+++ b/versioned_docs/version-4.x/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
@@ -152,7 +152,7 @@ mysql> SELECT DISTINCT j FROM test_jsonb_groupby;
    +------+----------+
    ```
 
-   This is because the first `123` is of type `BIGINT`, while the second `123` is of type `TINYINT`, resulting in different binary representations. You can verify their types with the following query:
+   This is because the first `123` is stored internally as a 64-bit integer (`json_type` reports `bigint`), while the second `123` is stored as a narrow integer (`json_type` reports `int` for all sub-`bigint` integer widths), resulting in different binary representations. You can verify their types with the following query:
    ```sql
    mysql> SELECT j, json_type(j, '$') FROM test_jsonb;
    +------+------------------+

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/binary-functions/to-base64-binary.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/binary-functions/to-base64-binary.md
@@ -27,7 +27,7 @@ Returns VARCHAR type, representing the Base64 encoded string.
 
 Special cases:
 - If input is NULL, returns NULL
-- If input is an empty string, returns an empty string
+- If input is an empty VARBINARY (zero bytes), returns an empty string
 
 ## Examples
 

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-floor.md
@@ -32,7 +32,7 @@ $type$ represents the unit of period
 | -- | -- |
 | `date_or_time_expr` | A valid date expression, supporting input of date/datetime/timestamptz types. For specific formats, please refer to [timestamptz conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/timestamptz-conversion), [datetime conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/datetime-conversion) and [date conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/date-conversion) |
 | `period` | Specifies the number of units each period consists of, of `INT` type. The starting time point is 0001-01-01T00:00:00 |
-| `type` | Can be: YEAR, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND |
+| `type` | Can be: YEAR, QUARTER, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND |
 
 ## Return Value
 

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-add.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-add.md
@@ -92,5 +92,5 @@ SELECT MINUTES_ADD(NULL, 10), MINUTES_ADD('2023-07-13 22:28:18', NULL) AS result
 
 -- Calculation result exceeds datetime range, throws error
 SELECT MINUTES_ADD('9999-12-31 23:59:59', 2) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minutes_add of 9999-12-31 23:59:59, 2 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minute_add of 9999-12-31 23:59:59, 2 out of range
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-sub.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/minutes-sub.md
@@ -92,5 +92,5 @@ SELECT MINUTES_SUB(NULL, 10), MINUTES_SUB('2023-07-13 22:28:18', NULL) AS result
 
 -- Calculation result exceeds datetime range, throws error
 SELECT MINUTES_SUB('0000-01-01 00:00:00', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minutes_add of 0000-01-01 00:00:00, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation minute_add of 0000-01-01 00:00:00, -1 out of range
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/months-add.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/months-add.md
@@ -95,8 +95,8 @@ SELECT MONTHS_ADD(NULL, 5), MONTHS_ADD('2023-07-13', NULL) AS result;
 
 -- Calculation result exceeds date range
 SELECT MONTHS_ADD('9999-12-31', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 9999-12-31, 1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 9999-12-31, 1 out of range
 
 SELECT MONTHS_ADD('0000-01-01', -1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 0000-01-01, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 0000-01-01, -1 out of range
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/months-sub.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/months-sub.md
@@ -95,8 +95,8 @@ SELECT MONTHS_SUB('2025-10-10 11:22:33.123+07:00', 1);
 
 --- Calculation result exceeds date range
 mysql> SELECT MONTHS_SUB('0000-01-01', 1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 0000-01-01, -1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 0000-01-01, -1 out of range
 
 mysql> SELECT MONTHS_SUB('9999-12-31', -1) AS result;
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation months_add of 9999-12-31, 1 out of range
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation month_add of 9999-12-31, 1 out of range
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/previous-day.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/previous-day.md
@@ -1,13 +1,14 @@
 ---
 {
     "title": "PREVIOUS_DAY",
-    "language": "en"
+    "language": "en",
+    "description": "Returns the first date matching the target day of the week before the specified date."
 }
 ---
 
 ## Description
 
-The PREVIOUS_DAY function returns the first date that matches the target day of the week before the specified date. For example, `PREVIOUS_DAY('2020-01-31', 'MONDAY')` represents the first Monday before 2020-01-31. This function supports DATE, DATETIME, and TIMESTAMPTZ types, and ignores the time part of the input (calculating based on the date part only).
+The PREVIOUS_DAY function returns the first date that matches the target day of the week before the specified date. For example, `PREVIOUS_DAY('2020-01-31', 'MONDAY')` represents the first Monday before 2020-01-31. This function accepts DATE and DATETIME inputs, ignoring any time portion (calculation is based on the date part only).
 
 ## Syntax
 


### PR DESCRIPTION
## Summary

A pass of doc fixes where the documentation disagreed with what the engine (or the companion tools `doris-streamloader` and `doris-flink-connector`) actually does. Each one was verified against the source.

### `doris-streamloader.md` — `workers` default

Best Practices said the default was "the number of CPU cores". `apache/doris-streamloader/main.go` defines `flag.IntVar(&workers, "workers", 0, ...)` — the default is `0`, which means **automatic mode** (the tool computes a value from import size, `disk_throughput`, and `streamload_throughput`, typically resolving to 1, 2, 4, or 8). CPU cores are not consulted anywhere in `calculateAndCheckWorkers`.

### `flink-doris-connector.md` — `source.use-flight-sql` default

The parameter table said default = `FALSE`, contradicting the prose nearby ("Starting from Doris 2.1, ADBC is the default read protocol"). `apache/doris-flink-connector` `ConfigurationOptions.java` defines `USE_FLIGHT_SQL_DEFAULT = true` since the 25.1.0 connector (PR #574, commit `e691bf89`, 2025-03-13).

Updated the parameter table to `TRUE` in `docs/` and `version-4.x/` (which are paired with the current 25.x connector). `version-2.1/` and `version-3.x/` were left untouched — the connector versions paired with those Doris releases did default to `FALSE`, and the prose claim there is a separate issue that warrants a wider rewrite.

### `json.md` — `read_json_by_line` default

The detailed description further down the page said "Default: false", contradicting the matrix and tip at the top of the same page. The actual default in `JsonFileFormatProperties.java:62-69` is **`true` if neither `read_json_by_line` nor `strip_outer_array` is supplied**; setting `strip_outer_array=true` flips it to `false`. Broker Load and Routine Load always force `true`.

### `JSON.md` — `json_type` returns `"int"`, not `"TINYINT"`

The prose claimed the second `123` was of type `TINYINT`, but the sample output immediately above shows the result `int`. `json_type` (see `be/src/util/jsonb_document.h` `typeName()` around lines 647-680) returns the string `"int"` for `T_Int8`, `T_Int16`, and `T_Int32` — there is no `"tinyint"` / `"smallint"` value. Reworded the prose to match what users actually see.

### `to-base64-binary.md` — edge-case wording

Said "If input is an empty string, returns an empty string". The function takes `VARBINARY`, not string. Reworded to "If input is an empty VARBINARY (zero bytes), returns an empty string".

### `date-floor.md` — QUARTER missing from the type list

`date_ceil` lists `QUARTER` in its type list but `date_floor` did not. The engine supports `date_floor(x, INTERVAL n QUARTER)` — see `fe/fe-core/.../scalar/QuarterFloor.java` and `BuiltinScalarFunctions.java:987 scalar(QuarterFloor.class, "quarter_floor")`. `version-3.x/` already had a tip stating "QUARTER is supported since 3.0.8 and 3.1.0", but the type list still didn't mention it. Added `QUARTER` to the type list in `docs/`, `version-4.x/`, and `version-3.x/`. `version-2.1/` left untouched (engine in 2.1 didn't support `QUARTER` for floor).

### `minutes-sub` / `minutes-add` / `months-sub` / `months-add` — singular vs plural in error tag

Error messages were transcribed as `Operation minutes_add of …` / `Operation months_add of …`, but the engine's `get_time_unit_name` in `be/src/exprs/function/datetime_errors.h` returns the singular tags `minute_add` / `month_add`:

```c++
case TimeUnit::MINUTE: return "minute_add";
case TimeUnit::MONTH:  return "month_add";
```

So the actual error a user sees is `Operation minute_add of …`. The throw-on-overflow refactor that introduced these messages landed in Sept 2025, so this only applies to `docs/` / `version-4.x/` and their zh counterparts (in 2.1/3.x these calls return NULL with no error message).

### `previous-day.md` — frontmatter `description` + TIMESTAMPTZ claim

- Frontmatter was missing a `description` field.
- The body said the function supports `DATE`, `DATETIME`, and `TIMESTAMPTZ`, but the parameter table only lists `DATE` and `DATETIME`, and the FE signature (`PreviousDay.java:40-41`) is `DATE_V2` only:
  ```java
  private static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
      FunctionSignature.ret(DateV2Type.INSTANCE).args(DateV2Type.INSTANCE, StringType.INSTANCE));
  ```
  Aligned the body wording to the parameter table (dropped TIMESTAMPTZ).

## Scope

Changes applied to `docs/`, `versioned_docs/version-{2.1,3.x,4.x}/` where the same content exists, and to `i18n/zh-CN/` for the cases where the English string is reused verbatim (param-table values, error messages, the QUARTER type list) or where the zh prose exists as a direct translation (the `workers` default sentence). For `read_json_by_line`, `JSON_TYPE`, `to-base64-binary`, and `previous-day`, the zh content is structured differently and was left for a separately translated edit.

Findings `#239` (`from_hex`) and `#240` (`to_hex`) were on the audit list but the source confirms the existing docs are already correct — those are not in this PR.

## Test plan

- [x] For each finding, verify the relevant Doris source (config constant, FE signature, BE implementation, error-message helper) and quote the file:line in the commit body.
- [x] Spot-check each rendered diff.
- [ ] CI build (docusaurus + sidebar checks).