### PR TITLE
[fix](doc) add missing FUNCTION keyword to zh DROP FUNCTION syntax

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/function/DROP-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/function/DROP-FUNCTION.md
@@ -13,7 +13,7 @@
 ## 语法
 
 ```sql
-DROP [ GLOBAL ] <function_name> ( <arg_type> )
+DROP [ GLOBAL ] FUNCTION <function_name> ( <arg_type> )
 ```
 
 ## 必选参数

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/function/DROP-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/function/DROP-FUNCTION.md
@@ -13,7 +13,7 @@
 ## 语法
 
 ```sql
-DROP [ GLOBAL ] <function_name> ( <arg_type> )
+DROP [ GLOBAL ] FUNCTION <function_name> ( <arg_type> )
 ```
 
 ## 必选参数

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-statements/function/DROP-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-statements/function/DROP-FUNCTION.md
@@ -13,7 +13,7 @@
 ## 语法
 
 ```sql
-DROP [ GLOBAL ] <function_name> ( <arg_type> )
+DROP [ GLOBAL ] FUNCTION <function_name> ( <arg_type> )
 ```
 
 ## 必选参数

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/function/DROP-FUNCTION.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/function/DROP-FUNCTION.md
@@ -13,7 +13,7 @@
 ## 语法
 
 ```sql
-DROP [ GLOBAL ] <function_name> ( <arg_type> )
+DROP [ GLOBAL ] FUNCTION <function_name> ( <arg_type> )
 ```
 
 ## 必选参数


### PR DESCRIPTION
## Summary

The Chinese `DROP FUNCTION` statement pages document the syntax as:

```
DROP [ GLOBAL ] <function_name> ( <arg_type> )
```

This drops the required `FUNCTION` keyword. The actual statement — and the English version of the same page — is:

```
DROP [ GLOBAL ] FUNCTION <function_name> ( <arg_type> )
```

Corrected the zh-CN current / 2.1 / 3.x / 4.x pages so they match the real syntax and the English docs.

Reported in #3263.

## Test plan

- [x] Confirmed all 4 English `DROP-FUNCTION.md` pages already use the correct `DROP [ GLOBAL ] FUNCTION ...` form.
- [x] Confirmed all 4 zh-CN pages were missing the keyword and now match.
- [ ] CI build.

Closes #3263