### PR TITLE
[doc] Add sample data setup to FOREACH combinator examples

### DIFF
--- a/docs/sql-manual/sql-functions/combinators/foreach.md
+++ b/docs/sql-manual/sql-functions/combinators/foreach.md
@@ -15,6 +15,29 @@ Converts an aggregate function for tables into an aggregate function for arrays 
 `AGGREGATE_FUNCTION_FOREACH(arg...)`
 
 ## Example
+
+Prepare the sample data:
+
+```sql
+CREATE TABLE db (
+    id INT,
+    a  ARRAY<INT>,
+    s  ARRAY<STRING>
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO db VALUES
+    (1, [1, 2, 3], ["ab", "123"]),
+    (2, [20],      ["cd"]),
+    (3, [100],     ["efg"]),
+    (4, NULL,      NULL),
+    (5, [null, 2], [null, "c"]);
+```
+
+Then run the FOREACH combinators:
+
 ```
 mysql [test]>select a , s from db;
 +-----------+---------------+

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/combinators/foreach.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/combinators/foreach.md
@@ -14,6 +14,29 @@
 `AGGREGATE_FUNCTION_FOREACH(arg...)`
 
 ## 举例
+
+准备示例数据：
+
+```sql
+CREATE TABLE db (
+    id INT,
+    a  ARRAY<INT>,
+    s  ARRAY<STRING>
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO db VALUES
+    (1, [1, 2, 3], ["ab", "123"]),
+    (2, [20],      ["cd"]),
+    (3, [100],     ["efg"]),
+    (4, NULL,      NULL),
+    (5, [null, 2], [null, "c"]);
+```
+
+然后执行 FOREACH 组合器：
+
 ```
 mysql [test]>select a , s from db;
 +-----------+---------------+

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/combinators/foreach.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/combinators/foreach.md
@@ -14,6 +14,29 @@
 `AGGREGATE_FUNCTION_FOREACH(arg...)`
 
 ## 举例
+
+准备示例数据：
+
+```sql
+CREATE TABLE db (
+    id INT,
+    a  ARRAY<INT>,
+    s  ARRAY<STRING>
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO db VALUES
+    (1, [1, 2, 3], ["ab", "123"]),
+    (2, [20],      ["cd"]),
+    (3, [100],     ["efg"]),
+    (4, NULL,      NULL),
+    (5, [null, 2], [null, "c"]);
+```
+
+然后执行 FOREACH 组合器：
+
 ```
 mysql [test]>select a , s from db;
 +-----------+---------------+

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/combinators/foreach.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/combinators/foreach.md
@@ -14,6 +14,29 @@
 `AGGREGATE_FUNCTION_FOREACH(arg...)`
 
 ## 举例
+
+准备示例数据：
+
+```sql
+CREATE TABLE db (
+    id INT,
+    a  ARRAY<INT>,
+    s  ARRAY<STRING>
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO db VALUES
+    (1, [1, 2, 3], ["ab", "123"]),
+    (2, [20],      ["cd"]),
+    (3, [100],     ["efg"]),
+    (4, NULL,      NULL),
+    (5, [null, 2], [null, "c"]);
+```
+
+然后执行 FOREACH 组合器：
+
 ```
 mysql [test]>select a , s from db;
 +-----------+---------------+

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/combinators/foreach.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/combinators/foreach.md
@@ -14,6 +14,29 @@
 `AGGREGATE_FUNCTION_FOREACH(arg...)`
 
 ## 举例
+
+准备示例数据：
+
+```sql
+CREATE TABLE db (
+    id INT,
+    a  ARRAY<INT>,
+    s  ARRAY<STRING>
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO db VALUES
+    (1, [1, 2, 3], ["ab", "123"]),
+    (2, [20],      ["cd"]),
+    (3, [100],     ["efg"]),
+    (4, NULL,      NULL),
+    (5, [null, 2], [null, "c"]);
+```
+
+然后执行 FOREACH 组合器：
+
 ```
 mysql [test]>select a , s from db;
 +-----------+---------------+

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/combinators/foreach.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/combinators/foreach.md
@@ -14,6 +14,29 @@ Converts an aggregate function for tables into an aggregate function for arrays 
 `AGGREGATE_FUNCTION_FOREACH(arg...)`
 
 ## example
+
+Prepare the sample data:
+
+```sql
+CREATE TABLE db (
+    id INT,
+    a  ARRAY<INT>,
+    s  ARRAY<STRING>
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO db VALUES
+    (1, [1, 2, 3], ["ab", "123"]),
+    (2, [20],      ["cd"]),
+    (3, [100],     ["efg"]),
+    (4, NULL,      NULL),
+    (5, [null, 2], [null, "c"]);
+```
+
+Then run the FOREACH combinators:
+
 ```
 mysql [test]>select a , s from db;
 +-----------+---------------+

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/combinators/foreach.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/combinators/foreach.md
@@ -14,6 +14,29 @@ Converts an aggregate function for tables into an aggregate function for arrays 
 `AGGREGATE_FUNCTION_FOREACH(arg...)`
 
 ## example
+
+Prepare the sample data:
+
+```sql
+CREATE TABLE db (
+    id INT,
+    a  ARRAY<INT>,
+    s  ARRAY<STRING>
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO db VALUES
+    (1, [1, 2, 3], ["ab", "123"]),
+    (2, [20],      ["cd"]),
+    (3, [100],     ["efg"]),
+    (4, NULL,      NULL),
+    (5, [null, 2], [null, "c"]);
+```
+
+Then run the FOREACH combinators:
+
 ```
 mysql [test]>select a , s from db;
 +-----------+---------------+

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/combinators/foreach.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/combinators/foreach.md
@@ -15,6 +15,29 @@ Converts an aggregate function for tables into an aggregate function for arrays 
 `AGGREGATE_FUNCTION_FOREACH(arg...)`
 
 ## Example
+
+Prepare the sample data:
+
+```sql
+CREATE TABLE db (
+    id INT,
+    a  ARRAY<INT>,
+    s  ARRAY<STRING>
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO db VALUES
+    (1, [1, 2, 3], ["ab", "123"]),
+    (2, [20],      ["cd"]),
+    (3, [100],     ["efg"]),
+    (4, NULL,      NULL),
+    (5, [null, 2], [null, "c"]);
+```
+
+Then run the FOREACH combinators:
+
 ```
 mysql [test]>select a , s from db;
 +-----------+---------------+


### PR DESCRIPTION
## Summary

The `FOREACH` combinator examples query a table named `db` but never show how to create or populate it, so readers cannot copy-paste and reproduce the documented results.

This PR adds a `CREATE TABLE` + `INSERT` block before the existing query examples, making the page self-contained and runnable. The setup was verified against a live Doris instance and reproduces all the example outputs in the doc.

Applied consistently across EN + ZH for versions 2.1 / 3.x / 4.x / current (8 files).

## Test plan

- [x] Ran the added `CREATE TABLE` + `INSERT` on a live cluster
- [x] Confirmed `sum_foreach`, `count_foreach`, `array_agg_foreach`, and `map_agg_foreach` return the documented results