### PR TITLE
[fix](doc) name the default column compression algorithm (ZSTD)

### DIFF
--- a/docs/table-design/column-compression.md
+++ b/docs/table-design/column-compression.md
@@ -122,4 +122,4 @@ PROPERTIES (
 );
 ```
 
-Supported values for `compression` are: `none`, `lz4`, `lz4f`, `lz4hc`, `zstd`, `snappy`, and `zlib`. If not specified explicitly, Doris uses the system default compression algorithm.
+Supported values for `compression` are: `none`, `lz4`, `lz4f`, `lz4hc`, `zstd`, `snappy`, and `zlib`. If not specified explicitly, Doris uses the default compression algorithm `ZSTD` (controlled by the FE configuration `default_compression_type`).

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/column-compression.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/table-design/column-compression.md
@@ -122,4 +122,4 @@ PROPERTIES (
 );
 ```
 
-`compression` 支持的取值：`none`、`lz4`、`lz4f`、`lz4hc`、`zstd`、`snappy`、`zlib`。如未显式指定，Doris 将使用系统默认的压缩算法。
+`compression` 支持的取值：`none`、`lz4`、`lz4f`、`lz4hc`、`zstd`、`snappy`、`zlib`。如未显式指定，Doris 将使用默认压缩算法 `ZSTD`（由 FE 配置项 `default_compression_type` 控制）。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/table-design/column-compression.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/table-design/column-compression.md
@@ -122,4 +122,4 @@ PROPERTIES (
 );
 ```
 
-`compression` 支持的取值：`none`、`lz4`、`lz4f`、`lz4hc`、`zstd`、`snappy`、`zlib`。如未显式指定，Doris 将使用系统默认的压缩算法。
+`compression` 支持的取值：`none`、`lz4`、`lz4f`、`lz4hc`、`zstd`、`snappy`、`zlib`。如未显式指定，Doris 将使用默认压缩算法 `ZSTD`（由 FE 配置项 `default_compression_type` 控制）。

--- a/versioned_docs/version-4.x/table-design/column-compression.md
+++ b/versioned_docs/version-4.x/table-design/column-compression.md
@@ -122,4 +122,4 @@ PROPERTIES (
 );
 ```
 
-Supported values for `compression` are: `none`, `lz4`, `lz4f`, `lz4hc`, `zstd`, `snappy`, and `zlib`. If not specified explicitly, Doris uses the system default compression algorithm.
+Supported values for `compression` are: `none`, `lz4`, `lz4f`, `lz4hc`, `zstd`, `snappy`, and `zlib`. If not specified explicitly, Doris uses the default compression algorithm `ZSTD` (controlled by the FE configuration `default_compression_type`).


### PR DESCRIPTION
## Summary

The column-compression page lists the supported `compression` values and then says:

> If not specified explicitly, Doris uses the system default compression algorithm.

…without naming which one. The default is **ZSTD** (FE configuration `default_compression_type`). Name it explicitly so users don't have to guess:

> If not specified explicitly, Doris uses the default compression algorithm `ZSTD` (controlled by the FE configuration `default_compression_type`).

Applied to the current/4.x EN and zh pages. The 2.1/3.x pages don't carry this sentence, so no change there.

Reported in #2652.

## Test plan

- [x] Default value confirmed in FE source (`Config.default_compression_type = "ZSTD"`).
- [x] Dead-link check passes on the changed files.
- [ ] CI build.

Closes #2652