### PR TITLE
[fix](doc) note that DATE_TRUNC time_unit must be a string constant

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/date-trunc.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/date-trunc.md
@@ -22,7 +22,7 @@ DATE_TRUNC(<time_unit>, <datetime>)
 | Parameter | Description |
 | -- | -- |
 | `<datetime>` | A valid date expression, supporting datetime or date type. For specific formats, please refer to [timestamptz conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/timestamptz-conversion), [datetime conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/datetime-conversion) and [date conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/date-conversion) |
-| `<time_unit>` | The time interval to truncate to. The available values are: [`second`,`minute`,`hour`,`day`,`week`,`month`,`quarter`,`year`] |
+| `<time_unit>` | The time interval to truncate to. The available values are: [`second`,`minute`,`hour`,`day`,`week`,`month`,`quarter`,`year`] The time unit must be a string constant; it cannot be a column or non-constant expression. |
 
 ## Return Value
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/date-trunc.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/date-trunc.md
@@ -24,7 +24,7 @@ DATE_TRUNC(<time_unit>, <datetime>)
 | 参数 | 说明 |
 | -- | -- |
 | `<datetime>` | 合法的日期表达式，支持输入 date/datetime/timestamptz 类型，具体格式请查看 [timestamptz的转换](../../../../sql-manual/basic-element/sql-data-types/conversion/timestamptz-conversion), [datetime 的转换](../../../../../current/sql-manual/basic-element/sql-data-types/conversion/datetime-conversion) 和 [date 的转换](../../../../../current/sql-manual/basic-element/sql-data-types/conversion/date-conversion) |
-| `<time_unit>` | 希望截断的时间间隔，可选的值如下：[`second`,`minute`,`hour`,`day`,`week`,`month`,`quarter`,`year`] |
+| `<time_unit>` | 希望截断的时间间隔，可选的值如下：[`second`,`minute`,`hour`,`day`,`week`,`month`,`quarter`,`year`] 该参数必须是字符串常量，不能是列或非常量表达式。 |
 
 ## 返回值
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-trunc.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-trunc.md
@@ -24,7 +24,7 @@ DATE_TRUNC(<time_unit>, <datetime>)
 | 参数 | 说明 |
 | -- | -- |
 | `<datetime>` | 合法的日期表达式，支持输入 date/datetime/timestamptz 类型，具体格式请查看 [timestamptz的转换](../../../../sql-manual/basic-element/sql-data-types/conversion/timestamptz-conversion), [datetime 的转换](../../../../../current/sql-manual/basic-element/sql-data-types/conversion/datetime-conversion) 和 [date 的转换](../../../../../current/sql-manual/basic-element/sql-data-types/conversion/date-conversion) |
-| `<time_unit>` | 希望截断的时间间隔，可选的值如下：[`second`,`minute`,`hour`,`day`,`week`,`month`,`quarter`,`year`] |
+| `<time_unit>` | 希望截断的时间间隔，可选的值如下：[`second`,`minute`,`hour`,`day`,`week`,`month`,`quarter`,`year`] 该参数必须是字符串常量，不能是列或非常量表达式。 |
 
 ## 返回值
 

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-trunc.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/date-trunc.md
@@ -22,7 +22,7 @@ DATE_TRUNC(<time_unit>, <datetime>)
 | Parameter | Description |
 | -- | -- |
 | `<datetime>` | A valid date expression, supporting datetime or date type. For specific formats, please refer to [timestamptz conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/timestamptz-conversion), [datetime conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/datetime-conversion) and [date conversion](../../../../sql-manual/basic-element/sql-data-types/conversion/date-conversion) |
-| `<time_unit>` | The time interval to truncate to. The available values are: [`second`,`minute`,`hour`,`day`,`week`,`month`,`quarter`,`year`] |
+| `<time_unit>` | The time interval to truncate to. The available values are: [`second`,`minute`,`hour`,`day`,`week`,`month`,`quarter`,`year`] The time unit must be a string constant; it cannot be a column or non-constant expression. |
 
 ## Return Value
 


### PR DESCRIPTION
## Summary

`DATE_TRUNC` accepts both argument orders — `(<datetime>, <time_unit>)` and `(<time_unit>, <datetime>)` — but the **time unit must be a string constant**; it cannot be a column or a non-constant expression. Passing a column there fails with `the ... parameter of date_trunc function must be a string constant`.

Added that constraint to the `<time_unit>` parameter description on the current/4.x EN and zh pages so the requirement is explicit.

Reported in #2673.

## Test plan

- [x] Confirmed in FE source (`DateTrunc.checkLegalityBeforeTypeCoercion` requires a string-literal time unit).
- [x] Dead-link check passes.
- [ ] CI build.

Closes #2673