### PR TITLE
[fix](doc) restructure zh 2.1 function-doc headings + add missing translation

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-contains.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-contains.md
@@ -6,23 +6,19 @@
 }
 ---
 
-## array_contains
-
-array_contains
-
 ## 描述
-
-## 语法
-
-`BOOLEAN array_contains(ARRAY<T> arr, T value)`
 
 判断数组中是否包含 value。返回结果如下：
 
 ```
-1    - value在数组arr中存在；
-0    - value不存在数组arr中；
-NULL - arr为NULL时。
+1    - value 在数组 arr 中存在；
+0    - value 不存在数组 arr 中；
+NULL - arr 为 NULL 时。
 ```
+
+## 语法
+
+`BOOLEAN array_contains(ARRAY<T> arr, T value)`
 
 ## 举例
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/quantile-functions/to-quantile-state.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/quantile-functions/to-quantile-state.md
@@ -6,28 +6,28 @@
 }
 ---
 
-## Description
+## 描述
 
 此函数将数值类型转化成 `QUANTILE_STATE` 类型。 compression 参数是可选项，可设置范围是[2048, 10000]，值越大，后续分位数近似计算的精度越高，内存消耗越大，计算耗时越长。 compression 参数未指定或设置的值在[2048, 10000]范围外，以 2048 的默认值运行
 
-## Syntax
+## 语法
 
 ```sql
 TO_QUANTILE_STATE(<raw_data>, <compression>)
 ```
 
-## Parameters
+## 参数
 
 | 参数 | 描述 |
 | -- | -- |
 | `<raw_data>` | 目标列。|
 | `<compression>` | 压缩阈值。|
 
-## Return value
+## 返回值
 
 转换之后的 `QUANTILE_STATE` 类型的列。
 
-## Example
+## 举例
 
 ```sql
 CREATE TABLE IF NOT EXISTS ${tableName_21} (

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/string-functions/multi-match-any.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/string-functions/multi-match-any.md
@@ -6,14 +6,13 @@
 }
 ---
 
-## multi_match_any
 ## 描述
+
+检查字符串 `haystack` 是否与 re2 语法中的正则表达式 `patterns` 相匹配。如果都没有匹配的正则表达式返回 0，否则返回 1。
+
 ## 语法
 
 `TINYINT multi_match_any(VARCHAR haystack, ARRAY<VARCHAR> patterns)`
-
-
-检查字符串 `haystack` 是否与 re2 语法中的正则表达式 `patterns` 相匹配。如果都没有匹配的正则表达式返回 0，否则返回 1。
 
 ## 举例
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/string-functions/multi-search-all-positions.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/string-functions/multi-search-all-positions.md
@@ -6,13 +6,13 @@
 }
 ---
 
-## multi_search_all_positions
 ## 描述
+
+返回一个 `ARRAY`，其中第 `i` 个元素为 `needles` 中第 `i` 个元素 `needle`，在字符串 `haystack` 中**首次**出现的位置。位置从 1 开始计数，0 代表未找到该元素。**大小写敏感**。
+
 ## 语法
 
 `ARRAY<INT> multi_search_all_positions(VARCHAR haystack, ARRAY<VARCHAR> needles)`
-
-返回一个 `ARRAY`，其中第 `i` 个元素为 `needles` 中第 `i` 个元素 `needle`，在字符串 `haystack` 中**首次**出现的位置。位置从 1 开始计数，0 代表未找到该元素。**大小写敏感**。
 
 ## 举例
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/string-functions/ngram-search.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/string-functions/ngram-search.md
@@ -6,7 +6,7 @@
 }
 ---
 
-## Description
+## 描述
 
 `DOUBLE ngram_search(VARCHAR text,VARCHAR pattern,INT gram_num)`
 
@@ -24,11 +24,11 @@ N-gram 相似度的计算为 2 * |Intersection| / (|text set| + |pattern set|)
 
 仅支持 ASCII 编码。
 
-## Syntax
+## 语法
 
 `DOUBLE ngram_search(VARCHAR text,VARCHAR pattern,INT gram_num)`
 
-## Example
+## 举例
 
 ```sql
 mysql> select ngram_search('123456789' , '12345' , 3);

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/table-and-view/sync-materialized-view/DROP-MATERIALIZED-VIEW.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/table-and-view/sync-materialized-view/DROP-MATERIALIZED-VIEW.md
@@ -1,0 +1,45 @@
+---
+{
+    "title": "DROP MATERIALIZED VIEW",
+    "language": "zh-CN",
+    "description": "删除同步物化视图。"
+}
+---
+
+## 描述
+
+删除同步物化视图。
+
+## 语法
+
+```sql
+DROP MATERIALIZED VIEW 
+[ IF EXISTS ] <materialized_view_name>
+ON <table_name>
+```
+
+## 必选参数
+
+**1. `<materialized_view_name>`**
+
+> 目标要删除的物化视图名称
+
+**2. `<table_name>`**
+
+> 物化视图所属的表
+
+## 权限控制
+
+执行此 SQL 命令的用户必须至少具有以下权限：
+
+| 权限 | 对象 | 说明                                     |
+| :---------------- | :------------- | :--------------------------------------------------- |
+| ALTER_PRIV        | 表    | 需要拥有当前被删除的物化视图所属表的 ALTER_PRIV 权限 |
+
+## 示例
+
+删除 lineitem 表上的 sync_agg_mv 同步物化视图
+
+```sql
+DROP MATERIALIZED VIEW sync_agg_mv on lineitem;
+```


### PR DESCRIPTION
## Summary

Structure/translation fixes in the Chinese 2.1 docs (reader-reported):

| Issue | File | Fix |
| --- | --- | --- |
| #2525 | string-functions/ngram-search | section headings still English (`## Description/Syntax/Example`) → 描述/语法/举例 |
| #2537 | quantile-functions/to-quantile-state | English headings → 描述/语法/参数/返回值/举例 |
| #2526 | string-functions/multi-search-all-positions | redundant title + empty `## 描述`/`## 语法` with desc & signature both under 语法 → restructure |
| #2527 | string-functions/multi-match-any | same empty-skeleton pattern → restructure |
| #2530 | array-functions/array-contains | redundant title + stray duplicate line + empty skeleton → restructure |
| #2544 | sync-materialized-view/DROP-MATERIALIZED-VIEW | zh 2.1 page missing (site showed English fallback) → add Chinese translation |

## Test plan

- [x] Dead-link check passes.
- [ ] CI build.

Closes #2525
Closes #2537
Closes #2526
Closes #2527
Closes #2530
Closes #2544