### PR TITLE
[fix](doc) use trim (not trim_in) on the zh 2.1 TRIM page

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/string-functions/trim.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/string-functions/trim.md
@@ -13,7 +13,7 @@
 ## 语法
 
 ```sql
-TRIM_IN( <str> [ , <rhs>])
+TRIM( <str> [ , <rhs>])
 ```
 ## 必选参数
 
@@ -35,7 +35,7 @@ TRIM_IN( <str> [ , <rhs>])
 ## 举例
 
 ```sql
-SELECT trim_in('   ab d   ') str;
+SELECT trim('   ab d   ') str;
 ```
 
 ```sql
@@ -47,7 +47,7 @@ SELECT trim_in('   ab d   ') str;
 ```
 
 ```sql
-SELECT trim_in('ababccaab','ab') str;
+SELECT trim('ababccaab','ab') str;
 ```
 
 ```sql


### PR DESCRIPTION
## Summary

The Chinese 2.1 `TRIM` page is titled **TRIM**, but its syntax and examples used `TRIM_IN` / `trim_in` — a different function. Renamed to `TRIM` / `trim` to match the page title and the English 2.1 page (which uses `trim` with the same examples/result).

(Scope kept minimal: only the function name is corrected. The example result and description match the English 2.1 page and are left as-is.)

Reported in #2522.

## Test plan

- [x] No `trim_in` remains; syntax + examples now use `TRIM`/`trim`, matching the EN 2.1 page.
- [x] Dead-link check passes.
- [ ] CI build.

Closes #2522