### PR TITLE
[fix](doc) add GROUP_CONCAT ORDER BY examples to 2.1/3.x group-concat docs

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -70,6 +70,34 @@ select GROUP_CONCAT(DISTINCT value) from test;
 +-----------------------+
 ```
 
+```sql
+select GROUP_CONCAT(value ORDER BY value DESC) from test;
+```
+
+```text
++-----------------------+
+| GROUP_CONCAT(`value`) |
++-----------------------+
+| c, c, b, a            |
++-----------------------+
+```
+
+:::note
+`GROUP_CONCAT` 中 `DISTINCT` 与 `ORDER BY` 组合自 2.1.6 起支持。
+:::
+
+```sql
+select GROUP_CONCAT(DISTINCT value ORDER BY value DESC) from test;
+```
+
+```text
++-----------------------+
+| GROUP_CONCAT(`value`) |
++-----------------------+
+| c, b, a               |
++-----------------------+
+```
+
 ```sql 
 select GROUP_CONCAT(value, " ") from test;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -70,6 +70,34 @@ select GROUP_CONCAT(DISTINCT value) from test;
 +-----------------------+
 ```
 
+```sql
+select GROUP_CONCAT(value ORDER BY value DESC) from test;
+```
+
+```text
++-----------------------+
+| GROUP_CONCAT(`value`) |
++-----------------------+
+| c, c, b, a            |
++-----------------------+
+```
+
+:::note
+`GROUP_CONCAT` 中 `DISTINCT` 与 `ORDER BY` 组合自 3.0.2 起支持。
+:::
+
+```sql
+select GROUP_CONCAT(DISTINCT value ORDER BY value DESC) from test;
+```
+
+```text
++-----------------------+
+| GROUP_CONCAT(`value`) |
++-----------------------+
+| c, b, a               |
++-----------------------+
+```
+
 ```sql 
 select GROUP_CONCAT(value, " ") from test;
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -70,6 +70,34 @@ select GROUP_CONCAT(DISTINCT value) from test;
 +-----------------------+
 ```
 
+```sql
+select GROUP_CONCAT(value ORDER BY value DESC) from test;
+```
+
+```text
++-----------------------+
+| GROUP_CONCAT(`value`) |
++-----------------------+
+| c, c, b, a            |
++-----------------------+
+```
+
+:::note
+Combining `DISTINCT` with `ORDER BY` inside `GROUP_CONCAT` is supported since 2.1.6.
+:::
+
+```sql
+select GROUP_CONCAT(DISTINCT value ORDER BY value DESC) from test;
+```
+
+```text
++-----------------------+
+| GROUP_CONCAT(`value`) |
++-----------------------+
+| c, b, a               |
++-----------------------+
+```
+
 ```sql 
 select GROUP_CONCAT(value, " ") from test;
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -70,6 +70,34 @@ select GROUP_CONCAT(DISTINCT value) from test;
 +-----------------------+
 ```
 
+```sql
+select GROUP_CONCAT(value ORDER BY value DESC) from test;
+```
+
+```text
++-----------------------+
+| GROUP_CONCAT(`value`) |
++-----------------------+
+| c, c, b, a            |
++-----------------------+
+```
+
+:::note
+Combining `DISTINCT` with `ORDER BY` inside `GROUP_CONCAT` is supported since 3.0.2.
+:::
+
+```sql
+select GROUP_CONCAT(DISTINCT value ORDER BY value DESC) from test;
+```
+
+```text
++-----------------------+
+| GROUP_CONCAT(`value`) |
++-----------------------+
+| c, b, a               |
++-----------------------+
+```
+
 ```sql 
 select GROUP_CONCAT(value, " ") from test;
 ```


### PR DESCRIPTION
## Summary

The `GROUP_CONCAT` page syntax already advertises `[ORDER BY {<col_name>|<expr>} [ASC|DESC]]`, but the Examples section on 2.1/3.x only showed the basic and `DISTINCT` forms, so a reader couldn't see how `ORDER BY` actually attaches *inside* `GROUP_CONCAT`. The current/4.x pages already carry two `ORDER BY` examples — backport them to 2.1/3.x (EN + zh), with a version note on the DISTINCT + ORDER BY combination so users on older patch releases don't hit a parser error.

Added examples (matching the form already shipped in current/4.x):

```sql
select GROUP_CONCAT(value ORDER BY value DESC) from test;
-- => "c, c, b, a"

-- DISTINCT + ORDER BY is supported since 2.1.6 / 3.0.2 — see note above the example
select GROUP_CONCAT(DISTINCT value ORDER BY value DESC) from test;
-- => "c, b, a"
```

### Version verification (from Doris source)
- Basic `GROUP_CONCAT(... ORDER BY ...)`: introduced in Nereids by apache/doris#15671 + apache/doris#16081 (Jan 2023, before 2.0 GA) → works on 2.1.x and 3.x.
- `GROUP_CONCAT(DISTINCT ... ORDER BY ...)`: apache/doris#38080, labels `dev/2.1.6-merged, dev/3.0.2-merged` → only valid on 2.1.6+ and 3.0.2+. The page therefore carries an inline `:::note` flagging this minimum-version requirement (2.1.6 in the 2.1 docs, 3.0.2 in the 3.x docs).

## Test plan
- [x] All 4 backported files now have 6 `GROUP_CONCAT(...)` example calls, matching current/4.x.
- [x] DISTINCT + ORDER BY example is accompanied by a minimum-version note (2.1.6 for the 2.1 docs, 3.0.2 for the 3.x docs).
- [x] Dead-link check passes.
- [ ] CI build.

Closes #3487