### PR TITLE
[fix](doc) clarify fs.defaultFS conditional-required nature in hive-catalog syntax

### DIFF
--- a/docs/lakehouse/catalogs/hive-catalog.mdx
+++ b/docs/lakehouse/catalogs/hive-catalog.mdx
@@ -30,7 +30,7 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
     'type'='hms', -- required
     'hive.metastore.type' = '<hive_metastore_type>', -- optional
     'hive.version' = '<hive_version>', -- optional
-    'fs.defaultFS' = '<fs_defaultfs>', -- optional
+    'fs.defaultFS' = '<fs_defaultfs>', -- required for write, optional for read-only
     {MetaStoreProperties},
     {StorageProperties},
     {HiveProperties},

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/hive-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/hive-catalog.mdx
@@ -30,7 +30,7 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
     'type'='hms', -- required
     'hive.metastore.type' = '<hive_metastore_type>', -- optional
     'hive.version' = '<hive_version>', -- optional
-    'fs.defaultFS' = '<fs_defaultfs>', -- optional
+    'fs.defaultFS' = '<fs_defaultfs>', -- 写入必填，只读时可选
     {MetaStoreProperties},
     {StorageProperties},
     {HiveProperties},

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/lakehouse/catalogs/hive-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/lakehouse/catalogs/hive-catalog.mdx
@@ -13,6 +13,10 @@ import TabItem from '@theme/TabItem';
 
 除了 Hive 外，很多其他系统也会使用 Hive Metastore 存储元数据。所以通过 Hive Catalog，我们不仅能访问 Hive 表，也能访问使用 Hive Metastore 作为元数据存储的其他表格式，如 Iceberg、Hudi 等。
 
+:::note
+通过 Doris 写入 Hive 的能力自 2.1.3 版本起支持，2.1.3 之前的版本仅支持查询。
+:::
+
 ## 适用场景
 
 | 场景 | 说明                 |
@@ -30,7 +34,7 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
     'type'='hms', -- required
     'hive.metastore.type' = '<hive_metastore_type>', -- optional
     'hive.version' = '<hive_version>', -- optional
-    'fs.defaultFS' = '<fs_defaultfs>', -- optional
+    'fs.defaultFS' = '<fs_defaultfs>', -- 写入必填，只读时可选
     {MetaStoreProperties},
     {StorageProperties},
     {HiveProperties},

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/lakehouse/catalogs/hive-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/lakehouse/catalogs/hive-catalog.mdx
@@ -30,7 +30,7 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
     'type'='hms', -- required
     'hive.metastore.type' = '<hive_metastore_type>', -- optional
     'hive.version' = '<hive_version>', -- optional
-    'fs.defaultFS' = '<fs_defaultfs>', -- optional
+    'fs.defaultFS' = '<fs_defaultfs>', -- 写入必填，只读时可选
     {MetaStoreProperties},
     {StorageProperties},
     {HiveProperties},

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/hive-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/hive-catalog.mdx
@@ -30,7 +30,7 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
     'type'='hms', -- required
     'hive.metastore.type' = '<hive_metastore_type>', -- optional
     'hive.version' = '<hive_version>', -- optional
-    'fs.defaultFS' = '<fs_defaultfs>', -- optional
+    'fs.defaultFS' = '<fs_defaultfs>', -- 写入必填，只读时可选
     {MetaStoreProperties},
     {StorageProperties},
     {HiveProperties},

--- a/versioned_docs/version-2.1/lakehouse/catalogs/hive-catalog.mdx
+++ b/versioned_docs/version-2.1/lakehouse/catalogs/hive-catalog.mdx
@@ -13,6 +13,10 @@ By connecting to Hive Metastore or metadata services compatible with Hive Metast
 
 In addition to Hive, many other systems use Hive Metastore to store metadata. Therefore, through the Hive Catalog, we can access not only Hive tables but also other table formats that use Hive Metastore for metadata storage, such as Iceberg and Hudi.
 
+:::note
+Writing to Hive through Doris is supported from version 2.1.3. Earlier 2.1.x releases only support querying.
+:::
+
 ## Applicable Scenarios
 
 | Scenario     | Description                                                  |
@@ -30,7 +34,7 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
     'type'='hms', -- required
     'hive.metastore.type' = '<hive_metastore_type>', -- optional
     'hive.version' = '<hive_version>', -- optional
-    'fs.defaultFS' = '<fs_defaultfs>', -- optional
+    'fs.defaultFS' = '<fs_defaultfs>', -- required for write, optional for read-only
     {MetaStoreProperties},
     {StorageProperties},
     {HiveProperties},

--- a/versioned_docs/version-3.x/lakehouse/catalogs/hive-catalog.mdx
+++ b/versioned_docs/version-3.x/lakehouse/catalogs/hive-catalog.mdx
@@ -30,7 +30,7 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
     'type'='hms', -- required
     'hive.metastore.type' = '<hive_metastore_type>', -- optional
     'hive.version' = '<hive_version>', -- optional
-    'fs.defaultFS' = '<fs_defaultfs>', -- optional
+    'fs.defaultFS' = '<fs_defaultfs>', -- required for write, optional for read-only
     {MetaStoreProperties},
     {StorageProperties},
     {HiveProperties},

--- a/versioned_docs/version-4.x/lakehouse/catalogs/hive-catalog.mdx
+++ b/versioned_docs/version-4.x/lakehouse/catalogs/hive-catalog.mdx
@@ -30,7 +30,7 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
     'type'='hms', -- required
     'hive.metastore.type' = '<hive_metastore_type>', -- optional
     'hive.version' = '<hive_version>', -- optional
-    'fs.defaultFS' = '<fs_defaultfs>', -- optional
+    'fs.defaultFS' = '<fs_defaultfs>', -- required for write, optional for read-only
     {MetaStoreProperties},
     {StorageProperties},
     {HiveProperties},


### PR DESCRIPTION
## Summary

Fixes #3466. The hive-catalog page's inline syntax block had `'fs.defaultFS' = '<fs_defaultfs>', -- optional`, while the page's own description (and the 2.1 page's note) says this property is required when writing through Doris. The two statements contradicted each other.

This PR makes the inline comment match the description across all maintained versions (EN + zh, current/dev/3.x/4.x/2.1):

- EN: `'fs.defaultFS' = '<fs_defaultfs>', -- required for write, optional for read-only`
- zh: `'fs.defaultFS' = '<fs_defaultfs>', -- 写入必填，只读时可选`

Additionally, the 2.1 pages get a top-of-page `:::note` clarifying that Hive write via Doris is only supported from 2.1.3 onward (per the [2.1.3 release notes](https://doris.apache.org/docs/releasenotes/v2.1/release-2.1.3)) — earlier 2.1.x releases are query-only.

## Test plan

- [x] Inline comment in the syntax block on each page reflects the conditional requirement
- [x] 2.1 EN + zh pages carry the "supported since 2.1.3" version note
- [x] Dead-link check passes