### PR TITLE
[fix](doc) correct default_compression_type default value and valid values list

### DIFF
--- a/docs/admin-manual/config/fe-config.md
+++ b/docs/admin-manual/config/fe-config.md
@@ -2152,9 +2152,9 @@ When create a table(or partition), you can specify its storage medium(HDD or SSD
 
 #### `default_compression_type`
 
-Default: lz4 (before 4.0.3), zstd (since 4.0.3)
+Default: LZ4F (before 4.0.3), ZSTD (since 4.0.3)
 
-When creating a table, you can specify its compression algorithm. If not set, this specifies the default compression type when creating a table. Valid values include: lz4, zstd.
+When creating a table, you can specify its compression algorithm. If not set, this specifies the default compression type when creating a table. Valid values: LZ4, LZ4F, LZ4HC, ZLIB, ZSTD, SNAPPY, NONE (case-insensitive).
 
 #### `enable_storage_policy`
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/config/fe-config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/config/fe-config.md
@@ -2167,9 +2167,9 @@ tablet 状态更新间隔
 
 #### `default_compression_type`
 
-默认值：lz4（4.0.3 之前），zstd（4.0.3 及之后）
+默认值：LZ4F（4.0.3 之前），ZSTD（4.0.3 及之后）
 
-创建表时可以指定其压缩算法。如果未设置，则此配置项指定创建表时的默认压缩类型。有效值包括：lz4、zstd。
+创建表时可以指定其压缩算法。如果未设置，则此配置项指定创建表时的默认压缩类型。有效值：LZ4、LZ4F、LZ4HC、ZLIB、ZSTD、SNAPPY、NONE（大小写不敏感）。
 
 #### `enable_storage_policy`
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/config/fe-config.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/config/fe-config.md
@@ -2167,9 +2167,9 @@ tablet 状态更新间隔
 
 #### `default_compression_type`
 
-默认值：lz4（4.0.3 之前），zstd（4.0.3 及之后）
+默认值：LZ4F（4.0.3 之前），ZSTD（4.0.3 及之后）
 
-创建表时可以指定其压缩算法。如果未设置，则此配置项指定创建表时的默认压缩类型。有效值包括：lz4、zstd。
+创建表时可以指定其压缩算法。如果未设置，则此配置项指定创建表时的默认压缩类型。有效值：LZ4、LZ4F、LZ4HC、ZLIB、ZSTD、SNAPPY、NONE（大小写不敏感）。
 
 #### `enable_storage_policy`
 

--- a/versioned_docs/version-4.x/admin-manual/config/fe-config.md
+++ b/versioned_docs/version-4.x/admin-manual/config/fe-config.md
@@ -2152,9 +2152,9 @@ When create a table(or partition), you can specify its storage medium(HDD or SSD
 
 #### `default_compression_type`
 
-Default: lz4 (before 4.0.3), zstd (since 4.0.3)
+Default: LZ4F (before 4.0.3), ZSTD (since 4.0.3)
 
-When creating a table, you can specify its compression algorithm. If not set, this specifies the default compression type when creating a table. Valid values include: lz4, zstd.
+When creating a table, you can specify its compression algorithm. If not set, this specifies the default compression type when creating a table. Valid values: LZ4, LZ4F, LZ4HC, ZLIB, ZSTD, SNAPPY, NONE (case-insensitive).
 
 #### `enable_storage_policy`
 


### PR DESCRIPTION
## Summary

Fixes #3463. The fe-config doc for `default_compression_type` had two factual errors:

1. **Default value** — doc said `lz4` (before 4.0.3) / `zstd` (since 4.0.3). The actual FE Config in apache/doris is `LZ4F` (before 4.0.3) and `ZSTD` (since 4.0.3). The default was changed by apache/doris#58923 (label `dev/4.0.3-merged`) — "[opt](compression) change default compression from lz4f to zstd". `LZ4` and `LZ4F` are different algorithms (raw block vs frame format), so the previous `lz4` was simply wrong.

2. **Valid values** — doc said "lz4, zstd". The `Config.java` description and `PropertyAnalyzer.stringToCompressionType` actually accept seven algorithms: `LZ4`, `LZ4F`, `LZ4HC`, `ZLIB`, `ZSTD`, `SNAPPY`, `NONE` (case-insensitive).

Source-of-truth references:
- `fe/fe-common/src/main/java/org/apache/doris/common/Config.java` (`default_compression_type` field, both pre-58923 and post-58923 values)
- `fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java#stringToCompressionType` (accepted values)

## Scope

Updated in 4 places (current/dev EN + zh, 4.x EN + zh):
- `docs/admin-manual/config/fe-config.md`
- `i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/config/fe-config.md`
- `versioned_docs/version-4.x/admin-manual/config/fe-config.md`
- `i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/config/fe-config.md`

The parameter does not exist in `branch-2.1` or `branch-3.0`, so the 2.1 docs need no change.

## Test plan

- [x] Each touched page shows the corrected default (`LZ4F` / `ZSTD`) and the full valid-values list
- [x] Dead-link check passes