### PR TITLE
[fix](doc) clarify type vs provider naming on CREATE-STORAGE-VAULT pages

### DIFF
--- a/docs/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
+++ b/docs/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
@@ -32,6 +32,10 @@ CREATE STORAGE VAULT [IF NOT EXISTS] <vault_name> [ <properties> ]
 | `[IF NOT EXISTS]` | If the specified storage vault already exists, the creation operation will not be executed, and no error will be thrown. This prevents duplicate creation of the same storage vault. |
 | `<properties>`    | A set of key-value pairs used to set or update specific properties of the storage vault. Each property consists of a key (<key>) and a value (<value>), separated by an equals sign (=). Multiple key-value pairs are separated by commas (,). |
 
+:::note
+The `type` property accepts only two values: `"S3"` or `"hdfs"` (case-insensitive). All object-storage backends — Amazon S3, Alibaba Cloud OSS, Tencent Cloud COS, Huawei Cloud OBS, Baidu Cloud BOS, MinIO, Azure Blob Storage, and Google Cloud Storage — use `"type" = "S3"` because Doris accesses them through the S3-compatible API. The actual cloud is selected by the separate `provider` property (`COS`, `OSS`, `S3`, `OBS`, `BOS`, `AZURE`, or `GCP`). The `s3.access_key` / `s3.secret_key` property names follow the same convention and are not specific to AWS S3.
+:::
+
 ### S3 Vault
 
 | Parameter              | Required | Description                                                                                                      |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
@@ -31,6 +31,10 @@ CREATE STORAGE VAULT [IF NOT EXISTS] <`vault_name`> [ <`properties`> ]
 | `[IF NOT EXISTS]` | 如果指定的存储库已经存在，则不会执行创建操作，并且不会抛出错误。这可以防止重复创建相同的存储库。 |
 | `PROPERTIES`      | 一组键值对，用来设置或更新存储库的具体属性。每个属性由键（`<key>`）和值（`<value>`）组成，并用等号 (`=`) 分隔。多个键值对之间用逗号 (`,`) 分隔。 |
 
+:::note
+`type` 属性只接受两种取值：`"S3"` 或 `"hdfs"`（不区分大小写）。所有对象存储后端 —— Amazon S3、阿里云 OSS、腾讯云 COS、华为云 OBS、百度云 BOS、MinIO、Azure Blob Storage、Google Cloud Storage —— 都使用 `"type" = "S3"`，因为 Doris 通过 S3 兼容 API 访问它们。具体的云厂商由 `provider` 属性指定（`COS`、`OSS`、`S3`、`OBS`、`BOS`、`AZURE`、`GCP` 之一）。`s3.access_key` / `s3.secret_key` 属性命名同理，并非特指 AWS S3。
+:::
+
 ### S3 Vault
 
 | 参数              | 是否必需 | 描述                                                                                                      |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
@@ -31,6 +31,10 @@ CREATE STORAGE VAULT [IF NOT EXISTS] <`vault_name`> [ <`properties`> ]
 | `[IF NOT EXISTS]` | 如果指定的存储库已经存在，则不会执行创建操作，并且不会抛出错误。这可以防止重复创建相同的存储库。 |
 | `PROPERTIES`      | 一组键值对，用来设置或更新存储库的具体属性。每个属性由键（`<key>`）和值（`<value>`）组成，并用等号 (`=`) 分隔。多个键值对之间用逗号 (`,`) 分隔。 |
 
+:::note
+`type` 属性只接受两种取值：`"S3"` 或 `"hdfs"`（不区分大小写）。所有对象存储后端 —— Amazon S3、阿里云 OSS、腾讯云 COS、华为云 OBS、百度云 BOS、MinIO、Azure Blob Storage、Google Cloud Storage —— 都使用 `"type" = "S3"`，因为 Doris 通过 S3 兼容 API 访问它们。具体的云厂商由 `provider` 属性指定（`COS`、`OSS`、`S3`、`OBS`、`BOS`、`AZURE`、`GCP` 之一）。`s3.access_key` / `s3.secret_key` 属性命名同理，并非特指 AWS S3。
+:::
+
 ### S3 Vault
 
 | 参数              | 是否必需 | 描述                                                                                                      |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
@@ -31,6 +31,10 @@ CREATE STORAGE VAULT [IF NOT EXISTS] <`vault_name`> [ <`properties`> ]
 | `[IF NOT EXISTS]` | 如果指定的存储库已经存在，则不会执行创建操作，并且不会抛出错误。这可以防止重复创建相同的存储库。 |
 | `PROPERTIES`      | 一组键值对，用来设置或更新存储库的具体属性。每个属性由键（`<key>`）和值（`<value>`）组成，并用等号 (`=`) 分隔。多个键值对之间用逗号 (`,`) 分隔。 |
 
+:::note
+`type` 属性只接受两种取值：`"S3"` 或 `"hdfs"`（不区分大小写）。所有对象存储后端 —— Amazon S3、阿里云 OSS、腾讯云 COS、华为云 OBS、百度云 BOS、MinIO、Azure Blob Storage、Google Cloud Storage —— 都使用 `"type" = "S3"`，因为 Doris 通过 S3 兼容 API 访问它们。具体的云厂商由 `provider` 属性指定（`COS`、`OSS`、`S3`、`OBS`、`BOS`、`AZURE`、`GCP` 之一）。`s3.access_key` / `s3.secret_key` 属性命名同理，并非特指 AWS S3。
+:::
+
 ### S3 Vault
 
 | 参数              | 是否必需 | 描述                                                                                                      |

--- a/versioned_docs/version-3.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
@@ -32,6 +32,10 @@ CREATE STORAGE VAULT [IF NOT EXISTS] <vault_name> [ <properties> ]
 | `[IF NOT EXISTS]` | If the specified storage vault already exists, the creation operation will not be executed, and no error will be thrown. This prevents duplicate creation of the same storage vault. |
 | `<properties>`    | A set of key-value pairs used to set or update specific properties of the storage vault. Each property consists of a key (<key>) and a value (<value>), separated by an equals sign (=). Multiple key-value pairs are separated by commas (,). |
 
+:::note
+The `type` property accepts only two values: `"S3"` or `"hdfs"` (case-insensitive). All object-storage backends — Amazon S3, Alibaba Cloud OSS, Tencent Cloud COS, Huawei Cloud OBS, Baidu Cloud BOS, MinIO, Azure Blob Storage, and Google Cloud Storage — use `"type" = "S3"` because Doris accesses them through the S3-compatible API. The actual cloud is selected by the separate `provider` property (`COS`, `OSS`, `S3`, `OBS`, `BOS`, `AZURE`, or `GCP`). The `s3.access_key` / `s3.secret_key` property names follow the same convention and are not specific to AWS S3.
+:::
+
 ### S3 Vault
 
 | Parameter              | Required | Description                                                                                                      |

--- a/versioned_docs/version-4.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
@@ -32,6 +32,10 @@ CREATE STORAGE VAULT [IF NOT EXISTS] <vault_name> [ <properties> ]
 | `[IF NOT EXISTS]` | If the specified storage vault already exists, the creation operation will not be executed, and no error will be thrown. This prevents duplicate creation of the same storage vault. |
 | `<properties>`    | A set of key-value pairs used to set or update specific properties of the storage vault. Each property consists of a key (<key>) and a value (<value>), separated by an equals sign (=). Multiple key-value pairs are separated by commas (,). |
 
+:::note
+The `type` property accepts only two values: `"S3"` or `"hdfs"` (case-insensitive). All object-storage backends — Amazon S3, Alibaba Cloud OSS, Tencent Cloud COS, Huawei Cloud OBS, Baidu Cloud BOS, MinIO, Azure Blob Storage, and Google Cloud Storage — use `"type" = "S3"` because Doris accesses them through the S3-compatible API. The actual cloud is selected by the separate `provider` property (`COS`, `OSS`, `S3`, `OBS`, `BOS`, `AZURE`, or `GCP`). The `s3.access_key` / `s3.secret_key` property names follow the same convention and are not specific to AWS S3.
+:::
+
 ### S3 Vault
 
 | Parameter              | Required | Description                                                                                                      |


### PR DESCRIPTION
## Summary

Fixes #3124. The reporter pointed out that every non-HDFS example on the \`CREATE-STORAGE-VAULT\` page uses \`\"type\" = \"S3\"\` and \`s3.access_key\` / \`s3.secret_key\` — for OSS, COS, OBS, BOS, MinIO, Azure Blob, and GCS — which reads as a copy-paste mistake.

It is not a bug. The FE \`StorageVaultType\` enum at [\`fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java\`](https://github.com/apache/doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVault.java#L51-L65) defines only two values, \`S3\` and \`HDFS\` (verified identical on \`branch-3.0\`, \`branch-3.1\`, \`branch-4.0\`, \`branch-4.1\`). All object-storage backends speak to Doris through the S3-compatible client; the actual cloud is selected by the separate \`provider\` property (\`COS\`, \`OSS\`, \`S3\`, \`OBS\`, \`BOS\`, \`AZURE\`, \`GCP\`). The \`s3.*\` property prefix follows the same S3-API convention and is not literally about AWS S3.

This PR adds a \`:::note\` admonition immediately before the \`### S3 Vault\` parameters table on all six maintained pages (current/3.x/4.x EN + zh), so first-time readers don't read the examples as duplicated.

## Scope

6 files, +24 lines, +0 lines removed:
- \`docs/.../CREATE-STORAGE-VAULT.md\` (current EN)
- \`versioned_docs/version-3.x/.../CREATE-STORAGE-VAULT.md\`
- \`versioned_docs/version-4.x/.../CREATE-STORAGE-VAULT.md\`
- \`i18n/zh-CN/.../current/.../CREATE-STORAGE-VAULT.md\`
- \`i18n/zh-CN/.../version-3.x/.../CREATE-STORAGE-VAULT.md\`
- \`i18n/zh-CN/.../version-4.x/.../CREATE-STORAGE-VAULT.md\`

No changes to existing examples or parameter tables. \`version-2.1\` does not have the storage-vault feature so no edit needed there.

## Test plan

- [x] Note placed directly above \`### S3 Vault\` table on all 6 pages
- [x] Dead-link check passes
- [x] No example code changed

Closes #3124