### PR TITLE
[fix](doc) spell out 'integration' and 'Kafka' correctly

### DIFF
--- a/docs/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
+++ b/docs/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
@@ -145,7 +145,7 @@ Spark related parameters are as follows:
        - `s3.connection.request.timeout`: s3 request timeout, in milliseconds, the default is 3000
        - `s3.connection.timeout`: s3 connection timeout, in milliseconds, the default is 1000
 
-    Doris also supported `AWS Assume Role` for creating S3 Resource , please refer to [AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
+    Doris also supported `AWS Assume Role` for creating S3 Resource , please refer to [AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
 
 **4. Create JDBC resource**
 

--- a/docs/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
+++ b/docs/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
@@ -49,7 +49,7 @@ CREATE STORAGE VAULT [IF NOT EXISTS] <vault_name> [ <properties> ]
 
 1. `s3.endpoint` if neither `http://` nor `https://` prefix is not provided, ​​`http`​​ will be used by default. If a prefix is explicitly specified, it will take effect with the prefix;
 
-2. Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS intergration](../../../../lakehouse/storages/s3.md).
+2. Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS integration](../../../../lakehouse/storages/s3.md).
 
 ### HDFS vault
 
@@ -166,7 +166,7 @@ PROPERTIES (
 
 **Note:&#x20;**
 
-Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS intergration](../../../../lakehouse/storages/s3.md)
+Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS integration](../../../../lakehouse/storages/s3.md)
 
 
 ### 7. Create MinIO storage vault

--- a/docs/sql-manual/sql-statements/data-modification/backup-and-restore/CREATE-REPOSITORY.md
+++ b/docs/sql-manual/sql-statements/data-modification/backup-and-restore/CREATE-REPOSITORY.md
@@ -47,7 +47,7 @@ CREATE [READ ONLY] REPOSITORY <repo_name>
 
 **Note:&#x20;**
 
-Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
+Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
 
 ## Access Control Requirements
 
@@ -82,7 +82,7 @@ PROPERTIES
 ```
 **Note:&#x20;**
 
-Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
+Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
 
 Create a repository named hdfs_repo.
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
@@ -143,7 +143,7 @@ S3 相关参数如下：
       - `s3.connection.request.timeout`：s3 请求超时时间，单位毫秒，默认为 3000
       - `s3.connection.timeout`：s3 连接超时时间，单位毫秒，默认为 1000
 
-    Doris 也支持通过 `AWS Assume Role` 的方式创建 S3 Resource, 请参考如下文档配置和使用[AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
+    Doris 也支持通过 `AWS Assume Role` 的方式创建 S3 Resource, 请参考如下文档配置和使用[AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
 
 **4. 创建 JDBC resource**
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/load-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/load-manual.md
@@ -46,6 +46,6 @@ Doris 的导入主要涉及数据源、数据格式、导入方式、错误数�
 | [Broker Load](./import-way/broker-load-manual.md)        | 从对象存储、HDFS 等导入                     | csv、json、parquet、orc | 异步     |
 | [INSERT INTO VALUES](./import-way/insert-into-manual.md) | 通过 JDBC 等接口导入 | SQL                     | 同步     |
 | [INSERT INTO SELECT](./import-way/insert-into-manual.md) | 可以导入外部表或者对象存储、HDFS 中的文件      | SQL                     | 同步     |
-| [Routine Load](./import-way/routine-load-manual.md)      | 从 kakfa 实时导入                            | csv、json               | 异步     |
+| [Routine Load](./import-way/routine-load-manual.md)      | 从 Kafka 实时导入                            | csv、json               | 异步     |
 | [MySQL Load](./import-way/mysql-load-manual.md)          | 从本地数据导入                             | csv                     | 同步     |
 | [Group Commit](./group-commit-manual.md)          | 高频小批量导入                             | 根据使用的导入方式而定  | -     |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
@@ -143,7 +143,7 @@ S3 相关参数如下：
       - `s3.connection.request.timeout`：s3 请求超时时间，单位毫秒，默认为 3000
       - `s3.connection.timeout`：s3 连接超时时间，单位毫秒，默认为 1000
 
-    Doris 也支持通过 `AWS Assume Role` 的方式创建 S3 Resource, 请参考如下文档配置和使用[AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
+    Doris 也支持通过 `AWS Assume Role` 的方式创建 S3 Resource, 请参考如下文档配置和使用[AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
 
 **4. 创建 JDBC resource**
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
@@ -143,7 +143,7 @@ S3 相关参数如下：
       - `s3.connection.request.timeout`：s3 请求超时时间，单位毫秒，默认为 3000
       - `s3.connection.timeout`：s3 连接超时时间，单位毫秒，默认为 1000
 
-    Doris 也支持通过 `AWS Assume Role` 的方式创建 S3 Resource, 请参考如下文档配置和使用[AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
+    Doris 也支持通过 `AWS Assume Role` 的方式创建 S3 Resource, 请参考如下文档配置和使用[AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
 
 **4. 创建 JDBC resource**
 

--- a/versioned_docs/version-3.x/data-operate/import/data-source/amazon-s3.md
+++ b/versioned_docs/version-3.x/data-operate/import/data-source/amazon-s3.md
@@ -170,4 +170,4 @@ mysql> select * from test_s3load;
 10 rows in set (0.04 sec)
 ```
 
-Doris also supported `AWS Assume Role` for S3 Load and TVF, please refer to [AWS intergration](../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
+Doris also supported `AWS Assume Role` for S3 Load and TVF, please refer to [AWS integration](../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).

--- a/versioned_docs/version-3.x/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
@@ -145,7 +145,7 @@ Spark related parameters are as follows:
        - `s3.connection.request.timeout`: s3 request timeout, in milliseconds, the default is 3000
        - `s3.connection.timeout`: s3 connection timeout, in milliseconds, the default is 1000
 
-    Doris also supported `AWS Assume Role` for creating S3 Resource , please refer to [AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
+    Doris also supported `AWS Assume Role` for creating S3 Resource , please refer to [AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
 
 **4. Create JDBC resource**
 

--- a/versioned_docs/version-3.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
@@ -49,7 +49,7 @@ CREATE STORAGE VAULT [IF NOT EXISTS] <vault_name> [ <properties> ]
 
 1. `s3.endpoint` if neither `http://` nor `https://` prefix is not provided, ​​`http`​​ will be used by default. If a prefix is explicitly specified, it will take effect with the prefix;
 
-2. Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS intergration](../../../../lakehouse/storages/s3.md).
+2. Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS integration](../../../../lakehouse/storages/s3.md).
 
 ### HDFS vault
 
@@ -166,7 +166,7 @@ PROPERTIES (
 
 **Note:&#x20;**
 
-Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS intergration](../../../../lakehouse/storages/s3.md)
+Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS integration](../../../../lakehouse/storages/s3.md)
 
 
 ### 7. Create MinIO storage vault

--- a/versioned_docs/version-3.x/sql-manual/sql-statements/data-modification/backup-and-restore/CREATE-REPOSITORY.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-statements/data-modification/backup-and-restore/CREATE-REPOSITORY.md
@@ -47,7 +47,7 @@ CREATE [READ ONLY] REPOSITORY <repo_name>
 
 **Note:&#x20;**
 
-Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md).
+Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md).
 
 ## Access Control Requirements
 
@@ -83,7 +83,7 @@ PROPERTIES
 
 **Note:&#x20;**
 
-Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md).
+Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md).
 
 Create a repository named hdfs_repo.
 

--- a/versioned_docs/version-4.x/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-statements/cluster-management/compute-management/CREATE-RESOURCE.md
@@ -145,7 +145,7 @@ Spark related parameters are as follows:
        - `s3.connection.request.timeout`: s3 request timeout, in milliseconds, the default is 3000
        - `s3.connection.timeout`: s3 connection timeout, in milliseconds, the default is 1000
 
-    Doris also supported `AWS Assume Role` for creating S3 Resource , please refer to [AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
+    Doris also supported `AWS Assume Role` for creating S3 Resource , please refer to [AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
 
 **4. Create JDBC resource**
 

--- a/versioned_docs/version-4.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-statements/cluster-management/storage-management/CREATE-STORAGE-VAULT.md
@@ -49,7 +49,7 @@ CREATE STORAGE VAULT [IF NOT EXISTS] <vault_name> [ <properties> ]
 
 1. `s3.endpoint` if neither `http://` nor `https://` prefix is not provided, ​​`http`​​ will be used by default. If a prefix is explicitly specified, it will take effect with the prefix;
 
-2. Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS intergration](../../../../lakehouse/storages/s3.md).
+2. Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS integration](../../../../lakehouse/storages/s3.md).
 
 ### HDFS vault
 
@@ -166,7 +166,7 @@ PROPERTIES (
 
 **Note:&#x20;**
 
-Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS intergration](../../../../lakehouse/storages/s3.md)
+Doris also support `AWS Assume Role` for S3 Vault(only for AWS S3 now), please refer to [AWS integration](../../../../lakehouse/storages/s3.md)
 
 
 ### 7. Create MinIO storage vault

--- a/versioned_docs/version-4.x/sql-manual/sql-statements/data-modification/backup-and-restore/CREATE-REPOSITORY.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-statements/data-modification/backup-and-restore/CREATE-REPOSITORY.md
@@ -47,7 +47,7 @@ CREATE [READ ONLY] REPOSITORY <repo_name>
 
 **Note:&#x20;**
 
-Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
+Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
 
 ## Access Control Requirements
 
@@ -82,7 +82,7 @@ PROPERTIES
 ```
 **Note:&#x20;**
 
-Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS intergration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
+Doris also supported `AWS Assume Role` for creating AWS S3 Repository, please refer to [AWS integration](../../../../admin-manual/auth/integrations/aws-authentication-and-authorization.md#assumed-role-authentication).
 
 Create a repository named hdfs_repo.
 


### PR DESCRIPTION
## Summary

Two unrelated but trivial spelling typos across the maintained docs.

- \`intergration\` → \`integration\` in 13 files: \`CREATE-RESOURCE.md\`, \`CREATE-STORAGE-VAULT.md\`, \`CREATE-REPOSITORY.md\`, and \`data-source/amazon-s3.md\` across EN + zh for current / 2.1 / 3.x / 4.x where the typo existed.
- \`kakfa\` → \`Kafka\` in the zh-CN 2.1 \`load-manual.md\` Routine Load row.

Fixes #2612

## Test plan

- [x] \`grep -rn intergration\` and \`grep -rn kakfa\` return zero matches in the maintained trees
- [x] No line outside of the typo characters is modified (commit shows pure substitutions)