### PR TITLE
[doc] note that run-thirdparties-docker.sh only recognises eth[0-9] NIC names

### DIFF
--- a/community/developer-guide/regression-testing.md
+++ b/community/developer-guide/regression-testing.md
@@ -724,6 +724,8 @@ Before starting the containers, check the network configuration of the server or
 
 These correspond to the IP address (output of `hostname -i`, usually the IP of eth0), the host name (output of `hostname`), and the alias (the same as the host name), respectively.
 
+> **Note**: `run-thirdparties-docker.sh` detects the primary network interface by scanning for names matching `eth[0-9]`. Modern Linux distributions using systemd/udev assign predictable names such as `enp3s0`, `ens33`, or `eno1`, which the script does not recognize. If your host uses such a name, the script will fail to detect an interface — manually set the `eth_name` variable inside `run-thirdparties-docker.sh` to your actual interface name before running it.
+
 ### 1. Start the Container
 
 Doris currently supports Docker compose for data sources including es, mysql, pg, hive, sqlserver, oracle, iceberg, hudi, and trino. The related files are stored in the `docker/thirdparties/docker-compose` directory.

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/developer-guide/regression-testing.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/developer-guide/regression-testing.md
@@ -724,6 +724,8 @@ Doris 支持对接多种外部数据源的查询。回归框架提供了通过 D
 
 分别对应 IP 地址（`hostname -i` 输出，一般是 eth0 的 IP）、主机名（`hostname` 输出）、别名（同主机名）。
 
+> **注意**：`run-thirdparties-docker.sh` 通过匹配 `eth[0-9]` 模式来探测主网卡。现代 Linux 发行版（systemd/udev）通常使用 `enp3s0`、`ens33`、`eno1` 等可预测命名，脚本无法识别。如果你的主机网卡名不符合 `eth[0-9]` 模式，启动前请手动在 `run-thirdparties-docker.sh` 中将 `eth_name` 变量设为实际的网卡名。
+
 ### 1. 启动 Container
 
 Doris 目前支持 es、mysql、pg、hive、sqlserver、oracle、iceberg、hudi、trino 等数据源的 Docker compose。相关文件存放在 `docker/thirdparties/docker-compose` 目录下。


### PR DESCRIPTION
## Summary

\`docker/thirdparties/run-thirdparties-docker.sh\` detects the primary NIC by grep-ing for \`eth[0-9]\`. On modern Linux distros using systemd/udev predictable names (\`enp3s0\`, \`ens33\`, \`eno1\`, …), this silently fails and the container set-up cannot start.

Add a one-paragraph note to the **External Data Source e2e Tests › 0. Preparation** section in EN + zh community guides, telling the reader to set \`eth_name\` manually when their NIC doesn't match \`eth[0-9]\`.

Fixes #3196