### PR TITLE
Add release note and download links for Apache Doris 4.1.1

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/all-release.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/all-release.md
@@ -27,6 +27,8 @@
 
 <br />
 
+- [2026-05-24, Apache Doris 4.1.1 版本发布](./v4.1/release-4.1.1.md)
+
 - [2026-04-21, Apache Doris 4.1.0 版本发布](./v4.1/release-4.1.0.md)
 
 - [2026-04-07, Apache Doris 4.0.5 版本发布](./v4.0/release-4.0.5.md)

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/v4.1/release-4.1.1.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/v4.1/release-4.1.1.md
@@ -1,0 +1,213 @@
+---
+{
+    "title": "Release 4.1.1",
+    "language": "zh-CN",
+    "description": "Apache Doris 4.1.1 版本发布说明"
+}
+---
+
+# 新功能
+
+## 存储与压缩
+- 扫描路径新增自适应 batch size (#62835)
+- 新增 CompactionTaskTracker，提供系统表和 HTTP API (#61696)
+- MOR 表新增 value predicate 下推开关 (#60513)
+
+## 其他
+- 新增 json_object_flatten 标量函数 (#62825)
+
+# 改进
+
+## 存储与压缩
+- FileSplitter 跳过零长度文件，避免向 BE 发送空 split (#62482)
+- 顺序读 key 时避免单点读写 (#62476)
+- 为 AnnIndexIVFListCache 增加 stampede 保护 (#62442)
+- 限制 packed file 仅写入 rowset 的首个 segment (#62342)
+- 统一当前查询的运行时统计信息并暴露任务进度 (#60567)
+
+## 导入
+- 支持配置第三方 jar 下载镜像 (#62376)
+
+## 云原生
+- 新增 HashCRC32Return32，使 join_hash_table 使用 32 位 hash 值 (#62512)
+
+## 其他
+- 新增 current_database 内建别名 (#62591)
+
+# 问题修复
+
+## 索引与搜索
+- 修复深层嵌套复杂类型子类型校验被绕过的问题 (#63208)
+- 修复 getDeleteBitmapUpdateLock 中潜在的 NPE (#62809)
+- 修复 ANN 查询向量提取，兼容所有常量表达式类型 (#62637)
+- 将庞大的 function_string.h 拆分为按领域划分的多个文件 (#62262)
+- 修复 Iceberg/Paimon 表分区列生成时的 OOB 崩溃 (#62177)
+- 修复升级后 sessionVariables 的空指针异常 (#61959)
+- 优化 aggregate_function_orthogonal_bitmap.cpp 的编译耗时 (#61606)
+- drop index 时应设置 db_id (#58401)
+
+## 查询与执行
+- 修复远端 Flight SQL 结果接收器的初始化问题 (#63136)
+- 在空表的短路点查询中保留 LogicalOlapScan (#62948)
+- 修复 timestamptz literal 中 DST 春令跳变时段的处理 (#62945)
+- 修复 assert_num_rows_operator 中的 UB 和参数顺序 (#62800)
+- 通过新增 TimeStampTzType 签名匹配，在 LEAD/LAG 中保留 TIMESTAMPTZ (#62779)
+- 修复 exchange receiver 的依赖竞态 (#62777)
+- 为规范格式的 datetime 解析新增快速路径 (#62757)
+- 修复 isCountStar 将 count(null) 错误识别为 count(*) (#62548)
+- 修复 view 列在 lazy materialization 中丢失 colUniqueId (#62533)
+- 对齐 extra-join 消除的安全性检查 (#62527)
+- 修复 BE 节点文件句柄耗尽后 Doris 查询服务失败 (#62393)
+- 分区裁剪后按比例缩放列统计中的 num_nulls (#62265)
+- 修复审计日志关闭时 prepared statement QPS 指标未统计的问题 (#61621)
+- 升级 license-maven-plugin 到 2.1.0 (#58951)
+
+## 存储与压缩
+- 在 cloud snapshot manager 中避免任务嵌套 attach (#63189)
+- 物化 NG compaction 常规路径 (#63104)
+- Gson replay 后重建 broker load 存储属性 (#63094)
+- 系统库的统计信息缓存跳过处理 (#63089)
+- 修复 variant flat-leaf 根读取计划 (#63086)
+- 为 score() 解析 variant 子列索引 (#62992)
+- 避免删除不存在的 delete bitmap 文件 (#62967)
+- 跳过倾斜的 warmup rowset 延迟采样 (#62941)
+- 系统表返回未知统计信息 (#62913)
+- 在审计日志中将内部查询失败标记为 ERR (#62908)
+- 修复因错误信息变化导致 warm up 不重试的问题 (#62886)
+- 拒绝 add_cell 中超大的 block size (#62878)
+- 将 #include 指令移出 namespace 块，避免 ODR 违规 (#62871)
+- 为 cdc_client RPC 按类别添加超时限制 (#62870)
+- 新增 NestedGroup path 元数据支持 (#62848)
+- 通过 cache miss 时重发 query context，降低点查的网络开销 (#62836)
+- 构造 VariantStatsCaculator 时跳过完整 footer 扫描 (#62819)
+- warmup 任务取消/过期时避免 NPE 并清理过期 cache (#62805)
+- 首次动态分区初始化时持有表写锁，避免 CREATE MV 竞态 (#62755)
+- 支持为 StreamingJob 指定 compute_group (#62747)
+- 将 MemTracker 绑定到 cache 后台线程，修复 orphan crash (#62739)
+- 取消 alter 任务列表为空时按全部 rollup 任务处理 (#62712)
+- 移除 enable_nereids_load 开关 (#62703)
+- 增加部分 Sanity-check 以避免 NPE (#62691)
+- 修复升级时 RestoreJob 无法反序列化 Tablet (#62673)
+- 修复 force refresh 下 profile hitcache 不正确以及 sink id 不正确 (#62645)
+- 聚合非 MOW segment key 边界，减小 rowset meta 体积 (#62604)
+- 支持 ADMIN COMPACT TABLE type='FULL' 并在云模式启用 (#62596)
+- 优化 spill 场景下的可回收内存计量 (#62581)
+- 修复 no-key 表中 variant 列 uid=0 时的 compaction 失败 (#62571)
+- 将 ALTER 的 source/target 属性透传到运行时与持久化 (#62553)
+- 避免 TypedZoneMapIndexWriter 在每行产生临时 Field (#62544)
+- 修正错误的 for 循环 (#62517)
+- 读取时归一化遗留的单段 dot-key 子列路径 (#62409)
+- 修复 finalize 时缺少 local cache writer 导致的 BE 崩溃 (#62389)
+- 修复 InsertLoadJob 因任务永久卡在 PENDING 状态导致的内存泄漏 (#62282)
+- 新增 SC_COMPACTION_CONFLICT 错误码以重试跨 V1 的 compaction 失败 (#62272)
+- 为 streaming insert 任务新增按任务级别的指标 (#62224)
+- 减少 aggregate_function_reader_replace.cpp 的编译耗时 (#62047)
+- 减少 HybridSet/InListPredicate 的模板膨胀并修复 create_string_value_set 的 bug (#61999)
+- 在 PrimitiveType 枚举中弃用 TYPE_LAMBDA_FUNCTION (#61941)
+- 新增 get_version 与 get_tablet_stats 用例 (#61915)
+- 将旧版 VExpr execute 接口迁移到新的 execute_column（Part 1）(#61912)
+- 拒绝在损坏的存储路径上上传 snapshot (#61251)
+- 手动 full compaction 任务提交到线程池，替代游离线程 (#61222)
+- 新增零依赖、仅 JDK 的 fe-foundation 模块 (#61175)
+- meta_tool 新增 show_segment_data 操作 (#60608)
+- 清理 cache 时避免后台 LRU 更新引发的 SIGSEGV (#60533)
+- 修复 IOContext 的 Use-After-Free (#59947)
+- 云模式下优先调度最近活跃的 tablet (#59539)
+- 支持 file cache microbench 在运行时热加载配置 (#58922)
+- v2 下跳过将 agg delete bitmap v1 推送到 ms (#57990)
+- 校验 delete bitmap 版本 (#57989)
+- 暴露云模式下的 balance 指标 (#57200)
+
+## 导入
+- 任务 max interval 从首条记录到达后开始计算 (#63141)
+- 加载 JNI log4j2 properties 配置 (#63063)
+- 修复 broker load 在解析多文件路径时只静默加载首个文件 (#62969)
+- packed file 异步关闭采用非阻塞轮询 (#62938)
+- 避免拷贝 ANN 检索结果 (#62924)
+- 修复单表 S3 streaming 场景下 filteredRows 始终为 0 (#62816)
+- LoadStatistic.FileNumber 上报物理文件数 (#62804)
+- 自适应 flush 控制器使用 CPU 指标增量检测 CPU 压力 (#62744)
+- 拒绝静默无效的 ALTER key 与不支持的 load.* 属性 (#62680)
+- checkDataQuality 累积前滚动采样窗口 (#62636)
+- PostgreSQL CDC 使用按表 publication 替代 ALL TABLES (#62526)
+- 支持 StreamingInsertJob 创建和 alter 时指定 offset (#62490)
+- 修复 FE checkpoint 重启后 S3 offset 与任务统计丢失 (#62449)
+- 修复 EditLog replay 时 StreamingInsertJob.replayOnCommitted 的 NPE (#62416)
+- 限制自动 resume 次数并暴露结构化 FailureReason (#62345)
+- 修复 FE 重启后 show load 中 INSERT 任务统计丢失 (#62331)
+- 修复 NereidsStreamLoadTask 中无效的 String.format 模式 (#62225)
+- 更新 streaming job 使用的 flink cdc 版本 (#62212)
+- 非 master 的 stream load precommit 提前返回 (#62109)
+- group commit 之前校验 stream load 的 content length (#62110)
+- 在 stream load 日志中脱敏敏感 header (#62108)
+- 在 commit 和 rollback 中拒绝无效的 stream load token (#62111)
+- 使用 memtable 内存而非 load 内存来计算自适应 write buffer 大小 (#62104)
+- 修复 GenericPool 在过期 TLS 连接上 reopen 阻塞 18 分钟的问题 (#61951)
+- 修复协调 BE 重启时 routine load afterAborted 抛出 IllegalMonitorStateException (#61881)
+- 减少 scan_operator 的模板实例化以缩短编译时间 (#61227)
+- 支持自适应 memtable write buffer 大小 (#56948)
+- group commit 的 memory tracker 移除 NDEBUG 限制 (#56577)
+
+## 云原生
+- 保持正确的 DST fold 分支以跨越切换点 (#63034)
+- 在可用 backend 上清理 warmup 任务 (#62931)
+- 抽取 snapshot 集成钩子 (#62859)
+- 刷新 event warmup backend (#62839)
+- 避免 master 切换期间查询丢失结果包 (#62721)
+- 修复 collect_set merge 时的冗余拷贝 (#62640)
+- S3 文件系统支持 IAM role 鉴权 (#62584)
+- 修复 #59489 引入的 different_serialize 测试数据目录拼写错误 (#62480)
+- 修复 Set 算子运行时 filter 处理的竞态 (#62434)
+- 在 CRTP 聚合函数派生类上强制 `final`，使编译器可去虚化 (#62433)
+- 在 s3 client 单测中支持 IAM Role (#62303)
+- 将 project 下推到 Union 时为常量分配新的 ExprId (#62296)
+- 对客户端隐藏 KV_TXN_MAYBE_COMMITTED (#62244)
+- Branch-4.1: [feature](jsf) FE/BE 将 JuiceFS (jfs://) 视为 HDFS 兼容 #61031 (#61706)
+- 合并 ms 与 recycler 的 http 骨架 (#61502)
+
+## 湖仓
+- JDBC catalog 解耦元数据名 (#62806)
+- 修复 iceberg 与 maxcompute 的 p2 用例 (#62483)
+- 减少 datetime floor/ceil 函数的模板实例化 (#61515)
+
+## 安全与认证
+- 在 late arrival 路径中恢复 _applied_rf_num 更新 (#62872)
+- 支持 SSL 并将 MySQL CDC source 与 PG 对齐 (#62700)
+- 修复 __internal_schema.audit_log 中 workload_group 为空的问题 (#62651)
+- 修复 CTE 组合时 Ranger 列级权限被绕过 (#61741)
+- 修复 admin 操作的 HTTP API 鉴权框架 (#60761)
+
+## 其他
+- 修复 TIMESTAMPTZ 经过时间语义按 UTC 处理 (#63161)
+- 修正 Arrow UTF8/String 大小上限 (#63137)
+- 移除 `is_acting_on_a_slot` 中无用的 if (#63095)
+- `from_olap_string` 解析 datetime 失败不再抛异常 (#63035)
+- release 模式下移除 datetime transformers 检查 (#63003)
+- 避免格式化生成的 insert 错误 (#62982)
+- doris compose 支持 docker compose v2 (#62851)
+- 为负的不足一小时 TIMESTAMPTZ 偏移保留符号 (#62823)
+- 修复 VariantStatsCaculator 的 -Wtype-limits 错误 (#62632)
+- 修复 FE 启动参数透传 (#62587)
+- 修复 insert overwrite 的错误信息 (#62555)
+- License 检查 (#62534)
+- 将 report 逻辑迁移到 pipeline fragment context，去除 ctor 中的 callback 参数 (#62500)
+- 抽取 isDynamicScheduleTable 方法以减少重复代码 (#62477)
+- test_hive_compress_type_large_data 显式设置 parallel_pipeline_task_num (#62423)
+- JAVA_OPTS_FOR_JDK_17 移除 classhisto*=trace，避免 full gc 时打印类直方图 (#62422)
+- 修复 VExprContext 重建时 RuntimeFilter selectivity sampling_frequency 丢失 (#62355)
+- re-prepare 时关闭 snapshot reader 并加固 REST 错误处理 (#62337)
+- 移除 StringValueSet 的 FixedContainer 优化 (#62243)
+- DateTimeV2Type.acceptsType 要求精确匹配 (#62201)
+- 移除 BE cast 路径中的 io_helper 间接层 (#62179)
+- 减少 hash join build 的模板实例化 (#61349)
+- 优化 cast 的编译耗时 (#61276)
+- 减少 window 函数的模板实例化 (#61232)
+- 减少聚合函数的编译耗时 (#61179)
+- 修复 FE 因 websocket 启动失败导致启动失败 (#60369)
+- type_array 支持 max/min 聚合函数 (#58490)
+- 修复 AdminCreateClusterSnapshotCommand (#58119)
+- array_sort 新增 lambda functor 版本 (#57828)
+- clone snapshot 支持绝对路径文件 (#57685)
+- 显示 snapshot 数量 (#56491)
+- 将 watcher.stop() 移入加锁代码块 (#56462)
+- 处理长度超过 50 的自动分区名 (#56304)

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/v4.1/release-4.1.1.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/v4.1/release-4.1.1.md
@@ -162,7 +162,7 @@
 - 在 s3 client 单测中支持 IAM Role (#62303)
 - 将 project 下推到 Union 时为常量分配新的 ExprId (#62296)
 - 对客户端隐藏 KV_TXN_MAYBE_COMMITTED (#62244)
-- Branch-4.1: [feature](jsf) FE/BE 将 JuiceFS (jfs://) 视为 HDFS 兼容 #61031 (#61706)
+- FE/BE 将 JuiceFS (jfs://) 视为 HDFS 兼容 (#61706)
 - 合并 ms 与 recycler 的 http 骨架 (#61502)
 
 ## 湖仓

--- a/releasenotes/all-release.md
+++ b/releasenotes/all-release.md
@@ -28,6 +28,8 @@ This document presents a summary of Apache Doris versions released within one ye
 
 <br />
 
+- [2026-05-24, Apache Doris 4.1.1 is released](./v4.1/release-4.1.1.md)
+
 - [2026-04-21, Apache Doris 4.1.0 is released](./v4.1/release-4.1.0.md)
 
 - [2026-04-07, Apache Doris 4.0.5 is released](./v4.0/release-4.0.5.md)

--- a/releasenotes/v4.1/release-4.1.1.md
+++ b/releasenotes/v4.1/release-4.1.1.md
@@ -162,7 +162,7 @@
 - Support IAM Role for s3 client ut test (#62303)
 - Allocate fresh ExprId for constants when pushing project into Union (#62296)
 - Hide KV_TXN_MAYBE_COMMITTED from clients (#62244)
-- Branch-4.1: [feature](jsf) Treat JuiceFS (jfs://) as HDFS-compatible in FE/BE #61031 (#61706)
+- Treat JuiceFS (jfs://) as HDFS-compatible in FE/BE (#61706)
 - Merge ms and recycler http skeleton (#61502)
 
 ## Lakehouse

--- a/releasenotes/v4.1/release-4.1.1.md
+++ b/releasenotes/v4.1/release-4.1.1.md
@@ -1,0 +1,213 @@
+---
+{
+    "title": "Release 4.1.1",
+    "language": "en",
+    "description": "Here's the Apache Doris 4.1.1 release notes:"
+}
+---
+
+# New Features
+
+## Storage & Compaction
+- Add adaptive batch size for scan path (#62835)
+- Add CompactionTaskTracker with system table and HTTP API (#61696)
+- Add value predicate pushdown control for MOR tables (#60513)
+
+## Other
+- Add json_object_flatten scalar function (#62825)
+
+# Improvement
+
+## Storage & Compaction
+- Skip zero-length files in FileSplitter to avoid sending empty splits to BE (#62482)
+- Avoid single-point read/write during sequentially reading key (#62476)
+- Add stampede protection for AnnIndexIVFListCache (#62442)
+- Limit packed file writes to rowset first segment (#62342)
+- Unify current query runtime statistics and expose task progress (#60567)
+
+## Load
+- Make thirdparty jar download mirror configurable (#62376)
+
+## Cloud Native
+- Add HashCRC32Return32 and make join_hash_table use 32-bit hash value (#62512)
+
+## Other
+- Add current_database builtin alias (#62591)
+
+# Bugfix
+
+## Index & Search
+- Fix deep nested complex type subtype validation bypass (#63208)
+- Fix potential NPE in getDeleteBitmapUpdateLock (#62809)
+- Fix ANN query vector extraction to handle all constant expression types (#62637)
+- Split monolithic function_string.h into domain-specific files (#62262)
+- Fix OOB crash in partition column generation for Iceberg/Paimon tables (#62177)
+- Fix null pointer exception in sessionVariables after upgrade (#61959)
+- Optimize the compilation time of aggregate_function_orthogonal_bitmap.cpp (#61606)
+- Drop index should set db_id (#58401)
+
+## Query & Execution
+- Fix remote Flight SQL result receiver initialization (#63136)
+- Keep LogicalOlapScan for short-circuit point query on empty table (#62948)
+- Fix DST spring-forward gap handling in timestamptz literal (#62945)
+- Fix UB and param order in assert_num_rows_operator (#62800)
+- Preserve TIMESTAMPTZ in LEAD/LAG by adding TimeStampTzType signature matching (#62779)
+- Fix exchange receiver dependency race (#62777)
+- Add fast path for canonical format datetime parse (#62757)
+- Fix isCountStar incorrectly treating count(null) as count(*) (#62548)
+- Fix view columns losing colUniqueId in lazy materialization (#62533)
+- Align extra-join elimination safety check (#62527)
+- Fix Doris query service fails after the file handles on the BE node are used up (#62393)
+- Scale num_nulls in col stats when partition pruned (#62265)
+- Fix prepared statement QPS metrics not counted when audit log disabled (#61621)
+- Update license-maven-plugin to 2.1.0 (#58951)
+
+## Storage & Compaction
+- Avoid nested task attach in cloud snapshot manager (#63189)
+- Materialize NG compaction regular paths (#63104)
+- Rebuild broker load storage properties after Gson replay (#63094)
+- Skip statistics cache for system dbs (#63089)
+- Fix variant flat-leaf root read plan (#63086)
+- Resolve variant sub-column indexes for score() (#62992)
+- Avoid deleting nonexistent delete bitmap files (#62967)
+- Skip skewed warmup rowset latency samples (#62941)
+- Return unknown stats for system tables (#62913)
+- Mark internal query failures as ERR in audit log (#62908)
+- Fix warm up don't retry due to error message change (#62886)
+- Reject oversized block size in add_cell (#62878)
+- Move #include directives outside namespace blocks to avoid ODR violations (#62871)
+- Bound cdc_client RPCs with per-category timeouts (#62870)
+- Add NestedGroup path metadata support (#62848)
+- Reduce point-query network overhead by resending query context on cache miss (#62836)
+- Skip full footer scan when constructing VariantStatsCaculator (#62819)
+- Avoid NPE and clear stale cache on warmup job cancel/expire (#62805)
+- Hold table write lock across first-time dynamic partition setup to prevent CREATE MV race (#62755)
+- Support specifying compute_group for StreamingJob (#62747)
+- Attach MemTracker to cache background threads to fix orphan crash (#62739)
+- Treat empty cancel alter job list as all rollup jobs (#62712)
+- Remove enable_nereids_load switch (#62703)
+- Add some Sanity-check for avoid npe (#62691)
+- RestoreJob cannot deserialize Tablet when upgrade (#62673)
+- The profile hitcache not correct in force refresh and sink id not correct (#62645)
+- Aggregate non-MOW segment key bounds to reduce rowset meta size (#62604)
+- Support ADMIN COMPACT TABLE type='FULL' and enable it in cloud mode (#62596)
+- Refine revocable memory accounting for spill (#62581)
+- Fix compaction failure on no-key table with variant column uid=0 (#62571)
+- Propagate ALTER source/target properties to runtime and persistence (#62553)
+- Avoid per-row Field temporaries in TypedZoneMapIndexWriter (#62544)
+- Fix incorrect for-loop (#62517)
+- Normalize legacy single-part dot-key subcolumn paths on read (#62409)
+- Avoid BE crash when finalize misses local cache writer (#62389)
+- Fix InsertLoadJob memory leak caused by jobs permanently stuck in PENDING state (#62282)
+- Add SC_COMPACTION_CONFLICT error code to retry cross-V1 compaction failures (#62272)
+- Add per-job metrics for streaming insert jobs (#62224)
+- Reduce compile time of aggregate_function_reader_replace.cpp (#62047)
+- Reduce HybridSet/InListPredicate template bloat and fix create_string_value_set bug (#61999)
+- Deprecate TYPE_LAMBDA_FUNCTION in PrimitiveType enum (#61941)
+- Add get_version and get_tablet_stats case (#61915)
+- Migrate old VExpr execute interface to new execute_column (Part 1) (#61912)
+- Reject upload snapshots on broken storage path (#61251)
+- Submit manual full compaction task to thread pool instead of detached thread (#61222)
+- Add fe-foundation module with zero-dependency JDK-only utilities (#61175)
+- Add show_segment_data operation to meta_tool (#60608)
+- Avoid SIGSEGV in background LRU update when clear cache (#60533)
+- Fix IOContext Use-After-Free (#59947)
+- Prioritize scheduling the most recently active tablets in cloud (#59539)
+- Support config hot reload of file cache microbench in running state (#58922)
+- Skip agg delete bitmap v1 to ms when v2 (#57990)
+- Check delete bitmap version (#57989)
+- Exposes cloud balance metrics (#57200)
+
+## Load
+- Start counting task max interval after the first record is received (#63141)
+- Load JNI log4j2 properties config (#63063)
+- Fix broker load silently loaded only the first file when parsing multiple files path (#62969)
+- Poll packed file async close without blocking (#62938)
+- Avoid copying ANN search results (#62924)
+- Fix filteredRows always 0 on single-table S3 streaming (#62816)
+- Report physical file count in LoadStatistic.FileNumber (#62804)
+- Use CPU metrics delta for CPU pressure detection in adaptive flush controller (#62744)
+- Reject silent-no-op ALTER keys and unsupported load.* properties (#62680)
+- Roll sample window before accumulating in checkDataQuality (#62636)
+- Use per-table publication instead of ALL TABLES for PostgreSQL CDC (#62526)
+- Support specifying offset for StreamingInsertJob create and alter (#62490)
+- Fix S3 offset and job statistics lost after FE checkpoint restart (#62449)
+- Fix NPE in StreamingInsertJob.replayOnCommitted during EditLog replay (#62416)
+- Cap auto-resume attempts and expose structured FailureReason (#62345)
+- Fix INSERT job statistics lost in show load after FE restart (#62331)
+- Fix invalid String.format pattern in NereidsStreamLoadTask (#62225)
+- Update flink cdc version for streaming job (#62212)
+- Return early for non-master stream load precommit (#62109)
+- Validate stream load content length before group commit (#62110)
+- Mask sensitive headers in stream load logs (#62108)
+- Reject invalid stream load tokens on commit and rollback (#62111)
+- Using memtable memory instead of load memory to calculate adaptive write buffer size (#62104)
+- Fix GenericPool reopen blocking 18min on stale TLS connections (#61951)
+- Fix IllegalMonitorStateException in routine load afterAborted when coordinate BE restarts (#61881)
+- Reduce template instantiation in scan_operator to improve compile time (#61227)
+- Support adaptive memtable write buffer size (#56948)
+- Remove NDEBUG for groupcommit's memory tracker (#56577)
+
+## Cloud Native
+- Preserve correct DST fold branch to go cross the transition point (#63034)
+- Clear warmup jobs on available backends (#62931)
+- Extract snapshot integration hooks (#62859)
+- Refresh event warmup backends (#62839)
+- Avoid missing result packet for query during master switch (#62721)
+- Fix redundant copy in collect_set merge (#62640)
+- Support IAM role auth in S3 filesystem (#62584)
+- Fix typo in different_serialize test data directory introduced by #59489 (#62480)
+- Fix race condition in Set operator runtime filter processing (#62434)
+- Enforce `final` on CRTP aggregate function derived classes to enable compiler devirtualization (#62433)
+- Support IAM Role for s3 client ut test (#62303)
+- Allocate fresh ExprId for constants when pushing project into Union (#62296)
+- Hide KV_TXN_MAYBE_COMMITTED from clients (#62244)
+- Branch-4.1: [feature](jsf) Treat JuiceFS (jfs://) as HDFS-compatible in FE/BE #61031 (#61706)
+- Merge ms and recycler http skeleton (#61502)
+
+## Lakehouse
+- Decouple JDBC catalog metadata name (#62806)
+- Fix iceberg & maxcompute p2 case. (#62483)
+- Educe template instantiations in datetime floor/ceil functions (#61515)
+
+## Security & Authentication
+- Restore _applied_rf_num update in late arrival path (#62872)
+- Support SSL and align MySQL CDC source with PG (#62700)
+- Fix empty workload_group value __internal_schema.audit_log (#62651)
+- Fix Ranger column-level privilege bypass when CTE combined (#61741)
+- Fix HTTP API authentication framework for admin operations (#60761)
+
+## Other
+- Fix TIMESTAMPTZ elapsed-time semantics to use UTC (#63161)
+- Correct Arrow UTF8/String size limit (#63137)
+- Remove useless if in `is_acting_on_a_slot` (#63095)
+- No longer throws exceptions when parse datetime failed in `from_olap_string` (#63035)
+- Remove datetime transfomers check in release mode (#63003)
+- Avoid formatting generated insert errors (#62982)
+- Doris compose supports docker compose v2 (#62851)
+- Preserve sign for negative sub-hour TIMESTAMPTZ offsets (#62823)
+- Fix -Wtype-limits error in VariantStatsCaculator (#62632)
+- Fix FE startup argument forwarding (#62587)
+- Fix wrong error message of insert overwrite (#62555)
+- License check (#62534)
+- Move report logic to pipeline fragment context to remove callback parameter from ctor (#62500)
+- Extract isDynamicScheduleTable method to reduce code duplication (#62477)
+- Set parallel_pipeline_task_num explicitly in test_hive_compress_type_large_data. (#62423)
+- Remove classhisto*=trace in JAVA_OPTS_FOR_JDK_17 to prevent printing class histogram in full gc (#62422)
+- Fix RuntimeFilter selectivity sampling_frequency lost during VExprContext recreation (#62355)
+- Close snapshot readers on re-prepare and harden REST error handling (#62337)
+- Remove FixedContainer optimization for StringValueSet (#62243)
+- Require exact match in DateTimeV2Type.acceptsType (#62201)
+- Remove io_helper helper indirection from BE cast paths (#62179)
+- Reduce hash join build template instantiations (#61349)
+- Optimize the compilation time of cast. (#61276)
+- Reduce window function template instantiations (#61232)
+- Reduce the compilation time of aggregate functions. (#61179)
+- FE startup fail due to websocket startup (#60369)
+- Support max/min agg functions for type_array (#58490)
+- Fix AdminCreateClusterSnapshotCommand (#58119)
+- Add a lambda functor version for array_sort (#57828)
+- Clone snapshot support absolute path file (#57685)
+- Show the snapshot count (#56491)
+- Move watcher.stop() into locked code block (#56462)
+- Process auto partition name when its length exceeds 50 (#56304)

--- a/sidebarsReleases.json
+++ b/sidebarsReleases.json
@@ -5,6 +5,7 @@
             "type": "category",
             "label": "v4.1",
             "items": [
+                "v4.1/release-4.1.1",
                 "v4.1/release-4.1.0"
             ]
         },

--- a/src/constant/download.data.ts
+++ b/src/constant/download.data.ts
@@ -30,7 +30,7 @@ export enum ToolsEnum {
 
 export const ORIGIN = 'https://download.selectdb.com/';
 export enum VersionEnum {
-    Latest = '4.1.0',
+    Latest = '4.1.1',
     Prev = '4.0.5',
     Earlier = '3.1.4',
 }
@@ -40,6 +40,40 @@ export enum DownloadTypeEnum {
     Source = 'Source',
 }
 export const DORIS_VERSIONS: Option[] = [
+    {
+        label: '4.1.1',
+        value: '4.1.1',
+        majorVersion: '4.1',
+        children: [
+            {
+                label: CPUEnum.X64,
+                value: CPUEnum.X64,
+                gz: `${ORIGIN}apache-doris-4.1.1-bin-x64.tar.gz`,
+                asc: `${ORIGIN}apache-doris-4.1.1-bin-x64.tar.gz.asc`,
+                sha512: `${ORIGIN}apache-doris-4.1.1-bin-x64.tar.gz.sha512`,
+                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.1/',
+                version: '4.1.1',
+            },
+            {
+                label: CPUEnum.X64NoAvx2,
+                value: CPUEnum.X64NoAvx2,
+                gz: `${ORIGIN}apache-doris-4.1.1-bin-x64-noavx2.tar.gz`,
+                asc: `${ORIGIN}apache-doris-4.1.1-bin-x64-noavx2.tar.gz.asc`,
+                sha512: `${ORIGIN}apache-doris-4.1.1-bin-x64-noavx2.tar.gz.sha512`,
+                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.1/',
+                version: '4.1.1',
+            },
+            {
+                label: CPUEnum.ARM64,
+                value: CPUEnum.ARM64,
+                gz: `${ORIGIN}apache-doris-4.1.1-bin-arm64.tar.gz`,
+                asc: `${ORIGIN}apache-doris-4.1.1-bin-arm64.tar.gz.asc`,
+                sha512: `${ORIGIN}apache-doris-4.1.1-bin-arm64.tar.gz.sha512`,
+                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.1/',
+                version: '4.1.1',
+            },
+        ],
+    },
     {
         label: '4.1.0',
         value: '4.1.0',


### PR DESCRIPTION
## Summary

- Add 4.1.1 download links (x64 / x64-noavx2 / arm64) in `src/constant/download.data.ts` and bump `VersionEnum.Latest` to 4.1.1
- Add 4.1.1 release notes (English + zh-CN) under `releasenotes/v4.1/` and `i18n/zh-CN/.../v4.1/`, with content sourced from apache/doris#63426
- Wire 4.1.1 into `sidebarsReleases.json` and both `all-release.md` index files (release date: 2026-05-24)

## Test plan

- [ ] Verify 4.1.1 appears as the default selection on the download page
- [ ] Verify all three download URLs (gz / asc / sha512 × x64 / x64-noavx2 / arm64) resolve
- [ ] Verify the 4.1.1 release-notes page renders in both English and 简体中文
- [ ] Confirm the 2026-05-24 release date is correct (placeholder — adjust if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)