### PR TITLE
[doc] zh release-3.0.7: add missing '### 新函数' heading

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/v3.0/release-3.0.7.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/v3.0/release-3.0.7.md
@@ -20,13 +20,15 @@
 
 ### 查询执行
 
-- 新增数据函数：`cot`/`sec`/`cosec`
 - `Like` 语句支持 `escape` 语法
 
 ### 半结构化数据管理
 
 - 通过设置会话变量 `enable_add_index_for_new_data=true`，支持仅对新增数据构建不分词倒排索引和 NGram bloomfilter 索引
 
+### 新函数
+
+- 新增数学函数：`cot`/`sec`/`cosec`
 
 ## 改进
 


### PR DESCRIPTION
## Summary

The zh \`release-3.0.7.md\` page was missing the \`### New Functions\` (\`### 新函数\`) subsection under New Features. The single bullet under it (\`cot\` / \`sec\` / \`cosec\`) was instead misplaced under \`### 查询执行\`, leaving zh with 3 H3s under New Features versus 4 in EN.

Pull the bullet out of \`### 查询执行\` and add the proper \`### 新函数\` heading so the section structure matches the EN page exactly.

## Test plan

- [x] \`diff\` of H2/H3 headings between EN and zh is empty after the change
- [x] Bullet content unchanged — only the heading classification moves