### PR TITLE
[doc] zh release-2.1.10: keep Lakehouse as H3 under New Features

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/v2.1/release-2.1.10.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/v2.1/release-2.1.10.md
@@ -26,7 +26,7 @@
 - 支持了更多的 GEO 类型的计算函数`ST_CONTAINS ` , `ST_INTERSECTS`, `ST_TOUCHES`，`GeometryFromText`，`ST_Intersects`, `ST_Disjoint`, `ST_Touches`。[#49665](https://github.com/apache/doris/pull/49665) [#48695](https://github.com/apache/doris/pull/48695)
 - 支持 `years_of_week` 函数。[#48870](https://github.com/apache/doris/pull/48870)
 
-## 湖仓一体
+### 湖仓一体
 
 - Hive Catalog 支持 Catalog 级别的分区缓存开关控制 [#50724](https://github.com/apache/doris/pull/50724)
   - 更多详情，可参考[文档](https://doris.apache.org/zh-CN/docs/dev/lakehouse/meta-cache#关闭-hive-catalog-元数据缓存)


### PR DESCRIPTION
## Summary

The EN \`release-2.1.10\` page groups \`### Lakehouse\` (a single bullet about Hive Catalog partition-cache toggle) as an H3 under \`## New Features\`. The zh page had promoted it to a standalone \`## 湖仓一体\` H2 between New Features and Improvements, so the H2 set didn't match EN (zh had 5 H2s vs EN's 4).

Demote the heading back to \`### 湖仓一体\` H3 inside \`## 新功能\` so the section structure matches EN exactly. Body content is unchanged.

## Test plan

- [x] \`grep '^## '\` in zh now returns 4 H2s (行为变更 / 新功能 / 改进提升 / Bug 修复), matching EN
- [x] The single Lakehouse bullet still renders, now as an H3 sub-section