### PR TITLE
[doc] release-3.0.6 EN: split Storage section and promote Lakehouse bug-fix groupings

### DIFF
--- a/releasenotes/v3.0/release-3.0.6.md
+++ b/releasenotes/v3.0/release-3.0.6.md
@@ -48,13 +48,19 @@ Dear community members, the Apache Doris 3.0.6 version was officially released o
 
 ## Improvements
 
-### Storage 
+### Data Ingestion
+
+- **Implemented blacklist mechanism** to prevent Routine Load from distributing metadata to unavailable BEs [#50587](https://github.com/apache/doris/pull/50587)
+- **Increased default value** of `load_task_high_priority_threshold_second` [#50478](https://github.com/apache/doris/pull/50478)
+
+### Primary Key Model
+
+- **Reduced redundant log output** [#51093](https://github.com/apache/doris/pull/51093)
+
+### Storage
 
 - Streamlined Compaction Profile and logs [#50950](https://github.com/apache/doris/pull/50950)
 - Enhanced scheduling strategy to improve Compaction throughput [#49882](https://github.com/apache/doris/pull/49882) [#48759](https://github.com/apache/doris/pull/48759) [#51482](https://github.com/apache/doris/pull/51482) [#50672](https://github.com/apache/doris/pull/50672) [#49953](https://github.com/apache/doris/pull/49953) [#50819](https://github.com/apache/doris/pull/50819)
-- **Reduced redundant log output** [#51093](https://github.com/apache/doris/pull/51093)
-- **Implemented blacklist mechanism** to prevent Routine Load from distributing metadata to unavailable BEs [#50587](https://github.com/apache/doris/pull/50587)
-- **Increased default value** of `load_task_high_priority_threshold_second` [#50478](https://github.com/apache/doris/pull/50478)
 
 ### Storage-Compute Decoupled
 
@@ -138,19 +144,24 @@ Dear community members, the Apache Doris 3.0.6 version was officially released o
 
 ### Lakehouse
 
-- **Export fixes** 
-  - Fixed FE memory leaks [#51171](https://github.com/apache/doris/pull/51171)
-  - Prevented FE deadlocks [#50088](https://github.com/apache/doris/pull/50088)
-- **Catalog fixes** 
-  - Enabled composite predicate pushdown for JDBC Catalog [#50542](https://github.com/apache/doris/pull/50542)
-  - Fixed Deletion Vector reading for Alibaba Cloud OSS Paimon tables [#49645](https://github.com/apache/doris/pull/49645)
-  - Supported comma-containing Hive partition values [#49382](https://github.com/apache/doris/pull/49382)
-  - Corrected MaxCompute Timestamp column parsing [#49600](https://github.com/apache/doris/pull/49600)
-  - Enabled `information_schema` system tables for Trino Catalog [#49912](https://github.com/apache/doris/pull/49912)
-- **File formats** 
-  - Fixed LZO compression reading failures [#49538](https://github.com/apache/doris/pull/49538)
-  - Added legacy ORC file compatibility [#50358](https://github.com/apache/doris/pull/50358)
-  - Corrected complex type parsing in ORC files [#50136](https://github.com/apache/doris/pull/50136)
+#### Export fixes
+
+- Fixed FE memory leaks [#51171](https://github.com/apache/doris/pull/51171)
+- Prevented FE deadlocks [#50088](https://github.com/apache/doris/pull/50088)
+
+#### Catalog fixes
+
+- Enabled composite predicate pushdown for JDBC Catalog [#50542](https://github.com/apache/doris/pull/50542)
+- Fixed Deletion Vector reading for Alibaba Cloud OSS Paimon tables [#49645](https://github.com/apache/doris/pull/49645)
+- Supported comma-containing Hive partition values [#49382](https://github.com/apache/doris/pull/49382)
+- Corrected MaxCompute Timestamp column parsing [#49600](https://github.com/apache/doris/pull/49600)
+- Enabled `information_schema` system tables for Trino Catalog [#49912](https://github.com/apache/doris/pull/49912)
+
+#### File formats
+
+- Fixed LZO compression reading failures [#49538](https://github.com/apache/doris/pull/49538)
+- Added legacy ORC file compatibility [#50358](https://github.com/apache/doris/pull/50358)
+- Corrected complex type parsing in ORC files [#50136](https://github.com/apache/doris/pull/50136)
 
 ### Asynchronous Materialized Views
 


### PR DESCRIPTION
## Summary

While auditing 3.0.6 zh/EN parity, the zh page turned out to be more carefully organised than EN. Cross-port two structural improvements from zh:

### 1. Improvements section: split \`### Storage\`

EN \`### Storage\` was a catch-all that lumped together three distinct categories of bullets:

- Routine Load blacklist and \`load_task_high_priority_threshold_second\` → **Data Ingestion**
- Reduced redundant log output → **Primary Key Model**
- Compaction Profile / log streamlining and Compaction throughput scheduling → **Storage**

Split it into three proper H3s — \`### Data Ingestion\`, \`### Primary Key Model\`, \`### Storage\` — matching zh's \`### 导入\` / \`### 主键模型\` / \`### 存储优化\`. Bullet order, content, and PR refs are preserved; only grouping changes.

### 2. Bug Fixes › Lakehouse: promote ad-hoc groupings to H4

EN used bold paragraph leads (\`**Export fixes**\`, \`**Catalog fixes**\`, \`**File formats**\`) as ad-hoc sub-groupings inside a bullet list. zh uses proper H4 headings (\`#### Export 修复\`, \`#### Catalog 修复\`, \`#### 文件格式\`). Promote EN to the same H4 structure and flatten the nested 1-level-deep bullets to top-level so the on-page navigation matches.

No content additions; the set of PR references is unchanged on both sides (98 unique refs each).

## Test plan

- [x] zh and EN H2/H3/H4 structure now matches one-to-one (only translation differences remain)
- [x] \`grep -oE 'pull/[0-9]+' | sort -u | wc -l\` returns 98 on both sides