### PR TITLE
[doc] release-2.1.2 EN: backfill two Auto Partition behavior changes

### DIFF
--- a/releasenotes/v2.1/release-2.1.2.md
+++ b/releasenotes/v2.1/release-2.1.2.md
@@ -18,6 +18,14 @@
 
   - https://github.com/apache/doris/pull/33282
 
+3. Auto Partition syntax changes, see the [documentation](../../table-design/data-partitioning/auto-partitioning.md) for details.
+
+  - https://github.com/apache/doris/pull/32737
+
+4. Auto Partition is no longer allowed to coexist with Dynamic Partition on the same table.
+
+  - https://github.com/apache/doris/pull/33736
+
 
 ## Upgrade Problem
 

--- a/releasenotes/v2.1/release-2.1.2.md
+++ b/releasenotes/v2.1/release-2.1.2.md
@@ -18,7 +18,7 @@
 
   - https://github.com/apache/doris/pull/33282
 
-3. Auto Partition syntax changes, see the [documentation](../../table-design/data-partitioning/auto-partitioning.md) for details.
+3. Auto Partition syntax changes, see the [documentation](https://doris.apache.org/docs/2.1/table-design/data-partitioning/auto-partitioning) for details.
 
   - https://github.com/apache/doris/pull/32737
 


### PR DESCRIPTION
## Summary

The zh \`release-2.1.2\` page lists four entries under \"Behavior Changed\", the EN page only two. The two missing items are about Auto Partition and were already documented in zh:

- **Auto Partition syntax change** (apache/doris#32737) — link to the auto-partitioning doc for the new syntax.
- **Auto Partition is no longer allowed to coexist with Dynamic Partition** on the same table (apache/doris#33736).

Both are real upstream changes that landed in 2.1.2; port them over to EN so the two release notes are in parity.

## Test plan

- [x] EN and zh now list the same four Behavior Changed items, in the same order
- [x] PR-ref set (unique) on EN matches what zh references