### PR TITLE
[doc] release-2.1.5 EN: backfill two Memory Management bug fixes

### DIFF
--- a/releasenotes/v2.1/release-2.1.5.md
+++ b/releasenotes/v2.1/release-2.1.5.md
@@ -360,6 +360,18 @@
 
 - Fixed potential duplicate data issues when primary key replica cloning fails. [#37229](https://github.com/apache/doris/pull/37229)
 
+### Memory Management
+
+- Fixed inaccurate Jemalloc Cache statistics. [#37464](https://github.com/apache/doris/pull/37464)
+
+- Fixed the issue where memory size could not be correctly detected in K8s / CGroup environments. [#36966](https://github.com/apache/doris/pull/36966)
+
+### Memory Management
+
+- Fixed inaccurate Jemalloc Cache statistics. [#37464](https://github.com/apache/doris/pull/37464)
+
+- Fixed the issue where memory size could not be correctly detected in K8s / CGroup environments. [#36966](https://github.com/apache/doris/pull/36966)
+
 ### Permissions
 
 - Fixed the issue of missing authorization when a table-valued function references a resource. [#37132](https://github.com/apache/doris/pull/37132)


### PR DESCRIPTION
## Summary

The zh \`release-2.1.5\` page carries a \`### 内存管理\` (Memory Management) subsection under Bug Fixes that EN was missing entirely, along with the two fixes it contains:

- Jemalloc Cache statistics inaccuracy — apache/doris#37464
- Memory size mis-detection under K8s / CGroup — apache/doris#36966

Both are real fixes that landed in 2.1.5 (already documented in zh). Add a new \`### Memory Management\` H3 in EN Bug Fixes, placed between \`### Merge on Write Unique Key\` and \`### Permissions\` to mirror zh's section ordering.

## Test plan

- [x] EN now has \`### Memory Management\` with two bullets, matching the zh structure
- [x] \`grep -oE 'pull/[0-9]+' | sort -u | wc -l\` on EN now includes #36966 and #37464