### PR TITLE
[doc] release-3.0.4 EN: fix wrong PR ref for Hudi JNI Scanner item

### DIFF
--- a/releasenotes/v3.0/release-3.0.4.md
+++ b/releasenotes/v3.0/release-3.0.4.md
@@ -21,7 +21,7 @@ Dear community members, the Apache Doris 3.0.4 version was officially released o
   - For more information, please refer to documentation: [Export Overview - Apache Doris](https://doris.apache.org/docs/3.0/data-operate/export/export-overview)
 
 - When querying a data source with case-insensitive table names (such as Hive) through External Catalog, in previous versions, you can use any case to query the table name, but in version 3.0.4, Doris's own table name case sensitivity policy will be strictly followed.
-- The Hudi JNI Scanner has been replaced from Spark API to Hadoop API to enhance compatibility. Users can switch by setting the session variable `set hudi_jni_scanner=spark/hadoop`. [#44396](https://github.com/apache/doris/pull/44396) 
+- The Hudi JNI Scanner has been replaced from Spark API to Hadoop API to enhance compatibility. Users can switch by setting the session variable `set hudi_jni_scanner=spark/hadoop`. [#44267](https://github.com/apache/doris/pull/44267) 
 - The use of `auto bucket` in Colocate tables is prohibited.  [#44396](https://github.com/apache/doris/pull/44396) 
 - Paimon cache has been added to the Catalog, eliminating real-time data queries.  [#44911 ](https://github.com/apache/doris/pull/44911)
 - The default value of `max_broker_concurrency` has been increased to improve performance for large-scale data imports with Broker Load. [#44929](https://github.com/apache/doris/pull/44929) 


### PR DESCRIPTION
## Summary

In the EN \`release-3.0.4\` Behavior Changes section, the **Hudi JNI Scanner has been replaced from Spark API to Hadoop API** bullet links to apache/doris#44396. That PR is actually the one for the next bullet (\"The use of \`auto bucket\` in Colocate tables is prohibited\"). The Hudi JNI Scanner change is apache/doris#44267 — which zh \`release-3.0.4\` already references correctly.

Correct the PR link.

## Test plan

- [x] EN now references #44267 for the Hudi JNI Scanner item, matching zh
- [x] #44396 still appears on the Colocate auto-bucket line as it should