### PR TITLE
[feat](navbar) add Roadmap link to Community dropdown

### DIFF
--- a/src/components/home-next/NavbarNext.tsx
+++ b/src/components/home-next/NavbarNext.tsx
@@ -67,6 +67,7 @@ function buildNavItems(
         {
             label: 'Community',
             items: [
+                { label: 'Roadmap', href: 'https://github.com/apache/doris/issues/60036', external: true },
                 { label: 'Build with Us', href: joinCommunityHref },
                 { label: 'Join GitHub Discussions', href: 'https://github.com/apache/doris/discussions', external: true },
             ],


### PR DESCRIPTION
## Summary
- Add a `Roadmap` entry as the first item in the Community dropdown of the new home navbar, linking to https://github.com/apache/doris/issues/60036 (opens in a new tab).

## Test plan
- [ ] Open the homepage, hover the Community dropdown, confirm `Roadmap` appears first and opens the GitHub issue in a new tab.
- [ ] Open the mobile menu, expand Community, confirm the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)