### PR TITLE
[fix](doc) zh cut-ipv6 examples use wrong wrapper INET6_ATON, return NULL on cluster

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/cut-ipv6.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/cut-ipv6.md
@@ -42,7 +42,7 @@ CUT_IPV6(<ipv6_address>, <bytes_to_cut_for_ipv6>, <bytes_to_cut_for_ipv4>)
 
 截取纯 IPv6 地址的末尾字节。
 ```sql
-SELECT cut_ipv6(INET6_ATON('2001:db8::1'), 4, 4) as cut_result;
+SELECT cut_ipv6(to_ipv6('2001:db8::1'), 4, 4) as cut_result;
 +------------------+
 | cut_result       |
 +------------------+
@@ -52,29 +52,29 @@ SELECT cut_ipv6(INET6_ATON('2001:db8::1'), 4, 4) as cut_result;
 
 截取 IPv4 映射地址的末尾字节。
 ```sql
-SELECT cut_ipv6(INET6_ATON('::ffff:192.168.1.1'), 4, 4) as cut_result;
-+------------------+
-| cut_result       |
-+------------------+
-| ::ffff:192.168.0.0 |
-+------------------+
+SELECT cut_ipv6(to_ipv6('::ffff:192.168.1.1'), 4, 4) as cut_result;
++----------------+
+| cut_result     |
++----------------+
+| ::ffff:0.0.0.0 |
++----------------+
 ```
 
 使用不同的截取参数。
 ```sql
 SELECT 
-  cut_ipv6(INET6_ATON('2001:db8::1'), 8, 4) as ipv6_cut_8,
-  cut_ipv6(INET6_ATON('::ffff:192.168.1.1'), 4, 8) as ipv4_cut_8;
-+-------------+------------------+
-| ipv6_cut_8  | ipv4_cut_8      |
-+-------------+------------------+
-| 2001::      | ::ffff:192.0.0.0 |
-+-------------+------------------+
+  cut_ipv6(to_ipv6('2001:db8::1'), 8, 4) as ipv6_cut_8,
+  cut_ipv6(to_ipv6('::ffff:192.168.1.1'), 4, 8) as ipv4_cut_8;
++------------+------------+
+| ipv6_cut_8 | ipv4_cut_8 |
++------------+------------+
+| 2001:db8:: | ::         |
++------------+------------+
 ```
 
 参数值超出范围会抛出异常。
 ```sql
-SELECT cut_ipv6(INET6_ATON('2001:db8::1'), 17, 4);
+SELECT cut_ipv6(to_ipv6('2001:db8::1'), 17, 4);
 ERROR 1105 (HY000): errCode = 2, detailMessage = (...)[INVALID_ARGUMENT]Illegal value for argument 2 TINYINT of function cut_ipv6
 ```
 


### PR DESCRIPTION
## Summary

The Chinese version of `cut-ipv6.md` wraps the IPv6 input with `INET6_ATON(...)`, but `cut_ipv6` expects an `IPV6` type — `INET6_ATON` returns the packed-binary form (BLOB), so **every example on the current ZH page returns `NULL` on a real cluster, not the IPv6 strings shown in the doc**.

The EN version of the same page correctly uses `to_ipv6(...)`, which returns the `IPV6` type that `cut_ipv6` accepts.

This PR aligns the ZH wrapper with EN's and fixes the documented outputs to match what `cut_ipv6` actually returns.

## Verification on Apache Doris 4.1.1

| Example | Current ZH SQL | Actual return | ZH **doc** claims |
|---|---|---|---|
| 1 | `cut_ipv6(INET6_ATON('2001:db8::1'), 4, 4)` | `NULL` | `2001:db8::` ❌ |
| 2 | `cut_ipv6(INET6_ATON('::ffff:192.168.1.1'), 4, 4)` | `NULL` | `::ffff:192.168.0.0` ❌ |
| 3a | `cut_ipv6(INET6_ATON('2001:db8::1'), 8, 4)` | `NULL` | `2001::` ❌ |
| 3b | `cut_ipv6(INET6_ATON('::ffff:192.168.1.1'), 4, 8)` | `NULL` | `::ffff:192.0.0.0` ❌ |
| 4 | `cut_ipv6(INET6_ATON('2001:db8::1'), 17, 4)` | `NULL` (silently!) | `ERROR ... Illegal value for argument 2` ❌ |

After this fix (using `to_ipv6` like the EN page does):

| Example | New SQL | Actual return |
|---|---|---|
| 1 | `cut_ipv6(to_ipv6('2001:db8::1'), 4, 4)` | `2001:db8::` ✓ |
| 2 | `cut_ipv6(to_ipv6('::ffff:192.168.1.1'), 4, 4)` | `::ffff:0.0.0.0` ✓ |
| 3a | `cut_ipv6(to_ipv6('2001:db8::1'), 8, 4)` | `2001:db8::` ✓ |
| 3b | `cut_ipv6(to_ipv6('::ffff:192.168.1.1'), 4, 8)` | `::` ✓ |
| 4 | `cut_ipv6(to_ipv6('2001:db8::1'), 17, 4)` | `ERROR ... Illegal value for argument 2` ✓ |

## Changes

- 5 `SELECT` statements: `INET6_ATON(...)` → `to_ipv6(...)`
- 3 expected-output ASCII tables updated to match actual values
- Net: 1 file, +15 / -15 lines

## Scope

This PR is **only the ZH file** — the EN version is already correct.

ZH also lacks the "NULL inputs" example block that EN has — that's a separate "compose to EN's superset" task for a future PR, not part of this minimum-impact fix.

## Detection

Discovered by running `cut-ipv6.md` examples on a single-BE Apache Doris 4.1.1 cluster as part of a broader docs-vs-implementation verification effort. The discrepancy between documented outputs and actual returned values made it stand out.