### PR TITLE
[fix](doc) median.md: add missing setup in EN; align Example 2 SQL with its result

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/aggregate-functions/median.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/aggregate-functions/median.md
@@ -60,7 +60,7 @@ select datetime, median(scan_rows) from log_statis group by datetime;
 ```
 
 ```sql
-select median(scan_rows) from log_statis group by datetime;
+select median(scan_rows) from log_statis where scan_rows is null;
 ```
 
 ```text

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/median.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/median.md
@@ -30,6 +30,22 @@ Returns NULL if there is no valid data in the group.
 ## Example
 
 ```sql
+-- setup
+create table log_statis(
+    datetime datetime,
+    scan_rows int
+) distributed by hash(datetime) buckets 1
+properties ("replication_num"="1");
+insert into log_statis values
+    ('2025-08-25 10:00:00', 10),
+    ('2025-08-25 10:00:00', 50),
+    ('2025-08-25 10:00:00', 100),
+    ('2025-08-25 11:00:00', 20),
+    ('2025-08-25 11:00:00', 30),
+    ('2025-08-25 11:00:00', 40);
+```
+
+```sql
 select datetime, median(scan_rows) from log_statis group by datetime;
 ```
 

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/median.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/median.md
@@ -60,7 +60,7 @@ select datetime, median(scan_rows) from log_statis group by datetime;
 ```
 
 ```sql
-select median(scan_rows) from log_statis group by datetime;
+select median(scan_rows) from log_statis where scan_rows is null;
 ```
 
 ```text


### PR DESCRIPTION
## Summary

Two fixes to `sql-manual/sql-functions/aggregate-functions/median.md`, both found by running every example on a real Doris 4.1.1 cluster.

### Fix 1 — EN page is missing the setup block

The EN page jumps straight to `SELECT … FROM log_statis …` without first creating the table or inserting fixture rows, so every example fails with `Table [log_statis] does not exist` if a reader copy-pastes them. The ZH version already has the setup block. This PR brings the EN page in line — same `CREATE TABLE` + `INSERT` content, no other changes.

### Fix 2 — Example 2 SQL doesn't match its result block (EN + ZH)

The second example on both pages had:

- SQL block: `SELECT median(scan_rows) FROM log_statis GROUP BY datetime;`
- Result block: first line was the literal `select median(scan_rows) from log_statis where scan_rows is null;` (a captured command echo from mysql CLI), followed by a single `NULL` row.

So the result is actually the output of `WHERE scan_rows IS NULL`, not `GROUP BY datetime` — the SQL block was pasted from a different query by mistake.

Aligned the SQL block to match the result (the `WHERE` form). Two reasons that direction over the other:
1. The result body (single NULL row) is what `WHERE scan_rows IS NULL` returns; the `GROUP BY datetime` form returns two median rows on the fixture data.
2. Demonstrates the Description's note that median returns `NULL` when the group has no valid data.

A reader can now copy-paste Example 2 and reproduce the documented output.

## Verification on Apache Doris 4.1.1

With the setup block applied:

```sql
-- Example 1
SELECT datetime, median(scan_rows) FROM log_statis GROUP BY datetime;
-- → (2025-08-25 10:00 → 50.0), (2025-08-25 11:00 → 30.0)   ✓

-- Example 2 (after this fix)
SELECT median(scan_rows) FROM log_statis WHERE scan_rows IS NULL;
-- → NULL   ✓
```

## Changes

- `versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/median.md`  — add setup block (+16); fix Example 2 SQL (1 line)
- `i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/aggregate-functions/median.md`  — fix Example 2 SQL (1 line)

Total: 2 files, +17 / -1 lines, split into 2 logically-distinct commits for review.

## Detection

Discovered by running `median.md` examples on a single-BE Apache Doris 4.1.1 cluster as part of a broader docs-vs-implementation verification effort. The same effort already produced doris-website#3781 (merged) and doris-website#3786 (open).