### PR TITLE
[fix](doc) field.md: add missing setup; reconcile zh result tables with NULL row

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/field.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/field.md
@@ -30,6 +30,28 @@ FIELD(<expr>, <param> [, ...])
 ## 举例
 
 ```sql
+-- setup
+CREATE TABLE baseall (k1 INT, k7 VARCHAR(64))
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO baseall VALUES
+    (1, 'wangjing04'),
+    (2, 'wangyu14'),
+    (3, 'yuanyuan06');
+
+CREATE TABLE class_test (class_name VARCHAR(64))
+DISTRIBUTED BY HASH(class_name) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO class_test VALUES
+    ('Suzi'), ('Suzi'),
+    ('Ben'), ('Ben'),
+    ('Henry'), ('Henry'),
+    (NULL);
+```
+
+```sql
 SELECT k1, k7 FROM baseall WHERE k1 IN (1,2,3) ORDER BY FIELD(k1,2,1,3);
 ```
 
@@ -51,6 +73,7 @@ SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Hen
 +------------+
 | class_name |
 +------------+
+| NULL       |
 | Suzi       |
 | Suzi       |
 | Ben        |
@@ -74,6 +97,7 @@ SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Hen
 | Ben        |
 | Suzi       |
 | Suzi       |
+| NULL       |
 +------------+
 ```
 

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/field.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/field.md
@@ -33,6 +33,27 @@ FIELD(<expr>, <param> [, ...])
 ## Examples
 
 ```sql
+-- setup
+CREATE TABLE baseall (k1 INT, k7 VARCHAR(64))
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO baseall VALUES
+    (1, 'wangjing04'),
+    (2, 'wangyu14'),
+    (3, 'yuanyuan06');
+
+CREATE TABLE class_test (class_name VARCHAR(64))
+DISTRIBUTED BY HASH(class_name) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO class_test VALUES
+    ('Suzi'), ('Suzi'),
+    ('Ben'), ('Ben'),
+    ('Henry'), ('Henry');
+```
+
+```sql
 SELECT FIELD(2, 3, 1, 2, 5);
 ```
 


### PR DESCRIPTION
## Summary

Doc pages (4.x): \`scalar-functions/other-functions/field.md\` (EN + ZH).

**EN**: The two table-based examples reference \`baseall\` and \`class_test\` but the page never created/inserted into them — copy-paste fails. Added a setup block that materializes both tables with the rows shown in the existing expected results (Suzi/Ben/Henry, no NULL).

**ZH**: Two problems.

1. Same missing-setup issue as EN.
2. Internal inconsistency: the basic ASC and DESC result tables show 6 rows (no NULL), but the NULLS FIRST result table shows 7 rows with a NULL. A single dataset cannot produce both. The prose immediately above the examples explicitly explains *\"对于 NULL 值，可以使用 nulls first 或 nulls last 控制排序顺序\"*, confirming the author intends a dataset that contains NULL — so the basic ASC / DESC results, not the NULLS FIRST one, are the ones that are wrong.

The ZH fix:
- Setup includes 7 rows (Suzi×2, Ben×2, Henry×2, NULL).
- Basic ASC result: 7 rows, NULL first (\`FIELD\` returns 0 for values not in the list including NULL; Doris's default ASC puts NULLs first).
- DESC result: 7 rows, NULL last.
- NULLS FIRST result: unchanged (already correct).

## Verification

Ran the setup + every example end-to-end on a single-node Apache Doris 4.1.1 cluster. Every documented result block in this PR now matches the cluster output exactly.

Split into 2 commits so the EN-only and ZH-only changes are easy to review separately.

## Test plan

- [x] Run EN setup + all 3 EN examples → matches each documented result.
- [x] Run ZH setup + all 4 ZH examples → matches each documented result.
- [x] No prose changes; only example reproducibility/correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)