### PR TITLE
[fix](doc) replace-empty.md: align en/zh examples and add NULL/UTF-8 corner cases

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/replace-empty.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/replace-empty.md
@@ -37,6 +37,22 @@ REPLACE_EMPTY(<str>, <old>, <new>)
 
 ## 示例
 
+作为参照，`REPLACE` 会将 `<old>` 的每次出现替换为 `<new>`，字符串的其余部分保持不变：
+
+```sql
+SELECT replace('hello world', 'world', 'universe');
+```
+
+```text
++---------------------------------------------+
+| replace('hello world', 'world', 'universe') |
++---------------------------------------------+
+| hello universe                              |
++---------------------------------------------+
+```
+
+`REPLACE_EMPTY` 在常规情况下行为与 `REPLACE` 相同（见下面的例 2），但当 `<old>` 为空字符串时不同——此时会把 `<new>` 插入到 `<str>` 的每个字符前以及末尾（见例 1）。其余例子覆盖各种边界情况。
+
 1. 基本用法：old 为空字符串时插入
 ```sql
 SELECT replace_empty('abc', '', 'x');

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/replace-empty.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/replace-empty.md
@@ -28,46 +28,80 @@ REPLACE_EMPTY ( <str>, <old>, <new> )
 
 ## Return Value
 
-Returns the new string after replacing the substring. Special cases:
+Returns VARCHAR — the new string after replacing the substring. Special cases:
 
-- If any Parameter is NULL, NULL will be returned.
-- If `<old>` is an empty string, the string with the `<new>` string inserted before each character of the `<str>` string will be returned.
+- If any parameter is NULL, returns NULL.
+- If `<old>` is an empty string, returns the string with `<new>` inserted before every character of `<str>` and at the end.
+- If `<old>` is not found in `<str>`, returns `<str>` unchanged.
 
 ## Examples
 
+1. Basic usage: insert behavior when `<old>` is an empty string.
 
 ```sql
-SELECT replace('hello world', 'world', 'universe');
+SELECT replace_empty('abc', '', 'x');
 ```
 
 ```text
-+---------------------------------------------+
-| replace('hello world', 'world', 'universe') |
-+---------------------------------------------+
-| hello universe                              |
-+---------------------------------------------+
++-------------------------------+
+| replace_empty('abc', '', 'x') |
++-------------------------------+
+| xaxbxcx                       |
++-------------------------------+
 ```
 
+2. Plain substring replacement (same behavior as `REPLACE`).
+
 ```sql
-SELECT replace_empty("abc", '', 'xyz');
+SELECT replace_empty('hello', 'l', 'L');
 ```
 
 ```text
-+---------------------------------+
-| replace_empty('abc', '', 'xyz') |
-+---------------------------------+
-| xyzaxyzbxyzcxyz                 |
-+---------------------------------+
++----------------------------------+
+| replace_empty('hello', 'l', 'L') |
++----------------------------------+
+| heLLo                            |
++----------------------------------+
 ```
 
+3. Empty `<str>` together with empty `<old>`.
+
 ```sql
-SELECT replace_empty("", "", "xyz");
+SELECT replace_empty('', '', 'x');
 ```
 
 ```text
-+------------------------------+
-| replace_empty('', '', 'xyz') |
-+------------------------------+
-| xyz                          |
-+------------------------------+
++----------------------------+
+| replace_empty('', '', 'x') |
++----------------------------+
+| x                          |
++----------------------------+
+```
+
+4. NULL propagation.
+
+```sql
+SELECT replace_empty(NULL, 'old', 'new');
+```
+
+```text
++-----------------------------------+
+| replace_empty(NULL, 'old', 'new') |
++-----------------------------------+
+| NULL                              |
++-----------------------------------+
+```
+
+5. Multi-byte (UTF-8) `<new>`.
+
+```sql
+SELECT replace_empty('hello', 'l', 'ṭṛìṭ');
+```
+
+```text
++--------------------------------------------+
+| replace_empty('hello', 'l', 'ṭṛìṭ')        |
++--------------------------------------------+
+| heṭṛìṭṭṛìṭo                                |
++--------------------------------------------+
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/replace-empty.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/replace-empty.md
@@ -36,6 +36,22 @@ Returns VARCHAR — the new string after replacing the substring. Special cases:
 
 ## Examples
 
+For reference, `REPLACE` rewrites every occurrence of `<old>` and leaves the rest of the string untouched:
+
+```sql
+SELECT replace('hello world', 'world', 'universe');
+```
+
+```text
++---------------------------------------------+
+| replace('hello world', 'world', 'universe') |
++---------------------------------------------+
+| hello universe                              |
++---------------------------------------------+
+```
+
+`REPLACE_EMPTY` behaves the same in the ordinary case (see example 2 below), but differs when `<old>` is an empty string — it then inserts `<new>` before every character of `<str>` and at the end (example 1). The remaining examples cover the corner cases.
+
 1. Basic usage: insert behavior when `<old>` is an empty string.
 
 ```sql


### PR DESCRIPTION
## Summary

Doc page (4.x): `scalar-functions/string-functions/replace-empty.md` (EN + ZH).

This PR keeps the EN and ZH pages in lockstep with each other while adding the missing corner cases:

1. Both sides keep the original `SELECT replace('hello world', 'world', 'universe')` example, but it is now framed explicitly as a *contrast baseline* under "For reference" — readers see plain `REPLACE` behavior first, then the numbered list below shows where `REPLACE_EMPTY` differs.
2. Both sides now share the same numbered list of REPLACE_EMPTY examples covering: insert behavior / plain replace / empty `<str>` / NULL propagation / multi-byte (`ṭṛìṭ`) `<new>`. The NULL and UTF-8 cases were already on ZH; this brings EN up to parity.
3. EN's Return Value section gains the "if `<old>` is not in `<str>`, returns `<str>` unchanged" specification line and notes the VARCHAR return type — both were already on ZH.

## Verification

Every SQL example was run against a single-node Apache Doris 4.1.1 cluster using the actual mysql/mariadb client; the result blocks in this PR are the verbatim CLI output (including the wider padding MariaDB emits on the UTF-8 row, which is matched character-for-character).

## Test plan

- [x] Run every example on a 4.1.1 cluster — all 6 (1 reference + 5 numbered) match the result blocks exactly.
- [x] EN and ZH structure now identical: same intro, same numbered examples in the same order.
- [x] Confirm `REPLACE_EMPTY` behavior is unchanged; only doc text/examples are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)