### PR TITLE
[fix](doc) url-decode.md: merge en/zh examples, fix divider width and wrong fence tag

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/url-decode.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/url-decode.md
@@ -27,16 +27,30 @@ URL_DECODE( <str> )
 
 ## 示例
 
-```sql
+解码百分号编码的 URL —— `%3A` → `:`，`%2F` → `/`。
 
-select  URL_DECODE('Doris+Q%26A');
+```sql
+select url_decode('https%3A%2F%2Fdoris.apache.org%2Fzh-CN%2Fdocs%2Fsql-manual%2Fsql-functions%2Fstring-functions');
 ```
 
+```text
++-------------------------------------------------------------------------------------------------------------+
+| url_decode('https%3A%2F%2Fdoris.apache.org%2Fzh-CN%2Fdocs%2Fsql-manual%2Fsql-functions%2Fstring-functions') |
++-------------------------------------------------------------------------------------------------------------+
+| https://doris.apache.org/zh-CN/docs/sql-manual/sql-functions/string-functions                               |
++-------------------------------------------------------------------------------------------------------------+
+```
+
+解码 `application/x-www-form-urlencoded` 风格的字符串 —— `+` → 空格，`%26` → `&`。
+
 ```sql
+select url_decode('Doris+Q%26A');
+```
+
+```text
 +---------------------------+
 | url_decode('Doris+Q%26A') |
 +---------------------------+
 | Doris Q&A                 |
 +---------------------------+
-
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/url-decode.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/url-decode.md
@@ -27,13 +27,30 @@ The decoded value
 
 ##  Example
 
+Decoding a percent-encoded URL — `%3A` → `:`, `%2F` → `/`.
+
 ```sql
 select url_decode('https%3A%2F%2Fdoris.apache.org%2Fzh-CN%2Fdocs%2Fsql-manual%2Fsql-functions%2Fstring-functions');
 ```
+
 ```text
-+------------------------------------------------+
++-------------------------------------------------------------------------------------------------------------+
 | url_decode('https%3A%2F%2Fdoris.apache.org%2Fzh-CN%2Fdocs%2Fsql-manual%2Fsql-functions%2Fstring-functions') |
-+------------------------------------------------+
++-------------------------------------------------------------------------------------------------------------+
 | https://doris.apache.org/zh-CN/docs/sql-manual/sql-functions/string-functions                               |
-+------------------------------------------------+
++-------------------------------------------------------------------------------------------------------------+
+```
+
+Decoding a `application/x-www-form-urlencoded`-style string — `+` → space, `%26` → `&`.
+
+```sql
+select url_decode('Doris+Q%26A');
+```
+
+```text
++---------------------------+
+| url_decode('Doris+Q%26A') |
++---------------------------+
+| Doris Q&A                 |
++---------------------------+
 ```


### PR DESCRIPTION
## Summary

Doc page (4.x): \`scalar-functions/string-functions/url-decode.md\` (EN + ZH).

Each side had one example the other didn't, plus a small bug:

| Side | Had | Bug |
|------|-----|-----|
| EN | long-URL example | divider line is 48 chars but the column-name row is 111 chars, so the result table renders ragged on the docs site |
| ZH | short \`Doris+Q%26A\` example showing \`+\` → space and \`%26\` → \`&\` decoding | result block uses \`\`\`\`sql\`\`\` instead of \`\`\`\`text\`\`\`, so docusaurus syntax-highlights the ASCII grid as SQL |

This PR brings both pages to the same structure: two examples (long URL + form-encoded short string), each with a one-line intro, correct fence tags, and divider lines that match the actual mysql client output byte-for-byte.

## Verification

Both SQL examples run against a single-node Apache Doris 4.1.1 cluster; the result blocks in the PR are the verbatim CLI output.

## Test plan

- [x] Run both examples on the cluster — match documented results.
- [x] EN and ZH now mirror each other structurally.
- [x] Result blocks are tagged \`text\` so docusaurus does not syntax-highlight them as SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)