### PR TITLE
[doc] Add Confluent import configuration optimization FAQ

### DIFF
--- a/docs/faq/load-faq.md
+++ b/docs/faq/load-faq.md
@@ -72,6 +72,9 @@ curl --location-trusted -u root:"" \
     http://127.0.0.1:8030/api/db/loadtest/_stream_load
 ```
 
+### Confluent Import Configuration Optimization
+When using Confluent to import data into Doris, you need to adjust `buffer.count.records`. The default value is 10000, which can be increased to 50000 or larger; `buffer.size.bytes` can be increased to 100000000 or larger.
+
 ## Routine Load 
 
 ### Major Bug Fixes

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/faq/load-faq.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/faq/load-faq.md
@@ -72,6 +72,9 @@ curl --location-trusted -u root:"" \
     http://127.0.0.1:8030/api/db/loadtest/_stream_load
 ```
 
+### confluent导入配置优化
+在使用confluent导入数据到Doris时，需要调整下buffer.count.records，默认值为10000，可以调整到50000或者更大；buffer.size.bytes可以调整到100000000或者更大。
+
 ## Routine Load 
 
 ### 较严重的 Bug 修复


### PR DESCRIPTION
Add FAQ entry about optimizing Confluent import settings:
- buffer.count.records: increase from 10000 to 50000 or larger
- buffer.size.bytes: increase to 100000000 or larger

Both English and Chinese versions updated.

## Versions 

- [x] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [ ] Japanese candidate translation needed

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
- [ ] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync
