### PR TITLE
[fix](doc) array-contains.md zh: ';' → ',' between rows of the 4-row INSERT

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-contains.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-contains.md
@@ -89,7 +89,7 @@ PROPERTIES (
 INSERT INTO array_contains_test VALUES
 (1, [1000, 2000, 3000], ['apple', 'banana', 'cherry']),
 (2, [], []),
-(3, NULL, NULL);
+(3, NULL, NULL),
 (4, [1000, null, 3000], ['apple', null, 'cherry']);
 ```
 


### PR DESCRIPTION
## Summary

Doc page (4.x): \`scalar-functions/array-functions/array-contains.md\` (ZH).

One-character typo: the third row of the setup INSERT ends with \`;\` instead of \`,\`, terminating the INSERT after 3 rows and leaving the fourth row as an orphan statement the parser cannot handle:

\`\`\`
INSERT INTO array_contains_test VALUES
(1, [1000, 2000, 3000], ['apple', 'banana', 'cherry']),
(2, [], []),
(3, NULL, NULL);                                          ← was \`;\`, should be \`,\`
(4, [1000, null, 3000], ['apple', null, 'cherry']);
\`\`\`

The cluster fails with:

\`\`\`
ERROR 1105 (HY000): errCode = 2, detailMessage =
mismatched input '4' expecting {'(', 'SELECT', 'VALUES', 'WITH'}(line 1, pos 1)
\`\`\`

The EN page already uses a comma here. This change brings the ZH page in line.

## Verification

Reproduced the parser error on a single-node Apache Doris 4.1.1 cluster. With the comma in place all four rows insert and subsequent queries on the page work.

## Test plan

- [x] Run the setup block on a 4.1.1 cluster — all four rows insert.
- [x] No prose or other SQL changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)