### PR TITLE
[fix](doc) json-extract-bigint.md zh: first example calls json_extract_int instead of json_extract_bigint

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/json-functions/json-extract-bigint.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/json-functions/json-extract-bigint.md
@@ -33,7 +33,7 @@ JSON_EXTRACT_BIGINT(<json_object>, <json_path>)
 ## 示例
 1. 正常参数
     ```sql
-    SELECT json_extract_int('{"id": 122222222222223, "name": "doris"}', '$.id');
+    SELECT json_extract_bigint('{"id": 122222222222223, "name": "doris"}', '$.id');
     ```
     ```text
     +-------------------------------------------------------------------------+


### PR DESCRIPTION
## Summary

Doc page (4.x): \`scalar-functions/json-functions/json-extract-bigint.md\` (ZH).

The first example on the ZH page calls \`json_extract_int(...)\`:

\`\`\`sql
SELECT json_extract_int('{\"id\": 122222222222223, \"name\": \"doris\"}', '\$.id');
\`\`\`

…but the result block underneath shows the column header for \`json_extract_bigint(...)\` and the value \`122222222222223\`. That is the result of the *bigint* variant; the int variant returns NULL because \`122222222222223\` overflows 32-bit INT.

The page is titled JSON_EXTRACT_BIGINT and every other example uses the bigint variant — this was just a copy-paste typo on example 1.

## Verification

Confirmed on a single-node Apache Doris 4.1.1 cluster: \`json_extract_int(...)\` returns NULL for this value, \`json_extract_bigint(...)\` returns \`122222222222223\` as the doc shows.

## Test plan

- [x] Run the corrected SQL — returns \`122222222222223\` matching the result block.
- [x] No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)