### PR TITLE
[fix](doc) to-quantile-state.md zh: replace ${tableName_21} placeholder with the real table name

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/quantile-functions/to-quantile-state.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/quantile-functions/to-quantile-state.md
@@ -30,7 +30,7 @@ TO_QUANTILE_STATE(<raw_data>, <compression>)
 ## Example
 
 ```sql
-CREATE TABLE IF NOT EXISTS ${tableName_21} (
+CREATE TABLE IF NOT EXISTS quantile_state_agg_test (
          `dt` int(11) NULL COMMENT "",
          `id` int(11) NULL COMMENT "",
          `price` quantile_state QUANTILE_UNION NOT NULL COMMENT ""


### PR DESCRIPTION
## Summary

Doc page (4.x): \`scalar-functions/quantile-functions/to-quantile-state.md\` (ZH).

The ZH page's setup creates the table under a template placeholder that was never interpolated:

\`\`\`sql
CREATE TABLE IF NOT EXISTS \${tableName_21} (
    ...
);
\`\`\`

…while every following statement references the literal name \`quantile_state_agg_test\`. The cluster errors out with \`Table [quantile_state_agg_test] does not exist\` because nothing ever created a table with that name.

EN already uses \`quantile_state_agg_test\` throughout. Sync the ZH CREATE so the example actually works.

## Verification

After the fix, running the entire example block end-to-end on Apache Doris 4.1.1 produces the documented result table.

## Test plan

- [x] Run setup + INSERTs + SELECT on a 4.1.1 cluster — matches the documented output.
- [x] No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)