### PR TITLE
[fix](doc) from-base64.md zh: replace wrong base64 literals in UTF-8 example

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/from-base64.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/from-base64.md
@@ -115,14 +115,14 @@ SELECT FROM_BASE64('SGVsbG8gV29ybGQ='), FROM_BASE64('VGhlIHF1aWNrIGJyb3duIGZveA=
 
 7. UTF-8 多字节字符解码
 ```sql
-SELECT FROM_BASE64('4bmt4bmb4bmA'), FROM_BASE64('4bmN4bmNdW1haSBoZWxsbw==');
+SELECT FROM_BASE64('4bmt4bmbw6w='), FROM_BASE64('4biN4biNdW1haSBoZWxsbw==');
 ```
 ```text
-+---------------------------+---------------------------------------+
-| FROM_BASE64('4bmt4bmb4bmA') | FROM_BASE64('4bmN4bmNdW1haSBoZWxsbw==') |
-+---------------------------+---------------------------------------+
-| ṭṛì                       | ḍḍumai hello                          |
-+---------------------------+---------------------------------------+
++-----------------------------+-----------------------------------------+
+| FROM_BASE64('4bmt4bmbw6w=') | FROM_BASE64('4biN4biNdW1haSBoZWxsbw==') |
++-----------------------------+-----------------------------------------+
+| ṭṛì                         | ḍḍumai hello                            |
++-----------------------------+-----------------------------------------+
 ```
 
 8. 电子邮件地址解码


### PR DESCRIPTION
## Summary

Doc page (4.x): \`scalar-functions/string-functions/from-base64.md\` (ZH).

The UTF-8 example used base64 inputs that don't decode to the strings shown in the result column:

| Base64 literal | What the cluster actually returns | What the doc shows |
|---|---|---|
| \`4bmt4bmb4bmA\` | \`ṭṛṀ\` | \`ṭṛì\` |
| \`4bmN4bmNdW1haSBoZWxsbw==\` | \`ṍṍumai hello\` | \`ḍḍumai hello\` |

Most likely a typo where an \`i\` was written as \`m\` in two places (a single hex nibble different: B8 vs B9). Replace with the correct RFC 4648 base64 for the intended strings:

\`\`\`
'4bmt4bmbw6w='              → 'ṭṛì'
'4biN4biNdW1haSBoZWxsbw=='  → 'ḍḍumai hello'
\`\`\`

## Verification

Confirmed on Apache Doris 4.1.1 — the corrected base64 inputs return exactly the strings already shown in the result block.

## Test plan

- [x] Run the corrected SQL on a 4.1.1 cluster — outputs match.
- [x] Result-block divider widths updated to match the new (longer) base64 strings in the column headers.
- [x] No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)