### PR TITLE
[fix](doc) monthname.md en: break prose comment from SET onto its own line

### DIFF
--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/monthname.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/monthname.md
@@ -60,7 +60,8 @@ SELECT MONTHNAME(NULL) AS result;
 | NULL   |
 +--------+
 
----Control the output language by setting `lc_time_names`SET lc_time_names='zh_CN';
+---Control the output language by setting `lc_time_names`
+SET lc_time_names='zh_CN';
 SELECT MONTHNAME('2023-07-13 22:28:18') AS result;
 +--------+
 | result |


### PR DESCRIPTION
## Summary

Doc page (4.x): \`scalar-functions/date-time-functions/monthname.md\` (EN).

The 4th example began with the single line:

\`\`\`
---Control the output language by setting \`lc_time_names\`SET lc_time_names='zh_CN';
\`\`\`

The opening \`---\` is a SQL line comment, so the *entire* line — including the SET — was being commented out. The next SELECT then ran without \`lc_time_names\` actually being changed and returned \`July\` instead of the documented \`七月\`.

Break the SET onto its own line so it executes. ZH already does this.

## Verification

Confirmed on a single-node Apache Doris 4.1.1 cluster:

\`\`\`
mysql> SET lc_time_names='zh_CN';
mysql> SELECT MONTHNAME('2023-07-13 22:28:18') AS result;
+--------+
| result |
+--------+
| 七月   |
+--------+
\`\`\`

## Test plan

- [x] Apply the fix; \`SET lc_time_names='zh_CN'; SELECT MONTHNAME(...)\` executed on 4.1.1 cluster returns \`七月\` as the doc states.
- [x] No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)