### PR TITLE
[fix](doc) trim.md en: 2-arg trim peels both sides repeatedly; result is 'cca'

### DIFF
--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/trim.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/trim.md
@@ -46,16 +46,16 @@ SELECT trim('   ab d   ') str;
 +------+
 ```
 
-2. Remove specified strings from both ends
+2. Remove specified strings from both ends — `trim(str, rhs)` repeatedly strips `<rhs>` from both the leading and trailing ends of `<str>` until neither end starts/ends with `<rhs>`.
 ```sql
 SELECT trim('ababccaab', 'ab') str;
 ```
 ```text
-+---------+
-| str     |
-+---------+
-| ababcca |
-+---------+
++------+
+| str  |
++------+
+| cca  |
++------+
 ```
 
 3. UTF-8 character support


### PR DESCRIPTION
## Summary

Doc page (4.x): \`scalar-functions/string-functions/trim.md\` (EN).

The 2-arg trim example claimed:

\`\`\`sql
SELECT trim('ababccaab', 'ab') str;
\`\`\`
\`\`\`
| str     |
| ababcca |
\`\`\`

On Apache Doris 4.1.1 the cluster returns \`cca\`, not \`ababcca\`. \`trim(<str>, <rhs>)\` strips \`<rhs>\` from BOTH ends and repeats until neither end starts/ends with \`<rhs>\`:

\`\`\`
'ababccaab' -> peel 'ab' from front: 'abccaab' -> peel 'ab' again: 'ccaab' (front stops)
'ccaab'     -> peel 'ab' from back: 'cca' (back stops)
final: 'cca'
\`\`\`

The ZH counterpart already shows \`cca\`. Update EN's expected output and add a one-line intro that calls out the \"both ends, repeatedly\" semantics so the result no longer looks surprising.

## Verification

\`\`\`
mysql> SELECT trim('ababccaab', 'ab') str;
+------+
| str  |
+------+
| cca  |
+------+
\`\`\`

## Test plan

- [x] Run on a 4.1.1 cluster — returns \`cca\`.
- [x] Result-table widths updated to fit the shorter value.
- [x] No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)