### PR TITLE
[fix](doc) trim-in.md en: trim('ababccaab','ab') now returns 'cca', not 'ababccaab'

### DIFF
--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/trim-in.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/trim-in.md
@@ -60,16 +60,16 @@ SELECT trim_in('ababccaab', 'ab') str;
 +------+
 ```
 
-3. Comparison with TRIM function
+3. Comparison with TRIM function — `trim_in` treats the second argument as a *character set* and peels any of those characters from both ends, while `trim` treats it as a literal *substring* and peels exact matches from both ends. Both strip repeatedly until neither end has more to strip.
 ```sql
 SELECT trim_in('ababccaab', 'ab'), trim('ababccaab', 'ab');
 ```
 ```text
-+-----------------------------+--------------------------+
-| trim_in('ababccaab', 'ab')  | trim('ababccaab', 'ab')  |
-+-----------------------------+--------------------------+
-| cc                          | ababccaab                |
-+-----------------------------+--------------------------+
++----------------------------+-------------------------+
+| trim_in('ababccaab', 'ab') | trim('ababccaab', 'ab') |
++----------------------------+-------------------------+
+| cc                         | cca                     |
++----------------------------+-------------------------+
 ```
 
 4. Character set order does not matter


### PR DESCRIPTION
## Summary

Doc page (4.x): \`scalar-functions/string-functions/trim-in.md\` (EN).

The \"Comparison with TRIM\" example claimed that:

\`\`\`sql
SELECT trim_in('ababccaab', 'ab'), trim('ababccaab', 'ab');
\`\`\`

returns:

| trim_in | trim |
|---------|------|
| cc | ababccaab |

On Apache Doris 4.1.1 the second column is \`cca\`, not the input unchanged. \`trim(<str>, <rhs>)\` peels the literal \`<rhs>\` from both ends and repeats until neither end matches, so \`'ababccaab'\` peels \`'ab'\` twice from the front and once from the back, leaving \`'cca'\`.

The side-by-side example's pedagogical point still works — \`trim_in\` treats the 2nd arg as a *character set* (peels any \`a\` or \`b\`) while \`trim\` treats it as a literal *substring* (peels exact \`ab\`) — just with different output. Update the result row to match cluster reality and tighten the intro prose to call out the char-set-vs-substring contrast more clearly. See PR #3810 for the companion fix on trim.md's own page.

## Verification

\`\`\`
mysql> SELECT trim_in('ababccaab', 'ab'), trim('ababccaab', 'ab');
+----------------------------+-------------------------+
| trim_in('ababccaab', 'ab') | trim('ababccaab', 'ab') |
+----------------------------+-------------------------+
| cc                         | cca                     |
+----------------------------+-------------------------+
\`\`\`

## Test plan

- [x] Run on a 4.1.1 cluster — matches the new result row.
- [x] Divider widths updated to fit the shorter values.
- [x] No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)