### PR TITLE
[fix](doc) milliseconds-sub.md en: overflow example needs +1500 delta, not -1500

### DIFF
--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/milliseconds-sub.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/milliseconds-sub.md
@@ -60,8 +60,8 @@ SELECT MILLISECONDS_SUB('2023-01-01', 1500);
 +--------------------------------------+
 
 -- Calculation result exceeds the datetime range, throws an exception
-SELECT MILLISECONDS_SUB('0000-01-01',-1500);
-ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation milliseconds_add of 0000-01-01 00:00:00, -1500 out of range
+SELECT MILLISECONDS_SUB('0000-01-01', 1500);
+ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[E-218]Operation millisecond_add of 0000-01-01 00:00:00, -1500 out of range
 
 -- Any parameter is NULL, returns NULL
 SELECT MILLISECONDS_SUB(NULL, 100), MILLISECONDS_SUB('2023-01-01', NULL) AS after_sub;


### PR DESCRIPTION
## Summary

Doc page (4.x): \`scalar-functions/date-time-functions/milliseconds-sub.md\` (EN).

The \"calculation result exceeds the datetime range\" example claimed:

\`\`\`sql
SELECT MILLISECONDS_SUB('0000-01-01', -1500);
ERROR 1105 (HY000): ... -1500 out of range
\`\`\`

But \`MILLISECONDS_SUB(date, -1500)\` is equivalent to \`MILLISECONDS_ADD(date, 1500)\` and produces a valid \`0000-01-01 00:00:01.500000\` — not an error. The doc had the sign of the delta backwards. The ZH counterpart already uses \`+1500\`, which correctly underflows below 0000-01-01.

Also flip the error string's function name from \`milliseconds_add\` to \`millisecond_add\` (singular form), which is what 4.x actually prints in the underlying error.

## Verification

\`\`\`
mysql> SELECT MILLISECONDS_SUB('0000-01-01', -1500);
+---------------------------------------+
| MILLISECONDS_SUB('0000-01-01', -1500) |
+---------------------------------------+
| 0000-01-01 00:00:01.500000            |
+---------------------------------------+

mysql> SELECT MILLISECONDS_SUB('0000-01-01', 1500);
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[E-218]Operation millisecond_add of 0000-01-01 00:00:00, -1500 out of range
\`\`\`

## Test plan

- [x] Run both forms on a 4.1.1 cluster — only the +1500 form raises the documented error.
- [x] No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)