### PR TITLE
[fix](doc) array-count.md en: nested array_count + array_exists actually errors; document and add a workaround

### DIFF
--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
@@ -165,14 +165,22 @@ SELECT array_count(x -> array_size(x) > 2, [[1,2],[1,2,3],[4,5,6,7]]);
 +----------------------------------------------------------------+
 ```
 
-Nested higher-order function example - count arrays that contain elements greater than 5:
+Nested higher-order functions — `array_count` expects the lambda body to return a scalar that can be cast to BOOLEAN. When the inner `array_exists` returns an ARRAY of booleans (one per inner element), `array_count` can not consume it and reports a signature error:
+
 ```sql
 SELECT array_count(x -> array_exists(y -> y > 5, x), [[1,2,3],[4,5,6],[7,8,9]]);
-+--------------------------------------------------+
-| array_count(x -> array_exists(y -> y > 5, x), [[1,2,3],[4,5,6],[7,8,9]]) |
-+--------------------------------------------------+
-|                                              2   |
-+--------------------------------------------------+
+ERROR 1105 (HY000): errCode = 2, detailMessage = Can not find the compatibility function signature: array_count(ARRAY<ARRAY<BOOLEAN>>)
+```
+
+To count outer arrays that contain *any* element greater than 5, wrap the inner check so the lambda returns a scalar BOOLEAN — e.g. `size(array_filter(y -> y > 5, x)) > 0`:
+
+```sql
+SELECT array_count(x -> size(array_filter(y -> y > 5, x)) > 0, [[1,2,3],[4,5,6],[7,8,9]]);
++----------------------------------------------------------------------------------+
+| array_count(x -> size(array_filter(y -> y > 5, x)) > 0, [[1,2,3],[4,5,6],[7,8,9]]) |
++----------------------------------------------------------------------------------+
+|                                                                                2 |
++----------------------------------------------------------------------------------+
 ```
 
 Literal array example:


### PR DESCRIPTION
## Summary

Doc page (4.x): \`scalar-functions/array-functions/array-count.md\` (EN).

The \"nested higher-order function example\" claimed:

\`\`\`sql
SELECT array_count(x -> array_exists(y -> y > 5, x), [[1,2,3],[4,5,6],[7,8,9]]);
-> 2
\`\`\`

On Apache Doris 4.1.1 this actually errors:

\`\`\`
ERROR 1105 (HY000): errCode = 2, detailMessage =
Can not find the compatibility function signature: array_count(ARRAY<ARRAY<BOOLEAN>>)
\`\`\`

because the lambda \`x -> array_exists(y -> y > 5, x)\` returns an \`ARRAY<BOOLEAN>\` for each outer element (one bool per inner element), not a scalar boolean — and \`array_count\`'s lambda body must be scalar-castable. The ZH counterpart already documents this signature error.

This change:
1. Replaces the bogus \"-> 2\" output with the actual signature error and a one-paragraph intro explaining why \`array_exists\` doesn't compose into \`array_count\` directly. (Matches ZH's treatment.)
2. Adds a follow-up example that demonstrates the correct way to express the original intent — count outer arrays that contain *any* element greater than 5 — using \`size(array_filter(y -> y > 5, x)) > 0\` as the lambda body. That returns the integer \`2\` the original example was trying to teach.

## Verification

Both forms run on a single-node Apache Doris 4.1.1 cluster:
- Original nested form: errors with the documented detailMessage.
- Workaround form: returns \`2\`.

## Test plan

- [x] Run both forms on a 4.1.1 cluster — error reproduces; workaround returns 2.
- [x] Result-block divider widths match the cluster's column header.
- [x] No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)