### PR TITLE
[fix](doc) small A-disjoint backports: substring/intersect-count examples + url-encode zh fence

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/url-encode.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/url-encode.md
@@ -29,15 +29,14 @@ UTF-8 编码完成所提供文本的 URL 编码
 ## 示例
 
 ```sql
-select  URL_ENCODE('Doris Q&A');
+select URL_ENCODE('Doris Q&A');
 ```
 
-```sql
+```text
 +-------------------------+
 | url_encode('Doris Q&A') |
 +-------------------------+
 | Doris+Q%26A             |
 +-------------------------+
-
 ```
 

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/intersect-count.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/intersect-count.md
@@ -62,3 +62,17 @@ select intersect_count(user_id,dt,20250801) from pv_bitmap;
 |                                    3 |
 +--------------------------------------+
 ```
+
+Intersect two days — counts users present on both `20250801` and `20250802` (only `user_id` 3 appears on both):
+
+```sql
+select intersect_count(user_id,dt,20250801,20250802) from pv_bitmap;
+```
+
+```text
++-----------------------------------------------+
+| intersect_count(user_id,dt,20250801,20250802) |
++-----------------------------------------------+
+|                                             1 |
++-----------------------------------------------+
+```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/substring.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/substring.md
@@ -164,6 +164,18 @@ SELECT SUBSTRING('ṭṛì ḍḍumai hello', 5, 6);
 +--------------------------------------+
 ```
 
+11. Empty source string
+```sql
+SELECT substring('', 1, 3);
+```
+```text
++---------------------+
+| substring('', 1, 3) |
++---------------------+
+|                     |
++---------------------+
+```
+
 ### Keywords
 
     SUBSTRING, SUBSTR, MID


### PR DESCRIPTION
## Summary

Three small cross-port fixes in one PR; each is a minimum-impact change.

| File | Change |
|------|--------|
| \`versioned_docs/.../string-functions/substring.md\` | EN +1 example: empty source string returns empty (ZH already had this) |
| \`versioned_docs/.../aggregate-functions/intersect-count.md\` | EN +1 example: two-day intersection (ZH already had this) |
| \`i18n/zh-CN/.../string-functions/url-encode.md\` | ZH fence \`\`\`\`sql\`\`\`\` → \`\`\`\`text\`\`\`\` on the result block; drop one stray blank line |

## Verification

\`\`\`
mysql> SELECT substring('', 1, 3);                                                    -- ''
mysql> select intersect_count(user_id,dt,20250801,20250802) from pv_bitmap;           -- 1
\`\`\`

Both run on a single-node Apache Doris 4.1.1 cluster against a freshly-recreated \`pv_bitmap\` table seeded with the doc's own INSERT.

## Test plan

- [x] substring empty source returns empty.
- [x] intersect_count with two date filters returns 1 (only user 3 appears on both 20250801 and 20250802).
- [x] url-encode zh page renders result block as plain text, not syntax-highlighted as SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)