### PR TITLE
[fix](doc) explode-json-array-int-outer.md zh: rewrite (page was a stray copy of the json-outer page)

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/table-functions/explode-json-array-int-outer.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/table-functions/explode-json-array-int-outer.md
@@ -1,59 +1,75 @@
 ---
 {
-    "title": "EXPLODE_JSON_ARRAY_JSON_OUTER | Table Functions",
+    "title": "EXPLODE_JSON_ARRAY_INT_OUTER",
     "language": "zh-CN",
-    "description": "explodejsonarrayjsonouter 表函数，接受一个 JSON 数组，其实现逻辑是将 JSON 数组转换为数组类型然后再调用 explodeouter 函数处理，行为等价于：explodeouter(cast(<jsonarray> as Array<JSON>)) 。",
-    "sidebar_label": "EXPLODE_JSON_ARRAY_JSON_OUTER"
+    "description": "explode_json_array_int_outer 表函数，接受一个 JSON 数组。"
 }
 ---
 
-# EXPLODE_JSON_ARRAY_JSON_OUTER
-
 ## 描述
-`explode_json_array_json_outer` 表函数，接受一个 JSON 数组，其实现逻辑是将 JSON 数组转换为数组类型然后再调用 `explode_outer` 函数处理，行为等价于：`explode_outer(cast(<json_array> as Array<JSON>))`
-。需配合 [`LATERAL VIEW`](../../../query-data/lateral-view.md) 使用。
+`explode_json_array_int_outer` 表函数，接受一个 JSON 数组，其实现逻辑是将 JSON 数组转换为数组类型然后再调用 `explode_outer` 函数处理，行为等价于：`explode_outer(cast(<json_array> as Array<BIGINT>))`。
+需配合 [`LATERAL VIEW`](../../../query-data/lateral-view.md) 使用。
 
 ## 语法
 ```sql
-EXPLODE_JSON_ARRAY_JSON_OUTER(<json>)
+EXPLODE_JSON_ARRAY_INT_OUTER(<json>)
 ```
 
 ## 参数
 - `<json>` JSON 类型，其内容应该是数组。
 
 ## 返回值
-- 返回由 `<json>` 所有元素组成的单列多行数据，列类型为 `Nullable<JSON>`。
-- 如果 `<json>` 为 NULL 或者为空数组（元素个数为 0），返回 1 行 NULL 数据。
+- 返回由 `<json>` 所有元素组成的单列多行数据，列类型为 `Nullable<BIGINT>`。
+- 如果 `<json>` 为 NULL 或为空数组（元素个数为 0），则返回包含一行 NULL 的结果。
+- 如果 JSON 数组中的元素不是 INT 类型，函数会尝试将其转换为 INT；无法转换为 INT 的元素会被转换为 NULL。类型转换规则参见 [JSON 类型转换](../../basic-element/sql-data-types/conversion/json-conversion.md)。
 
-## 示例
+## 举例
 0. 准备数据
     ```sql
-        create table example(
-            k1 int
-        ) properties(
-            "replication_num" = "1"
-        );
+    create table example(
+        k1 int
+    ) properties(
+        "replication_num" = "1"
+    );
 
-        insert into example values(1);
+    insert into example values(1);
     ```
 1. 常规参数
     ```sql
-    select * from example lateral view explode_json_array_json_outer('[4, "abc", {"key": "value"}, 5.23, null]') t2 as c;
+    select * from example lateral view explode_json_array_int_outer('[4, 5, 5.23, null]') t2 as c;
     ```
     ```text
-    +------+-----------------+
-    | k1   | c               |
-    +------+-----------------+
-    |    1 | 4               |
-    |    1 | "abc"           |
-    |    1 | {"key":"value"} |
-    |    1 | 5.23            |
-    |    1 | NULL            |
-    +------+-----------------+
+    +------+------+
+    | k1   | c    |
+    +------+------+
+    |    1 |    4 |
+    |    1 |    5 |
+    |    1 |    5 |
+    |    1 | NULL |
+    +------+------+
     ```
-2. 空数组
+2. 非 INT 类型元素
     ```sql
-    select * from example lateral view explode_json_array_json_outer('[]') t2 as c;
+    select * from example 
+        lateral view 
+        explode_json_array_int_outer('["abc", "123.4", 9223372036854775808.0, 9223372036854775295.999999]') t2 as c;
+    ```
+    ```text
+    +------+---------------------+
+    | k1   | c                   |
+    +------+---------------------+
+    |    1 |                NULL |
+    |    1 |                 123 |
+    |    1 |                NULL |
+    |    1 | 9223372036854774784 |
+    +------+---------------------+
+    ```
+    > `9223372036854775808.0` 超出 `BIGINT` 的有效范围，因此转换为 NULL。
+    > 字符串 `"123.4"` 转换为 `123`。
+    > 字符串 `"abc"` 无法转换为 INT，结果为 NULL。
+3. 空数组
+    ```sql
+    select * from example lateral view explode_json_array_int_outer('[]') t2 as c;
     ```
     ```text
     +------+------+
@@ -62,9 +78,9 @@ EXPLODE_JSON_ARRAY_JSON_OUTER(<json>)
     |    1 | NULL |
     +------+------+
     ```
-3. NULL 参数
+4. NULL 参数
     ```sql
-    select * from example lateral view explode_json_array_json_outer(NULL) t2 as c;
+    select * from example lateral view explode_json_array_int_outer(NULL) t2 as c;
     ```
     ```text
     +------+------+
@@ -73,9 +89,9 @@ EXPLODE_JSON_ARRAY_JSON_OUTER(<json>)
     |    1 | NULL |
     +------+------+
     ```
-4. 非数组参数
+5. 非数组参数
     ```sql
-    select * from example lateral view explode_json_array_json_outer('{}') t2 as c;
+    select * from example lateral view explode_json_array_int_outer('{}') t2 as c;
     ```
     ```text
     +------+------+


### PR DESCRIPTION
## Summary

Doc page (4.x): \`i18n/zh-CN/.../table-functions/explode-json-array-int-outer.md\` (ZH).

The ZH page at this path was an exact copy of the \`explode-json-array-json-outer\` page — frontmatter title, prose, syntax block, parameters, examples — all describing the JSON-outer function instead of the INT-outer function the file path claims. Readers following the function-reference link landed on docs for the wrong function.

This PR replaces the ZH \`explode-json-array-int-outer.md\` content with a translation of the EN version of the same page, so the page actually describes \`explode_json_array_int_outer\`.

The \`explode-json-array-json-outer\` ZH page is untouched — it's already correct.

## Verification

\`\`\`
mysql> CREATE TABLE example(k1 int) properties('replication_num'='1');
mysql> INSERT INTO example VALUES(1);
mysql> select * from example lateral view explode_json_array_int_outer('[4, 5, 5.23, null]') t2 as c;
+------+------+
| k1   | c    |
+------+------+
|    1 |    4 |
|    1 |    5 |
|    1 |    5 |
|    1 | NULL |
+------+------+
\`\`\`

Matches the documented result block.

## Test plan

- [x] ZH page now matches EN page structurally (same examples, translated prose).
- [x] Lead example runs on Apache Doris 4.1.1 with the documented output.
- [x] explode-json-array-json-outer ZH page not modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)