### PR TITLE
[fix](doc) SELECT.md: add student/tb_book setup for the simple examples; flag JOIN/UNION snippets as illustrative

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/data-query/SELECT.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/data-query/SELECT.md
@@ -135,6 +135,28 @@ CTE 名称可以在其他 CTE 中引用，从而可以基于其他 CTE 定义 CT
 
 ## 示例
 
+下面示例 1-9 基于这两张表运行。其余示例（UNION、WITH、JOIN、TABLESAMPLE）引用的 `t1`、`t2`、`employee`、`left_tbl`、`tournament` 等表本页并未创建——这些片段仅用于展示语法形态，请在自己的表上执行。
+
+```sql
+CREATE TABLE student (Name VARCHAR(32), age INT)
+DISTRIBUTED BY HASH(Name) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO student VALUES
+  ('Alice', 18), ('Bob', 20), ('Carol', 22), ('Dave', 25), ('Eve', 30);
+
+CREATE TABLE tb_book (id INT, name VARCHAR(64), price DECIMAL(10,2), type VARCHAR(32))
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO tb_book VALUES
+  (1, 'SQL Cookbook',                          39.99, 'database'),
+  (2, 'Doris Internals',                       49.99, 'database'),
+  (3, 'The Rust Programming Language',         45.00, 'programming'),
+  (4, 'Designing Data-Intensive Applications', 55.00, 'database'),
+  (5, 'Clean Code',                            35.00, 'programming');
+```
+
 1. 查询年龄分别是 18,20,25 的学生姓名
 
    ```sql

--- a/versioned_docs/version-4.x/sql-manual/sql-statements/data-query/SELECT.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-statements/data-query/SELECT.md
@@ -138,6 +138,28 @@ Recursive CTE is currently not supported.
 
 ## Example
 
+Examples 1-9 below run against the following two tables. The remaining examples (UNION, WITH, JOIN, TABLESAMPLE) reference tables (`t1`, `t2`, `employee`, `left_tbl`, `tournament`, ...) that are not created on this page — those snippets are illustrative of the syntax shape; substitute your own tables to execute them.
+
+```sql
+CREATE TABLE student (Name VARCHAR(32), age INT)
+DISTRIBUTED BY HASH(Name) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO student VALUES
+  ('Alice', 18), ('Bob', 20), ('Carol', 22), ('Dave', 25), ('Eve', 30);
+
+CREATE TABLE tb_book (id INT, name VARCHAR(64), price DECIMAL(10,2), type VARCHAR(32))
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO tb_book VALUES
+  (1, 'SQL Cookbook',                          39.99, 'database'),
+  (2, 'Doris Internals',                       49.99, 'database'),
+  (3, 'The Rust Programming Language',         45.00, 'programming'),
+  (4, 'Designing Data-Intensive Applications', 55.00, 'database'),
+  (5, 'Clean Code',                            35.00, 'programming');
+```
+
 1. Query the names of students whose ages are 18, 20, 25
 
    ```sql


### PR DESCRIPTION
## Summary

Doc page (4.x): \`sql-manual/sql-statements/data-query/SELECT.md\` (EN + ZH).

The Examples section calls out roughly 15 different tables (\`student\`, \`tb_book\`, \`t1\`-\`t4\`, \`employee\`, \`info\`, \`left_tbl\`, \`right_tbl\`, \`tournament\`, \`test_table\`, \`users\`, \`student_01\`/\`student_02\`), none of which the page creates. Adding setup for all 15 would balloon the doc and is not really the page's intent — most of the multi-table examples (UNION / WITH / JOIN / TABLESAMPLE) are illustrative of the syntax shape rather than meant to run end-to-end.

This PR adds a single small setup block at the top of \`## Example\` that creates the two tables shared by the simplest 9 examples — \`student\` (5 rows) and \`tb_book\` (5 rows). After this change, examples 1-9 (IN-list filter, ALL EXCEPT, GROUP BY, DISTINCT, ORDER BY, LIMIT, CONCAT, SUM aggregation, expression aliases) all run end-to-end on Apache Doris 4.1.1.

A one-line note above the setup explains that the later JOIN / UNION / WITH / TABLESAMPLE examples reference tables not created on the page and are illustrative.

## Verification

Each of examples 1-9 runs against the new setup on a single-node Apache Doris 4.1.1 cluster.

## Test plan

- [x] Examples 1-9 produce results consistent with the documented intent.
- [x] EN and ZH updated in parallel.
- [x] No existing example removed or relabeled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)