### PR TITLE
[fix](doc) DESC-TABLE.md en: backport zh-only examples (Comment column, DESC ALL)

### DIFF
--- a/versioned_docs/version-4.x/sql-manual/sql-statements/table-and-view/table/DESC-TABLE.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-statements/table-and-view/table/DESC-TABLE.md
@@ -112,3 +112,35 @@ DESC test_table;
 | age     | int         | Yes  | false | NULL    | NONE  |
 +---------+-------------+------+-------+---------+-------+
 ```
+
+Set `show_column_comment_in_describe = true` (introduced in 3.0.7) to add the `Comment` column to the output:
+
+```sql
+SET show_column_comment_in_describe=true;
+DESC test_table;
+```
+```text
++---------+-------------+------+-------+---------+-------+----------+
+| Field   | Type        | Null | Key   | Default | Extra | Comment  |
++---------+-------------+------+-------+---------+-------+----------+
+| user_id | bigint      | No   | true  | NULL    |       | Key1     |
+| name    | varchar(20) | Yes  | false | NULL    | NONE  | username |
+| age     | int         | Yes  | false | NULL    | NONE  | user_age |
++---------+-------------+------+-------+---------+-------+----------+
+```
+
+2. Display the Schema of All Indexes of a Table
+
+```sql
+DESC test_table ALL;
+```
+
+```text
++------------+---------------+---------+-------------+--------------+------+-------+---------+-------+---------+------------+-------------+
+| IndexName  | IndexKeysType | Field   | Type        | InternalType | Null | Key   | Default | Extra | Visible | DefineExpr | WhereClause |
++------------+---------------+---------+-------------+--------------+------+-------+---------+-------+---------+------------+-------------+
+| test_table | UNIQUE_KEYS   | user_id | bigint      | bigint       | No   | true  | NULL    |       | true    |            |             |
+|            |               | name    | varchar(20) | varchar(20)  | Yes  | false | NULL    | NONE  | true    |            |             |
+|            |               | age     | int         | int          | Yes  | false | NULL    | NONE  | true    |            |             |
++------------+---------------+---------+-------------+--------------+------+-------+---------+-------+---------+------------+-------------+
+```


### PR DESCRIPTION
## Summary

The ZH page for `DESC-TABLE` documents two examples that the EN page is missing:

1. **`SET show_column_comment_in_describe = true` + `DESC test_table`** — surfaces the `Comment` column. The session variable was introduced in 3.0.7 and is already described in the EN Return-Value section (line 59), but the EN page never exemplifies it.
2. **`DESC test_table ALL`** — returns the schema across all indexes, including `IndexName`, `IndexKeysType`, `InternalType`, `Visible`, `DefineExpr`, `WhereClause`.

Translated both blocks to English and added them under the existing example 1. The expected outputs were captured directly from a fresh Doris 4.1.1 cluster against the page's `CREATE TABLE` schema, so `IndexKeysType = UNIQUE_KEYS` to match `UNIQUE KEY(user_id)` (avoiding a stale `DUP_KEYS` value).

## Verification

```
mysql> SET show_column_comment_in_describe=true;
mysql> DESC test_table;
+---------+-------------+------+-------+---------+-------+----------+
| Field   | Type        | Null | Key   | Default | Extra | Comment  |
+---------+-------------+------+-------+---------+-------+----------+
| user_id | bigint      | No   | true  | NULL    |       | Key1     |
| name    | varchar(20) | Yes  | false | NULL    | NONE  | username |
| age     | int         | Yes  | false | NULL    | NONE  | user_age |
+---------+-------------+------+-------+---------+-------+----------+

mysql> DESC test_table ALL;
+------------+---------------+---------+-------------+--------------+------+-------+---------+-------+---------+------------+-------------+
| IndexName  | IndexKeysType | Field   | Type        | InternalType | Null | Key   | Default | Extra | Visible | DefineExpr | WhereClause |
+------------+---------------+---------+-------------+--------------+------+-------+---------+-------+---------+------------+-------------+
| test_table | UNIQUE_KEYS   | user_id | bigint      | bigint       | No   | true  | NULL    |       | true    |            |             |
|            |               | name    | varchar(20) | varchar(20)  | Yes  | false | NULL    | NONE  | true    |            |             |
|            |               | age     | int         | int          | Yes  | false | NULL    | NONE  | true    |            |             |
+------------+---------------+---------+-------------+--------------+------+-------+---------+-------+---------+------------+-------------+
```

## Related

- PR #3831 fixes the corresponding zh-side issues (`demo.` qualifier, stale `DUP_KEYS`) on the same examples. This PR adds the EN equivalents so the two language versions stay in sync.

## Test plan

- [x] Verified the EN expected output exactly matches Doris 4.1.1 cluster output
- [x] `IndexKeysType` matches the schema's UNIQUE KEY (no copy-paste stale value)
- [x] Page renders correctly (no fence/markdown issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)