### PR TITLE
[fix](doc) array-functions zh: re-flag downgraded code fences as ```sql

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-contains.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-contains.md
@@ -168,7 +168,7 @@ SELECT array_contains([1, 2, 3], 'string');
 ```
 
 当查找值类型无法和数组元素进行类型转换时, 会返回错误
-```
+```sql
 SELECT array_contains([1, 2, 3], [4, 5, 6]);
 ERROR 1105 (HY000): errCode = 2, detailMessage = can not cast from origin type ARRAY<TINYINT> to target type=TINYINT
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-enumerate-uniq.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-enumerate-uniq.md
@@ -109,7 +109,7 @@ ERROR 1105 (HY000): errCode = 2, detailMessage = lengths of all arrays of functi
 ```
 
 IP 类型支持的例子
-```
+```sql
 SELECT array_enumerate_uniq(CAST(['192.168.1.1', '192.168.1.2', '192.168.1.1'] AS ARRAY<IPV4>));
 +------------------------------------------------------------------------------------------+
 | array_enumerate_uniq(CAST(['192.168.1.1', '192.168.1.2', '192.168.1.1'] AS ARRAY<IPV4>)) |
@@ -128,13 +128,13 @@ mysql> SELECT array_enumerate_uniq(CAST(['2001:db8::1', '2001:db8::2', '2001:db8
 复杂类型示例：
 
 嵌套数组类型不支持，报错：
-```
+```sql
 SELECT array_enumerate_uniq([[1,2],[3,4],[5,6]]);
 ERROR 1105 (HY000): errCode = 2, detailMessage = array_enumerate_uniq does not support type ARRAY<ARRAY<TINYINT>>, expression is array_enumerate_uniq([[1, 2], [3, 4], [5, 6]])
 ```
 
 map 类型不支持，报错：
-```
+```sql
 SELECT array_enumerate_uniq([{'k':1},{'k':2},{'k':3}]);
 ERROR 1105 (HY000): errCode = 2, detailMessage = array_enumerate_uniq does not support type ARRAY<MAP<VARCHAR(1),TINYINT>>, expression is array_enumerate_uniq([map('k', 1), map('k', 2), map('k', 3)])
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-exists.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-exists.md
@@ -85,7 +85,7 @@ SELECT array_exists(x -> x > 0, []);
 ```
 
 NULL 数组和lambda 表达式组合，参数中有lambda 表达式结合NULL 会报错，无lambda 表达式则返回 NULL：
-```
+```sql
  SELECT array_exists(NULL);
 +--------------------+
 | array_exists(NULL) |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-first-index.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-first-index.md
@@ -85,7 +85,7 @@ SELECT array_first_index(x -> x > 0, []);
 ```
 
 NULL 数组和lambda 表达式组合，参数中有lambda 表达式结合NULL 会报错，无lambda 表达式则返回 0：
-``` 
+```sql
 SELECT array_first_index(NULL);
 +-------------------------+
 | array_first_index(NULL) |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-first.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/array-functions/array-first.md
@@ -86,7 +86,7 @@ SELECT array_first(x -> x > 0, []);
 ```
 
 输入参数为NULL 会报错：
-```
+```sql
 SELECT array_first(x -> x > 2, NULL);
 ERROR 1105 (HY000): errCode = 2, detailMessage = lambda argument must be array but is NULL
 


### PR DESCRIPTION
## Summary

For five array-function pages the ZH side has example blocks whose opening fence is a plain `\`\`\`` (or empty info string) instead of `\`\`\`sql`. CommonMark renders them the same way, but the doc verifier treats them as illustrative blobs and skips execution, so ZH was being reported as missing examples it actually had.

Re-flagged the affected fences:

| File | Lines | Change |
|---|---|---|
| `array-exists.md` | 88 | ``` → ```sql |
| `array-first.md` | 89 | ``` → ```sql |
| `array-first-index.md` | 88 | ``` → ```sql (also drops a stray trailing space) |
| `array-contains.md` | 171 | ``` → ```sql |
| `array-enumerate-uniq.md` | 112, 131, 137 | ``` → ```sql |

No content added or removed — the examples were already there, they just weren't being identified as runnable SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)