### PR TITLE
[fix](doc) ALTER-USER.md: add CREATE USER setup so examples are runnable end-to-end

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/account-management/ALTER-USER.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-statements/account-management/ALTER-USER.md
@@ -89,6 +89,12 @@ password_policy:
 
 ## 示例
 
+准备：先创建用户 `jack`，作为下面示例的目标用户：
+
+```sql
+CREATE USER jack@'%' IDENTIFIED BY "12345";
+```
+
 - 修改用户的密码
 
 ```sql

--- a/versioned_docs/version-4.x/sql-manual/sql-statements/account-management/ALTER-USER.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-statements/account-management/ALTER-USER.md
@@ -88,6 +88,12 @@ The user executing this SQL command must have at least the following privileges:
 
 ## Example
 
+Setup — create user `jack` so the examples below have a target user:
+
+```sql
+CREATE USER jack@'%' IDENTIFIED BY "12345";
+```
+
 - Change the user's password
 
 ```sql


### PR DESCRIPTION
## Summary

The Examples section on both EN and ZH runs four `ALTER USER` statements against `jack@'%'` without ever showing the `CREATE USER` statement that puts `jack` in place. Anyone copy-pasting from the doc into a fresh cluster hits `User 'jack'@'%' does not exist` on the very first example.

Added a setup block at the top of the Examples section that creates `jack` first. This mirrors the pattern used by other Account Management pages and by the recently merged Bucket-1 missing-setup fixes.

## Verification

End-to-end on a fresh Doris 4.1.1 cluster:

```sql
CREATE USER jack@'%' IDENTIFIED BY "12345";
ALTER USER jack@'%' IDENTIFIED BY "abcde";
ALTER USER jack@'%' FAILED_LOGIN_ATTEMPTS 3 PASSWORD_LOCK_TIME 1 DAY;
ALTER USER jack@'%' ACCOUNT_UNLOCK;
ALTER USER jack@'%' COMMENT "this is my first user";
-- all five statements succeed
```

## Related

Surfaced by the doc verifier re-sweep on 2026-05-29 against a freshly redeployed cluster. The other three "P0" pages on that triage (`sql-blocking.md`, `PLAN-REPLAYER-DUMP.md`, `CREATE-ROLE.md`) are not in this PR — they work cleanly on a fresh cluster on first run, and their re-run failures are tool-harness pollution against shared global namespaces (SQL_BLOCK_RULE, top-level DATABASE, ROLE) rather than doc bugs. That class of issue is already recorded in `doris-verify/ISSUES.md` for tool follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)