### PR TITLE
[fix](doc) v4.x: remove stray control characters that break HTML minifier

### DIFF
--- a/docs/sql-manual/basic-element/sql-data-types/semi-structured/STRUCT.md
+++ b/docs/sql-manual/basic-element/sql-data-types/semi-structured/STRUCT.md
@@ -144,7 +144,7 @@ The STRUCT type is used to combine multiple fields into a single structure, wher
       >
   ) ENGINE=OLAP
   DUPLICATE KEY(id)
-  DISTRIBUTED BY HASH(id) BUCKETS 1
+  DISTRIBUTED BY HASH(id) BUCKETS 1
   PROPERTIES (
       "replication_allocation" = "tag.location.default: 1"
   );

--- a/docs/sql-manual/sql-functions/aggregate-functions/sequence-count.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/sequence-count.md
@@ -26,7 +26,7 @@ SEQUENCE_COUNT(<pattern>, <timestamp>, <cond_1> [, <cond_2>, ..., <cond_n>]);
 | -- | -- |
 | `<pattern>` | Pattern string, see **Pattern syntax** below. Supports type String. |
 | `<timestamp>` | Column considered to contain time data. Supports type Date, DateTime. |
-| `<cond_n>` | Conditions that describe the chain of events. Supports type Bool. Up to 32 condition arguments can be passed. The function takes only the events described in these conditions into account. If the sequence contains data that isnt described in a condition, the function skips them. |
+| `<cond_n>` | Conditions that describe the chain of events. Supports type Bool. Up to 32 condition arguments can be passed. The function takes only the events described in these conditions into account. If the sequence contains data that isn't described in a condition, the function skips them. |
 
 **Pattern syntax**
 

--- a/docs/sql-manual/sql-functions/aggregate-functions/sequence-match.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/sequence-match.md
@@ -27,7 +27,7 @@ SEQUENCE_MATCH(<pattern>, <timestamp>, <cond_1> [, <cond_2>, ..., <cond_n>])
 | -- | -- |
 | `<pattern>` | Pattern string. See **Pattern syntax** below. Supports type String. |
 | `<timestamp>` | Column considered to contain time data. Supports type Date, DateTime. |
-| `<cond_n>` | Conditions that describe the chain of events. Supports type Bool. Up to 32 condition arguments can be passed. The function takes only the events described in these conditions into account. If the sequence contains data that isnt described in a condition, the function skips them. |
+| `<cond_n>` | Conditions that describe the chain of events. Supports type Bool. Up to 32 condition arguments can be passed. The function takes only the events described in these conditions into account. If the sequence contains data that isn't described in a condition, the function skips them. |
 
 **Pattern syntax**
 
@@ -43,7 +43,7 @@ SEQUENCE_MATCH(<pattern>, <timestamp>, <cond_1> [, <cond_2>, ..., <cond_n>])
 
 1: if the pattern is matched.
 
-0: if the pattern isnt matched.
+0: if the pattern isn't matched.
 If there is no valid data in the group, returns NULL.
 
 ## Examples

--- a/versioned_docs/version-4.x/sql-manual/basic-element/sql-data-types/semi-structured/STRUCT.md
+++ b/versioned_docs/version-4.x/sql-manual/basic-element/sql-data-types/semi-structured/STRUCT.md
@@ -144,7 +144,7 @@ The STRUCT type is used to combine multiple fields into a single structure, wher
       >
   ) ENGINE=OLAP
   DUPLICATE KEY(id)
-  DISTRIBUTED BY HASH(id) BUCKETS 1
+  DISTRIBUTED BY HASH(id) BUCKETS 1
   PROPERTIES (
       "replication_allocation" = "tag.location.default: 1"
   );

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/sequence-count.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/sequence-count.md
@@ -26,7 +26,7 @@ SEQUENCE_COUNT(<pattern>, <timestamp>, <cond_1> [, <cond_2>, ..., <cond_n>]);
 | -- | -- |
 | `<pattern>` | Pattern string, see **Pattern syntax** below. Supports type String. |
 | `<timestamp>` | Column considered to contain time data. Supports type Date, DateTime. |
-| `<cond_n>` | Conditions that describe the chain of events. Supports type Bool. Up to 32 condition arguments can be passed. The function takes only the events described in these conditions into account. If the sequence contains data that isnt described in a condition, the function skips them. |
+| `<cond_n>` | Conditions that describe the chain of events. Supports type Bool. Up to 32 condition arguments can be passed. The function takes only the events described in these conditions into account. If the sequence contains data that isn't described in a condition, the function skips them. |
 
 **Pattern syntax**
 

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/sequence-match.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/sequence-match.md
@@ -27,7 +27,7 @@ SEQUENCE_MATCH(<pattern>, <timestamp>, <cond_1> [, <cond_2>, ..., <cond_n>])
 | -- | -- |
 | `<pattern>` | Pattern string. See **Pattern syntax** below. Supports type String. |
 | `<timestamp>` | Column considered to contain time data. Supports type Date, DateTime. |
-| `<cond_n>` | Conditions that describe the chain of events. Supports type Bool. Up to 32 condition arguments can be passed. The function takes only the events described in these conditions into account. If the sequence contains data that isnt described in a condition, the function skips them. |
+| `<cond_n>` | Conditions that describe the chain of events. Supports type Bool. Up to 32 condition arguments can be passed. The function takes only the events described in these conditions into account. If the sequence contains data that isn't described in a condition, the function skips them. |
 
 **Pattern syntax**
 
@@ -43,7 +43,7 @@ SEQUENCE_MATCH(<pattern>, <timestamp>, <cond_1> [, <cond_2>, ..., <cond_n>])
 
 1: if the pattern is matched.
 
-0: if the pattern isnt matched.
+0: if the pattern isn't matched.
 If there is no valid data in the group, returns NULL.
 
 ## Examples


### PR DESCRIPTION
## Summary

- `STRUCT.md` (semi-structured data types) had a trailing `0x03` byte after `DISTRIBUTED BY HASH(id) BUCKETS 1` on line 147.
- `sequence-count.md` and `sequence-match.md` (aggregate functions) had `0x19` standing in for the apostrophe in "isn't" (three occurrences across the two files).
- The Docusaurus HTML minifier rejects control characters in the input stream, so these pages fail the build for both `/cloud/26.x/...` and `/enterprise/4.x/...` URL paths.
- Applied the same fix in `docs/` (next) and `versioned_docs/version-4.x/`. Chinese (i18n) copies and other version trees were already clean.

## Test plan

- [ ] `yarn build` (or the project's site build) completes without the previous `Control character in input stream` errors on the three affected pages.
- [ ] Spot-check the rendered pages for STRUCT, sequence-count, sequence-match in both `enterprise/4.x` and `cloud/26.x` and confirm "isn't" displays with a normal apostrophe and the `DISTRIBUTED BY ... BUCKETS 1` line renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)