### PR TITLE
[doc](udf) remove the expiration_time in create function

### DIFF
--- a/docs/query-data/udf/java-user-defined-function.md
+++ b/docs/query-data/udf/java-user-defined-function.md
@@ -544,12 +544,13 @@ The BE caches JARs globally and supports a customizable expiration time. Add the
 | `static_load` | Whether to use the static cache loading method | `false` |
 | `expiration_time` | JAR expiration time, in minutes | `360` |
 
+- `expiration_time` will be removed after 4.1.1 version。
+
 How it works:
 
 - After static cache loading is enabled, the UDF instance is cached after initialization completes on the first call.
 - On subsequent calls to the UDF, the cache is checked first; if there is a miss, the relevant initialization is executed.
-- A background thread checks periodically. If the UDF has not been called within the configured expiration time, it is cleared from the cache.
-- If the UDF is called again before expiration, the cache timestamp is automatically refreshed.
+- When Drop Function, it's will be cleared from the cache.
 
 Example code:
 
@@ -570,8 +571,7 @@ PROPERTIES (
     "symbol" = "org.apache.doris.udf.Print", 
     "always_nullable"="true",
     "type" = "JAVA_UDF",
-    "static_load" = "true", // default value is false
-    "expiration_time" = "60" // default value is 360 minutes
+    "static_load" = "true" // default value is false
 );
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/query-data/udf/java-user-defined-function.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/query-data/udf/java-user-defined-function.md
@@ -537,19 +537,20 @@ public class FunctionUdf {
 
 ### 方案 2：BE 全局缓存 JAR 包
 
-BE 全局缓存 JAR 包，并支持自定义过期淘汰时间。在 `CREATE FUNCTION` 时增加以下两个属性字段：
+BE 全局缓存 JAR 包，并支持自定义过期淘汰时间。在 `CREATE FUNCTION` 时增加以下属性字段：
 
 | 属性 | 说明 | 默认值 |
 | --- | --- | --- |
 | `static_load` | 是否使用静态 cache 加载方式 | `false` |
 | `expiration_time` | JAR 包过期时间，单位为分钟 | `360` |
 
+- `expiration_time` 字段自 4.1.1 版本之后删除，但对之前的版本无任何兼容性问题。
+
 工作机制如下：
 
 - 启用静态 cache 加载方式后，第一次调用该 UDF 时，初始化完成后会将该 UDF 实例缓存起来。
 - 后续调用该 UDF 时，先在 cache 中查找；若未命中，再执行相关初始化操作。
-- 后台有线程定期检查，如果在配置的过期淘汰时间内一直未被调用，则会从 cache 中清理掉。
-- 如果在过期前被再次调用，则会自动更新缓存时间点。
+- 在 Drop Function 时，会自动清理相关的cache.
 
 示例代码如下：
 
@@ -570,8 +571,7 @@ PROPERTIES (
     "symbol" = "org.apache.doris.udf.Print", 
     "always_nullable"="true",
     "type" = "JAVA_UDF",
-    "static_load" = "true", // default value is false
-    "expiration_time" = "60" // default value is 360 minutes
+    "static_load" = "true" // default value is false
 );
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/query-data/udf/java-user-defined-function.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/query-data/udf/java-user-defined-function.md
@@ -544,12 +544,14 @@ BE 全局缓存 JAR 包，并支持自定义过期淘汰时间。在 `CREATE FUN
 | `static_load` | 是否使用静态 cache 加载方式 | `false` |
 | `expiration_time` | JAR 包过期时间，单位为分钟 | `360` |
 
+- `expiration_time` 字段自 4.1.1 版本之后删除，但对之前的版本无任何兼容性问题。
+
 工作机制如下：
 
 - 启用静态 cache 加载方式后，第一次调用该 UDF 时，初始化完成后会将该 UDF 实例缓存起来。
 - 后续调用该 UDF 时，先在 cache 中查找；若未命中，再执行相关初始化操作。
-- 后台有线程定期检查，如果在配置的过期淘汰时间内一直未被调用，则会从 cache 中清理掉。
-- 如果在过期前被再次调用，则会自动更新缓存时间点。
+- 在 Drop Function 时，会自动清理相关的cache.
+
 
 示例代码如下：
 
@@ -570,8 +572,7 @@ PROPERTIES (
     "symbol" = "org.apache.doris.udf.Print", 
     "always_nullable"="true",
     "type" = "JAVA_UDF",
-    "static_load" = "true", // default value is false
-    "expiration_time" = "60" // default value is 360 minutes
+    "static_load" = "true" // default value is false
 );
 ```
 

--- a/versioned_docs/version-4.x/query-data/udf/java-user-defined-function.md
+++ b/versioned_docs/version-4.x/query-data/udf/java-user-defined-function.md
@@ -544,12 +544,13 @@ The BE caches JARs globally and supports a customizable expiration time. Add the
 | `static_load` | Whether to use the static cache loading method | `false` |
 | `expiration_time` | JAR expiration time, in minutes | `360` |
 
+- `expiration_time` will be removed after 4.1.1 version。
+
 How it works:
 
 - After static cache loading is enabled, the UDF instance is cached after initialization completes on the first call.
 - On subsequent calls to the UDF, the cache is checked first; if there is a miss, the relevant initialization is executed.
-- A background thread checks periodically. If the UDF has not been called within the configured expiration time, it is cleared from the cache.
-- If the UDF is called again before expiration, the cache timestamp is automatically refreshed.
+- When Drop Function, it's will be cleared from the cache.
 
 Example code:
 


### PR DESCRIPTION
## Versions 

- [x] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [ ] Japanese candidate translation needed

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
- [ ] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync
