### PR TITLE
[fix](doc) REVOKE-FROM.md (2.1 + 3.x en): drop the impossible REVOKE-roles-FROM-ROLE example

### DIFF
--- a/versioned_docs/version-2.1/sql-manual/sql-statements/account-management/REVOKE-FROM.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-statements/account-management/REVOKE-FROM.md
@@ -125,9 +125,3 @@ Users executing this SQL command must have at least the following privileges:
    ```sql
    REVOKE USAGE_PRIV ON WORKLOAD GROUP '%' FROM 'jack'@'%';
    ```
-
-- Revoke roles from a user:
-
-   ```sql
-   REVOKE 'role1','role2' FROM ROLE 'test_role';
-   ```

--- a/versioned_docs/version-3.x/sql-manual/sql-statements/account-management/REVOKE-FROM.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-statements/account-management/REVOKE-FROM.md
@@ -138,12 +138,6 @@ Users executing this SQL command must have at least the following privileges:
    REVOKE USAGE_PRIV ON WORKLOAD GROUP '%' FROM 'jack'@'%';
    ```
 
-- Revoke roles from a user:
-
-   ```sql
-   REVOKE 'role1','role2' FROM ROLE 'test_role';
-   ```
-
 - Revoke the usage privilege on all compute groups from a user:
 
    ```sql


### PR DESCRIPTION
## Summary

The Examples section on the EN 2.1 and 3.x `REVOKE-FROM` pages contains:

```sql
REVOKE 'role1','role2' FROM ROLE 'test_role';
```

This syntax has **never** been accepted by Doris — confirmed against the source on every release branch (2.1, 3.0, 3.1, 4.0, 4.1).

## Evidence from the Doris source

**Grammar** (`fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4`, identical shape on every branch):

```antlr
| GRANT  roles+=identifierOrText (COMMA roles+=identifierOrText)* TO   userIdentify    #grantRole
| REVOKE roles+=identifierOrText (COMMA roles+=identifierOrText)* FROM userIdentify    #revokeRole
```

Compare to the **privilege** variants (same file, just above), which DO accept `(userIdentify | ROLE identifierOrText)`. The role-list form only has the `userIdentify` branch — there is no `FROM ROLE` for `REVOKE roles`.

**Command class** (`fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/RevokeRoleCommand.java`, line 37):

```java
/**
 * REVOKE role [, role] FROM user_identity
 */
public class RevokeRoleCommand ... {
    public RevokeRoleCommand(UserIdentity userIdentity, List<String> roles) { ... }
}
```

Only `UserIdentity` is accepted as the recipient; there is no role-recipient overload.

**No legacy parser path:** the older `fe/fe-core/.../analysis/RevokeStmt.java` was removed; Nereids is the only entry point. (Verified with `find fe -name RevokeStmt.java` → empty.)

**Page-internal inconsistency:**
- The Syntax block on the same page lists `REVOKE <role_list> FROM <user_identity>` — no `FROM ROLE` branch.
- The prose above the example reads "Revoke roles from a user", but `test_role` is a role, not a user.

So the example is wrong three independent ways and would fail at the parser with `extraneous input 'ROLE'` on any version it was tried against.

## Changes

- `versioned_docs/version-2.1/.../REVOKE-FROM.md` — remove the bad example.
- `versioned_docs/version-3.x/.../REVOKE-FROM.md` — remove the bad example.

## Left alone

- **ZH** (2.1 / 3.x / 4.x / current): the corresponding "example 6" slot is a *different* statement — `REVOKE USAGE_PRIV ON WORKLOAD GROUP 'g1' FROM ROLE 'test_role';` — which IS supported (it's the privilege-FROM-ROLE form). ZH versions stay as-is.
- **`ja-source/`**: out of scope for this PR set (the Japanese translation is owned separately).
- **4.x EN** and **dev/master EN**: covered in the sibling PRs (4.x: #3850; dev: #3846).

🤖 Generated with [Claude Code](https://claude.com/claude-code)