### PR TITLE
[fix](doc) v3.x: replace stray ${tableName_21} placeholder in quantile docs

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/quantile-functions/to-quantile-state.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/quantile-functions/to-quantile-state.md
@@ -30,7 +30,7 @@ TO_QUANTILE_STATE(<raw_data>, <compression>)
 ## Example
 
 ```sql
-CREATE TABLE IF NOT EXISTS ${tableName_21} (
+CREATE TABLE IF NOT EXISTS quantile_state_agg_test (
          `dt` int(11) NULL COMMENT "",
          `id` int(11) NULL COMMENT "",
          `price` quantile_state QUANTILE_UNION NOT NULL COMMENT ""

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/quantile-functions/quantile-percent.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/quantile-functions/quantile-percent.md
@@ -30,7 +30,7 @@ A `Double` type to represent quantile.
 ## Example
 
 ```sql
-CREATE TABLE IF NOT EXISTS ${tableName_21} (
+CREATE TABLE IF NOT EXISTS quantile_state_agg_test (
          `dt` int(11) NULL COMMENT "",
          `id` int(11) NULL COMMENT "",
          `price` quantile_state QUANTILE_UNION NOT NULL COMMENT ""


### PR DESCRIPTION
## Problem

The CREATE TABLE example in two v3.x quantile-function pages carries an unsubstituted doc-template variable `${tableName_21}`, while the INSERT/SELECT statements that follow all reference the literal table `quantile_state_agg_test`. On a real cluster the CREATE builds a table literally named `${tableName_21}`, so every subsequent statement fails:

```
errCode = 2, detailMessage = Table [quantile_state_agg_test] does not exist in database [...]
```

Each page is broken in only one language; the other language was already correct:

| File | Lang |
|---|---|
| `versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/quantile-functions/quantile-percent.md` | EN |
| `i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/quantile-functions/to-quantile-state.md` | ZH |

## Fix

Use the literal name `quantile_state_agg_test` in the CREATE TABLE so it matches the INSERT/SELECT that follow.

## Cluster verification (Doris 3.1.4-rc02, fresh single-node cluster)

```
SELECT dt, id, quantile_percent(quantile_union(price), 0)
  FROM quantile_state_agg_test GROUP BY dt, id ORDER BY dt, id;
+----------+------+--------------------------------------------+
| dt       | id   | quantile_percent(quantile_union(price), 0) |
+----------+------+--------------------------------------------+
| 20220201 |    0 |                                          1 |
| 20220201 |    1 |                                         -1 |
+----------+------+--------------------------------------------+
```

Matches the documented expected output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)