### PR TITLE
[fix](doc) v3.x: fix misplaced backtick in point-query CREATE TABLE

### DIFF
--- a/versioned_docs/version-3.x/query-acceleration/high-concurrent-point-query.md
+++ b/versioned_docs/version-3.x/query-acceleration/high-concurrent-point-query.md
@@ -62,7 +62,7 @@ CREATE TABLE `tbl_point_query` (
 ) ENGINE=OLAP
 UNIQUE KEY(`k1`)
 COMMENT 'OLAP'
-DISTRIBUTED BY HASH(`k1)` BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 PROPERTIES (
     "replication_allocation" = "tag.location.default: 1",
     "enable_unique_key_merge_on_write" = "true",


### PR DESCRIPTION
## Problem

In `versioned_docs/version-3.x/query-acceleration/high-concurrent-point-query.md`, the `DISTRIBUTED BY` clause of the example table has a misplaced backtick — `HASH(`k1)`` instead of `HASH(`k1`)`. The malformed column reference makes the parser reject the whole `CREATE TABLE`:

```
errCode = 2, detailMessage =
missing ')' at 'BUCKETS'(line 13, pos 26)
```

The ZH version of this page already has the correct `HASH(`k1`)`, so only the EN page changes.

## Fix

`DISTRIBUTED BY HASH(`k1)` BUCKETS 1` → `DISTRIBUTED BY HASH(`k1`) BUCKETS 1`

## Cluster verification (Doris 3.1.4-rc02, fresh single-node cluster)

The corrected statement creates the table successfully:

```
CREATE TABLE `tbl_point_query` ( ... )
ENGINE=OLAP UNIQUE KEY(`k1`) COMMENT 'OLAP'
DISTRIBUTED BY HASH(`k1`) BUCKETS 1
PROPERTIES ( "replication_allocation" = "tag.location.default: 1",
             "enable_unique_key_merge_on_write" = "true",
             "light_schema_change" = "true",
             "store_row_column" = "true" );
-- Query OK; SHOW TABLES LIKE 'tbl_point_query' returns the table.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)