### PR TITLE
[fix](doc) dev: replace stray ${tableName_21} placeholder in to-quantile-state

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/quantile-functions/to-quantile-state.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/quantile-functions/to-quantile-state.md
@@ -30,7 +30,7 @@ TO_QUANTILE_STATE(<raw_data>, <compression>)
 ## Example
 
 ```sql
-CREATE TABLE IF NOT EXISTS ${tableName_21} (
+CREATE TABLE IF NOT EXISTS quantile_state_agg_test (
          `dt` int(11) NULL COMMENT "",
          `id` int(11) NULL COMMENT "",
          `price` quantile_state QUANTILE_UNION NOT NULL COMMENT ""


### PR DESCRIPTION
Backport of #3852 / #3856 to **dev** (`i18n/zh-CN/.../current/`).

## Problem

The ZH `to-quantile-state.md` CREATE TABLE example carries the unsubstituted doc-template variable `${tableName_21}`, while the INSERT/SELECT that follow reference the literal `quantile_state_agg_test`. On a real cluster the CREATE makes a table literally named `${tableName_21}`, so every later statement fails with table-not-found.

## Fix

Use the literal name `quantile_state_agg_test` in the CREATE TABLE.

## Cluster verification (Doris master build, `doris-0.0.0-trunk`)

```
SELECT dt, id, quantile_percent(quantile_union(price), 0)
  FROM quantile_state_agg_test GROUP BY dt, id ORDER BY dt, id;
+----------+------+--------------------------------------------+
| 20220201 |    0 |                                          1 |
| 20220201 |    1 |                                         -1 |
+----------+------+--------------------------------------------+
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)