### PR TITLE
[fix](doc) dev: un-glue SET lc_time_names from comment line in MONTHNAME example

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/monthname.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/monthname.md
@@ -60,7 +60,8 @@ SELECT MONTHNAME(NULL) AS result;
 | NULL   |
 +--------+
 
----Control the output language by setting `lc_time_names`SET lc_time_names='zh_CN';
+-- Control the output language by setting `lc_time_names`
+SET lc_time_names='zh_CN';
 SELECT MONTHNAME('2023-07-13 22:28:18') AS result;
 +--------+
 | result |


### PR DESCRIPTION
The EN dev `monthname.md` localization example put the explanatory comment and the `SET` statement on a single `--` comment line:

```sql
---Control the output language by setting `lc_time_names`SET lc_time_names='zh_CN';
SELECT MONTHNAME('2023-07-13 22:28:18') AS result;
+--------+
| result |
+--------+
| 七月   |
+--------+
```

Because the entire line is a SQL line-comment, `SET lc_time_names='zh_CN';` is commented out. A reader copy-pasting the block runs the `SELECT` in the default `en_US` session and gets `July`, not the documented `七月` — so the localization example is inert and misleading.

**Fix:** move `SET` onto its own line (matching the `-- ` comment style used by the other comments in the same block). The documented output values are all correct; only the formatting was broken.

```sql
-- Control the output language by setting `lc_time_names`
SET lc_time_names='zh_CN';
SELECT MONTHNAME('2023-07-13 22:28:18') AS result;
```

**Scope:** dev EN only. The ZH page (`i18n/zh-CN/.../current/.../monthname.md`) and the v4.x EN page already have `SET` on its own line, so they are unaffected — no backport needed.

**Verification** — run end-to-end on a live master daily build (`doris-0.0.0-2e72603618c`):

```
SELECT MONTHNAME('2023-07-13 22:28:18');     -> July
SET lc_time_names='zh_CN';
SELECT MONTHNAME('2023-07-13 22:28:18');     -> 七月
SET lc_time_names='AR_sa';
SELECT MONTHNAME('2023-07-13 22:28:18');     -> يوليو
```

All three outputs match the documented expected values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)