### PR TITLE
[fix](doc) dev: fix array_count nested higher-order example (EN)

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
@@ -165,14 +165,22 @@ SELECT array_count(x -> array_size(x) > 2, [[1,2],[1,2,3],[4,5,6,7]]);
 +----------------------------------------------------------------+
 ```
 
-Nested higher-order function example - count arrays that contain elements greater than 5:
+Nested higher-order functions — `array_count` expects the lambda body to return a scalar that can be cast to BOOLEAN. When the inner `array_exists` returns an ARRAY of booleans (one per inner element), `array_count` can not consume it and reports a signature error:
+
 ```sql
 SELECT array_count(x -> array_exists(y -> y > 5, x), [[1,2,3],[4,5,6],[7,8,9]]);
-+--------------------------------------------------+
-| array_count(x -> array_exists(y -> y > 5, x), [[1,2,3],[4,5,6],[7,8,9]]) |
-+--------------------------------------------------+
-|                                              2   |
-+--------------------------------------------------+
+ERROR 1105 (HY000): errCode = 2, detailMessage = Can not find the compatibility function signature: array_count(ARRAY<ARRAY<BOOLEAN>>)
+```
+
+To count outer arrays that contain *any* element greater than 5, wrap the inner check so the lambda returns a scalar BOOLEAN — e.g. `size(array_filter(y -> y > 5, x)) > 0`:
+
+```sql
+SELECT array_count(x -> size(array_filter(y -> y > 5, x)) > 0, [[1,2,3],[4,5,6],[7,8,9]]);
++----------------------------------------------------------------------------------+
+| array_count(x -> size(array_filter(y -> y > 5, x)) > 0, [[1,2,3],[4,5,6],[7,8,9]]) |
++----------------------------------------------------------------------------------+
+|                                                                                2 |
++----------------------------------------------------------------------------------+
 ```
 
 Literal array example:


### PR DESCRIPTION
## What

The **dev EN** `array-count` page presented this nested higher-order example as if it works, claiming a result of `2`:

```sql
SELECT array_count(x -> array_exists(y -> y > 5, x), [[1,2,3],[4,5,6],[7,8,9]]);
```

But `array_exists` returns an **ARRAY** (one boolean per inner element), and `array_count` expects the lambda body to return a scalar it can cast to BOOLEAN. On a live cluster this errors:

```
ERROR 1105 (HY000): errCode = 2, detailMessage =
  Can not find the compatibility function signature: array_count(ARRAY<ARRAY<BOOLEAN>>)
```

## Fix

This is intended behavior, not a signature gap — the **dev ZH**, **v4.x ZH** and **v4.x EN** pages already document this exact error as the "lambda returns an array" failure case. This PR brings dev EN in line with the v4.x EN treatment: show the signature error, then give a working alternative whose lambda returns a scalar BOOLEAN:

```sql
SELECT array_count(x -> size(array_filter(y -> y > 5, x)) > 0, [[1,2,3],[4,5,6],[7,8,9]]);
-- 2
```

## Verified live

Both statements run on a master daily build (`doris-0.0.0-2e72603618c`): the first reproduces the signature error verbatim, the second returns `2`.

## Scope

**EN-only.** dev ZH, v4.x EN and v4.x ZH already document the error correctly, so no backport is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)