### PR TITLE
[doc] Add docs for HUMAN_READABLE_SECONDS function

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/human_readable_seconds.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/human_readable_seconds.md
@@ -1,0 +1,116 @@
+---
+
+{
+"title": "HUMAN_READABLE_SECONDS",
+"language": "en"
+}
+
+---
+
+## Description
+
+Converts a number of seconds into a human-readable duration string using weeks, days, hours, minutes, and seconds.
+
+Behavior matches Presto/Trino semantics:
+
+* values are rounded to whole seconds
+* negative values use their absolute value
+* milliseconds are not emitted
+* `NaN` and `Infinity` inputs are rejected
+
+## Syntax
+
+```sql
+HUMAN_READABLE_SECONDS(<x>)
+```
+
+## Parameters
+
+| Parameter | Description                                                                |
+| --------- | -------------------------------------------------------------------------- |
+| `<x>`     | Any numeric SQL type representing a number of seconds                      |
+
+## Return Value
+
+Returns a `VARCHAR` string representing the formatted duration.
+
+## Special Cases
+
+* When `<x>` is `NULL`, returns `NULL`
+* Fractional values are rounded to the nearest whole second
+* Negative values are converted using absolute value
+* `NaN` and `Infinity` values raise an error: `Invalid argument value ... for function human_readable_seconds`
+
+## Examples
+
+```sql
+select human_readable_seconds(3661);
+```
+
+```text
++------------------------------+
+| human_readable_seconds(3661) |
++------------------------------+
+| 1 hour, 1 minute, 1 second   |
++------------------------------+
+```
+
+```sql
+select human_readable_seconds(475.33);
+```
+
+```text
++--------------------------------+
+| human_readable_seconds(475.33) |
++--------------------------------+
+| 7 minutes, 55 seconds          |
++--------------------------------+
+```
+
+```sql
+select human_readable_seconds(0.9);
+```
+
+```text
++-----------------------------+
+| human_readable_seconds(0.9) |
++-----------------------------+
+| 1 second                    |
++-----------------------------+
+```
+
+```sql
+select human_readable_seconds(-96);
+```
+
+```text
++------------------------------+
+| human_readable_seconds(-96)  |
++------------------------------+
+| 1 minute, 36 seconds         |
++------------------------------+
+```
+
+```sql
+select human_readable_seconds(56363463);
+```
+
+```text
++----------------------------------------------------------+
+| human_readable_seconds(56363463)                         |
++----------------------------------------------------------+
+| 93 weeks, 1 day, 8 hours, 31 minutes, 3 seconds          |
++----------------------------------------------------------+
+```
+
+```sql
+select human_readable_seconds(NULL);
+```
+
+```text
++------------------------------+
+| human_readable_seconds(NULL) |
++------------------------------+
+| NULL                         |
++------------------------------+
+```


### PR DESCRIPTION
This document describes the HUMAN_READABLE_SECONDS function, detailing its behavior, syntax, parameters, return value, special cases, and examples of usage.

## Versions

* [x] dev
* [ ] 4.x
* [ ] 3.x
* [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

* [ ] Chinese
* [x] English
* [ ] Japanese candidate translation needed

## Docs Checklist

* [x] Checked by AI
* [x] Test Cases Built
* [x] Updated required version and language counterparts, or explained why not
* [x] If only one language changed, confirmed whether source/translation counterparts need sync

### Notes

* Added English documentation only because the function is newly introduced and does not yet exist in released branches.
* Chinese and Japanese translations can be added later during documentation synchronization.
* Regression tests and FE/BE consistency tests were added together with the implementation.
