### PR TITLE
[fix](sql-functions) provide setup data for examples querying an undefined table

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/get-format.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/get-format.md
@@ -43,6 +43,11 @@ Returns a format string. The results for different arguments are shown in the ta
 If the second argument is not one of `'USA', 'JIS', 'ISO', 'EUR', 'INTERNAL'` or is NULL, the function returns NULL.
 
 ## Examples
+<!-- setup-sql
+CREATE TABLE get_format_test (id INT, lc VARCHAR(20)) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO get_format_test VALUES (1,'USA'),(2,'JIS'),(3,'ISO'),(4,'EUR'),(5,'INTERNAL'),(6,'Doris');
+-->
+
 ```sql
 SELECT * FROM get_format_test
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/maketime.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/maketime.md
@@ -35,6 +35,11 @@ Returns a value of type TIME, in the format `hour:minute:second`. When the input
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_maketime (id INT, `hour` BIGINT, `minute` BIGINT, sec FLOAT) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_maketime VALUES (1,12,15,30),(2,14,56,12.5789),(3,1234,11,4),(4,-1234,6,52),(5,20,60,12),(6,14,51,66),(7,NULL,15,16),(8,7,NULL,8),(9,1,2,NULL),(10,23,-40,12),(11,20,6,-12);
+-->
+
 ```sql
 SELECT `hour`, `minute`, `sec`, MAKETIME(`hour`, `minute`, `sec`) AS ans FROM `test_maketime`;
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
@@ -43,6 +43,11 @@ select ipv4_num_to_string(3232235521);
 +--------------------------------+
 ```
 
+<!-- setup-sql
+CREATE TABLE ipv4_bi (num BIGINT) DISTRIBUTED BY HASH(num) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_bi VALUES (-1),(0),(2130706433),(4294967295),(4294967296);
+-->
+
 ```sql
 select num,ipv4_num_to_string(num) from ipv4_bi;
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
@@ -38,6 +38,11 @@ select ipv4_string_to_num_or_null('192.168.0.1');
 +-------------------------------------------+ 
 ```
 
+<!-- setup-sql
+CREATE TABLE ipv4_str (str VARCHAR(50)) DISTRIBUTED BY HASH(str) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_str VALUES ('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+-->
+
 ```sql
 select str, ipv4_string_to_num_or_null(str) from ipv4_str; 
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
@@ -29,6 +29,11 @@ Returns a VARCHAR value with the converted encoding, allowing proper pinyin-base
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE class_test (class_id INT, class_name VARCHAR(50), student_ids ARRAY<INT>) DISTRIBUTED BY HASH(class_id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO class_test VALUES (1,'啊',[1]),(2,'哈',[2]),(3,'哦',[3]),(4,'张',[4]),(5,'我',[5]),(6,'asd',[6]),(7,'qwe',[7]),(8,'z',[8]);
+-->
+
 ```sql
 SELECT * FROM class_test ORDER BY class_name;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/get-format.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/get-format.md
@@ -43,6 +43,11 @@ GET_FORMAT({DATE|DATETIME|TIME}, {'EUR'|'USA'|'JIS'|'ISO'|'INTERNAL'})
 当第二个参数不为 `'USA', 'JIS', 'ISO', 'EUR', 'INTERNAL'` 之一或者为 NULL 时返回 NULL
 
 ## 举例
+<!-- setup-sql
+CREATE TABLE get_format_test (id INT, lc VARCHAR(20)) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO get_format_test VALUES (1,'USA'),(2,'JIS'),(3,'ISO'),(4,'EUR'),(5,'INTERNAL'),(6,'Doris');
+-->
+
 ```sql
 SELECT * FROM get_format_test
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/maketime.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/maketime.md
@@ -35,6 +35,11 @@ MAKETIME(`<hour>`, `<minute>`, `<second>`)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_maketime (id INT, `hour` BIGINT, `minute` BIGINT, sec FLOAT) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_maketime VALUES (1,12,15,30),(2,14,56,12.5789),(3,1234,11,4),(4,-1234,6,52),(5,20,60,12),(6,14,51,66),(7,NULL,15,16),(8,7,NULL,8),(9,1,2,NULL),(10,23,-40,12),(11,20,6,-12);
+-->
+
 ```sql
 SELECT `hour`, `minute`, `sec`, MAKETIME(`hour`, `minute`, `sec`) AS ans FROM `test_maketime`;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
@@ -40,6 +40,11 @@ select ipv4_num_to_string(3232235521);
 | 192.168.0.1                    |
 +--------------------------------+
 ```
+<!-- setup-sql
+CREATE TABLE ipv4_bi (num BIGINT) DISTRIBUTED BY HASH(num) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_bi VALUES (-1),(0),(2130706433),(4294967295),(4294967296);
+-->
+
 ```sql
 select num,ipv4_num_to_string(num) from ipv4_bi;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
@@ -37,6 +37,11 @@ select ipv4_string_to_num_or_null('192.168.0.1');
 | 3232235521                                | 
 +-------------------------------------------+ 
 ```
+<!-- setup-sql
+CREATE TABLE ipv4_str (str VARCHAR(50)) DISTRIBUTED BY HASH(str) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_str VALUES ('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+-->
+
 ```sql
 select str, ipv4_string_to_num_or_null(str) from ipv4_str; 
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
@@ -29,6 +29,11 @@ CONVERT_TO(<column>, <character>)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE class_test (class_id INT, class_name VARCHAR(50), student_ids ARRAY<INT>) DISTRIBUTED BY HASH(class_id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO class_test VALUES (1,'啊',[1]),(2,'哈',[2]),(3,'哦',[3]),(4,'张',[4]),(5,'我',[5]),(6,'asd',[6]),(7,'qwe',[7]),(8,'z',[8]);
+-->
+
 ```sql
 SELECT * FROM class_test ORDER BY class_name;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
@@ -37,6 +37,11 @@ select ipv4_num_to_string(3232235521);
 | 192.168.0.1                    |
 +--------------------------------+
 ```
+<!-- setup-sql
+CREATE TABLE ipv4_bi (num BIGINT) DISTRIBUTED BY HASH(num) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_bi VALUES (-1),(0),(2130706433),(4294967295),(4294967296);
+-->
+
 ```sql
 select num,ipv4_num_to_string(num) from ipv4_bi;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
@@ -37,6 +37,11 @@ select ipv4_string_to_num_or_null('192.168.0.1');
 | 3232235521                                | 
 +-------------------------------------------+ 
 ```
+<!-- setup-sql
+CREATE TABLE ipv4_str (str VARCHAR(50)) DISTRIBUTED BY HASH(str) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_str VALUES ('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+-->
+
 ```sql
 select str, ipv4_string_to_num_or_null(str) from ipv4_str; 
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
@@ -29,6 +29,11 @@ CONVERT_TO(<column>, <character>)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE class_test (class_id INT, class_name VARCHAR(50), student_ids ARRAY<INT>) DISTRIBUTED BY HASH(class_id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO class_test VALUES (1,'啊',[1]),(2,'哈',[2]),(3,'哦',[3]),(4,'张',[4]),(5,'我',[5]),(6,'asd',[6]),(7,'qwe',[7]),(8,'z',[8]);
+-->
+
 ```sql
 SELECT * FROM class_test ORDER BY class_name;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
@@ -37,6 +37,11 @@ select ipv4_num_to_string(3232235521);
 | 192.168.0.1                    |
 +--------------------------------+
 ```
+<!-- setup-sql
+CREATE TABLE ipv4_bi (num BIGINT) DISTRIBUTED BY HASH(num) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_bi VALUES (-1),(0),(2130706433),(4294967295),(4294967296);
+-->
+
 ```sql
 select num,ipv4_num_to_string(num) from ipv4_bi;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
@@ -37,6 +37,11 @@ select ipv4_string_to_num_or_null('192.168.0.1');
 | 3232235521                                | 
 +-------------------------------------------+ 
 ```
+<!-- setup-sql
+CREATE TABLE ipv4_str (str VARCHAR(50)) DISTRIBUTED BY HASH(str) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_str VALUES ('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+-->
+
 ```sql
 select str, ipv4_string_to_num_or_null(str) from ipv4_str; 
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
@@ -29,6 +29,11 @@ CONVERT_TO(<column>, <character>)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE class_test (class_id INT, class_name VARCHAR(50), student_ids ARRAY<INT>) DISTRIBUTED BY HASH(class_id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO class_test VALUES (1,'啊',[1]),(2,'哈',[2]),(3,'哦',[3]),(4,'张',[4]),(5,'我',[5]),(6,'asd',[6]),(7,'qwe',[7]),(8,'z',[8]);
+-->
+
 ```sql
 SELECT * FROM class_test ORDER BY class_name;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/get-format.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/get-format.md
@@ -43,6 +43,11 @@ GET_FORMAT({DATE|DATETIME|TIME}, {'EUR'|'USA'|'JIS'|'ISO'|'INTERNAL'})
 当第二个参数不为 `'USA', 'JIS', 'ISO', 'EUR', 'INTERNAL'` 之一或者为 NULL 时返回 NULL
 
 ## 举例
+<!-- setup-sql
+CREATE TABLE get_format_test (id INT, lc VARCHAR(20)) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO get_format_test VALUES (1,'USA'),(2,'JIS'),(3,'ISO'),(4,'EUR'),(5,'INTERNAL'),(6,'Doris');
+-->
+
 ```sql
 SELECT * FROM get_format_test
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/maketime.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/maketime.md
@@ -35,6 +35,11 @@ MAKETIME(`<hour>`, `<minute>`, `<second>`)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_maketime (id INT, `hour` BIGINT, `minute` BIGINT, sec FLOAT) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_maketime VALUES (1,12,15,30),(2,14,56,12.5789),(3,1234,11,4),(4,-1234,6,52),(5,20,60,12),(6,14,51,66),(7,NULL,15,16),(8,7,NULL,8),(9,1,2,NULL),(10,23,-40,12),(11,20,6,-12);
+-->
+
 ```sql
 SELECT `hour`, `minute`, `sec`, MAKETIME(`hour`, `minute`, `sec`) AS ans FROM `test_maketime`;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
@@ -40,6 +40,11 @@ select ipv4_num_to_string(3232235521);
 | 192.168.0.1                    |
 +--------------------------------+
 ```
+<!-- setup-sql
+CREATE TABLE ipv4_bi (num BIGINT) DISTRIBUTED BY HASH(num) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_bi VALUES (-1),(0),(2130706433),(4294967295),(4294967296);
+-->
+
 ```sql
 select num,ipv4_num_to_string(num) from ipv4_bi;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
@@ -37,6 +37,11 @@ select ipv4_string_to_num_or_null('192.168.0.1');
 | 3232235521                                | 
 +-------------------------------------------+ 
 ```
+<!-- setup-sql
+CREATE TABLE ipv4_str (str VARCHAR(50)) DISTRIBUTED BY HASH(str) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_str VALUES ('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+-->
+
 ```sql
 select str, ipv4_string_to_num_or_null(str) from ipv4_str; 
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
@@ -29,6 +29,11 @@ CONVERT_TO(<column>, <character>)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE class_test (class_id INT, class_name VARCHAR(50), student_ids ARRAY<INT>) DISTRIBUTED BY HASH(class_id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO class_test VALUES (1,'啊',[1]),(2,'哈',[2]),(3,'哦',[3]),(4,'张',[4]),(5,'我',[5]),(6,'asd',[6]),(7,'qwe',[7]),(8,'z',[8]);
+-->
+
 ```sql
 SELECT * FROM class_test ORDER BY class_name;
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
@@ -40,6 +40,11 @@ select ipv4_num_to_string(3232235521);
 +--------------------------------+
 ```
 
+<!-- setup-sql
+CREATE TABLE ipv4_bi (num BIGINT) DISTRIBUTED BY HASH(num) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_bi VALUES (-1),(0),(2130706433),(4294967295),(4294967296);
+-->
+
 ```sql
 select num,ipv4_num_to_string(num) from ipv4_bi;
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
@@ -38,6 +38,11 @@ select ipv4_string_to_num_or_null('192.168.0.1');
 +-------------------------------------------+ 
 ```
 
+<!-- setup-sql
+CREATE TABLE ipv4_str (str VARCHAR(50)) DISTRIBUTED BY HASH(str) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_str VALUES ('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+-->
+
 ```sql
 select str, ipv4_string_to_num_or_null(str) from ipv4_str; 
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
@@ -29,6 +29,11 @@ Returns a VARCHAR value with the converted encoding, allowing proper pinyin-base
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE class_test (class_id INT, class_name VARCHAR(50), student_ids ARRAY<INT>) DISTRIBUTED BY HASH(class_id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO class_test VALUES (1,'啊',[1]),(2,'哈',[2]),(3,'哦',[3]),(4,'张',[4]),(5,'我',[5]),(6,'asd',[6]),(7,'qwe',[7]),(8,'z',[8]);
+-->
+
 ```sql
 SELECT * FROM class_test ORDER BY class_name;
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
@@ -40,6 +40,11 @@ select ipv4_num_to_string(3232235521);
 +--------------------------------+
 ```
 
+<!-- setup-sql
+CREATE TABLE ipv4_bi (num BIGINT) DISTRIBUTED BY HASH(num) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_bi VALUES (-1),(0),(2130706433),(4294967295),(4294967296);
+-->
+
 ```sql
 select num,ipv4_num_to_string(num) from ipv4_bi;
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
@@ -38,6 +38,11 @@ select ipv4_string_to_num_or_null('192.168.0.1');
 +-------------------------------------------+ 
 ```
 
+<!-- setup-sql
+CREATE TABLE ipv4_str (str VARCHAR(50)) DISTRIBUTED BY HASH(str) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_str VALUES ('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+-->
+
 ```sql
 select str, ipv4_string_to_num_or_null(str) from ipv4_str; 
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
@@ -29,6 +29,11 @@ Returns a VARCHAR value with the converted encoding, allowing proper pinyin-base
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE class_test (class_id INT, class_name VARCHAR(50), student_ids ARRAY<INT>) DISTRIBUTED BY HASH(class_id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO class_test VALUES (1,'啊',[1]),(2,'哈',[2]),(3,'哦',[3]),(4,'张',[4]),(5,'我',[5]),(6,'asd',[6]),(7,'qwe',[7]),(8,'z',[8]);
+-->
+
 ```sql
 SELECT * FROM class_test ORDER BY class_name;
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/get-format.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/get-format.md
@@ -43,6 +43,11 @@ Returns a format string. The results for different arguments are shown in the ta
 If the second argument is not one of `'USA', 'JIS', 'ISO', 'EUR', 'INTERNAL'` or is NULL, the function returns NULL.
 
 ## Examples
+<!-- setup-sql
+CREATE TABLE get_format_test (id INT, lc VARCHAR(20)) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO get_format_test VALUES (1,'USA'),(2,'JIS'),(3,'ISO'),(4,'EUR'),(5,'INTERNAL'),(6,'Doris');
+-->
+
 ```sql
 SELECT * FROM get_format_test
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/maketime.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/maketime.md
@@ -35,6 +35,11 @@ Returns a value of type TIME, in the format `hour:minute:second`. When the input
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_maketime (id INT, `hour` BIGINT, `minute` BIGINT, sec FLOAT) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_maketime VALUES (1,12,15,30),(2,14,56,12.5789),(3,1234,11,4),(4,-1234,6,52),(5,20,60,12),(6,14,51,66),(7,NULL,15,16),(8,7,NULL,8),(9,1,2,NULL),(10,23,-40,12),(11,20,6,-12);
+-->
+
 ```sql
 SELECT `hour`, `minute`, `sec`, MAKETIME(`hour`, `minute`, `sec`) AS ans FROM `test_maketime`;
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-num-to-string.md
@@ -43,6 +43,11 @@ select ipv4_num_to_string(3232235521);
 +--------------------------------+
 ```
 
+<!-- setup-sql
+CREATE TABLE ipv4_bi (num BIGINT) DISTRIBUTED BY HASH(num) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_bi VALUES (-1),(0),(2130706433),(4294967295),(4294967296);
+-->
+
 ```sql
 select num,ipv4_num_to_string(num) from ipv4_bi;
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-null.md
@@ -38,6 +38,11 @@ select ipv4_string_to_num_or_null('192.168.0.1');
 +-------------------------------------------+ 
 ```
 
+<!-- setup-sql
+CREATE TABLE ipv4_str (str VARCHAR(50)) DISTRIBUTED BY HASH(str) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO ipv4_str VALUES ('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+-->
+
 ```sql
 select str, ipv4_string_to_num_or_null(str) from ipv4_str; 
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/convert-to.md
@@ -29,6 +29,11 @@ Returns a VARCHAR value with the converted encoding, allowing proper pinyin-base
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE class_test (class_id INT, class_name VARCHAR(50), student_ids ARRAY<INT>) DISTRIBUTED BY HASH(class_id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO class_test VALUES (1,'啊',[1]),(2,'哈',[2]),(3,'哦',[3]),(4,'张',[4]),(5,'我',[5]),(6,'asd',[6]),(7,'qwe',[7]),(8,'z',[8]);
+-->
+
 ```sql
 SELECT * FROM class_test ORDER BY class_name;
 ```


### PR DESCRIPTION
Several SQL-function reference pages contain examples of the form `SELECT ... FROM <table>` together with an expected result table, but the page never defines `<table>`. As written these examples cannot be run or reproduced — a reader who copies them gets `Table [...] does not exist`.

This PR adds the missing `CREATE TABLE` + `INSERT` for each such table, carried in a standard HTML comment (`<!-- setup-sql ... -->`) placed just before the first example that uses the table. Because it is an HTML comment, **the rendered page is unchanged** and **no documented expected output is modified** — the comment only records the data the examples already assume, making each example self-contained and reproducible.

The table contents were reverse-derived from the output already printed on each page (e.g. `get_format_test` from its `SELECT *`, `test_maketime` from its shown `hour`/`minute`/`sec` columns) and verified end-to-end on a live cluster of the matching release for every doc tree.

### Pages and version coverage
| Function | Table | dev (`current`) | `version-4.x` | `version-3.x` | `version-2.1` |
| --- | --- | :-: | :-: | :-: | :-: |
| `GET_FORMAT` | `get_format_test` | ✅ | ✅ | — (page absent) | — (page absent) |
| `MAKETIME` | `test_maketime` | ✅ | ✅ | — (page absent) | — (page absent) |
| `CONVERT_TO` | `class_test` | ✅ | ✅ | ✅ | ✅ |
| `IPV4_NUM_TO_STRING` | `ipv4_bi` | ✅ | ✅ | ✅ | ✅ |
| `IPV4_STRING_TO_NUM_OR_NULL` | `ipv4_str` | ✅ | ✅ | ✅ | ✅ |

Each ✅ is updated in EN + ZH. Verification clusters: dev/current + version-4.x on a 4.1.1 build and a master daily build; version-3.x on a 3.1.4 cluster; version-2.1 on a 2.1.11 cluster. On every tree the affected examples failed with "table does not exist" before the change and pass (output matches the doc cell-for-cell) after it.

No `ja-source` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)