### PR TITLE
[fix](sql-functions) provide setup data for window-function examples querying an undefined table

### DIFF
--- a/docs/sql-manual/sql-functions/window-functions/lag.md
+++ b/docs/sql-manual/sql-functions/window-functions/lag.md
@@ -29,6 +29,11 @@ Returns the same data type as the input expression.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 Calculate the difference between each salesperson's current sales amount and the previous day's sales amount:
 
 ```sql

--- a/docs/sql-manual/sql-functions/window-functions/lead.md
+++ b/docs/sql-manual/sql-functions/window-functions/lead.md
@@ -29,6 +29,11 @@ Returns the same data type as the input expression.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 Calculate the difference between each salesperson's current sales and next day's sales:
 
 ```sql

--- a/docs/sql-manual/sql-functions/window-functions/ntile.md
+++ b/docs/sql-manual/sql-functions/window-functions/ntile.md
@@ -33,6 +33,11 @@ If a statement contains both an ORDER BY clause in the NTILE function and an ORD
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE student_scores (name VARCHAR(20), score INT) DISTRIBUTED BY HASH(name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO student_scores VALUES ('Alice',98),('Bob',95),('Charlie',90),('David',85),('Eve',82),('Frank',78),('Grace',75),('Henry',70);
+-->
+
 ```sql
 SELECT 
     name,

--- a/docs/sql-manual/sql-functions/window-functions/rank.md
+++ b/docs/sql-manual/sql-functions/window-functions/rank.md
@@ -22,6 +22,11 @@ Returns a BIGINT rank value. Returns the same rank for identical values, but cre
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE employees (department VARCHAR(20), employee_name VARCHAR(20), salary INT) DISTRIBUTED BY HASH(employee_name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO employees VALUES ('Sales','Alice',10000),('Sales','Bob',10000),('Sales','Charlie',8000),('IT','David',12000),('IT','Eve',11000),('IT','Frank',11000),('IT','Grace',9000);
+-->
+
 ```sql
 SELECT 
     department,

--- a/docs/sql-manual/sql-functions/window-functions/row-number.md
+++ b/docs/sql-manual/sql-functions/window-functions/row-number.md
@@ -22,6 +22,11 @@ Returns a BIGINT sequence number, starting from 1 and incrementing continuously.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE int_t (x INT, y INT) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO int_t VALUES (1,1),(1,2),(1,2),(2,1),(2,2),(2,3),(3,1),(3,1),(3,2);
+-->
+
 ```sql
 select x, y, row_number() over(partition by x order by y) as rank from int_t;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/window-functions/lag.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/window-functions/lag.md
@@ -30,6 +30,11 @@ LAG ( <expr> [, <offset> [, <default> ] ] )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 计算每个销售员当前销售额与前一天销售额的差值：
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/window-functions/lead.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/window-functions/lead.md
@@ -30,6 +30,11 @@ LEAD ( <expr> [ , <offset> [ , <default> ] ] )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 计算每个销售员当前销售额与下一天销售额的差值：
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/window-functions/ntile.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/window-functions/ntile.md
@@ -35,6 +35,11 @@ NTILE( <constant_value> )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE student_scores (name VARCHAR(20), score INT) DISTRIBUTED BY HASH(name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO student_scores VALUES ('Alice',98),('Bob',95),('Charlie',90),('David',85),('Eve',82),('Frank',78),('Grace',75),('Henry',70);
+-->
+
 ```sql
 SELECT 
     name,

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/window-functions/rank.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/window-functions/rank.md
@@ -24,6 +24,11 @@ RANK()
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE employees (department VARCHAR(20), employee_name VARCHAR(20), salary INT) DISTRIBUTED BY HASH(employee_name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO employees VALUES ('Sales','Alice',10000),('Sales','Bob',10000),('Sales','Charlie',8000),('IT','David',12000),('IT','Eve',11000),('IT','Frank',11000),('IT','Grace',9000);
+-->
+
 ```sql
 SELECT 
     department,

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/window-functions/row-number.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/window-functions/row-number.md
@@ -24,6 +24,11 @@ ROW_NUMBER()
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE int_t (x INT, y INT) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO int_t VALUES (1,1),(1,2),(1,2),(2,1),(2,2),(2,3),(3,1),(3,1),(3,2);
+-->
+
 ```sql
 select x, y, row_number() over(partition by x order by y) as rank from int_t;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/lag.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/lag.md
@@ -29,6 +29,11 @@ LAG ( <expr>, <offset>, <default> )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 计算每个销售员当前销售额与前一天销售额的差值：
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/lead.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/lead.md
@@ -29,6 +29,11 @@ LEAD ( <expr> [ , <offset> [ , <default> ] ] )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 计算每个销售员当前销售额与下一天销售额的差值：
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/ntile.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/ntile.md
@@ -33,6 +33,11 @@ NTILE( <constant_value> )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE student_scores (name VARCHAR(20), score INT) DISTRIBUTED BY HASH(name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO student_scores VALUES ('Alice',98),('Bob',95),('Charlie',90),('David',85),('Eve',82),('Frank',78),('Grace',75),('Henry',70);
+-->
+
 ```sql
 SELECT 
     name,

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/rank.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/rank.md
@@ -22,6 +22,11 @@ RANK()
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE employees (department VARCHAR(20), employee_name VARCHAR(20), salary INT) DISTRIBUTED BY HASH(employee_name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO employees VALUES ('Sales','Alice',10000),('Sales','Bob',10000),('Sales','Charlie',8000),('IT','David',12000),('IT','Eve',11000),('IT','Frank',11000),('IT','Grace',9000);
+-->
+
 ```sql
 SELECT 
     department,

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/row-number.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/window-functions/row-number.md
@@ -22,6 +22,11 @@ ROW_NUMBER()
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE int_t (x INT, y INT) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO int_t VALUES (1,1),(1,2),(1,2),(2,1),(2,2),(2,3),(3,1),(3,1),(3,2);
+-->
+
 ```sql
 select x, y, row_number() over(partition by x order by y) as rank from int_t;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/lag.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/lag.md
@@ -29,6 +29,11 @@ LAG ( <expr>, <offset>, <default> )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 计算每个销售员当前销售额与前一天销售额的差值：
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/lead.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/lead.md
@@ -29,6 +29,11 @@ LEAD ( <expr> [ , <offset> [ , <default> ] ] )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 计算每个销售员当前销售额与下一天销售额的差值：
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/ntile.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/ntile.md
@@ -33,6 +33,11 @@ NTILE( <constant_value> )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE student_scores (name VARCHAR(20), score INT) DISTRIBUTED BY HASH(name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO student_scores VALUES ('Alice',98),('Bob',95),('Charlie',90),('David',85),('Eve',82),('Frank',78),('Grace',75),('Henry',70);
+-->
+
 ```sql
 SELECT 
     name,

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/rank.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/rank.md
@@ -22,6 +22,11 @@ RANK()
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE employees (department VARCHAR(20), employee_name VARCHAR(20), salary INT) DISTRIBUTED BY HASH(employee_name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO employees VALUES ('Sales','Alice',10000),('Sales','Bob',10000),('Sales','Charlie',8000),('IT','David',12000),('IT','Eve',11000),('IT','Frank',11000),('IT','Grace',9000);
+-->
+
 ```sql
 SELECT 
     department,

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/row-number.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/window-functions/row-number.md
@@ -22,6 +22,11 @@ ROW_NUMBER()
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE int_t (x INT, y INT) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO int_t VALUES (1,1),(1,2),(1,2),(2,1),(2,2),(2,3),(3,1),(3,1),(3,2);
+-->
+
 ```sql
 select x, y, row_number() over(partition by x order by y) as rank from int_t;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/window-functions/lag.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/window-functions/lag.md
@@ -30,6 +30,11 @@ LAG ( <expr> [, <offset> [, <default> ] ] )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 计算每个销售员当前销售额与前一天销售额的差值：
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/window-functions/lead.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/window-functions/lead.md
@@ -30,6 +30,11 @@ LEAD ( <expr> [ , <offset> [ , <default> ] ] )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 计算每个销售员当前销售额与下一天销售额的差值：
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/window-functions/ntile.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/window-functions/ntile.md
@@ -35,6 +35,11 @@ NTILE( <constant_value> )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE student_scores (name VARCHAR(20), score INT) DISTRIBUTED BY HASH(name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO student_scores VALUES ('Alice',98),('Bob',95),('Charlie',90),('David',85),('Eve',82),('Frank',78),('Grace',75),('Henry',70);
+-->
+
 ```sql
 SELECT 
     name,

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/window-functions/rank.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/window-functions/rank.md
@@ -24,6 +24,11 @@ RANK()
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE employees (department VARCHAR(20), employee_name VARCHAR(20), salary INT) DISTRIBUTED BY HASH(employee_name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO employees VALUES ('Sales','Alice',10000),('Sales','Bob',10000),('Sales','Charlie',8000),('IT','David',12000),('IT','Eve',11000),('IT','Frank',11000),('IT','Grace',9000);
+-->
+
 ```sql
 SELECT 
     department,

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/window-functions/row-number.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/window-functions/row-number.md
@@ -24,6 +24,11 @@ ROW_NUMBER()
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE int_t (x INT, y INT) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO int_t VALUES (1,1),(1,2),(1,2),(2,1),(2,2),(2,3),(3,1),(3,1),(3,2);
+-->
+
 ```sql
 select x, y, row_number() over(partition by x order by y) as rank from int_t;
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/lag.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/lag.md
@@ -29,6 +29,11 @@ Returns the same data type as the input expression.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 Calculate the difference between each salesperson's current sales amount and the previous day's sales amount:
 
 ```sql

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/lead.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/lead.md
@@ -29,6 +29,11 @@ Returns the same data type as the input expression.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 Calculate the difference between each salesperson's current sales and next day's sales:
 
 ```sql

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/ntile.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/ntile.md
@@ -33,6 +33,11 @@ If a statement contains both an ORDER BY clause in the NTILE function and an ORD
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE student_scores (name VARCHAR(20), score INT) DISTRIBUTED BY HASH(name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO student_scores VALUES ('Alice',98),('Bob',95),('Charlie',90),('David',85),('Eve',82),('Frank',78),('Grace',75),('Henry',70);
+-->
+
 ```sql
 SELECT 
     name,

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/rank.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/rank.md
@@ -22,6 +22,11 @@ Returns a BIGINT rank value. Returns the same rank for identical values, but cre
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE employees (department VARCHAR(20), employee_name VARCHAR(20), salary INT) DISTRIBUTED BY HASH(employee_name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO employees VALUES ('Sales','Alice',10000),('Sales','Bob',10000),('Sales','Charlie',8000),('IT','David',12000),('IT','Eve',11000),('IT','Frank',11000),('IT','Grace',9000);
+-->
+
 ```sql
 SELECT 
     department,

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/row-number.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/window-functions/row-number.md
@@ -22,6 +22,11 @@ Returns a BIGINT sequence number, starting from 1 and incrementing continuously.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE int_t (x INT, y INT) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO int_t VALUES (1,1),(1,2),(1,2),(2,1),(2,2),(2,3),(3,1),(3,1),(3,2);
+-->
+
 ```sql
 select x, y, row_number() over(partition by x order by y) as rank from int_t;
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/lag.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/lag.md
@@ -29,6 +29,11 @@ Returns the same data type as the input expression.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 Calculate the difference between each salesperson's current sales amount and the previous day's sales amount:
 
 ```sql

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/lead.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/lead.md
@@ -29,6 +29,11 @@ Returns the same data type as the input expression.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 Calculate the difference between each salesperson's current sales and next day's sales:
 
 ```sql

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/ntile.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/ntile.md
@@ -33,6 +33,11 @@ If a statement contains both an ORDER BY clause in the NTILE function and an ORD
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE student_scores (name VARCHAR(20), score INT) DISTRIBUTED BY HASH(name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO student_scores VALUES ('Alice',98),('Bob',95),('Charlie',90),('David',85),('Eve',82),('Frank',78),('Grace',75),('Henry',70);
+-->
+
 ```sql
 SELECT 
     name,

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/rank.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/rank.md
@@ -22,6 +22,11 @@ Returns a BIGINT rank value. Returns the same rank for identical values, but cre
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE employees (department VARCHAR(20), employee_name VARCHAR(20), salary INT) DISTRIBUTED BY HASH(employee_name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO employees VALUES ('Sales','Alice',10000),('Sales','Bob',10000),('Sales','Charlie',8000),('IT','David',12000),('IT','Eve',11000),('IT','Frank',11000),('IT','Grace',9000);
+-->
+
 ```sql
 SELECT 
     department,

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/row-number.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/window-functions/row-number.md
@@ -22,6 +22,11 @@ Returns a BIGINT sequence number, starting from 1 and incrementing continuously.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE int_t (x INT, y INT) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO int_t VALUES (1,1),(1,2),(1,2),(2,1),(2,2),(2,3),(3,1),(3,1),(3,2);
+-->
+
 ```sql
 select x, y, row_number() over(partition by x order by y) as rank from int_t;
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/window-functions/lag.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/window-functions/lag.md
@@ -29,6 +29,11 @@ Returns the same data type as the input expression.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 Calculate the difference between each salesperson's current sales amount and the previous day's sales amount:
 
 ```sql

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/window-functions/lead.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/window-functions/lead.md
@@ -29,6 +29,11 @@ Returns the same data type as the input expression.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE stock_ticker (stock_symbol VARCHAR(10), closing_date DATETIME, closing_price DOUBLE) DISTRIBUTED BY HASH(stock_symbol) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO stock_ticker VALUES ('JDR','2014-09-13 00:00:00',12.86),('JDR','2014-09-14 00:00:00',12.89),('JDR','2014-09-15 00:00:00',12.94),('JDR','2014-09-16 00:00:00',12.55),('JDR','2014-09-17 00:00:00',14.03),('JDR','2014-09-18 00:00:00',14.75),('JDR','2014-09-19 00:00:00',13.98);
+-->
+
 Calculate the difference between each salesperson's current sales and next day's sales:
 
 ```sql

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/window-functions/ntile.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/window-functions/ntile.md
@@ -33,6 +33,11 @@ If a statement contains both an ORDER BY clause in the NTILE function and an ORD
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE student_scores (name VARCHAR(20), score INT) DISTRIBUTED BY HASH(name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO student_scores VALUES ('Alice',98),('Bob',95),('Charlie',90),('David',85),('Eve',82),('Frank',78),('Grace',75),('Henry',70);
+-->
+
 ```sql
 SELECT 
     name,

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/window-functions/rank.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/window-functions/rank.md
@@ -22,6 +22,11 @@ Returns a BIGINT rank value. Returns the same rank for identical values, but cre
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE employees (department VARCHAR(20), employee_name VARCHAR(20), salary INT) DISTRIBUTED BY HASH(employee_name) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO employees VALUES ('Sales','Alice',10000),('Sales','Bob',10000),('Sales','Charlie',8000),('IT','David',12000),('IT','Eve',11000),('IT','Frank',11000),('IT','Grace',9000);
+-->
+
 ```sql
 SELECT 
     department,

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/window-functions/row-number.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/window-functions/row-number.md
@@ -22,6 +22,11 @@ Returns a BIGINT sequence number, starting from 1 and incrementing continuously.
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE int_t (x INT, y INT) DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO int_t VALUES (1,1),(1,2),(1,2),(2,1),(2,2),(2,3),(3,1),(3,1),(3,2);
+-->
+
 ```sql
 select x, y, row_number() over(partition by x order by y) as rank from int_t;
 ```


### PR DESCRIPTION
The `LAG`, `LEAD`, `NTILE`, `RANK` and `ROW_NUMBER` window-function pages each show a `SELECT ... FROM <table>` example with an expected result, but never define the table on the page. As written these examples cannot be run or reproduced — a reader who copies them gets `Table [...] does not exist`.

This PR adds the missing `CREATE TABLE` + `INSERT` for each table, carried in a standard HTML comment (`<!-- setup-sql ... -->`) just before the example. Because it is an HTML comment, **the rendered page is unchanged** and **no documented expected output is modified** — it only records the data the examples already assume, making each example self-contained and reproducible.

Table contents were reverse-derived from the output already printed on each page and verified end-to-end on the matching release cluster for every doc tree.

### Pages and tables
| Function | Table |
| --- | --- |
| `LAG` / `LEAD` | `stock_ticker` |
| `NTILE` | `student_scores` |
| `RANK` | `employees` |
| `ROW_NUMBER` | `int_t` |

Each page is updated in EN + ZH across the dev/`current`, `version-4.x`, `version-3.x` and `version-2.1` doc trees (40 files). Verification clusters: 4.1.1 (4.x), 3.1.4 (3.x), 2.1.11 (2.1), master build (dev). On every tree the affected examples failed with "table does not exist" before this change and pass (output matches the doc) after it. No `ja-source` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)