### PR TITLE
[fix](sql-functions) provide setup data for date-time-function examples querying an undefined table

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/period-add.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/period-add.md
@@ -40,6 +40,11 @@ If the `period` parameter is negative or its month part is invalid, the function
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_period_add (period BIGINT, month BIGINT) DISTRIBUTED BY HASH(period) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_period_add VALUES (200803,2),(200809,5),(803,2),(6910,3),(7001,1),(12345611,123456),(NULL,10),(202510,NULL);
+-->
+
 ```sql
 SELECT `period`, `month`, PERIOD_ADD(`period`, `month`) AS ans FROM test_period_add;
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/period-diff.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/period-diff.md
@@ -39,6 +39,11 @@ If the parameters are negative or their month parts are invalid, the function wi
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_period_diff (period_1 LARGEINT, period_2 LARGEINT) DISTRIBUTED BY HASH(period_1) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_period_diff VALUES (200802,200703),(200703,200802),(7001,6912),(NULL,2510),(2510,NULL),(9223372036854775807,101),(9223372036854775808,101);
+-->
+
 ```sql
 SELECT `period_1`, `period_2`, PERIOD_DIFF(`period_1`, `period_2`) AS DIFF FROM `test_period_diff`;
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/time-format.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/date-time-functions/time-format.md
@@ -57,6 +57,13 @@ Special cases:
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_time_format (id INT, tm VARCHAR(30)) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_time_format VALUES (1,'00:00:00'),(2,'00:00:00.123456'),(3,'12:34:56'),(4,'12:34:56.789012'),(5,'23:59:59'),(6,'23:59:59.999999'),(7,'08:00:00'),(8,'15:00:00'),(9,'100:00:00'),(10,'123:45:56'),(11,'838:59:59.999999'),(12,'-00:00:01'),(13,'-12:34:56.000001'),(14,'-838:59:59.999999');
+CREATE TABLE test_format (fmt VARCHAR(10)) DISTRIBUTED BY HASH(fmt) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_format VALUES ('%Y'),('%y'),('%m'),('%d'),('%c'),('%e');
+-->
+
 ```sql
 SELECT * FROM test_time_format;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/period-add.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/period-add.md
@@ -40,6 +40,11 @@ PERIOD_ADD(`<period>`, `<month>`)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_period_add (period BIGINT, month BIGINT) DISTRIBUTED BY HASH(period) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_period_add VALUES (200803,2),(200809,5),(803,2),(6910,3),(7001,1),(12345611,123456),(NULL,10),(202510,NULL);
+-->
+
 ```sql
 SELECT `period`, `month`, PERIOD_ADD(`period`, `month`) AS ans FROM test_period_add;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/period-diff.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/period-diff.md
@@ -39,6 +39,11 @@ PERIOD_DIFF(`<period_1>`, `<period_2>`)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_period_diff (period_1 LARGEINT, period_2 LARGEINT) DISTRIBUTED BY HASH(period_1) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_period_diff VALUES (200802,200703),(200703,200802),(7001,6912),(NULL,2510),(2510,NULL),(9223372036854775807,101),(9223372036854775808,101);
+-->
+
 ```sql
 SELECT `period_1`, `period_2`, PERIOD_DIFF(`period_1`, `period_2`) AS DIFF FROM `test_period_diff`;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/time-format.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/date-time-functions/time-format.md
@@ -57,6 +57,13 @@ TIME_FORMAT(<time_or_datetime_expr>, <format>)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_time_format (id INT, tm VARCHAR(30)) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_time_format VALUES (1,'00:00:00'),(2,'00:00:00.123456'),(3,'12:34:56'),(4,'12:34:56.789012'),(5,'23:59:59'),(6,'23:59:59.999999'),(7,'08:00:00'),(8,'15:00:00'),(9,'100:00:00'),(10,'123:45:56'),(11,'838:59:59.999999'),(12,'-00:00:01'),(13,'-12:34:56.000001'),(14,'-838:59:59.999999');
+CREATE TABLE test_format (fmt VARCHAR(10)) DISTRIBUTED BY HASH(fmt) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_format VALUES ('%Y'),('%y'),('%m'),('%d'),('%c'),('%e');
+-->
+
 ```sql
 SELECT * FROM test_time_format;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/period-add.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/period-add.md
@@ -40,6 +40,11 @@ PERIOD_ADD(`<period>`, `<month>`)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_period_add (period BIGINT, month BIGINT) DISTRIBUTED BY HASH(period) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_period_add VALUES (200803,2),(200809,5),(803,2),(6910,3),(7001,1),(12345611,123456),(NULL,10),(202510,NULL);
+-->
+
 ```sql
 SELECT `period`, `month`, PERIOD_ADD(`period`, `month`) AS ans FROM test_period_add;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/period-diff.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/period-diff.md
@@ -39,6 +39,11 @@ PERIOD_DIFF(`<period_1>`, `<period_2>`)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_period_diff (period_1 LARGEINT, period_2 LARGEINT) DISTRIBUTED BY HASH(period_1) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_period_diff VALUES (200802,200703),(200703,200802),(7001,6912),(NULL,2510),(2510,NULL),(9223372036854775807,101),(9223372036854775808,101);
+-->
+
 ```sql
 SELECT `period_1`, `period_2`, PERIOD_DIFF(`period_1`, `period_2`) AS DIFF FROM `test_period_diff`;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/time-format.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/time-format.md
@@ -57,6 +57,13 @@ TIME_FORMAT(<time_or_datetime_expr>, <format>)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_time_format (id INT, tm VARCHAR(30)) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_time_format VALUES (1,'00:00:00'),(2,'00:00:00.123456'),(3,'12:34:56'),(4,'12:34:56.789012'),(5,'23:59:59'),(6,'23:59:59.999999'),(7,'08:00:00'),(8,'15:00:00'),(9,'100:00:00'),(10,'123:45:56'),(11,'838:59:59.999999'),(12,'-00:00:01'),(13,'-12:34:56.000001'),(14,'-838:59:59.999999');
+CREATE TABLE test_format (fmt VARCHAR(10)) DISTRIBUTED BY HASH(fmt) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_format VALUES ('%Y'),('%y'),('%m'),('%d'),('%c'),('%e');
+-->
+
 ```sql
 SELECT * FROM test_time_format;
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/period-add.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/period-add.md
@@ -40,6 +40,11 @@ If the `period` parameter is negative or its month part is invalid, the function
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_period_add (period BIGINT, month BIGINT) DISTRIBUTED BY HASH(period) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_period_add VALUES (200803,2),(200809,5),(803,2),(6910,3),(7001,1),(12345611,123456),(NULL,10),(202510,NULL);
+-->
+
 ```sql
 SELECT `period`, `month`, PERIOD_ADD(`period`, `month`) AS ans FROM test_period_add;
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/period-diff.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/period-diff.md
@@ -39,6 +39,11 @@ If the parameters are negative or their month parts are invalid, the function wi
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_period_diff (period_1 LARGEINT, period_2 LARGEINT) DISTRIBUTED BY HASH(period_1) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_period_diff VALUES (200802,200703),(200703,200802),(7001,6912),(NULL,2510),(2510,NULL),(9223372036854775807,101),(9223372036854775808,101);
+-->
+
 ```sql
 SELECT `period_1`, `period_2`, PERIOD_DIFF(`period_1`, `period_2`) AS DIFF FROM `test_period_diff`;
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/time-format.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/date-time-functions/time-format.md
@@ -57,6 +57,13 @@ Special cases:
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_time_format (id INT, tm VARCHAR(30)) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_time_format VALUES (1,'00:00:00'),(2,'00:00:00.123456'),(3,'12:34:56'),(4,'12:34:56.789012'),(5,'23:59:59'),(6,'23:59:59.999999'),(7,'08:00:00'),(8,'15:00:00'),(9,'100:00:00'),(10,'123:45:56'),(11,'838:59:59.999999'),(12,'-00:00:01'),(13,'-12:34:56.000001'),(14,'-838:59:59.999999');
+CREATE TABLE test_format (fmt VARCHAR(10)) DISTRIBUTED BY HASH(fmt) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_format VALUES ('%Y'),('%y'),('%m'),('%d'),('%c'),('%e');
+-->
+
 ```sql
 SELECT * FROM test_time_format;
 ```


### PR DESCRIPTION
The `PERIOD_ADD`, `PERIOD_DIFF` and `TIME_FORMAT` pages each show a `SELECT ... FROM <table>` example with an expected result, but never define the table on the page. As written these examples cannot be run or reproduced — a reader who copies them gets `Table [...] does not exist`.

This PR adds the missing `CREATE TABLE` + `INSERT` for each table, carried in a standard HTML comment (`<!-- setup-sql ... -->`) just before the example. Because it is an HTML comment, **the rendered page is unchanged** and **no documented expected output is modified**.

Table contents were reverse-derived from the output already printed on each page and verified end-to-end on the matching cluster for each doc tree.

### Pages and tables
| Function | Table(s) |
| --- | --- |
| `PERIOD_ADD` | `test_period_add` |
| `PERIOD_DIFF` | `test_period_diff` |
| `TIME_FORMAT` | `test_time_format`, `test_format` |

These pages exist only in the dev/`current` and `version-4.x` trees; updated in EN + ZH (12 files). Verified on a 4.1.1 cluster (4.x) and a master build (dev): the affected examples failed with "table does not exist" before this change and pass (output matches the doc, including the full TIME_FORMAT specifier table) after it. No `ja-source` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)