### PR TITLE
[fix](docs) remove unsupported grouping_id order by example

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/grouping-id.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/grouping-id.md
@@ -2,13 +2,13 @@
 {
     "title": "GROUPING_ID",
     "language": "zh-CN",
-    "description": "GROUPINGID 是一个用于计算分组层级的函数。当 SQL 语句中使用了 GROUP BY 子句时，该函数可以在 SELECT、HAVING 或 ORDER BY 子句中使用，返回一个 BIGINT 值，该值表示各分组列聚合情况对应的二进制位图转换为十进制后的结果。"
+    "description": "GROUPINGID 是一个用于计算分组层级的函数。当 SQL 语句中使用了 GROUP BY 子句时，该函数可以在 SELECT 或 HAVING 子句中使用，返回一个 BIGINT 值，该值表示各分组列聚合情况对应的二进制位图转换为十进制后的结果。"
 }
 ---
 
 ## 描述
 
-GROUPING_ID 是一个用于计算分组层级的函数。当 SQL 语句中使用了 GROUP BY 子句时，该函数可以在 SELECT、HAVING 或 ORDER BY 子句中使用，返回一个 BIGINT 值，该值表示各分组列聚合情况对应的二进制位图转换为十进制后的结果。
+GROUPING_ID 是一个用于计算分组层级的函数。当 SQL 语句中使用了 GROUP BY 子句时，该函数可以在 SELECT 或 HAVING 子句中使用，返回一个 BIGINT 值，该值表示各分组列聚合情况对应的二进制位图转换为十进制后的结果。
 
 ## 语法
 
@@ -28,47 +28,7 @@ GROUPING_ID ( <column_expression>[ ,...n ] )
 
 ## 示例
 
-### 示例 A: 识别分组层级
-
-下面的例子按部门和职级统计雇员人数，并使用 GROUPING_ID 函数计算每一行的聚合程度。
-
-```sql
-SELECT
-  department,
-  CASE 
-    WHEN GROUPING_ID(department, level) = 0 THEN level
-    WHEN GROUPING_ID(department, level) = 1 THEN CONCAT('Total: ', department)
-    WHEN GROUPING_ID(department, level) = 3 THEN 'Total: Company'
-    ELSE 'Unknown'
-  END AS 'Job Title',
-  COUNT(uid) AS 'Employee Count'
-FROM employee 
-GROUP BY ROLLUP(department, level)
-ORDER BY GROUPING_ID(department, level) ASC;
-```
-
-
-```text
-+--------------------+---------------------------+----------------+
-| department         | Job Title                 | Employee Count |
-+--------------------+---------------------------+----------------+
-| Board of Directors | Senior                    |              2 |
-| Technology         | Senior                    |              3 |
-| Sales              | Senior                    |              1 |
-| Sales              | Assistant                 |              2 |
-| Sales              | Trainee                   |              1 |
-| Marketing          | Senior                    |              1 |
-| Marketing          | Trainee                   |              2 |
-| Marketing          | Assistant                 |              1 |
-| Board of Directors | Total: Board of Directors |              2 |
-| Technology         | Total: Technology         |              3 |
-| Sales              | Total: Sales              |              4 |
-| Marketing          | Total: Marketing          |              4 |
-| NULL               | Total: Company            |             13 |
-+--------------------+---------------------------+----------------+
-```
-
-### 示例 B: 过滤结果集
+### 示例 A: 过滤结果集
 
 下面的例子返回部门中级别为 "Senior" 的雇员统计数据。
 

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/grouping-id.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/other-functions/grouping-id.md
@@ -8,7 +8,7 @@
 
 ## Description
 
-Computes the level of grouping for rows in a GROUP BY query. The GROUPING_ID function returns an integer bitmap indicating which columns in the GROUP BY list are not aggregated for a given output row. It can be used in the SELECT list, HAVING, or ORDER BY clauses when a GROUP BY is specified.
+Computes the level of grouping for rows in a GROUP BY query. The GROUPING_ID function returns an integer bitmap indicating which columns in the GROUP BY list are not aggregated for a given output row. It can be used in the SELECT list or HAVING clause when a GROUP BY is specified.
 
 ## Syntax
 
@@ -28,46 +28,7 @@ Returns a BIGINT value representing the grouping bitmap for the given columns.
 
 ## Examples
 
-### Example A: Identify grouping levels
-
-```sql
-SELECT
-  department,
-  CASE 
-    WHEN GROUPING_ID(department, level) = 0 THEN level
-    WHEN GROUPING_ID(department, level) = 1 THEN CONCAT('Total: ', department)
-    WHEN GROUPING_ID(department, level) = 3 THEN 'Total: Company'
-    ELSE 'Unknown'
-  END AS `Job Title`,
-  COUNT(uid) AS `Employee Count`
-FROM employee 
-GROUP BY ROLLUP(department, level)
-ORDER BY GROUPING_ID(department, level) ASC;
-```
-
-*Expected Output:*
-
-```text
-+--------------------+---------------------------+----------------+
-| department         | Job Title                 | Employee Count |
-+--------------------+---------------------------+----------------+
-| Board of Directors | Senior                    |              2 |
-| Technology         | Senior                    |              3 |
-| Sales              | Senior                    |              1 |
-| Sales              | Assistant                 |              2 |
-| Sales              | Trainee                   |              1 |
-| Marketing          | Senior                    |              1 |
-| Marketing          | Trainee                   |              2 |
-| Marketing          | Assistant                 |              1 |
-| Board of Directors | Total: Board of Directors |              2 |
-| Technology         | Total: Technology         |              3 |
-| Sales              | Total: Sales              |              4 |
-| Marketing          | Total: Marketing          |              4 |
-| NULL               | Total: Company            |             13 |
-+--------------------+---------------------------+----------------+
-```
-
-### Example B: Filter result set using GROUPING_ID
+### Example A: Filter result set using GROUPING_ID
 
 ```sql
 SELECT


### PR DESCRIPTION
Remove the 4.x GROUPING_ID example that orders directly by GROUPING_ID, which is rejected by Doris 4.1.

Key changes:
- Remove the unsupported ORDER BY GROUPING_ID example from 4.x English and Chinese docs.
- Update 4.x descriptions to mention SELECT and HAVING usage only.

Validation:
- Not run; documentation-only change.
