### PR TITLE
[fix](sql-functions) provide setup data for HLL-function examples querying an undefined table

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
@@ -28,6 +28,11 @@ Returns the estimated cardinality of the HLL type value, representing the number
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_uv (id INT, uv_set HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_uv VALUES (1, hll_hash('a')), (1, hll_hash('b')), (1, hll_hash('c'));
+-->
+
 ```sql
 select HLL_CARDINALITY(uv_set) from test_uv;
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
@@ -24,6 +24,11 @@ HLL_FROM_BASE64(<input>)
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_union_agg(hll_from_base64(hll_to_base64(pv))), hll_union_agg(pv) from test_hll;
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
@@ -35,6 +35,11 @@ Due to the non-guaranteed order of elements in a HLL, the generated Base64 strin
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_to_base64(NULL);
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
@@ -28,6 +28,11 @@ HLL_CARDINALITY(<hll>)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_uv (id INT, uv_set HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_uv VALUES (1, hll_hash('a')), (1, hll_hash('b')), (1, hll_hash('c'));
+-->
+
 ```sql
 select HLL_CARDINALITY(uv_set) from test_uv;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
@@ -24,6 +24,11 @@ HLL_FROM_BASE64(<input>)
 
 ## 示例
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_union_agg(hll_from_base64(hll_to_base64(pv))), hll_union_agg(pv) from test_hll;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
@@ -35,6 +35,11 @@ HLL 基于 Base64 编码后的字符串。
 
 ## 示例
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_to_base64(NULL);
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
@@ -28,6 +28,11 @@ HLL_CARDINALITY(<hll>)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_uv (id INT, uv_set HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_uv VALUES (1, hll_hash('a')), (1, hll_hash('b')), (1, hll_hash('c'));
+-->
+
 ```sql
 select HLL_CARDINALITY(uv_set) from test_uv;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
@@ -24,6 +24,11 @@ HLL_FROM_BASE64(<input>)
 
 ## 示例
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_union_agg(hll_from_base64(hll_to_base64(pv))), hll_union_agg(pv) from test_hll;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
@@ -24,6 +24,11 @@ HLL_TO_BASE64(<hll_input>)
 
 ## 示例
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_to_base64(NULL);
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
@@ -28,6 +28,11 @@ HLL_CARDINALITY(<hll>)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_uv (id INT, uv_set HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_uv VALUES (1, hll_hash('a')), (1, hll_hash('b')), (1, hll_hash('c'));
+-->
+
 ```sql
 select HLL_CARDINALITY(uv_set) from test_uv;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
@@ -24,6 +24,11 @@ HLL_FROM_BASE64(<input>)
 
 ## 示例
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_union_agg(hll_from_base64(hll_to_base64(pv))), hll_union_agg(pv) from test_hll;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
@@ -24,6 +24,11 @@ HLL_TO_BASE64(<hll_input>)
 
 ## 示例
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_to_base64(NULL);
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
@@ -28,6 +28,11 @@ HLL_CARDINALITY(<hll>)
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_uv (id INT, uv_set HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_uv VALUES (1, hll_hash('a')), (1, hll_hash('b')), (1, hll_hash('c'));
+-->
+
 ```sql
 select HLL_CARDINALITY(uv_set) from test_uv;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
@@ -24,6 +24,11 @@ HLL_FROM_BASE64(<input>)
 
 ## 示例
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_union_agg(hll_from_base64(hll_to_base64(pv))), hll_union_agg(pv) from test_hll;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
@@ -35,6 +35,11 @@ HLL 基于 Base64 编码后的字符串。
 
 ## 示例
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_to_base64(NULL);
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
@@ -28,6 +28,11 @@ Returns the estimated cardinality of the HLL type value, representing the number
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_uv (id INT, uv_set HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_uv VALUES (1, hll_hash('a')), (1, hll_hash('b')), (1, hll_hash('c'));
+-->
+
 ```sql
 select HLL_CARDINALITY(uv_set) from test_uv;
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
@@ -24,6 +24,11 @@ HLL_FROM_BASE64(<input>)
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_union_agg(hll_from_base64(hll_to_base64(pv))), hll_union_agg(pv) from test_hll;
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
@@ -24,6 +24,11 @@ HLL_TO_BASE64(<hll_input>)
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_to_base64(NULL);
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
@@ -28,6 +28,11 @@ Returns the estimated cardinality of the HLL type value, representing the number
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_uv (id INT, uv_set HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_uv VALUES (1, hll_hash('a')), (1, hll_hash('b')), (1, hll_hash('c'));
+-->
+
 ```sql
 select HLL_CARDINALITY(uv_set) from test_uv;
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
@@ -24,6 +24,11 @@ HLL_FROM_BASE64(<input>)
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_union_agg(hll_from_base64(hll_to_base64(pv))), hll_union_agg(pv) from test_hll;
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
@@ -26,6 +26,11 @@ HLL_TO_BASE64(<hll_input>)
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_to_base64(NULL);
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-cardinality.md
@@ -28,6 +28,11 @@ Returns the estimated cardinality of the HLL type value, representing the number
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_uv (id INT, uv_set HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_uv VALUES (1, hll_hash('a')), (1, hll_hash('b')), (1, hll_hash('c'));
+-->
+
 ```sql
 select HLL_CARDINALITY(uv_set) from test_uv;
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-from-base64.md
@@ -24,6 +24,11 @@ HLL_FROM_BASE64(<input>)
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_union_agg(hll_from_base64(hll_to_base64(pv))), hll_union_agg(pv) from test_hll;
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/hll-functions/hll-to-base64.md
@@ -35,6 +35,11 @@ Due to the non-guaranteed order of elements in a HLL, the generated Base64 strin
 
 ## Examples
 
+<!-- setup-sql
+CREATE TABLE test_hll (id INT, pv HLL HLL_UNION) AGGREGATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_hll VALUES (1, hll_hash('a')), (2, hll_hash('b')), (3, hll_hash('c'));
+-->
+
 ```sql
 select hll_to_base64(NULL);
 ```


### PR DESCRIPTION
The `HLL_CARDINALITY`, `HLL_FROM_BASE64` and `HLL_TO_BASE64` pages each show a `SELECT ... FROM <table>` example with an expected result, but never define the table on the page. As written these examples cannot be run or reproduced — a reader who copies them gets `Table [...] does not exist`.

This PR adds the missing `CREATE TABLE` + `INSERT` for each table, carried in a standard HTML comment (`<!-- setup-sql ... -->`) just before the example. The tables are aggregate tables with an `HLL HLL_UNION` column populated via `hll_hash(...)`. Because it is an HTML comment, **the rendered page is unchanged** and **no documented expected output is modified**.

Table contents were reverse-derived from the printed output and verified end-to-end on the matching cluster for each doc tree.

### Pages and tables
| Function | Table |
| --- | --- |
| `HLL_CARDINALITY` | `test_uv` |
| `HLL_FROM_BASE64` | `test_hll` |
| `HLL_TO_BASE64` | `test_hll` |

Updated in EN + ZH across the dev/`current`, `version-4.x`, `version-3.x` and `version-2.1` trees (24 files). Verified on 4.1.1 (4.x), 3.1.4 (3.x), 2.1.11 (2.1) and a master build (dev): the affected examples failed with "table does not exist" before this change and pass (cardinality matches the doc) after it. No `ja-source` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)