### PR TITLE
[fix](sql-functions) provide setup data for numeric-function examples querying an undefined table

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
@@ -59,6 +59,11 @@ Returns an integer or a float-point number:
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_enhanced_round (rid INT, number INT) DISTRIBUTED BY HASH(rid) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_enhanced_round VALUES (1,1);
+-->
+
 ```sql
 select round_bankers(0.4);
 ```

--- a/docs/sql-manual/sql-functions/scalar-functions/numeric-functions/uniform.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/numeric-functions/uniform.md
@@ -32,6 +32,13 @@ Note that unlike Snowflake's [common usage](https://docs.snowflake.com/en/sql-re
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE it (k0 INT) DISTRIBUTED BY HASH(k0) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO it VALUES (NULL),(1),(2),(3),(4),(5);
+CREATE TABLE fn_test (ksint INT) DISTRIBUTED BY HASH(ksint) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO fn_test VALUES (1);
+-->
+
 When all input parameters are integers, return an integer:
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
@@ -59,6 +59,11 @@ ROUND_BANKERS(<x> [ , <d>])
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_enhanced_round (rid INT, number INT) DISTRIBUTED BY HASH(rid) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_enhanced_round VALUES (1,1);
+-->
+
 ```sql
 select round_bankers(0.4);
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/numeric-functions/uniform.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/numeric-functions/uniform.md
@@ -32,6 +32,13 @@ UNIFORM( <min> , <max> , <gen> )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE it (k0 INT) DISTRIBUTED BY HASH(k0) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO it VALUES (NULL),(1),(2),(3),(4),(5);
+CREATE TABLE fn_test (ksint INT) DISTRIBUTED BY HASH(ksint) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO fn_test VALUES (1);
+-->
+
 输入参数全为整数时，返回整数：
 
 ```sql

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
@@ -59,6 +59,11 @@ ROUND_BANKERS(<x> [ , <d>])
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_enhanced_round (rid INT, number INT) DISTRIBUTED BY HASH(rid) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_enhanced_round VALUES (1,1);
+-->
+
 ```sql
 select round_bankers(0.4);
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
@@ -59,6 +59,11 @@ ROUND_BANKERS(<x> [ , <d>])
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_enhanced_round (rid INT, number INT) DISTRIBUTED BY HASH(rid) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_enhanced_round VALUES (1,1);
+-->
+
 ```sql
 select round_bankers(0.4);
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
@@ -59,6 +59,11 @@ ROUND_BANKERS(<x> [ , <d>])
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_enhanced_round (rid INT, number INT) DISTRIBUTED BY HASH(rid) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_enhanced_round VALUES (1,1);
+-->
+
 ```sql
 select round_bankers(0.4);
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/numeric-functions/uniform.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/numeric-functions/uniform.md
@@ -32,6 +32,13 @@ UNIFORM( <min> , <max> , <gen> )
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE it (k0 INT) DISTRIBUTED BY HASH(k0) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO it VALUES (NULL),(1),(2),(3),(4),(5);
+CREATE TABLE fn_test (ksint INT) DISTRIBUTED BY HASH(ksint) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO fn_test VALUES (1);
+-->
+
 输入参数全为整数时，返回整数：
 
 ```sql

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
@@ -59,6 +59,11 @@ Returns an integer or a float-point number:
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_enhanced_round (rid INT, number INT) DISTRIBUTED BY HASH(rid) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_enhanced_round VALUES (1,1);
+-->
+
 ```sql
 select round_bankers(0.4);
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
@@ -59,6 +59,11 @@ Returns an integer or a float-point number:
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_enhanced_round (rid INT, number INT) DISTRIBUTED BY HASH(rid) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_enhanced_round VALUES (1,1);
+-->
+
 ```sql
 select round_bankers(0.4);
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/numeric-functions/round-bankers.md
@@ -59,6 +59,11 @@ Returns an integer or a float-point number:
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_enhanced_round (rid INT, number INT) DISTRIBUTED BY HASH(rid) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_enhanced_round VALUES (1,1);
+-->
+
 ```sql
 select round_bankers(0.4);
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/numeric-functions/uniform.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/numeric-functions/uniform.md
@@ -32,6 +32,13 @@ Note that unlike Snowflake's [common usage](https://docs.snowflake.com/en/sql-re
 
 ## Example
 
+<!-- setup-sql
+CREATE TABLE it (k0 INT) DISTRIBUTED BY HASH(k0) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO it VALUES (NULL),(1),(2),(3),(4),(5);
+CREATE TABLE fn_test (ksint INT) DISTRIBUTED BY HASH(ksint) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO fn_test VALUES (1);
+-->
+
 When all input parameters are integers, return an integer:
 
 ```sql


### PR DESCRIPTION
The `ROUND_BANKERS` and `UNIFORM` pages each show a `SELECT ... FROM <table>` example with an expected result, but never define the table on the page. As written these examples cannot be run or reproduced — a reader who copies them gets `Table [...] does not exist`.

This PR adds the missing `CREATE TABLE` + `INSERT` for each table, carried in a standard HTML comment (`<!-- setup-sql ... -->`) just before the example. Because it is an HTML comment, **the rendered page is unchanged** and **no documented expected output is modified**.

### Pages and tables
| Function | Table(s) |
| --- | --- |
| `ROUND_BANKERS` | `test_enhanced_round` |
| `UNIFORM` | `it`, `fn_test` |

`ROUND_BANKERS` is updated in EN + ZH across dev/`current`, `version-4.x`, `version-3.x` and `version-2.1`; `UNIFORM` exists only in dev/`current` and `version-4.x` (12 files total). Verified end-to-end: ROUND_BANKERS on 4.1.1 / 3.1.4 / 2.1.11 / master, UNIFORM on 4.1.1 / master. The deterministic examples failed with "table does not exist" before this change and match the documented output after it. (`UNIFORM`s `random()`-seeded examples are inherently non-deterministic, as the page itself notes — those keep showing sample output.) No `ja-source` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)