### PR TITLE
[fix](sql-functions) provide setup data for the EXPORT_SET table example

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/string-functions/export-set.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/string-functions/export-set.md
@@ -37,6 +37,11 @@ Returns a string. For each bit in `bits`, from the least significant bit to the 
 If `number_of_bits` is out of range [-2^31, 2^31 - 1] or any parameter in the function is NULL, return NULL.
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_export_set (`bits` BIGINT, `on` VARCHAR(20), `off` VARCHAR(20), `sep` VARCHAR(20), `num_of_b` INT) DISTRIBUTED BY HASH(`bits`) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_export_set VALUES (-1,'1','0',',',50),(-2,'1','0','',64),(5,'Y','N',',',5),(5,'1','0','',64),(5,'','0','',65),(6,'1','','',63),(19284249819,'1','0',',',64),(9,'apache','doris','|123|',64),(NULL,'1','0',',',5),(5,NULL,'0','',5),(5,'1',NULL,',',10),(5,'1','0',NULL,10),(5,'1','0',',',NULL);
+-->
+
 ```sql
 SELECT EXPORT_SET(-2, '1', '0');
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/string-functions/export-set.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/string-functions/export-set.md
@@ -39,6 +39,11 @@ EXPORT_SET(bits, on, off[, separator[, number_of_bits]])
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_export_set (`bits` BIGINT, `on` VARCHAR(20), `off` VARCHAR(20), `sep` VARCHAR(20), `num_of_b` INT) DISTRIBUTED BY HASH(`bits`) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_export_set VALUES (-1,'1','0',',',50),(-2,'1','0','',64),(5,'Y','N',',',5),(5,'1','0','',64),(5,'','0','',65),(6,'1','','',63),(19284249819,'1','0',',',64),(9,'apache','doris','|123|',64),(NULL,'1','0',',',5),(5,NULL,'0','',5),(5,'1',NULL,',',10),(5,'1','0',NULL,10),(5,'1','0',',',NULL);
+-->
+
 ```sql
 SELECT EXPORT_SET(-2, '1', '0');
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/export-set.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/export-set.md
@@ -39,6 +39,11 @@ EXPORT_SET(bits, on, off[, separator[, number_of_bits]])
 
 ## 举例
 
+<!-- setup-sql
+CREATE TABLE test_export_set (`bits` BIGINT, `on` VARCHAR(20), `off` VARCHAR(20), `sep` VARCHAR(20), `num_of_b` INT) DISTRIBUTED BY HASH(`bits`) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_export_set VALUES (-1,'1','0',',',50),(-2,'1','0','',64),(5,'Y','N',',',5),(5,'1','0','',64),(5,'','0','',65),(6,'1','','',63),(19284249819,'1','0',',',64),(9,'apache','doris','|123|',64),(NULL,'1','0',',',5),(5,NULL,'0','',5),(5,'1',NULL,',',10),(5,'1','0',NULL,10),(5,'1','0',',',NULL);
+-->
+
 ```sql
 SELECT EXPORT_SET(-2, '1', '0');
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/export-set.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/string-functions/export-set.md
@@ -37,6 +37,11 @@ Returns a string. For each bit in `bits`, from the least significant bit to the 
 If `number_of_bits` is out of range [-2^31, 2^31 - 1] or any parameter in the function is NULL, return NULL.
 ## Example
 
+<!-- setup-sql
+CREATE TABLE test_export_set (`bits` BIGINT, `on` VARCHAR(20), `off` VARCHAR(20), `sep` VARCHAR(20), `num_of_b` INT) DISTRIBUTED BY HASH(`bits`) BUCKETS 1 PROPERTIES("replication_num"="1");
+INSERT INTO test_export_set VALUES (-1,'1','0',',',50),(-2,'1','0','',64),(5,'Y','N',',',5),(5,'1','0','',64),(5,'','0','',65),(6,'1','','',63),(19284249819,'1','0',',',64),(9,'apache','doris','|123|',64),(NULL,'1','0',',',5),(5,NULL,'0','',5),(5,'1',NULL,',',10),(5,'1','0',NULL,10),(5,'1','0',',',NULL);
+-->
+
 ```sql
 SELECT EXPORT_SET(-2, '1', '0');
 ```


### PR DESCRIPTION
The `EXPORT_SET` page shows `SELECT ... FROM test_export_set` examples with an expected result, but never defines `test_export_set`. As written these examples cannot be run or reproduced — a reader who copies them gets `Table [...] does not exist`.

This PR adds the missing `CREATE TABLE` + `INSERT`, carried in a standard HTML comment (`<!-- setup-sql ... -->`) just before the example. Because it is an HTML comment, **the rendered page is unchanged** and **no documented expected output is modified**.

The table contents were reverse-derived from the printed input table and verified end-to-end on `version-4.x` (a 4.1.1 cluster) and dev/`current` (a master build): both the input table and the `EXPORT_SET(...)` results match the documented output exactly, including the row whose separator is the literal `|123|`.

The page exists only in the dev/`current` and `version-4.x` trees; updated in EN + ZH (4 files). No `ja-source` changes.

> Note: a separate, pre-existing inconsistency on this page — one example whose SQL selects a single column while its output table shows six (`bits | on | off | sep | num_of_b | ans`) — is **not** addressed here; it is tracked in #3879 so the SQL/output correction can be reviewed on its own.