### PR TITLE
fix(docs): correct typos in Fluent Bit and Logstash config examples

### DIFF
--- a/docs/connection-integration/data-integration/fluentbit.md
+++ b/docs/connection-integration/data-integration/fluentbit.md
@@ -201,7 +201,7 @@ This scenario requires two configuration files:
     table your_table
     # add 'collect_time' to the record
     time_key collect_time
-    # 'collect_time' is timestamp, change it to datatime
+    # 'collect_time' is timestamp, change it to datetime
     header columns collect_time=from_unixtime(collect_time)
     log_request true
     log_progress_interval 10

--- a/docs/observability/log.md
+++ b/docs/observability/log.md
@@ -400,7 +400,7 @@ Follow these steps:
             "load_to_single_tablet" => "true"
             }
 
-            # field mapping: doris fileld name => logstash field name
+            # field mapping: doris field name => logstash field name
             # %{} to get a logstash field, [] for nested field such as [host][name] for host.name
             mapping => {
             "ts" => "%{@timestamp}"


### PR DESCRIPTION
## Description
Fix two spelling errors in documentation:

1. **fluentbit.md**: `datatime` → `datetime` in Fluent Bit configuration comment
2. **log.md**: `fileld` → `field` in Logstash configuration comment

## Changes
- `docs/connection-integration/data-integration/fluentbit.md`: fix "datatime" typo in Fluent Bit Stream Load comment
- `docs/observability/log.md`: fix "fileld" typo in Logstash field mapping comment

Closes #3881