### PR TITLE
[fix](sql-functions) add example setup tables to aggregate pages in version-3.x / version-2.1

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
@@ -28,6 +28,24 @@ BITMAP_INTERSECT(BITMAP <value>)
 
 ## 举例
 
+```sql
+-- setup
+CREATE TABLE user_tags (
+	tag VARCHAR(20),
+	date DATETIME,
+	user_id BITMAP bitmap_union
+) AGGREGATE KEY(tag, date) DISTRIBUTED BY HASH(tag) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO user_tags VALUES
+	('A', '2020-05-18', to_bitmap(1)),
+	('A', '2020-05-18', to_bitmap(2)),
+	('A', '2020-05-19', to_bitmap(2)),
+	('A', '2020-05-19', to_bitmap(3)),
+	('B', '2020-05-18', to_bitmap(4)),
+	('B', '2020-05-19', to_bitmap(4)),
+	('B', '2020-05-19', to_bitmap(5));
+```
+
 表结构
 
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/corr.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/corr.md
@@ -33,6 +33,27 @@ CORR(<expr1>, <expr2>)
 ## 举例
 
 ```sql
+-- setup
+create table test_corr(
+    id int,
+    k1 double,
+    k2 double
+) distributed by hash (id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_corr values 
+    (1, 20, 22),
+    (1, 10, 20),
+    (2, 36, 21),
+    (2, 30, 22),
+    (2, 25, 20),
+    (3, 25, NULL),
+    (4, 25, 21),
+    (4, 25, 22),
+    (4, 25, 20);
+```
+
+```sql
 select * from test_corr;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/count.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/count.md
@@ -31,6 +31,39 @@ COUNT(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table test_count(
+    id int,
+    name varchar(20),
+    sex int
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_count values
+    (1, '1', 1),
+    (2, '2', 1),
+    (3, '3', 1),
+    (4, '0', 1),
+    (4, '4', 1),
+    (5, NULL, 1);
+
+create table test_insert(
+    id int,
+    name varchar(20),
+    sex int
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_insert values
+    (1, '1', 1),
+    (2, '2', 1),
+    (3, '3', 1),
+    (4, '0', 1),
+    (4, '4', 1),
+    (5, NULL, 1);
+```
+
+```sql
 select * from test_count;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/covar-samp.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/covar-samp.md
@@ -31,6 +31,23 @@ COVAR_SAMP(<expr1>, <expr2>)
 
 ## 举例
 
+```sql
+-- setup
+create table baseall(
+    id int,
+    x double,
+    y double
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into baseall values
+    (1, 1.0, 2.0),
+    (2, 2.0, 3.0),
+    (3, 3.0, 4.0),
+    (4, 4.0, NULL),
+    (5, NULL, 5.0);
+```
+
 ```
 select covar_samp(x,y) from baseall;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/covar.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/covar.md
@@ -35,6 +35,23 @@ COVAR(<expr1>, <expr2>)
 
 ## 举例
 
+```sql
+-- setup
+create table baseall(
+    id int,
+    x double,
+    y double
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into baseall values
+    (1, 1.0, 2.0),
+    (2, 2.0, 3.0),
+    (3, 3.0, 4.0),
+    (4, 4.0, NULL),
+    (5, NULL, 5.0);
+```
+
 ```
 select covar(x,y) from baseall;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -32,6 +32,20 @@ GROUP_CONCAT([DISTINCT] <str>[, <sep>] [ORDER BY { <col_name> | <expr>} [ASC | D
 ## 举例
 
 ```sql
+-- setup
+create table test(
+    value varchar(10)
+) distributed by hash(value) buckets 1
+properties ("replication_num"="1");
+
+insert into test values
+    ("a"),
+    ("b"),
+    ("c"),
+    ("c");
+```
+
+```sql
 select value from test;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
@@ -28,6 +28,24 @@ BITMAP_INTERSECT(BITMAP <value>)
 
 ## 举例
 
+```sql
+-- setup
+CREATE TABLE user_tags (
+	tag VARCHAR(20),
+	date DATETIME,
+	user_id BITMAP bitmap_union
+) AGGREGATE KEY(tag, date) DISTRIBUTED BY HASH(tag) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO user_tags VALUES
+	('A', '2020-05-18', to_bitmap(1)),
+	('A', '2020-05-18', to_bitmap(2)),
+	('A', '2020-05-19', to_bitmap(2)),
+	('A', '2020-05-19', to_bitmap(3)),
+	('B', '2020-05-18', to_bitmap(4)),
+	('B', '2020-05-19', to_bitmap(4)),
+	('B', '2020-05-19', to_bitmap(5));
+```
+
 表结构
 
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/corr-welford.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/corr-welford.md
@@ -33,6 +33,27 @@ CORR_WELFORD(<expr1>, <expr2>)
 ## 举例
 
 ```sql
+-- setup
+create table test_corr(
+    id int,
+    k1 double,
+    k2 double
+) distributed by hash (id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_corr values 
+    (1, 20, 22),
+    (1, 10, 20),
+    (2, 36, 21),
+    (2, 30, 22),
+    (2, 25, 20),
+    (3, 25, NULL),
+    (4, 25, 21),
+    (4, 25, 22),
+    (4, 25, 20);
+```
+
+```sql
 select * from test_corr;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/corr.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/corr.md
@@ -33,6 +33,27 @@ CORR(<expr1>, <expr2>)
 ## 举例
 
 ```sql
+-- setup
+create table test_corr(
+    id int,
+    k1 double,
+    k2 double
+) distributed by hash (id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_corr values 
+    (1, 20, 22),
+    (1, 10, 20),
+    (2, 36, 21),
+    (2, 30, 22),
+    (2, 25, 20),
+    (3, 25, NULL),
+    (4, 25, 21),
+    (4, 25, 22),
+    (4, 25, 20);
+```
+
+```sql
 select * from test_corr;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/count.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/count.md
@@ -31,6 +31,39 @@ COUNT(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table test_count(
+    id int,
+    name varchar(20),
+    sex int
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_count values
+    (1, '1', 1),
+    (2, '2', 1),
+    (3, '3', 1),
+    (4, '0', 1),
+    (4, '4', 1),
+    (5, NULL, 1);
+
+create table test_insert(
+    id int,
+    name varchar(20),
+    sex int
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_insert values
+    (1, '1', 1),
+    (2, '2', 1),
+    (3, '3', 1),
+    (4, '0', 1),
+    (4, '4', 1),
+    (5, NULL, 1);
+```
+
+```sql
 select * from test_count;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/covar-samp.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/covar-samp.md
@@ -31,6 +31,23 @@ COVAR_SAMP(<expr1>, <expr2>)
 
 ## 举例
 
+```sql
+-- setup
+create table baseall(
+    id int,
+    x double,
+    y double
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into baseall values
+    (1, 1.0, 2.0),
+    (2, 2.0, 3.0),
+    (3, 3.0, 4.0),
+    (4, 4.0, NULL),
+    (5, NULL, 5.0);
+```
+
 ```
 select covar_samp(x,y) from baseall;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/covar.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/covar.md
@@ -35,6 +35,23 @@ COVAR(<expr1>, <expr2>)
 
 ## 举例
 
+```sql
+-- setup
+create table baseall(
+    id int,
+    x double,
+    y double
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into baseall values
+    (1, 1.0, 2.0),
+    (2, 2.0, 3.0),
+    (3, 3.0, 4.0),
+    (4, 4.0, NULL),
+    (5, NULL, 5.0);
+```
+
 ```
 select covar(x,y) from baseall;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -32,6 +32,20 @@ GROUP_CONCAT([DISTINCT] <str>[, <sep>] [ORDER BY { <col_name> | <expr>} [ASC | D
 ## 举例
 
 ```sql
+-- setup
+create table test(
+    value varchar(10)
+) distributed by hash(value) buckets 1
+properties ("replication_num"="1");
+
+insert into test values
+    ("a"),
+    ("b"),
+    ("c"),
+    ("c");
+```
+
+```sql
 select value from test;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
@@ -28,6 +28,24 @@ The data type of the return value is BITMAP.
 
 ## Example
 
+```sql
+-- setup
+CREATE TABLE user_tags (
+	tag VARCHAR(20),
+	date DATETIME,
+	user_id BITMAP bitmap_union
+) AGGREGATE KEY(tag, date) DISTRIBUTED BY HASH(tag) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO user_tags VALUES
+	('A', '2020-05-18', to_bitmap(1)),
+	('A', '2020-05-18', to_bitmap(2)),
+	('A', '2020-05-19', to_bitmap(2)),
+	('A', '2020-05-19', to_bitmap(3)),
+	('B', '2020-05-18', to_bitmap(4)),
+	('B', '2020-05-19', to_bitmap(4)),
+	('B', '2020-05-19', to_bitmap(5));
+```
+
 Table schema
 
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/corr.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/corr.md
@@ -33,6 +33,27 @@ The return value is of type DOUBLE, the covariance of expr1 and expr2, except th
 ## Example
 
 ```sql
+-- setup
+create table test_corr(
+    id int,
+    k1 double,
+    k2 double
+) distributed by hash (id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_corr values 
+    (1, 20, 22),
+    (1, 10, 20),
+    (2, 36, 21),
+    (2, 30, 22),
+    (2, 25, 20),
+    (3, 25, NULL),
+    (4, 25, 21),
+    (4, 25, 22),
+    (4, 25, 20);
+```
+
+```sql
 select * from test_corr;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/count.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/count.md
@@ -31,6 +31,39 @@ The return value is of numeric type. If expr is NULL, there will be no parameter
 ## Example
 
 ```sql
+-- setup
+create table test_count(
+    id int,
+    name varchar(20),
+    sex int
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_count values
+    (1, '1', 1),
+    (2, '2', 1),
+    (3, '3', 1),
+    (4, '0', 1),
+    (4, '4', 1),
+    (5, NULL, 1);
+
+create table test_insert(
+    id int,
+    name varchar(20),
+    sex int
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_insert values
+    (1, '1', 1),
+    (2, '2', 1),
+    (3, '3', 1),
+    (4, '0', 1),
+    (4, '4', 1),
+    (5, NULL, 1);
+```
+
+```sql
 select * from test_count;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/covar-samp.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/covar-samp.md
@@ -31,6 +31,23 @@ Returns the sample covariance of expr1 and expr2, special case:
 
 ## Example
 
+```sql
+-- setup
+create table baseall(
+    id int,
+    x double,
+    y double
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into baseall values
+    (1, 1.0, 2.0),
+    (2, 2.0, 3.0),
+    (3, 3.0, 4.0),
+    (4, 4.0, NULL),
+    (5, NULL, 5.0);
+```
+
 ```
 select covar_samp(x,y) from baseall;
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/covar.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/covar.md
@@ -35,6 +35,23 @@ Returns the covariance value of expr1 and expr2, special case:
 
 ## Example
 
+```sql
+-- setup
+create table baseall(
+    id int,
+    x double,
+    y double
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into baseall values
+    (1, 1.0, 2.0),
+    (2, 2.0, 3.0),
+    (3, 3.0, 4.0),
+    (4, 4.0, NULL),
+    (5, NULL, 5.0);
+```
+
 ```
 select covar(x,y) from baseall;
 ```

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -32,6 +32,20 @@ Returns a value of type VARCHAR.
 ## Example
 
 ```sql
+-- setup
+create table test(
+    value varchar(10)
+) distributed by hash(value) buckets 1
+properties ("replication_num"="1");
+
+insert into test values
+    ("a"),
+    ("b"),
+    ("c"),
+    ("c");
+```
+
+```sql
 select value from test;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-intersect.md
@@ -28,6 +28,24 @@ The data type of the return value is BITMAP.
 
 ## Example
 
+```sql
+-- setup
+CREATE TABLE user_tags (
+	tag VARCHAR(20),
+	date DATETIME,
+	user_id BITMAP bitmap_union
+) AGGREGATE KEY(tag, date) DISTRIBUTED BY HASH(tag) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO user_tags VALUES
+	('A', '2020-05-18', to_bitmap(1)),
+	('A', '2020-05-18', to_bitmap(2)),
+	('A', '2020-05-19', to_bitmap(2)),
+	('A', '2020-05-19', to_bitmap(3)),
+	('B', '2020-05-18', to_bitmap(4)),
+	('B', '2020-05-19', to_bitmap(4)),
+	('B', '2020-05-19', to_bitmap(5));
+```
+
 Table schema
 
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/corr-welford.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/corr-welford.md
@@ -33,6 +33,27 @@ The return value is of type DOUBLE, the covariance of expr1 and expr2, except th
 ## Example
 
 ```sql
+-- setup
+create table test_corr(
+    id int,
+    k1 double,
+    k2 double
+) distributed by hash (id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_corr values 
+    (1, 20, 22),
+    (1, 10, 20),
+    (2, 36, 21),
+    (2, 30, 22),
+    (2, 25, 20),
+    (3, 25, NULL),
+    (4, 25, 21),
+    (4, 25, 22),
+    (4, 25, 20);
+```
+
+```sql
 select * from test_corr;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/corr.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/corr.md
@@ -33,6 +33,27 @@ The return value is of type DOUBLE, the covariance of expr1 and expr2, except th
 ## Example
 
 ```sql
+-- setup
+create table test_corr(
+    id int,
+    k1 double,
+    k2 double
+) distributed by hash (id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_corr values 
+    (1, 20, 22),
+    (1, 10, 20),
+    (2, 36, 21),
+    (2, 30, 22),
+    (2, 25, 20),
+    (3, 25, NULL),
+    (4, 25, 21),
+    (4, 25, 22),
+    (4, 25, 20);
+```
+
+```sql
 select * from test_corr;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/count.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/count.md
@@ -31,6 +31,39 @@ The return value is of numeric type. If expr is NULL, there will be no parameter
 ## Example
 
 ```sql
+-- setup
+create table test_count(
+    id int,
+    name varchar(20),
+    sex int
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_count values
+    (1, '1', 1),
+    (2, '2', 1),
+    (3, '3', 1),
+    (4, '0', 1),
+    (4, '4', 1),
+    (5, NULL, 1);
+
+create table test_insert(
+    id int,
+    name varchar(20),
+    sex int
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into test_insert values
+    (1, '1', 1),
+    (2, '2', 1),
+    (3, '3', 1),
+    (4, '0', 1),
+    (4, '4', 1),
+    (5, NULL, 1);
+```
+
+```sql
 select * from test_count;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/covar-samp.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/covar-samp.md
@@ -31,6 +31,23 @@ Returns the sample covariance of expr1 and expr2, special case:
 
 ## Example
 
+```sql
+-- setup
+create table baseall(
+    id int,
+    x double,
+    y double
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into baseall values
+    (1, 1.0, 2.0),
+    (2, 2.0, 3.0),
+    (3, 3.0, 4.0),
+    (4, 4.0, NULL),
+    (5, NULL, 5.0);
+```
+
 ```
 select covar_samp(x,y) from baseall;
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/covar.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/covar.md
@@ -35,6 +35,23 @@ Returns the covariance value of expr1 and expr2, special case:
 
 ## Example
 
+```sql
+-- setup
+create table baseall(
+    id int,
+    x double,
+    y double
+) distributed by hash(id) buckets 1
+properties ("replication_num"="1");
+
+insert into baseall values
+    (1, 1.0, 2.0),
+    (2, 2.0, 3.0),
+    (3, 3.0, 4.0),
+    (4, 4.0, NULL),
+    (5, NULL, 5.0);
+```
+
 ```
 select covar(x,y) from baseall;
 ```

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-concat.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-concat.md
@@ -32,6 +32,20 @@ Returns a value of type VARCHAR.
 ## Example
 
 ```sql
+-- setup
+create table test(
+    value varchar(10)
+) distributed by hash(value) buckets 1
+properties ("replication_num"="1");
+
+insert into test values
+    ("a"),
+    ("b"),
+    ("c"),
+    ("c");
+```
+
+```sql
 select value from test;
 ```
 


### PR DESCRIPTION
Several aggregate-function pages already carry a visible inline setup block (`CREATE TABLE` + `INSERT`) on the dev / `version-4.x` docs, but the `version-3.x` and `version-2.1` copies are missing it — so their `SELECT ... FROM <table>` examples cannot be run or reproduced (a reader gets `Table [...] does not exist`).

This PR ports the same visible inline setup block to the `version-3.x` and `version-2.1` copies (EN + ZH), for the pages whose older docs use the **same** example and data as 4.x:

| Page | version-3.x | version-2.1 |
| --- | :-: | :-: |
| `CORR` | ✅ | ✅ |
| `CORR_WELFORD` | ✅ | (absent) |
| `COUNT` | ✅ | ✅ |
| `COVAR` | ✅ | ✅ |
| `COVAR_SAMP` | ✅ | ✅ |
| `GROUP_CONCAT` | ✅ | ✅ |
| `BITMAP_INTERSECT` | ✅ | ✅ |

Each example was verified end-to-end to resolve its table and match that versions documented output — `version-3.x` on a 3.1.4 cluster and `version-2.1` on a 2.1.11 cluster (all pass). EN + ZH, 26 files. No `ja-source` changes.

> Pages whose older-version docs use different tables / data / output than 4.x (e.g. `AVG` uses `log_statis` in 3.x but `t1` in 4.x; `group_bit` has no NULL row in older docs) are **not** included here — those need a per-version reconstruction and will be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)