### PR TITLE
[fix](sql-functions) reconstruct example setup tables for aggregate pages (version-3.x / version-2.1)

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/any-value.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/any-value.md
@@ -33,6 +33,12 @@ ANY_VALUE(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table cost2(id int, name varchar(20)) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into cost2 values (2,'jack'),(3,'jack');
+```
+
+```sql
 select id, any_value(name) from cost2 group by id;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/array-agg.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/array-agg.md
@@ -32,6 +32,12 @@ ARRAY_AGG(<col>)
 ## 举例
 
 ```sql
+-- setup
+create table test_doris_array_agg(c1 int, c2 varchar(20)) distributed by hash(c1) buckets 1 properties ("replication_num"="1");
+insert into test_doris_array_agg values (1,'a'),(1,'b'),(2,'c'),(2,null),(3,null);
+```
+
+```sql
 select * from test_doris_array_agg;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/avg-weighted.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/avg-weighted.md
@@ -30,6 +30,12 @@ AVG_WEIGHTED(<x>, <weight>)
 ## 举例
 
 ```sql
+-- setup
+create table test_doris_avg_weighted(k1 int, k2 int) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into test_doris_avg_weighted values (10,100),(20,200),(30,300),(40,400);
+```
+
+```sql
 select k1,k2 from test_doris_avg_weighted;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-union-count.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-union-count.md
@@ -29,6 +29,12 @@ BITMAP_UNION_COUNT(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, page int, user_id bitmap bitmap_union) aggregate key(dt,page) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,100,bitmap_from_string('100,200,300')),(2,200,bitmap_from_string('300'));
+```
+
+```sql
 select dt,page,bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-union-int.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-union-int.md
@@ -29,6 +29,12 @@ BITMAP_UNION_INT(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, page int, user_id bitmap bitmap_union) aggregate key(dt,page) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,100,bitmap_from_string('100,200,300')),(1,300,bitmap_from_string('300')),(2,200,bitmap_from_string('300'));
+```
+
+```sql
 select dt,page,bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-and.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-and.md
@@ -29,6 +29,12 @@ GROUP_BIT_AND(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
+```sql
 select * from group_bit;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-or.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-or.md
@@ -29,6 +29,12 @@ GROUP_BIT_OR(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
+```sql
 select * from group_bit;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-xor.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-xor.md
@@ -28,6 +28,12 @@ GROUP_BIT_XOR(<expr>)
 
 ## 举例
 
+```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
 ```
 select * from group_bit;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bitmap-xor.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bitmap-xor.md
@@ -29,6 +29,12 @@ GROUP_BITMAP_XOR(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table pv_bitmap(id int, page varchar(10), user_id bitmap bitmap_union) aggregate key(id,page) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,'m',bitmap_from_string('4,7,8')),(2,'m',bitmap_from_string('1,3,6,15')),(3,'m',bitmap_from_string('4,7'));
+```
+
+```sql
  select page, bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/intersect-count.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/intersect-count.md
@@ -31,6 +31,12 @@ INTERSECT_COUNT(<bitmap_column>, <column_to_filter>, <filter_values>)
 ## 举例
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, user_id bitmap bitmap_union) aggregate key(dt) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (4,bitmap_from_string('1,2,3')),(3,bitmap_from_string('1,2,3,4,5'));
+```
+
+```sql
 select dt,bitmap_to_string(user_id) from pv_bitmap where dt in (3,4);
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/max-by.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/aggregate-functions/max-by.md
@@ -30,6 +30,12 @@ MAX_BY(<expr1>, <expr2>)
 ## 举例
 
 ```sql
+-- setup
+create table tbl(k1 int, k2 int, k3 int, k4 int) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into tbl values (0,3,2,100),(1,2,3,4),(4,3,2,1),(3,4,2,1);
+```
+
+```sql
 select * from tbl;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/any-value.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/any-value.md
@@ -33,6 +33,12 @@ ANY_VALUE(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table cost2(id int, name varchar(20)) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into cost2 values (2,'jack'),(3,'jack');
+```
+
+```sql
 select id, any_value(name) from cost2 group by id;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/array-agg.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/array-agg.md
@@ -32,6 +32,12 @@ ARRAY_AGG(<col>)
 ## 举例
 
 ```sql
+-- setup
+create table test_doris_array_agg(c1 int, c2 varchar(20)) distributed by hash(c1) buckets 1 properties ("replication_num"="1");
+insert into test_doris_array_agg values (1,'a'),(1,'b'),(2,'c'),(2,null),(3,null);
+```
+
+```sql
 select * from test_doris_array_agg;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/avg-weighted.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/avg-weighted.md
@@ -30,6 +30,12 @@ AVG_WEIGHTED(<x>, <weight>)
 ## 举例
 
 ```sql
+-- setup
+create table test_doris_avg_weighted(k1 int, k2 int) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into test_doris_avg_weighted values (10,100),(20,200),(30,300),(40,400);
+```
+
+```sql
 select k1,k2 from test_doris_avg_weighted;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-union-count.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-union-count.md
@@ -29,6 +29,12 @@ BITMAP_UNION_COUNT(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, page int, user_id bitmap bitmap_union) aggregate key(dt,page) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,100,bitmap_from_string('100,200,300')),(2,200,bitmap_from_string('300'));
+```
+
+```sql
 select dt,page,bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-union-int.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-union-int.md
@@ -29,6 +29,12 @@ BITMAP_UNION_INT(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, page int, user_id bitmap bitmap_union) aggregate key(dt,page) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,100,bitmap_from_string('100,200,300')),(1,300,bitmap_from_string('300')),(2,200,bitmap_from_string('300'));
+```
+
+```sql
 select dt,page,bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-and.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-and.md
@@ -29,6 +29,12 @@ GROUP_BIT_AND(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
+```sql
 select * from group_bit;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-or.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-or.md
@@ -29,6 +29,12 @@ GROUP_BIT_OR(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
+```sql
 select * from group_bit;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-xor.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-xor.md
@@ -28,6 +28,12 @@ GROUP_BIT_XOR(<expr>)
 
 ## 举例
 
+```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
 ```
 select * from group_bit;
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bitmap-xor.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bitmap-xor.md
@@ -29,6 +29,12 @@ GROUP_BITMAP_XOR(<expr>)
 ## 举例
 
 ```sql
+-- setup
+create table pv_bitmap(id int, page varchar(10), user_id bitmap bitmap_union) aggregate key(id,page) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,'m',bitmap_from_string('4,7,8')),(2,'m',bitmap_from_string('1,3,6,15')),(3,'m',bitmap_from_string('4,7'));
+```
+
+```sql
  select page, bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/intersect-count.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/intersect-count.md
@@ -31,6 +31,12 @@ INTERSECT_COUNT(<bitmap_column>, <column_to_filter>, <filter_values>)
 ## 举例
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, user_id bitmap bitmap_union) aggregate key(dt) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (4,bitmap_from_string('1,2,3')),(3,bitmap_from_string('1,2,3,4,5'));
+```
+
+```sql
 select dt,bitmap_to_string(user_id) from pv_bitmap where dt in (3,4);
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/max-by.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/aggregate-functions/max-by.md
@@ -30,6 +30,12 @@ MAX_BY(<expr1>, <expr2>)
 ## 举例
 
 ```sql
+-- setup
+create table tbl(k1 int, k2 int, k3 int, k4 int) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into tbl values (0,3,2,100),(1,2,3,4),(4,3,2,1),(3,4,2,1);
+```
+
+```sql
 select * from tbl;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/any-value.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/any-value.md
@@ -33,6 +33,12 @@ Returns any non-NULL value if a non-NULL value exists, otherwise returns NULL.
 ## Example
 
 ```sql
+-- setup
+create table cost2(id int, name varchar(20)) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into cost2 values (2,'jack'),(3,'jack');
+```
+
+```sql
 select id, any_value(name) from cost2 group by id;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/array-agg.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/array-agg.md
@@ -33,6 +33,12 @@ Returns a value of ARRAY type.Special cases:
 ## Example
 
 ```sql
+-- setup
+create table test_doris_array_agg(c1 int, c2 varchar(20)) distributed by hash(c1) buckets 1 properties ("replication_num"="1");
+insert into test_doris_array_agg values (1,'a'),(1,'b'),(2,'c'),(2,null),(3,null);
+```
+
+```sql
 select * from test_doris_array_agg;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/avg-weighted.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/avg-weighted.md
@@ -30,6 +30,12 @@ The sum of the products of corresponding values and weights is accumulated, divi
 ## Example
 
 ```sql
+-- setup
+create table test_doris_avg_weighted(k1 int, k2 int) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into test_doris_avg_weighted values (10,100),(20,200),(30,300),(40,400);
+```
+
+```sql
 select k1,k2 from test_doris_avg_weighted;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-union-count.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-union-count.md
@@ -29,6 +29,12 @@ Returns the size of the Bitmap union, that is, the number of elements after dedu
 ## Example
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, page int, user_id bitmap bitmap_union) aggregate key(dt,page) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,100,bitmap_from_string('100,200,300')),(2,200,bitmap_from_string('300'));
+```
+
+```sql
 select dt,page,bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-union-int.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/bitmap-union-int.md
@@ -29,6 +29,12 @@ Returns the number of distinct values in a column.
 ## Example
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, page int, user_id bitmap bitmap_union) aggregate key(dt,page) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,100,bitmap_from_string('100,200,300')),(1,300,bitmap_from_string('300')),(2,200,bitmap_from_string('300'));
+```
+
+```sql
 select dt,page,bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-and.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-and.md
@@ -29,6 +29,12 @@ Returns an integer value.
 ## Example
 
 ```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
+```sql
 select * from group_bit;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-or.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-or.md
@@ -29,6 +29,12 @@ Returns an integer value
 ## Example
 
 ```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
+```sql
 select * from group_bit;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-xor.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bit-xor.md
@@ -29,6 +29,12 @@ Returns an integer value
 ## Example
 
 ```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
+```sql
 select * from group_bit;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bitmap-xor.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/group-bitmap-xor.md
@@ -29,6 +29,12 @@ The data type of the return value is BITMAP.
 ## Example
 
 ```sql
+-- setup
+create table pv_bitmap(id int, page varchar(10), user_id bitmap bitmap_union) aggregate key(id,page) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,'m',bitmap_from_string('4,7,8')),(2,'m',bitmap_from_string('1,3,6,15')),(3,'m',bitmap_from_string('4,7'));
+```
+
+```sql
  select page, bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/intersect-count.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/intersect-count.md
@@ -31,6 +31,12 @@ Returns a value of type BIGINT.
 ## Example
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, user_id bitmap bitmap_union) aggregate key(dt) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (4,bitmap_from_string('1,2,3')),(3,bitmap_from_string('1,2,3,4,5'));
+```
+
+```sql
 select dt,bitmap_to_string(user_id) from pv_bitmap where dt in (3,4);
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/max-by.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/aggregate-functions/max-by.md
@@ -30,6 +30,12 @@ Returns the same data type as the input expression <expr1>.
 ## Example
 
 ```sql
+-- setup
+create table tbl(k1 int, k2 int, k3 int, k4 int) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into tbl values (0,3,2,100),(1,2,3,4),(4,3,2,1),(3,4,2,1);
+```
+
+```sql
 select * from tbl;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/any-value.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/any-value.md
@@ -33,6 +33,12 @@ Returns any non-NULL value if a non-NULL value exists, otherwise returns NULL.
 ## Example
 
 ```sql
+-- setup
+create table cost2(id int, name varchar(20)) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into cost2 values (2,'jack'),(3,'jack');
+```
+
+```sql
 select id, any_value(name) from cost2 group by id;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/array-agg.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/array-agg.md
@@ -33,6 +33,12 @@ Returns a value of ARRAY type.Special cases:
 ## Example
 
 ```sql
+-- setup
+create table test_doris_array_agg(c1 int, c2 varchar(20)) distributed by hash(c1) buckets 1 properties ("replication_num"="1");
+insert into test_doris_array_agg values (1,'a'),(1,'b'),(2,'c'),(2,null),(3,null);
+```
+
+```sql
 select * from test_doris_array_agg;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/avg-weighted.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/avg-weighted.md
@@ -30,6 +30,12 @@ The sum of the products of corresponding values and weights is accumulated, divi
 ## Example
 
 ```sql
+-- setup
+create table test_doris_avg_weighted(k1 int, k2 int) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into test_doris_avg_weighted values (10,100),(20,200),(30,300),(40,400);
+```
+
+```sql
 select k1,k2 from test_doris_avg_weighted;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-union-count.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-union-count.md
@@ -29,6 +29,12 @@ Returns the size of the Bitmap union, that is, the number of elements after dedu
 ## Example
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, page int, user_id bitmap bitmap_union) aggregate key(dt,page) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,100,bitmap_from_string('100,200,300')),(2,200,bitmap_from_string('300'));
+```
+
+```sql
 select dt,page,bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-union-int.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/bitmap-union-int.md
@@ -29,6 +29,12 @@ Returns the number of distinct values in a column.
 ## Example
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, page int, user_id bitmap bitmap_union) aggregate key(dt,page) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,100,bitmap_from_string('100,200,300')),(1,300,bitmap_from_string('300')),(2,200,bitmap_from_string('300'));
+```
+
+```sql
 select dt,page,bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-and.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-and.md
@@ -29,6 +29,12 @@ Returns an integer value.
 ## Example
 
 ```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
+```sql
 select * from group_bit;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-or.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-or.md
@@ -29,6 +29,12 @@ Returns an integer value
 ## Example
 
 ```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
+```sql
 select * from group_bit;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-xor.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bit-xor.md
@@ -29,6 +29,12 @@ Returns an integer value
 ## Example
 
 ```sql
+-- setup
+create table group_bit(value int) distributed by hash(value) buckets 1 properties ("replication_num"="1");
+insert into group_bit values (3),(1),(2),(4);
+```
+
+```sql
 select * from group_bit;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bitmap-xor.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/group-bitmap-xor.md
@@ -29,6 +29,12 @@ The data type of the return value is BITMAP.
 ## Example
 
 ```sql
+-- setup
+create table pv_bitmap(id int, page varchar(10), user_id bitmap bitmap_union) aggregate key(id,page) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (1,'m',bitmap_from_string('4,7,8')),(2,'m',bitmap_from_string('1,3,6,15')),(3,'m',bitmap_from_string('4,7'));
+```
+
+```sql
  select page, bitmap_to_string(user_id) from pv_bitmap;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/intersect-count.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/intersect-count.md
@@ -31,6 +31,12 @@ Returns a value of type BIGINT.
 ## Example
 
 ```sql
+-- setup
+create table pv_bitmap(dt int, user_id bitmap bitmap_union) aggregate key(dt) distributed by hash(dt) buckets 1 properties ("replication_num"="1");
+insert into pv_bitmap values (4,bitmap_from_string('1,2,3')),(3,bitmap_from_string('1,2,3,4,5'));
+```
+
+```sql
 select dt,bitmap_to_string(user_id) from pv_bitmap where dt in (3,4);
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/max-by.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/aggregate-functions/max-by.md
@@ -30,6 +30,12 @@ Returns the same data type as the input expression <expr1>.
 ## Example
 
 ```sql
+-- setup
+create table tbl(k1 int, k2 int, k3 int, k4 int) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into tbl values (0,3,2,100),(1,2,3,4),(4,3,2,1),(3,4,2,1);
+```
+
+```sql
 select * from tbl;
 ```
 


### PR DESCRIPTION
Follow-up to #3884. These aggregate-function pages query a table that the `version-3.x` / `version-2.1` docs never define, so the examples cannot be run or reproduced (`Table [...] does not exist`).

Unlike #3884 (where the older docs matched 4.x and the setup could be copied), the older docs here use **different example data** than 4.x — so the setup is **reconstructed from each older pages own printed output** and emitted as a visible inline block (consistent with the 4.x pages).

Pages (EN + ZH, `version-3.x` and `version-2.1`):

| | |
| --- | --- |
| `GROUP_BIT_AND` / `GROUP_BIT_OR` / `GROUP_BIT_XOR` | `group_bit` |
| `ARRAY_AGG` | `test_doris_array_agg` |
| `MAX_BY` | `tbl` |
| `ANY_VALUE` | `cost2` |
| `AVG_WEIGHTED` | `test_doris_avg_weighted` |
| `BITMAP_UNION_COUNT` / `BITMAP_UNION_INT` / `GROUP_BITMAP_XOR` / `INTERSECT_COUNT` | `pv_bitmap` (built via `bitmap_from_string`) |

Each example was verified end-to-end to resolve its table and match that versions documented output — `version-3.x` on a 3.1.4 cluster and `version-2.1` on a 2.1.11 cluster (all pass). 44 files. No `ja-source` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)