### PR TITLE
[fix](sql-functions) reconstruct example setup tables for array-function pages (version-3.x / version-2.1)

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
@@ -33,6 +33,12 @@ ARRAY_COUNT(<lambda>, <arr> [ , <arr> ... ] )
 ## 举例
 
 ```sql
+-- setup
+create table array_test(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,[1,null,2],[null,3,1]),(5,[],[]),(6,null,null);
+```
+
+```sql
 select array_count(x -> x, [0, 1, 2, 3]);
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-filter.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-filter.md
@@ -32,6 +32,14 @@ ARRAY_FILTER(<arr>, <filter_column>)
 ## 举例
 
 ```sql
+-- setup
+create table array_test(id int, c_array array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3,4,5]),(2,[6,7,8]),(3,[]),(4,null);
+create table array_test2(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test2 values (1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,null,null);
+```
+
+```sql
 select c_array,array_filter(c_array,[0,1,0]) from array_test;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-first-index.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-first-index.md
@@ -32,6 +32,12 @@ ARRAY_FIRST_INDEX(<lambda>, <arr> [, ...])
 ## 举例
 
 ```sql
+-- setup
+create table array_test(id int, col2 array<int>, col3 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3],[3,4,5]),(2,[1,null,2],[null,3,1]),(3,[1,2,3],[9,8,7]),(4,null,null);
+```
+
+```sql
 select array_first_index(x->x+1>3, [2, 3, 4]);
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-last-index.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-last-index.md
@@ -32,6 +32,12 @@ ARRAY_LAST_INDEX(<lambda>, <arr> [, ...])
 ## 举例
 
 ```sql
+-- setup
+create table array_test(id int, col2 array<int>, col3 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3],[3,4,5]),(2,[1,null,2],[null,3,1]),(3,[1,2,3],[9,8,7]),(4,null,null);
+```
+
+```sql
 select array_last_index(x -> x is null, [null, null, 1, 2]);
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-sortby.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-sortby.md
@@ -34,6 +34,14 @@ ARRAY_SORTBY(<lambda>, <arr> [, ...])
 ## 举例
 
 ```sql
+-- setup
+create table test_array_sortby(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into test_array_sortby values (0,null,[2]),(1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,null,null),(5,[3],null),(6,[1,2],[2,1]),(7,[null],[null]),(8,[1,2,3],[3,2,1]);
+create table array_test2(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test2 values (1,[1,2,3],[10,11,12]),(2,[4,3,5],[10,20,30]),(3,[-40,30,-100],[30,10,20]);
+```
+
+```sql
 select array_sortby(['a','b','c'],[3,2,1]);
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array.md
@@ -29,6 +29,12 @@ ARRAY([ <element> [, ...] ])
 ## 举例
 
 ```sql
+-- setup
+create table nested(qid int, creationDate datetime) distributed by hash(creationDate) buckets 1 properties ("replication_num"="1");
+insert into nested values (null,'2009-06-16 07:40:56'),(null,'2009-06-16 07:50:05'),(null,'2009-06-16 08:09:18'),(null,'2009-06-16 08:15:45');
+```
+
+```sql
 select array("1", 2, 1.1);
 ```
 ```text

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
@@ -33,6 +33,12 @@ ARRAY_COUNT(<lambda>, <arr> [ , <arr> ... ] )
 ## 举例
 
 ```sql
+-- setup
+create table array_test(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,[1,null,2],[null,3,1]),(5,[],[]),(6,null,null);
+```
+
+```sql
 select array_count(x -> x, [0, 1, 2, 3]);
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-filter.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-filter.md
@@ -32,6 +32,14 @@ ARRAY_FILTER(<arr>, <filter_column>)
 ## 举例
 
 ```sql
+-- setup
+create table array_test(id int, c_array array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3,4,5]),(2,[6,7,8]),(3,[]),(4,null);
+create table array_test2(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test2 values (1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,null,null);
+```
+
+```sql
 select c_array,array_filter(c_array,[0,1,0]) from array_test;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-first-index.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-first-index.md
@@ -32,6 +32,12 @@ ARRAY_FIRST_INDEX(<lambda>, <arr> [, ...])
 ## 举例
 
 ```sql
+-- setup
+create table array_test(id int, col2 array<int>, col3 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3],[3,4,5]),(2,[1,null,2],[null,3,1]),(3,[1,2,3],[9,8,7]),(4,null,null);
+```
+
+```sql
 select array_first_index(x->x+1>3, [2, 3, 4]);
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-last-index.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-last-index.md
@@ -32,6 +32,12 @@ ARRAY_LAST_INDEX(<lambda>, <arr> [, ...])
 ## 举例
 
 ```sql
+-- setup
+create table array_test(id int, col2 array<int>, col3 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3],[3,4,5]),(2,[1,null,2],[null,3,1]),(3,[1,2,3],[9,8,7]),(4,null,null);
+```
+
+```sql
 select array_last_index(x -> x is null, [null, null, 1, 2]);
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-sortby.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-sortby.md
@@ -34,6 +34,14 @@ ARRAY_SORTBY(<lambda>, <arr> [, ...])
 ## 举例
 
 ```sql
+-- setup
+create table test_array_sortby(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into test_array_sortby values (0,null,[2]),(1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,null,null),(5,[3],null),(6,[1,2],[2,1]),(7,[null],[null]),(8,[1,2,3],[3,2,1]);
+create table array_test2(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test2 values (1,[1,2,3],[10,11,12]),(2,[4,3,5],[10,20,30]),(3,[-40,30,-100],[30,10,20]);
+```
+
+```sql
 select array_sortby(['a','b','c'],[3,2,1]);
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array.md
@@ -29,6 +29,12 @@ ARRAY([ <element> [, ...] ])
 ## 举例
 
 ```sql
+-- setup
+create table nested(qid int, creationDate datetime) distributed by hash(creationDate) buckets 1 properties ("replication_num"="1");
+insert into nested values (null,'2009-06-16 07:40:56'),(null,'2009-06-16 07:50:05'),(null,'2009-06-16 08:09:18'),(null,'2009-06-16 08:15:45');
+```
+
+```sql
 select array("1", 2, 1.1);
 ```
 ```text

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
@@ -34,6 +34,12 @@ After applying the lambda expression, returns the number of non-zero elements in
 ## Example
 
 ```sql
+-- setup
+create table array_test(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,[1,null,2],[null,3,1]),(5,[],[]),(6,null,null);
+```
+
+```sql
 select array_count(x -> x, [0, 1, 2, 3]);
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-filter.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-filter.md
@@ -32,6 +32,14 @@ Performs the specified expression calculation on the internal data of the input 
 ## Example
 
 ```sql
+-- setup
+create table array_test(id int, c_array array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3,4,5]),(2,[6,7,8]),(3,[]),(4,null);
+create table array_test2(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test2 values (1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,null,null);
+```
+
+```sql
 select c_array,array_filter(c_array,[0,1,0]) from array_test;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-first-index.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-first-index.md
@@ -32,6 +32,12 @@ Returns the index of the first non-zero value. If no such index is found, return
 ## Example
 
 ```sql
+-- setup
+create table array_test(id int, col2 array<int>, col3 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3],[3,4,5]),(2,[1,null,2],[null,3,1]),(3,[1,2,3],[9,8,7]),(4,null,null);
+```
+
+```sql
 select array_first_index(x->x+1>3, [2, 3, 4]);
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-last-index.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-last-index.md
@@ -33,6 +33,12 @@ Returns the index of the last non-zero value. If no such index is found, returns
 ## Example
 
 ```sql
+-- setup
+create table array_test(id int, col2 array<int>, col3 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3],[3,4,5]),(2,[1,null,2],[null,3,1]),(3,[1,2,3],[9,8,7]),(4,null,null);
+```
+
+```sql
 select array_last_index(x -> x is null, [null, null, 1, 2]);
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-sortby.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array-sortby.md
@@ -34,6 +34,14 @@ Returns a sorted ARRAY type result.
 ## Example
 
 ```sql
+-- setup
+create table test_array_sortby(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into test_array_sortby values (0,null,[2]),(1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,null,null),(5,[3],null),(6,[1,2],[2,1]),(7,[null],[null]),(8,[1,2,3],[3,2,1]);
+create table array_test2(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test2 values (1,[1,2,3],[10,11,12]),(2,[4,3,5],[10,20,30]),(3,[-40,30,-100],[30,10,20]);
+```
+
+```sql
 select array_sortby(['a','b','c'],[3,2,1]);
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/array-functions/array.md
@@ -30,6 +30,12 @@ Returns an array.
 ## Example
 
 ```sql
+-- setup
+create table nested(qid int, creationDate datetime) distributed by hash(creationDate) buckets 1 properties ("replication_num"="1");
+insert into nested values (null,'2009-06-16 07:40:56'),(null,'2009-06-16 07:50:05'),(null,'2009-06-16 08:09:18'),(null,'2009-06-16 08:15:45');
+```
+
+```sql
 select array("1", 2, 1.1);
 ```
 ```text

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-count.md
@@ -34,6 +34,12 @@ After applying the lambda expression, returns the number of non-zero elements in
 ## Example
 
 ```sql
+-- setup
+create table array_test(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,[1,null,2],[null,3,1]),(5,[],[]),(6,null,null);
+```
+
+```sql
 select array_count(x -> x, [0, 1, 2, 3]);
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-filter.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-filter.md
@@ -32,6 +32,14 @@ Performs the specified expression calculation on the internal data of the input 
 ## Example
 
 ```sql
+-- setup
+create table array_test(id int, c_array array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3,4,5]),(2,[6,7,8]),(3,[]),(4,null);
+create table array_test2(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test2 values (1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,null,null);
+```
+
+```sql
 select c_array,array_filter(c_array,[0,1,0]) from array_test;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-first-index.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-first-index.md
@@ -32,6 +32,12 @@ Returns the index of the first non-zero value. If no such index is found, return
 ## Example
 
 ```sql
+-- setup
+create table array_test(id int, col2 array<int>, col3 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3],[3,4,5]),(2,[1,null,2],[null,3,1]),(3,[1,2,3],[9,8,7]),(4,null,null);
+```
+
+```sql
 select array_first_index(x->x+1>3, [2, 3, 4]);
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-last-index.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-last-index.md
@@ -33,6 +33,12 @@ Returns the index of the last non-zero value. If no such index is found, returns
 ## Example
 
 ```sql
+-- setup
+create table array_test(id int, col2 array<int>, col3 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test values (1,[1,2,3],[3,4,5]),(2,[1,null,2],[null,3,1]),(3,[1,2,3],[9,8,7]),(4,null,null);
+```
+
+```sql
 select array_last_index(x -> x is null, [null, null, 1, 2]);
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-sortby.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array-sortby.md
@@ -34,6 +34,14 @@ Returns a sorted ARRAY type result.
 ## Example
 
 ```sql
+-- setup
+create table test_array_sortby(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into test_array_sortby values (0,null,[2]),(1,[1,2,3,4,5],[10,20,-40,80,-100]),(2,[6,7,8],[10,12,13]),(3,[1],[-100]),(4,null,null),(5,[3],null),(6,[1,2],[2,1]),(7,[null],[null]),(8,[1,2,3],[3,2,1]);
+create table array_test2(id int, c_array1 array<int>, c_array2 array<int>) distributed by hash(id) buckets 1 properties ("replication_num"="1");
+insert into array_test2 values (1,[1,2,3],[10,11,12]),(2,[4,3,5],[10,20,30]),(3,[-40,30,-100],[30,10,20]);
+```
+
+```sql
 select array_sortby(['a','b','c'],[3,2,1]);
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/array-functions/array.md
@@ -30,6 +30,12 @@ Returns an array.
 ## Example
 
 ```sql
+-- setup
+create table nested(qid int, creationDate datetime) distributed by hash(creationDate) buckets 1 properties ("replication_num"="1");
+insert into nested values (null,'2009-06-16 07:40:56'),(null,'2009-06-16 07:50:05'),(null,'2009-06-16 08:09:18'),(null,'2009-06-16 08:15:45');
+```
+
+```sql
 select array("1", 2, 1.1);
 ```
 ```text


### PR DESCRIPTION
These array-function pages query a table that the `version-3.x` / `version-2.1` docs never define, so the examples cannot be run or reproduced (`Table [...] does not exist`).

Following the same approach as #3885, the setup is **reconstructed from each older pages own printed output** and emitted as a visible inline block.

Pages (EN + ZH, `version-3.x` and `version-2.1`):

| Page | Table(s) |
| --- | --- |
| `ARRAY` | `nested` |
| `ARRAY_COUNT` | `array_test` |
| `ARRAY_FILTER` | `array_test`, `array_test2` |
| `ARRAY_FIRST_INDEX` | `array_test` |
| `ARRAY_LAST_INDEX` | `array_test` |
| `ARRAY_SORTBY` | `test_array_sortby`, `array_test2` |

Each example was verified end-to-end to resolve its table and match that versions documented output — `version-3.x` on a 3.1.4 cluster and `version-2.1` on a 2.1.11 cluster (all pass). 24 files. No `ja-source` changes.

> `ARRAY_MAP` is intentionally left out of this PR: its example has a pre-existing SQL/output column mismatch (the SQL selects one column but the output shows two), tracked separately in #3887.