### PR TITLE
[fix](sql-functions) reconstruct example1 setup for EXPLODE_SPLIT (version-3.x / version-2.1)

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-functions/explode-split.md
@@ -32,6 +32,12 @@ EXPLODE_SPLIT_OUTER(<str>, <delimiter>)
 ## 举例
 
 ```sql
+-- setup
+create table example1(k1 int, k2 varchar(50)) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into example1 values (1,''),(2,null),(3,','),(4,'1'),(5,'1,2,3'),(6,'a, b, c');
+```
+
+```sql
 select * from example1 order by k1;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/table-functions/explode-split.md
@@ -32,6 +32,12 @@ EXPLODE_SPLIT_OUTER(<str>, <delimiter>)
 ## 举例
 
 ```sql
+-- setup
+create table example1(k1 int, k2 varchar(50)) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into example1 values (1,''),(2,null),(3,','),(4,'1'),(5,'1,2,3'),(6,'a, b, c');
+```
+
+```sql
 select * from example1 order by k1;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/table-functions/explode-split.md
@@ -33,6 +33,12 @@ Returns a sequence of the split substrings. If the string is empty or NULL, no r
 ## Examples
 
 ```sql
+-- setup
+create table example1(k1 int, k2 varchar(50)) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into example1 values (1,''),(2,null),(3,','),(4,'1'),(5,'1,2,3'),(6,'a, b, c');
+```
+
+```sql
 select * from example1 order by k1;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/table-functions/explode-split.md
@@ -33,6 +33,12 @@ Returns a sequence of the split substrings. If the string is empty or NULL, no r
 ## Examples
 
 ```sql
+-- setup
+create table example1(k1 int, k2 varchar(50)) distributed by hash(k1) buckets 1 properties ("replication_num"="1");
+insert into example1 values (1,''),(2,null),(3,','),(4,'1'),(5,'1,2,3'),(6,'a, b, c');
+```
+
+```sql
 select * from example1 order by k1;
 ```
 


### PR DESCRIPTION
The `EXPLODE_SPLIT` pages early examples query `example1`, which the `version-3.x` / `version-2.1` docs never define (the page only defines `example2`, used by the later examples). So those examples cannot be run or reproduced (`Table [...] does not exist`).

This PR adds the missing `example1` `CREATE TABLE` + `INSERT`, reconstructed from the pages own `select * from example1` output, as a visible inline block before the first example that uses it.

Verified on `version-3.x` (3.1.4) and `version-2.1` (2.1.11): all but one example resolve and match the documented output. EN + ZH (4 files). No `ja-source` changes.

> One example has a pre-existing output bug — its rows are not sorted despite `ORDER BY e1` (the engine correctly returns `1,2,3` but the doc shows `2,3,1`). That is **not** addressed here; it is tracked in #3889.