### PR TITLE
[fix](docs) add table setup for IF example in 3.x/2.1

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/conditional-functions/if.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/conditional-functions/if.md
@@ -28,6 +28,13 @@ IF(<condition>, <value_true>, <value_false_or_null>)
 ## 举例
 
 ```sql
+create table test(
+    user_id int
+) properties('replication_num' = '1');
+insert into test values(1),(2);
+```
+
+```sql
 SELECT user_id, IF(user_id = 1, "true", "false") AS test_if FROM test;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/conditional-functions/if.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/conditional-functions/if.md
@@ -28,6 +28,13 @@ IF(<condition>, <value_true>, <value_false_or_null>)
 ## 举例
 
 ```sql
+create table test(
+    user_id int
+) properties('replication_num' = '1');
+insert into test values(1),(2);
+```
+
+```sql
 SELECT user_id, IF(user_id = 1, "true", "false") AS test_if FROM test;
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/conditional-functions/if.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/conditional-functions/if.md
@@ -33,6 +33,13 @@ The result of the IF expression:
 ## Examples
 
 ```sql
+create table test(
+    user_id int
+) properties('replication_num' = '1');
+insert into test values(1),(2);
+```
+
+```sql
 SELECT user_id, IF(user_id = 1, 'true', 'false') AS test_if FROM test;
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/conditional-functions/if.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/conditional-functions/if.md
@@ -33,6 +33,13 @@ The result of the IF expression:
 ## Examples
 
 ```sql
+create table test(
+    user_id int
+) properties('replication_num' = '1');
+insert into test values(1),(2);
+```
+
+```sql
 SELECT user_id, IF(user_id = 1, 'true', 'false') AS test_if FROM test;
 ```
 


### PR DESCRIPTION
### Problem

The `IF` function page (version-3.x and version-2.1, EN + ZH) shows:

```sql
SELECT user_id, IF(user_id = 1, 'true', 'false') AS test_if FROM test;
```

but the page never defines `test`, so anyone copy-pasting the example hits `table does not exist`.

### Fix

Add a visible `CREATE TABLE` + `INSERT` block before the example (matching the "prepare data" style already used on the 4.x copy of this page), so the example is self-contained and reproducible. Renders as an ordinary code block; no change to the example SQL or its expected output.

### Verification

Ran the modified pages end-to-end on fresh live clusters — Doris **3.1.4** (for version-3.x) and **2.1.11** (for version-2.1). The example reproduces the documented output exactly, cell for cell.

Files: version-3.x + version-2.1, EN + ZH (4 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)