### PR TITLE
[fix](docs) add table setup for IPV4_STRING_TO_NUM_OR_DEFAULT example in 3.x/2.1

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
@@ -36,6 +36,13 @@ select ipv4_string_to_num_or_default('192.168.0.1');
 ```
 
 ```sql
+create table ipv4_str(
+    str varchar(20)
+) properties('replication_num' = '1');
+insert into ipv4_str values('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+```
+
+```sql
 select str, ipv4_string_to_num_or_default(str) from ipv4_str; 
 ```
 ```text

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
@@ -36,6 +36,13 @@ select ipv4_string_to_num_or_default('192.168.0.1');
 ```
 
 ```sql
+create table ipv4_str(
+    str varchar(20)
+) properties('replication_num' = '1');
+insert into ipv4_str values('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+```
+
+```sql
 select str, ipv4_string_to_num_or_default(str) from ipv4_str; 
 ```
 ```text

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
@@ -37,6 +37,13 @@ select ipv4_string_to_num_or_default('192.168.0.1');
 ```
 
 ```sql
+create table ipv4_str(
+    str varchar(20)
+) properties('replication_num' = '1');
+insert into ipv4_str values('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+```
+
+```sql
 select str, ipv4_string_to_num_or_default(str) from ipv4_str; 
 ```
 ```text

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv4-string-to-num-or-default.md
@@ -37,6 +37,13 @@ select ipv4_string_to_num_or_default('192.168.0.1');
 ```
 
 ```sql
+create table ipv4_str(
+    str varchar(20)
+) properties('replication_num' = '1');
+insert into ipv4_str values('0.0.0.0'),('127.0.0.1'),('255.255.255.255'),('invalid');
+```
+
+```sql
 select str, ipv4_string_to_num_or_default(str) from ipv4_str; 
 ```
 ```text


### PR DESCRIPTION
### Problem

The `IPV4_STRING_TO_NUM_OR_DEFAULT` page (version-3.x and version-2.1, EN + ZH) shows:

```sql
select str, ipv4_string_to_num_or_default(str) from ipv4_str;
```

but the page never defines `ipv4_str`, so the example fails with `table does not exist`.

### Fix

Add a visible `CREATE TABLE` + `INSERT` block before the example so it is self-contained. No change to the example SQL or its expected output.

### Verification

Ran the modified pages end-to-end on fresh live clusters — Doris **3.1.4** (version-3.x) and **2.1.11** (version-2.1). The example reproduces the documented output exactly (`0.0.0.0`→0, `127.0.0.1`→2130706433, `255.255.255.255`→4294967295, `invalid`→0).

Files: version-3.x + version-2.1, EN + ZH (4 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)