### PR TITLE
[fix](sql-functions) provide setup data for FIELD examples (3.x / 2.1 + dev zh)

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/other-functions/field.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/other-functions/field.md
@@ -29,6 +29,28 @@ FIELD(<expr>, <param> [, ...])
 
 ## 举例
 
+```sql
+-- setup
+CREATE TABLE baseall (k1 INT, k7 VARCHAR(64))
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO baseall VALUES
+    (1, 'wangjing04'),
+    (2, 'wangyu14'),
+    (3, 'yuanyuan06');
+
+CREATE TABLE class_test (class_name VARCHAR(64))
+DISTRIBUTED BY HASH(class_name) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO class_test VALUES
+    ('Suzi'), ('Suzi'),
+    ('Ben'), ('Ben'),
+    ('Henry'), ('Henry'),
+    (NULL);
+```
+
 直接使用 `FIELD` 查找位置（基于 1 的索引）：
 
 ```sql
@@ -65,6 +87,7 @@ SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Hen
 +------------+
 | class_name |
 +------------+
+| NULL       |
 | Suzi       |
 | Suzi       |
 | Ben        |
@@ -88,6 +111,7 @@ SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Hen
 | Ben        |
 | Suzi       |
 | Suzi       |
+| NULL       |
 +------------+
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/other-functions/field.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/scalar-functions/other-functions/field.md
@@ -30,6 +30,42 @@ FIELD(<expr>, <param> [, ...])
 ## 举例
 
 ```sql
+-- setup
+CREATE TABLE baseall (k1 INT, k7 VARCHAR(64))
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO baseall VALUES
+    (1, 'wangjing04'),
+    (2, 'wangyu14'),
+    (3, 'yuanyuan06');
+
+CREATE TABLE class_test (class_name VARCHAR(64))
+DISTRIBUTED BY HASH(class_name) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO class_test VALUES
+    ('Suzi'), ('Suzi'),
+    ('Ben'), ('Ben'),
+    ('Henry'), ('Henry'),
+    (NULL);
+```
+
+直接使用 `FIELD` 查找位置（基于 1 的索引）：
+
+```sql
+SELECT FIELD(2, 3, 1, 2, 5);
+```
+
+```text
++----------------------+
+| FIELD(2, 3, 1, 2, 5) |
++----------------------+
+|                    3 |
++----------------------+
+```
+
+```sql
 SELECT k1, k7 FROM baseall WHERE k1 IN (1,2,3) ORDER BY FIELD(k1,2,1,3);
 ```
 
@@ -51,6 +87,7 @@ SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Hen
 +------------+
 | class_name |
 +------------+
+| NULL       |
 | Suzi       |
 | Suzi       |
 | Ben        |
@@ -74,6 +111,7 @@ SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Hen
 | Ben        |
 | Suzi       |
 | Suzi       |
+| NULL       |
 +------------+
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/other-functions/field.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/scalar-functions/other-functions/field.md
@@ -30,6 +30,42 @@ FIELD(<expr>, <param> [, ...])
 ## 举例
 
 ```sql
+-- setup
+CREATE TABLE baseall (k1 INT, k7 VARCHAR(64))
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO baseall VALUES
+    (1, 'wangjing04'),
+    (2, 'wangyu14'),
+    (3, 'yuanyuan06');
+
+CREATE TABLE class_test (class_name VARCHAR(64))
+DISTRIBUTED BY HASH(class_name) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO class_test VALUES
+    ('Suzi'), ('Suzi'),
+    ('Ben'), ('Ben'),
+    ('Henry'), ('Henry'),
+    (NULL);
+```
+
+直接使用 `FIELD` 查找位置（基于 1 的索引）：
+
+```sql
+SELECT FIELD(2, 3, 1, 2, 5);
+```
+
+```text
++----------------------+
+| FIELD(2, 3, 1, 2, 5) |
++----------------------+
+|                    3 |
++----------------------+
+```
+
+```sql
 SELECT k1, k7 FROM baseall WHERE k1 IN (1,2,3) ORDER BY FIELD(k1,2,1,3);
 ```
 
@@ -51,6 +87,7 @@ SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Hen
 +------------+
 | class_name |
 +------------+
+| NULL       |
 | Suzi       |
 | Suzi       |
 | Ben        |
@@ -74,6 +111,7 @@ SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Hen
 | Ben        |
 | Suzi       |
 | Suzi       |
+| NULL       |
 +------------+
 ```
 

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/other-functions/field.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/scalar-functions/other-functions/field.md
@@ -33,6 +33,28 @@ FIELD(<expr>, <param> [, ...])
 ## Examples
 
 ```sql
+-- setup
+CREATE TABLE baseall (k1 INT, k7 VARCHAR(64))
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO baseall VALUES
+    (1, 'wangjing04'),
+    (2, 'wangyu14'),
+    (3, 'yuanyuan06');
+
+CREATE TABLE class_test (class_name VARCHAR(64))
+DISTRIBUTED BY HASH(class_name) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO class_test VALUES
+    ('Suzi'), ('Suzi'),
+    ('Ben'), ('Ben'),
+    ('Henry'), ('Henry'),
+    (NULL);
+```
+
+```sql
 SELECT FIELD(2, 3, 1, 2, 5);
 ```
 
@@ -58,6 +80,8 @@ SELECT k1, k7 FROM baseall WHERE k1 IN (1,2,3) ORDER BY FIELD(k1, 2, 1, 3);
 +------+------------+
 ```
 
+Custom string ordering. `FIELD` returns `0` for values not in the list — including `NULL`, which is why the `NULL` row sorts to the top in the ascending default:
+
 ```sql
 SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Henry');
 ```
@@ -66,6 +90,47 @@ SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Hen
 +------------+
 | class_name |
 +------------+
+| NULL       |
+| Suzi       |
+| Suzi       |
+| Ben        |
+| Ben        |
+| Henry      |
+| Henry      |
++------------+
+```
+
+Descending — `NULL` (FIELD = 0) is now last:
+
+```sql
+SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Henry') DESC;
+```
+
+```text
++------------+
+| class_name |
++------------+
+| Henry      |
+| Henry      |
+| Ben        |
+| Ben        |
+| Suzi       |
+| Suzi       |
+| NULL       |
++------------+
+```
+
+You can also use `NULLS FIRST` / `NULLS LAST` to control `NULL` placement independently of the sort direction:
+
+```sql
+SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Henry') NULLS FIRST;
+```
+
+```text
++------------+
+| class_name |
++------------+
+| NULL       |
 | Suzi       |
 | Suzi       |
 | Ben        |

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/other-functions/field.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/scalar-functions/other-functions/field.md
@@ -33,6 +33,28 @@ FIELD(<expr>, <param> [, ...])
 ## Examples
 
 ```sql
+-- setup
+CREATE TABLE baseall (k1 INT, k7 VARCHAR(64))
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO baseall VALUES
+    (1, 'wangjing04'),
+    (2, 'wangyu14'),
+    (3, 'yuanyuan06');
+
+CREATE TABLE class_test (class_name VARCHAR(64))
+DISTRIBUTED BY HASH(class_name) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO class_test VALUES
+    ('Suzi'), ('Suzi'),
+    ('Ben'), ('Ben'),
+    ('Henry'), ('Henry'),
+    (NULL);
+```
+
+```sql
 SELECT FIELD(2, 3, 1, 2, 5);
 ```
 
@@ -58,6 +80,8 @@ SELECT k1, k7 FROM baseall WHERE k1 IN (1,2,3) ORDER BY FIELD(k1, 2, 1, 3);
 +------+------------+
 ```
 
+Custom string ordering. `FIELD` returns `0` for values not in the list — including `NULL`, which is why the `NULL` row sorts to the top in the ascending default:
+
 ```sql
 SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Henry');
 ```
@@ -66,6 +90,47 @@ SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Hen
 +------------+
 | class_name |
 +------------+
+| NULL       |
+| Suzi       |
+| Suzi       |
+| Ben        |
+| Ben        |
+| Henry      |
+| Henry      |
++------------+
+```
+
+Descending — `NULL` (FIELD = 0) is now last:
+
+```sql
+SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Henry') DESC;
+```
+
+```text
++------------+
+| class_name |
++------------+
+| Henry      |
+| Henry      |
+| Ben        |
+| Ben        |
+| Suzi       |
+| Suzi       |
+| NULL       |
++------------+
+```
+
+You can also use `NULLS FIRST` / `NULLS LAST` to control `NULL` placement independently of the sort direction:
+
+```sql
+SELECT class_name FROM class_test ORDER BY FIELD(class_name, 'Suzi', 'Ben', 'Henry') NULLS FIRST;
+```
+
+```text
++------------+
+| class_name |
++------------+
+| NULL       |
 | Suzi       |
 | Suzi       |
 | Ben        |


### PR DESCRIPTION
The `FIELD` example pages query `baseall` and `class_test`, which the older copies never define, so a reader who runs them hits `table does not exist`. The **version-4.x** page already carries a `-- setup` block and a self-consistent example set; the other copies lacked it.

For the **zh** copies there was also a pre-existing inconsistency: the ascending/descending outputs omitted the `NULL` row that the `NULLS FIRST` example shows (no single `class_test` could satisfy both). version-4.x already resolved this.

Port the version-4.x Examples section (setup + consistent custom-sort examples) to:
- **EN**: version-3.x, version-2.1
- **ZH**: dev (current), version-3.x, version-2.1

version-4.x (EN+ZH) and dev EN already have it — unchanged.

**Verification** — every touched example executed end-to-end on fresh single-BE clusters, reproducing the doc's printed output cell-for-cell (`NULLS FIRST/LAST` confirmed working on 2.1):

| version | cluster | FIELD |
|---|---|---|
| dev | master daily (doris-0.0.0-2e72603618c) | P9 F0 (ZH; EN control P9 F0) |
| 3.x | 3.1.4-rc02 | P9 F0 (EN+ZH) |
| 2.1 | 2.1.11-rc01 | P9 F0 (EN+ZH) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)