### PR TITLE
[fix](sql-functions) provide setup data for MEDIAN example (dev)

### DIFF
--- a/docs/sql-manual/sql-functions/aggregate-functions/median.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/median.md
@@ -30,6 +30,22 @@ Returns NULL if there is no valid data in the group.
 ## Example
 
 ```sql
+-- setup
+create table log_statis(
+    datetime datetime,
+    scan_rows int
+) distributed by hash(datetime) buckets 1
+properties ("replication_num"="1");
+insert into log_statis values
+    ('2025-08-25 10:00:00', 10),
+    ('2025-08-25 10:00:00', 50),
+    ('2025-08-25 10:00:00', 100),
+    ('2025-08-25 11:00:00', 20),
+    ('2025-08-25 11:00:00', 30),
+    ('2025-08-25 11:00:00', 40);
+```
+
+```sql
 select datetime, median(scan_rows) from log_statis group by datetime;
 ```
 
@@ -44,7 +60,7 @@ select datetime, median(scan_rows) from log_statis group by datetime;
 ```
 
 ```sql
-select median(scan_rows) from log_statis group by datetime;
+select median(scan_rows) from log_statis where scan_rows is null;
 ```
 
 ```text

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/aggregate-functions/median.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/aggregate-functions/median.md
@@ -60,7 +60,7 @@ select datetime, median(scan_rows) from log_statis group by datetime;
 ```
 
 ```sql
-select median(scan_rows) from log_statis group by datetime;
+select median(scan_rows) from log_statis where scan_rows is null;
 ```
 
 ```text


### PR DESCRIPTION
The dev `MEDIAN` page queried `log_statis` without defining it, so the example errored with `table does not exist`; its second example's SQL and printed output were also mismatched.

Port the **version-4.x** Example section to dev (EN+ZH): a `-- setup` block that creates `log_statis` and loads rows whose per-group medians are exactly the `50` / `30` the doc prints (`MEDIAN` = `percentile 0.5` is deterministic), plus the self-consistent NULL example. version-4.x already has this and is unchanged. (MEDIAN only exists in dev + 4.x.)

**Verification** — executed end-to-end on the local master daily build (doris-0.0.0-2e72603618c): dev EN **P4 F0**, dev ZH **P4 F0**, every touched example reproducing the doc's printed output cell-for-cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)