### PR TITLE
[doc] Add JSON nesting depth limit to docs

### DIFF
--- a/docs/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
+++ b/docs/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
@@ -422,6 +422,7 @@ Object{
 - Size limit can be adjusted via the BE configuration parameter string_type_length_soft_limit_bytes
 - Maximum adjustment up to 2,147,483,643 bytes (approximately 2 GB)
 - In Doris JSON type Objects, key length cannot exceed 255 bytes
+- JSON supports a maximum nesting depth of 100 levels
 
 ## Usage Example
 A tutorial for JSON datatype including create table, load data and query.

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/basic-element/sql-data-types/semi-structured/JSON.md
@@ -428,6 +428,7 @@ Object{
 - 可通过 BE 配置 string_type_length_soft_limit_bytes 参数调整大小限制
 - 最大可调整至 2,147,483,643 字节（约 2 GB）
 - Doris JSON 类型的 Object 中，key 长度不能超过 255 个字节
+- JSON 的嵌套层级最多支持 100 层
 
 ## 使用示例
     用一个从建表、导数据、查询全周期的例子说明JSON数据类型的功能和用法。


### PR DESCRIPTION
## Summary
- Document the JSON nesting depth limit in the English JSON data type doc.
- Add the corresponding Chinese localized description.

## Validation
- Ran `git diff --cached --check` before committing.
- Documentation-only change; no site build was run.
