### PR TITLE
[fix](docs) ipv6_cidr_to_range examples error on 4.x/dev (INET6_ATON -> to_ipv6) + reserved-word alias + truncated IPv6

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/ip-functions/ipv6-cidr-to-range.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/ip-functions/ipv6-cidr-to-range.md
@@ -36,7 +36,7 @@ Return Value Meaning:
 
 Calculate address range for /64 network segment.
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64) as range;
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64) as `range`;
 +---------------------------------------------------------------+
 | range                                                         |
 +---------------------------------------------------------------+
@@ -46,7 +46,7 @@ SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64) as range;
 
 Calculate address range for /48 network segment.
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8:1::1'), 48) as range;
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8:1::1'), 48) as `range`;
 +---------------------------------------------------------------------+
 | range                                                               |
 +---------------------------------------------------------------------+
@@ -57,8 +57,8 @@ SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8:1::1'), 48) as range;
 Access specific fields in the struct.
 ```sql
 SELECT 
-  ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64).min as min_ip,
-  ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64).max as max_ip;
+  ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64).min as min_ip,
+  ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64).max as max_ip;
 +------------+-------------------------------+
 | min_ip     | max_ip                        |
 +------------+-------------------------------+
@@ -68,7 +68,7 @@ SELECT
 
 CIDR prefix out of range throws an exception.
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 129);
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 129);
 ERROR 1105 (HY000): errCode = 2, detailMessage = (...)[INVALID_ARGUMENT]Illegal cidr value '129'
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/ip-functions/ipv6-cidr-to-range.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/ip-functions/ipv6-cidr-to-range.md
@@ -41,7 +41,7 @@ IPV6_CIDR_TO_RANGE(<ipv6_address>, <cidr_prefix>)
 
 计算 /64 网段的地址范围。
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64) as range;
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64) as `range`;
 +----------------------------------------+
 | range                                  |
 +----------------------------------------+
@@ -51,19 +51,19 @@ SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64) as range;
 
 计算 /48 网段的地址范围。
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8:1::1'), 48) as range;
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8:1::1'), 48) as `range`;
 +----------------------------------------+
 | range                                  |
 +----------------------------------------+
-| {"min": "2001:db8:1::", "max": "2001:db8:1:ffff:ffff:ffff:ffff"} |
+| {"min": "2001:db8:1::", "max": "2001:db8:1:ffff:ffff:ffff:ffff:ffff"} |
 +----------------------------------------+
 ```
 
 访问结构体中的具体字段。
 ```sql
 SELECT 
-  ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64).min as min_ip,
-  ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64).max as max_ip;
+  ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64).min as min_ip,
+  ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64).max as max_ip;
 +-------------+----------------------------------+
 | min_ip      | max_ip                           |
 +-------------+----------------------------------+
@@ -73,7 +73,7 @@ SELECT
 
 CIDR 前缀超出范围会抛出异常。
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 129);
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 129);
 ERROR 1105 (HY000): errCode = 2, detailMessage = (...)[INVALID_ARGUMENT]Illegal cidr value '129'
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv6-cidr-to-range.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv6-cidr-to-range.md
@@ -41,7 +41,7 @@ IPV6_CIDR_TO_RANGE(<ipv6_address>, <cidr_prefix>)
 
 计算 /64 网段的地址范围。
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64) as range;
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64) as `range`;
 +----------------------------------------+
 | range                                  |
 +----------------------------------------+
@@ -51,19 +51,19 @@ SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64) as range;
 
 计算 /48 网段的地址范围。
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8:1::1'), 48) as range;
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8:1::1'), 48) as `range`;
 +----------------------------------------+
 | range                                  |
 +----------------------------------------+
-| {"min": "2001:db8:1::", "max": "2001:db8:1:ffff:ffff:ffff:ffff"} |
+| {"min": "2001:db8:1::", "max": "2001:db8:1:ffff:ffff:ffff:ffff:ffff"} |
 +----------------------------------------+
 ```
 
 访问结构体中的具体字段。
 ```sql
 SELECT 
-  ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64).min as min_ip,
-  ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64).max as max_ip;
+  ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64).min as min_ip,
+  ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64).max as max_ip;
 +-------------+----------------------------------+
 | min_ip      | max_ip                           |
 +-------------+----------------------------------+
@@ -73,7 +73,7 @@ SELECT
 
 CIDR 前缀超出范围会抛出异常。
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 129);
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 129);
 ERROR 1105 (HY000): errCode = 2, detailMessage = (...)[INVALID_ARGUMENT]Illegal cidr value '129'
 ```
 

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv6-cidr-to-range.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/ip-functions/ipv6-cidr-to-range.md
@@ -36,7 +36,7 @@ Return Value Meaning:
 
 Calculate address range for /64 network segment.
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64) as range;
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64) as `range`;
 +---------------------------------------------------------------+
 | range                                                         |
 +---------------------------------------------------------------+
@@ -46,7 +46,7 @@ SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64) as range;
 
 Calculate address range for /48 network segment.
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8:1::1'), 48) as range;
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8:1::1'), 48) as `range`;
 +---------------------------------------------------------------------+
 | range                                                               |
 +---------------------------------------------------------------------+
@@ -57,8 +57,8 @@ SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8:1::1'), 48) as range;
 Access specific fields in the struct.
 ```sql
 SELECT 
-  ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64).min as min_ip,
-  ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64).max as max_ip;
+  ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64).min as min_ip,
+  ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 64).max as max_ip;
 +------------+-------------------------------+
 | min_ip     | max_ip                        |
 +------------+-------------------------------+
@@ -68,7 +68,7 @@ SELECT
 
 CIDR prefix out of range throws an exception.
 ```sql
-SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 129);
+SELECT ipv6_cidr_to_range(to_ipv6('2001:db8::1'), 129);
 ERROR 1105 (HY000): errCode = 2, detailMessage = (...)[INVALID_ARGUMENT]Illegal cidr value '129'
 ```
 


### PR DESCRIPTION
### Problem

On the **dev (current)** and **4.x** trees, every example on
`ipv6_cidr_to_range` wraps the input in `INET6_ATON('...')`. The value
`INET6_ATON` returns is rejected by `ipv6_cidr_to_range`, so on both **4.1.1**
and **master** the examples error instead of producing the documented output:

```
SELECT ipv6_cidr_to_range(INET6_ATON('2001:db8::1'), 64);
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]Invalid IPv6 value
```

The 2.1/3.x docs use the working `to_ipv6('...')` form.

### Fix (dev + 4.x, EN + ZH)

- `INET6_ATON(...)` → `to_ipv6(...)` so the examples run.
- `` as range `` → `` as `range` `` — `range` is a reserved keyword and otherwise
  fails to parse (`mismatched input 'range'`).
- ZH `/48` example: the expected `max` was truncated by one group
  (`2001:db8:1:ffff:ffff:ffff:ffff` → `2001:db8:1:ffff:ffff:ffff:ffff:ffff`); the
  EN doc was already correct.

### Verification

Ran every example on the page end-to-end against a live **Apache Doris 4.1.1**
cluster (dev tree verified against it too): all pass. The `/48` range now returns
the full address on both languages:

```
SELECT ipv6_cidr_to_range(to_ipv6('2001:db8:1::1'), 48) as `range`;
+---------------------------------------------------------------------+
| {"min":"2001:db8:1::", "max":"2001:db8:1:ffff:ffff:ffff:ffff:ffff"} |
+---------------------------------------------------------------------+
```

The out-of-range example still raises `Illegal cidr value '129'` as documented.
