### PR TITLE
[feat](download) add Doris Streamloader 1.0.3 download links

### DIFF
--- a/src/constant/download.data.ts
+++ b/src/constant/download.data.ts
@@ -3257,6 +3257,25 @@ export const TOOL_VERSIONS = [
         value: ToolsEnum.StreamLoader,
         children: [
             {
+                label: '1.0.3',
+                value: '1.0.3',
+                children: [
+                    {
+                        label: CPUEnum.X64,
+                        value: CPUEnum.X64,
+                        gz: 'https://download.selectdb.com/apache-doris-streamloader-1.0.3-bin-x64.tar.gz',
+                        Binary: 'https://download.selectdb.com/apache-doris-streamloader-1.0.3-bin-x64.tar.gz',
+                    },
+                    {
+                        label: CPUEnum.ARM64,
+                        value: CPUEnum.ARM64,
+                        gz: 'https://download.selectdb.com/apache-doris-streamloader-1.0.3-bin-arm64.tar.gz',
+                        Binary: 'https://download.selectdb.com/apache-doris-streamloader-1.0.3-bin-arm64.tar.gz',
+                    },
+                ],
+                source: 'https://downloads.apache.org/doris/doris-streamloader/1.0.3/apache-doris-streamloader-1.0.3-src.tar.gz',
+            },
+            {
                 label: '1.0.2',
                 value: '1.0.2',
                 children: [


### PR DESCRIPTION
## Summary

Add download links for **Doris Streamloader 1.0.3** in `src/constant/download.data.ts`, placed at the top of the Streamloader version list (newest-first), following the existing 1.0.2 entry pattern (`.tar.gz`):

- **x64**: `https://download.selectdb.com/apache-doris-streamloader-1.0.3-bin-x64.tar.gz`
- **ARM64**: `https://download.selectdb.com/apache-doris-streamloader-1.0.3-bin-arm64.tar.gz`
- **source**: `https://downloads.apache.org/doris/doris-streamloader/1.0.3/apache-doris-streamloader-1.0.3-src.tar.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)