### PR TITLE
[fix](doc) v3.x/v2.1 zh: fix full-width commas in CTE example SQL

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/query-data/cte.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/query-data/cte.md
@@ -24,9 +24,9 @@ Doris **不支持** 递归 CTE。有关递归 CTE 的详细解释，可以参考
 
 ```sql
 WITH
-  cte1 AS (SELECT a，b FROM table1)，
-  cte2 AS (SELECT c，d FROM table2)
-SELECT b，d FROM cte1 JOIN cte2
+  cte1 AS (SELECT a, b FROM table1),
+  cte2 AS (SELECT c, d FROM table2)
+SELECT b, d FROM cte1 JOIN cte2
 WHERE cte1.a = cte2.c;
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/query-data/cte.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/query-data/cte.md
@@ -24,9 +24,9 @@ Doris **不支持** 递归 CTE。有关递归 CTE 的详细解释，可以参考
 
 ```sql
 WITH
-  cte1 AS (SELECT a，b FROM table1)，
-  cte2 AS (SELECT c，d FROM table2)
-SELECT b，d FROM cte1 JOIN cte2
+  cte1 AS (SELECT a, b FROM table1),
+  cte2 AS (SELECT c, d FROM table2)
+SELECT b, d FROM cte1 JOIN cte2
 WHERE cte1.a = cte2.c;
 ```
 


### PR DESCRIPTION
## Problem

The **Simple CTE** example in the Chinese `query-data/cte.md` used full-width commas (`，` U+FF0C) **inside the SQL code block**:

```sql
WITH
  cte1 AS (SELECT a，b FROM table1)，
  cte2 AS (SELECT c，d FROM table2)
SELECT b，d FROM cte1 JOIN cte2
WHERE cte1.a = cte2.c;
```

Pasted as-is the statement fails to parse (`errCode = 2 ... we meet an error when parsing`). The English counterpart and the **Nested CTE** block on the same page already use half-width commas — only this one block was affected.

## Fix

Replace the 4 full-width commas with half-width `,` in the simple-example SQL, making the ZH snippet identical to the canonical EN one. Chinese **prose** commas are left untouched.

## Versions

- [ ] dev — N/A (ZH already rewritten, no longer contains this example)
- [ ] 4.x — N/A (same as dev)
- [x] 3.x
- [x] 2.1

## Languages

- [x] Chinese (only the ZH source carried the typo)
- [ ] English — N/A (already correct)
- [ ] Japanese — not touched

## Verification

The snippet is an illustrative example over undefined `table1`/`table2` (no setup, no expected-output table), so it has no cluster oracle to run end-to-end; correctness is established against the already-correct EN counterpart and the half-width Nested-CTE block on the same page. The change is a pure full-width→half-width comma typo fix confined to the SQL fence.