### PR TITLE
[fix][doc] quote the session_context value in kill-query SET_VAR hint example

### DIFF
--- a/docs/admin-manual/workload-management/kill-query.md
+++ b/docs/admin-manual/workload-management/kill-query.md
@@ -85,7 +85,7 @@ SET session_context = "trace_id:your_trace_id";
 You can also set it through a Hint on a single query statement, without modifying the session variable:
 
 ```sql
-SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 ```
 
 ## Execute the KILL Operation
@@ -153,7 +153,7 @@ There are two ways to bind the Trace ID:
 - Embed a Hint in the query statement (suitable for connection-pool reuse scenarios):
 
     ```sql
-    SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+    SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
     ```
 
 Once bound, cancel the query at any time with the following command:

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/workload-management/kill-query.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/workload-management/kill-query.md
@@ -85,7 +85,7 @@ SET session_context = "trace_id:your_trace_id";
 也可在单条查询语句中通过 Hint 设置，无需修改会话变量：
 
 ```sql
-SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 ```
 
 ## 执行 KILL 操作
@@ -153,7 +153,7 @@ KILL 55;
 - 在查询语句中内嵌 Hint（适合连接池复用场景）：
 
     ```sql
-    SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+    SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
     ```
 
 绑定后，可在任意时刻通过以下命令取消该查询：

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/workload-management/kill-query.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/workload-management/kill-query.md
@@ -150,7 +150,7 @@ KILL [CONNECTION] connection_id;
 	- 在查询语句中添加 Trace ID
 
 		```sql
-		SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+		SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 		```
 	
 	之后，管控工具可以通过 Trace ID 随时取消正在执行的操作。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/workload-management/kill-query.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/workload-management/kill-query.md
@@ -150,7 +150,7 @@ KILL [CONNECTION] connection_id;
 	- 在查询语句中添加 Trace ID
 
 		```sql
-		SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+		SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 		```
 	
 	之后，管控工具可以通过 Trace ID 随时取消正在执行的操作。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/workload-management/kill-query.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/workload-management/kill-query.md
@@ -85,7 +85,7 @@ SET session_context = "trace_id:your_trace_id";
 也可在单条查询语句中通过 Hint 设置，无需修改会话变量：
 
 ```sql
-SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 ```
 
 ## 执行 KILL 操作
@@ -153,7 +153,7 @@ KILL 55;
 - 在查询语句中内嵌 Hint（适合连接池复用场景）：
 
     ```sql
-    SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+    SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
     ```
 
 绑定后，可在任意时刻通过以下命令取消该查询：

--- a/ja-source/docusaurus-plugin-content-docs/current/admin-manual/workload-management/kill-query.md
+++ b/ja-source/docusaurus-plugin-content-docs/current/admin-manual/workload-management/kill-query.md
@@ -141,6 +141,6 @@ KILL [CONNECTION] connection_id;
 - クエリ文にTrace IDを追加する
 
 		```sql
-		SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+		SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 		```
 その後、管理システムはTrace IDを使用していつでも実行中のオペレーションをキャンセルできます。

--- a/ja-source/docusaurus-plugin-content-docs/version-2.1/admin-manual/workload-management/kill-query.md
+++ b/ja-source/docusaurus-plugin-content-docs/version-2.1/admin-manual/workload-management/kill-query.md
@@ -141,6 +141,6 @@ KILL [CONNECTION] connection_id;
 - クエリステートメントにTrace IDを追加する
 
 		```sql
-		SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+		SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 		```
 その後、管理システムはTrace IDを使用して、実行中の操作をいつでもキャンセルできます。

--- a/ja-source/docusaurus-plugin-content-docs/version-3.x/admin-manual/workload-management/kill-query.md
+++ b/ja-source/docusaurus-plugin-content-docs/version-3.x/admin-manual/workload-management/kill-query.md
@@ -141,6 +141,6 @@ KILL [CONNECTION] connection_id;
 - クエリステートメントにTrace IDを追加する
 
 		```sql
-		SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+		SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 		```
 その後、管理システムはTrace IDを使用して実行中の操作をいつでもキャンセルできます。

--- a/ja-source/docusaurus-plugin-content-docs/version-4.x/admin-manual/workload-management/kill-query.md
+++ b/ja-source/docusaurus-plugin-content-docs/version-4.x/admin-manual/workload-management/kill-query.md
@@ -141,6 +141,6 @@ KILL [CONNECTION] connection_id;
 - クエリ文にTrace IDを追加する
 
 		```sql
-		SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+		SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 		```
 その後、管理システムはTrace IDを使用して実行中のオペレーションをいつでもキャンセルできます。

--- a/versioned_docs/version-2.1/admin-manual/workload-management/kill-query.md
+++ b/versioned_docs/version-2.1/admin-manual/workload-management/kill-query.md
@@ -150,7 +150,7 @@ The `CONNECTION` keyword can be omitted.
 	- Add Trace ID in the query statement
 
 		```sql
-		SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+		SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 		```
 	
 	Afterward, management system can cancel running operations at any time using the Trace ID.

--- a/versioned_docs/version-3.x/admin-manual/workload-management/kill-query.md
+++ b/versioned_docs/version-3.x/admin-manual/workload-management/kill-query.md
@@ -150,7 +150,7 @@ The `CONNECTION` keyword can be omitted.
 	- Add Trace ID in the query statement
 
 		```sql
-		SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+		SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 		```
 	
 	Afterward, management system can cancel running operations at any time using the Trace ID.

--- a/versioned_docs/version-4.x/admin-manual/workload-management/kill-query.md
+++ b/versioned_docs/version-4.x/admin-manual/workload-management/kill-query.md
@@ -85,7 +85,7 @@ SET session_context = "trace_id:your_trace_id";
 You can also set it through a Hint on a single query statement, without modifying the session variable:
 
 ```sql
-SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
 ```
 
 ## Execute the KILL Operation
@@ -153,7 +153,7 @@ There are two ways to bind the Trace ID:
 - Embed a Hint in the query statement (suitable for connection-pool reuse scenarios):
 
     ```sql
-    SELECT /*+SET_VAR(session_context=trace_id:your_trace_id)*/ * FROM table ...;
+    SELECT /*+SET_VAR(session_context="trace_id:your_trace_id")*/ * FROM table ...;
     ```
 
 Once bound, cancel the query at any time with the following command:


### PR DESCRIPTION
The per-query `SET_VAR` hint example in kill-query used an unquoted `session_context` value. Since the value contains `:`, it must be quoted — otherwise the hint truncates the value at the colon and the trace_id is lost (the session-level `SET` example above already uses quotes).

Updated the example in current / 3.0 / 2.1 docs (English + Chinese).

Related: apache/doris#64569
