### PR TITLE
[doc](maxcompute) Clarify MaxCompute DDL metadata visibility delay

### DIFF
--- a/docs/lakehouse/catalogs/maxcompute-catalog.md
+++ b/docs/lakehouse/catalogs/maxcompute-catalog.md
@@ -396,6 +396,8 @@ Starting from version 4.1.0, Doris supports creating and dropping MaxCompute dat
 - Does not support creating clustered tables, transactional tables, Delta Tables, or external tables.
 :::
 
+When creating or dropping databases or tables, Doris invokes the corresponding MaxCompute API to perform the operation. After the operation returns, metadata changes on the MaxCompute side need a short time before they are fully visible to subsequent operations.
+
 This feature is only available when the `mc.enable.namespace.schema` property is set to `true`.
 
 ### Creating and Dropping Databases

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/maxcompute-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/maxcompute-catalog.md
@@ -399,6 +399,8 @@ CREATE TABLE mc_tbl AS SELECT * FROM other_table;
 - 不支持创建聚簇表、事务表、Delta Table 和外部表。
 :::
 
+创建或删除库表时，Doris 会调用 MaxCompute API 执行对应操作。操作返回后，MaxCompute 侧元数据变更需要短暂时间才能对后续操作完全可见。
+
 该功能仅在 `mc.enable.namespace.schema` 属性为 `true` 时可用。
 
 ### 创建和删除库

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/maxcompute-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/maxcompute-catalog.md
@@ -399,6 +399,8 @@ CREATE TABLE mc_tbl AS SELECT * FROM other_table;
 - 不支持创建聚簇表、事务表、Delta Table 和外部表。
 :::
 
+创建或删除库表时，Doris 会调用 MaxCompute API 执行对应操作。操作返回后，MaxCompute 侧元数据变更需要短暂时间才能对后续操作完全可见。
+
 该功能仅在 `mc.enable.namespace.schema` 属性为 `true` 时可用。
 
 ### 创建和删除库

--- a/ja-source/docusaurus-plugin-content-docs/current/lakehouse/catalogs/maxcompute-catalog.md
+++ b/ja-source/docusaurus-plugin-content-docs/current/lakehouse/catalogs/maxcompute-catalog.md
@@ -229,6 +229,8 @@ CREATE TABLE mc_tbl AS SELECT * FROM other_table;
 - クラスター化されたテーブル、トランザクショナルテーブル、Delta Tables、外部テーブルの作成はサポートしていません。
 :::
 
+データベースやテーブルを作成または削除する際、Dorisは対応するMaxCompute APIを呼び出して操作を実行します。操作が返された後、MaxCompute側のメタデータ変更が後続の操作から完全に見えるようになるまで、短い時間が必要です。
+
 > この機能は`mc.enable.namespace.schema`プロパティが`true`に設定されている場合のみ利用可能です。
 
 ### データベースの作成と削除

--- a/ja-source/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/maxcompute-catalog.md
+++ b/ja-source/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/maxcompute-catalog.md
@@ -229,6 +229,8 @@ CREATE TABLE mc_tbl AS SELECT * FROM other_table;
 - クラスター化テーブル、トランザクションテーブル、Delta Tables、または外部テーブルの作成はサポートしていません。
 :::
 
+データベースやテーブルを作成または削除する際、Dorisは対応するMaxCompute APIを呼び出して操作を実行します。操作が返された後、MaxCompute側のメタデータ変更が後続の操作から完全に見えるようになるまで、短い時間が必要です。
+
 > この機能は`mc.enable.namespace.schema`プロパティが`true`に設定されている場合のみ利用可能です。
 
 ### データベースの作成と削除

--- a/versioned_docs/version-4.x/lakehouse/catalogs/maxcompute-catalog.md
+++ b/versioned_docs/version-4.x/lakehouse/catalogs/maxcompute-catalog.md
@@ -396,6 +396,8 @@ Starting from version 4.1.0, Doris supports creating and dropping MaxCompute dat
 - Does not support creating clustered tables, transactional tables, Delta Tables, or external tables.
 :::
 
+When creating or dropping databases or tables, Doris invokes the corresponding MaxCompute API to perform the operation. After the operation returns, metadata changes on the MaxCompute side need a short time before they are fully visible to subsequent operations.
+
 This feature is only available when the `mc.enable.namespace.schema` property is set to `true`.
 
 ### Creating and Dropping Databases


### PR DESCRIPTION
## Versions 

- [x] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [x] Japanese candidate translation needed

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync
