### PR TITLE
[feature][search] Add env-gated Algolia DocSearch alongside local search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,6 +89,13 @@ const SKIP_BLOG = LANDING_ONLY || process.env.SKIP_BLOG === 'true';
 const SKIP_COMMUNITY = LANDING_ONLY || process.env.SKIP_COMMUNITY === 'true';
 const SKIP_RELEASES = LANDING_ONLY || process.env.SKIP_RELEASES === 'true';
 const SKIP_SEARCH = LANDING_ONLY || process.env.SKIP_SEARCH === 'true';
+// Opt-in Algolia DocSearch, gated by env so we can A/B against the existing
+// local search before cutting over. When true, the Algolia theme is loaded
+// ALONGSIDE the local-search theme (the local theme stays so its @generated
+// index module keeps compiling), and the SearchBar swizzle renders Algolia's
+// bar instead of the local one. Requires ALGOLIA_APP_ID / ALGOLIA_SEARCH_API_KEY
+// / ALGOLIA_INDEX_NAME to be set, or the Algolia theme validation will fail.
+const USE_ALGOLIA = !SKIP_SEARCH && process.env.USE_ALGOLIA === 'true';
 
 const LINK_BEHAVIOR_VALUES = new Set(['ignore', 'log', 'warn', 'throw']);
 function getBrokenLinkBehavior(envName, fallback) {
@@ -188,7 +195,10 @@ const config = {
         },
     ],
     projectName: 'apache/doris-website', // Usually your repo name.
-    customFields: {},
+    customFields: {
+        // Read by the SearchBar swizzle to choose Algolia vs local search.
+        useAlgolia: USE_ALGOLIA,
+    },
     future: {
         experimental_faster: true,
     },
@@ -386,10 +396,30 @@ const config = {
                 ignoreFiles: [/^docs\/(?:[^/]+\/)?key-features\//],
             },
         ],
+        // Algolia DocSearch (modal-only; see `searchPagePath: false` below).
+        // Loaded additively so the local-search @generated module still exists
+        // for the SearchBar swizzle; which bar actually renders is decided at
+        // runtime via customFields.useAlgolia.
+        ...(USE_ALGOLIA ? ['@docusaurus/theme-search-algolia'] : []),
     ],
     themeConfig:
         /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
         ({
+            // Present only when USE_ALGOLIA is set. The Algolia theme validates
+            // these, so appId / apiKey (search-only key) / indexName must come
+            // from the environment. searchPagePath:false keeps DocSearch as a
+            // modal so it doesn't fight the local-search /search route.
+            ...(USE_ALGOLIA
+                ? {
+                      algolia: {
+                          appId: process.env.ALGOLIA_APP_ID,
+                          apiKey: process.env.ALGOLIA_SEARCH_API_KEY,
+                          indexName: process.env.ALGOLIA_INDEX_NAME,
+                          contextualSearch: true,
+                          searchPagePath: false,
+                      },
+                  }
+                : {}),
             matomo: {
                 matomoUrl: 'https://analytics.apache.org/',
                 siteId: '43',

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "@docusaurus/plugin-client-redirects": "3.6.3",
         "@docusaurus/plugin-pwa": "3.6.3",
         "@docusaurus/preset-classic": "3.6.3",
+        "@docusaurus/theme-search-algolia": "3.6.3",
         "@emotion/css": "^11.13.5",
         "@mdx-js/react": "^3.0.0",
         "@yang1666204/docusaurus-search-local": "0.0.7",

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -1,3 +1,19 @@
+import React from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import "../../utils/proxiedGenerated";
-import SearchBar from "./SearchBar";
-export default SearchBar;
+import LocalSearchBar from "./SearchBar";
+import AlgoliaSearchBar from "@docusaurus/theme-search-algolia/lib/theme/SearchBar";
+
+// Env-gated swizzle: render Algolia's DocSearch bar when USE_ALGOLIA was set at
+// build time (surfaced via customFields.useAlgolia), otherwise the existing
+// local search bar. Both modules are imported unconditionally — they only run
+// their themeConfig-dependent hooks when actually mounted, so the unused branch
+// is inert.
+export default function SearchBar(props) {
+  const { siteConfig } = useDocusaurusContext();
+  return siteConfig.customFields?.useAlgolia ? (
+    <AlgoliaSearchBar {...props} />
+  ) : (
+    <LocalSearchBar {...props} />
+  );
+}

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,5 @@
+# Algolia-Crawler-Verif: AD8797796C86C8D5
+
 User-agent: Googlebot
 Allow: /
 


### PR DESCRIPTION
## What

Enable Apache Doris docs to opt into **Algolia DocSearch** without removing the existing local search (`@yang1666204/docusaurus-search-local`).

## Why

The Algolia Crawler needs a domain-verification token served from `robots.txt`, and we want to A/B Algolia against the current local search before fully cutting over rather than swapping it out in one step.

## Changes

| File | Change |
|------|--------|
| `static/robots.txt` | Add Algolia Crawler domain-verification token |
| `docusaurus.config.js` | `USE_ALGOLIA` build flag; conditionally load the Algolia theme + `themeConfig.algolia` (read from env); expose `customFields.useAlgolia` |
| `src/theme/SearchBar/index.js` | Swizzle renders Algolia's bar or the local bar at runtime based on `customFields.useAlgolia` |
| `package.json` | Pin `@docusaurus/theme-search-algolia@3.6.3` as a direct dependency |

## Design notes

- **Additive, not a replacement.** The local-search theme stays loaded in both modes so its `@generated` index module (which the `proxiedGenerated` swizzle depends on) keeps compiling.
- **Modal-only** DocSearch (`searchPagePath: false`) so it doesn't collide with the local `/search` route. `contextualSearch: true` keeps results scoped per version/locale.
- **Default behavior is unchanged**: with `USE_ALGOLIA` unset, the site builds and serves the existing local search exactly as before.

## How to enable

```bash
USE_ALGOLIA=true \
ALGOLIA_APP_ID=xxxx \
ALGOLIA_SEARCH_API_KEY=xxxx \   # search-only public key
ALGOLIA_INDEX_NAME=doris \
yarn build
```

## Testing

- Default (local-search) path: config passes `node --check`; logically untouched.
- ⚠️ The `USE_ALGOLIA=true` path has **not** been built end-to-end here (requires live Algolia credentials). Import path/default export for the Algolia SearchBar were verified, but a real `USE_ALGOLIA=true` build should be run before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
