### PR TITLE
[fix](docs) fix 404 card links on the getting-started intro page

### DIFF
--- a/docs/getting-started/intro.mdx
+++ b/docs/getting-started/intro.mdx
@@ -40,19 +40,19 @@ Welcome to Apache Doris! This guide helps you find the right resources for your 
 <GettingStartedCard
     title="Alternative to ClickHouse"
     description="Learn how Apache Doris compares to and replaces ClickHouse"
-    link="alternatives/alternative-to-clickhouse"
+    link="/why-doris/compare#clickhouse"
 />
 
 <GettingStartedCard
     title="Alternative to Elasticsearch"
     description="Learn how Apache Doris serves as an alternative to Elasticsearch"
-    link="alternatives/alternative-to-elasticsearch"
+    link="/why-doris/compare#elastic"
 />
 
 <GettingStartedCard
     title="Alternative to Trino"
     description="Learn how Apache Doris replaces or works together with Trino"
-    link="alternatives/alternative-to-trino"
+    link="/why-doris/compare#trino"
 />
 </div>
 
@@ -78,18 +78,18 @@ Welcome to Apache Doris! This guide helps you find the right resources for your 
 <GettingStartedCard
     title="Use Cases"
     description="Learn about real-world use cases and success stories"
-    link="../use-cases/overview"
+    link="/why-doris/users"
 />
 
 <GettingStartedCard
     title="Benchmarks"
     description="View performance benchmark results"
-    link="../benchmark/overview"
+    link="/why-doris/benchmarks"
 />
 
 <GettingStartedCard
     title="Architecture and Concepts"
     description="Dive into how Doris works internally"
-    link="../architecture-concepts/overview"
+    link="../features-architecture/intro"
 />
 </div>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/getting-started/intro.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/getting-started/intro.mdx
@@ -40,19 +40,19 @@ import GettingStartedCard from '@site/src/components/getting-started-card/gettin
 <GettingStartedCard
     title="替代 ClickHouse"
     description="了解 Apache Doris 如何对比和替代 ClickHouse"
-    link="alternatives/alternative-to-clickhouse"
+    link="/why-doris/compare#clickhouse"
 />
 
 <GettingStartedCard
     title="替代 Elasticsearch"
     description="了解 Apache Doris 如何作为 Elasticsearch 的替代方案"
-    link="alternatives/alternative-to-elasticsearch"
+    link="/why-doris/compare#elastic"
 />
 
 <GettingStartedCard
     title="替代 Trino"
     description="了解 Apache Doris 如何替代或与 Trino 协同工作"
-    link="alternatives/alternative-to-trino"
+    link="/why-doris/compare#trino"
 />
 </div>
 
@@ -78,19 +78,19 @@ import GettingStartedCard from '@site/src/components/getting-started-card/gettin
 <GettingStartedCard
     title="使用场景"
     description="了解真实的应用案例和成功故事"
-    link="../use-cases/overview"
+    link="/why-doris/users"
 />
 
 <GettingStartedCard
     title="性能测试"
     description="查看性能基准测试数据"
-    link="../benchmark/overview"
+    link="/why-doris/benchmarks"
 />
 
 <GettingStartedCard
     title="架构与概念"
     description="深入了解 Doris 内部工作原理"
-    link="../architecture-concepts/overview"
+    link="../features-architecture/intro"
 />
 </div>
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/getting-started/intro.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/getting-started/intro.mdx
@@ -40,19 +40,19 @@ import GettingStartedCard from '@site/src/components/getting-started-card/gettin
 <GettingStartedCard
     title="替代 ClickHouse"
     description="了解 Apache Doris 如何对比和替代 ClickHouse"
-    link="alternatives/alternative-to-clickhouse"
+    link="/why-doris/compare#clickhouse"
 />
 
 <GettingStartedCard
     title="替代 Elasticsearch"
     description="了解 Apache Doris 如何作为 Elasticsearch 的替代方案"
-    link="alternatives/alternative-to-elasticsearch"
+    link="/why-doris/compare#elastic"
 />
 
 <GettingStartedCard
     title="替代 Trino"
     description="了解 Apache Doris 如何替代或与 Trino 协同工作"
-    link="alternatives/alternative-to-trino"
+    link="/why-doris/compare#trino"
 />
 </div>
 
@@ -78,19 +78,19 @@ import GettingStartedCard from '@site/src/components/getting-started-card/gettin
 <GettingStartedCard
     title="使用场景"
     description="了解真实的应用案例和成功故事"
-    link="../use-cases/overview"
+    link="/why-doris/users"
 />
 
 <GettingStartedCard
     title="性能测试"
     description="查看性能基准测试数据"
-    link="../benchmark/overview"
+    link="/why-doris/benchmarks"
 />
 
 <GettingStartedCard
     title="架构与概念"
     description="深入了解 Doris 内部工作原理"
-    link="../architecture-concepts/overview"
+    link="../features-architecture/intro"
 />
 </div>
 

--- a/src/components/why-doris-next/CompareNext.tsx
+++ b/src/components/why-doris-next/CompareNext.tsx
@@ -1,4 +1,4 @@
-import React, { JSX, useState } from 'react';
+import React, { JSX, useEffect, useState } from 'react';
 import { LayoutNext } from '../home-next/LayoutNext';
 import { WhyChooseSection } from './sections/WhyChooseSection';
 import { CoverFlowSection } from './sections/CoverFlowSection';
@@ -93,6 +93,17 @@ function TabSwitcher({ active, onChange }: TabSwitcherProps): JSX.Element {
 
 export default function CompareNext(): JSX.Element {
     const [active, setActive] = useState<string>('clickhouse');
+
+    // Allow deep-linking to a specific competitor tab via URL hash, e.g.
+    // /why-doris/compare#elastic. Read on mount (client-only; window is
+    // undefined during SSR) and fall back to the default ClickHouse tab.
+    useEffect(() => {
+        const hash = window.location.hash.replace(/^#/, '');
+        if (hash && TABS.some(tab => tab.id === hash && tab.enabled)) {
+            setActive(hash);
+        }
+    }, []);
+
     const content = CONTENT[active];
 
     return (

--- a/versioned_docs/version-4.x/getting-started/intro.mdx
+++ b/versioned_docs/version-4.x/getting-started/intro.mdx
@@ -40,19 +40,19 @@ Welcome to Apache Doris! This guide helps you find the right resources for your 
 <GettingStartedCard
     title="Alternative to ClickHouse"
     description="Learn how Apache Doris compares to and replaces ClickHouse"
-    link="alternatives/alternative-to-clickhouse"
+    link="/why-doris/compare#clickhouse"
 />
 
 <GettingStartedCard
     title="Alternative to Elasticsearch"
     description="Learn how Apache Doris serves as an alternative to Elasticsearch"
-    link="alternatives/alternative-to-elasticsearch"
+    link="/why-doris/compare#elastic"
 />
 
 <GettingStartedCard
     title="Alternative to Trino"
     description="Learn how Apache Doris replaces or works together with Trino"
-    link="alternatives/alternative-to-trino"
+    link="/why-doris/compare#trino"
 />
 </div>
 
@@ -78,18 +78,18 @@ Welcome to Apache Doris! This guide helps you find the right resources for your 
 <GettingStartedCard
     title="Use Cases"
     description="Learn about real-world use cases and success stories"
-    link="../use-cases/overview"
+    link="/why-doris/users"
 />
 
 <GettingStartedCard
     title="Benchmarks"
     description="View performance benchmark results"
-    link="../benchmark/overview"
+    link="/why-doris/benchmarks"
 />
 
 <GettingStartedCard
     title="Architecture and Concepts"
     description="Dive into how Doris works internally"
-    link="../architecture-concepts/overview"
+    link="../features-architecture/intro"
 />
 </div>


### PR DESCRIPTION
## What this PR does

Fixes the 404 card links on the **Getting Started → intro** page.

The cards in *"I am migrating from another technology"* and *"I want to explore further"* pointed to doc paths that don't exist, so every card returned 404:

- `alternatives/alternative-to-clickhouse` / `-elasticsearch` / `-trino`
- `../use-cases/overview`
- `../benchmark/overview`
- `../architecture-concepts/overview`

## Changes

| Section | Card | New target |
| --- | --- | --- |
| Migrating | Alternative to ClickHouse | `/why-doris/compare#clickhouse` |
| Migrating | Alternative to Elasticsearch | `/why-doris/compare#elastic` |
| Migrating | Alternative to Trino | `/why-doris/compare#trino` |
| Explore | Use Cases | `/why-doris/users` |
| Explore | Benchmarks | `/why-doris/benchmarks` |
| Explore | Architecture and Concepts | `../features-architecture/intro` |

- The migrating cards **deep-link** to the comparison page. `CompareNext` now reads the URL hash on mount and opens the matching competitor tab (falling back to the default ClickHouse tab), so `#clickhouse` / `#elastic` / `#trino` land on the right comparison.
- The Architecture card uses a **relative** doc link (`../features-architecture/intro`) so it stays correct across doc versions.

## Scope

Applied consistently across the current and `version-4.x` docs, in both English and Chinese — 4 `intro.mdx` files — plus the shared `src/components/why-doris-next/CompareNext.tsx` component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
