### PR TITLE
add broker load deprecation document

### DIFF
--- a/docs/data-operate/import/import-way/broker-load-manual.md
+++ b/docs/data-operate/import/import-way/broker-load-manual.md
@@ -23,6 +23,10 @@
 
 Broker Load is initiated through the MySQL API. Doris actively pulls data from a remote data source according to the information in the `LOAD` statement. It is an **asynchronous import** method. After submission, you need to use the `SHOW LOAD` statement to check the import progress and result.
 
+:::caution Note
+This method is deprecated and will be removed in version 5.0. Please use "insert into table select xxx from tvf or catalog table" instead.
+:::
+
 Broker Load is suitable for the following typical scenarios:
 
 - The source data is stored in a remote system (such as object storage or HDFS).

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/import-way/broker-load-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/import-way/broker-load-manual.md
@@ -23,6 +23,10 @@
 
 Broker Load 通过 MySQL API 发起，由 Doris 根据 `LOAD` 语句中的信息主动从远程数据源拉取数据。它是一种**异步导入**方式，提交后需要通过 `SHOW LOAD` 语句查看导入进度与结果。
 
+:::caution Note
+该方法已废弃，将在 5.0 版本中移除。请改用语法： "insert into table select xxx from tvf or catalog table".
+:::
+
 Broker Load 适用于以下典型场景：
 
 - 源数据存储在远程系统（如对象存储、HDFS）

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/import-way/broker-load-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/import/import-way/broker-load-manual.md
@@ -23,6 +23,10 @@
 
 Broker Load 通过 MySQL API 发起，由 Doris 根据 `LOAD` 语句中的信息主动从远程数据源拉取数据。它是一种**异步导入**方式，提交后需要通过 `SHOW LOAD` 语句查看导入进度与结果。
 
+:::caution Note
+该方法已废弃，将在 5.0 版本中移除。请改用语法： "insert into table select xxx from tvf or catalog table".
+:::
+
 Broker Load 适用于以下典型场景：
 
 - 源数据存储在远程系统（如对象存储、HDFS）

--- a/versioned_docs/version-4.x/data-operate/import/import-way/broker-load-manual.md
+++ b/versioned_docs/version-4.x/data-operate/import/import-way/broker-load-manual.md
@@ -23,6 +23,10 @@
 
 Broker Load is initiated through the MySQL API. Doris actively pulls data from a remote data source according to the information in the `LOAD` statement. It is an **asynchronous import** method. After submission, you need to use the `SHOW LOAD` statement to check the import progress and result.
 
+:::caution Note
+This method is deprecated and will be removed in version 5.0. Please use "insert into table select xxx from tvf or catalog table" instead.
+:::
+
 Broker Load is suitable for the following typical scenarios:
 
 - The source data is stored in a remote system (such as object storage or HDFS).


### PR DESCRIPTION
## Versions 

- [x] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [ ] Japanese candidate translation needed

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
- [ ] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync
