### PR TITLE
fix: use doc version context in breadcrumbs

### DIFF
--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -3,7 +3,8 @@ import clsx from 'clsx';
 import { ThemeClassNames } from '@docusaurus/theme-common';
 import {
     useSidebarBreadcrumbs,
-    useActivePluginAndVersion,
+    useDocsVersion,
+    useVersions,
 } from '@docusaurus/plugin-content-docs/client';
 import { useHomePageRoute } from '@docusaurus/theme-common/internal';
 import Link from '@docusaurus/Link';
@@ -69,14 +70,15 @@ function BreadcrumbsItem({
 export default function DocBreadcrumbs(): JSX.Element | null {
     const breadcrumbs = useSidebarBreadcrumbs();
     const homePageRoute = useHomePageRoute();
-    const activePluginAndVersion = useActivePluginAndVersion();
+    const versionMetadata = useDocsVersion();
+    const versions = useVersions(versionMetadata.pluginId);
     if (!breadcrumbs) {
         return null;
     }
     // Drop the top-level sidebar section group (e.g. "Get Started"),
     // since it's a visual grouping and has no destination page.
     const visibleBreadcrumbs = breadcrumbs.length > 1 ? breadcrumbs.slice(1) : breadcrumbs;
-    const activeVersion = activePluginAndVersion?.activeVersion;
+    const activeVersion = versions.find(version => version.name === versionMetadata.version);
     const versionMainDocPath = activeVersion?.docs.find(doc => doc.id === activeVersion.mainDocId)?.path;
     return (
         <nav
@@ -89,14 +91,14 @@ export default function DocBreadcrumbs(): JSX.Element | null {
         >
             <ul className="breadcrumbs" itemScope itemType="https://schema.org/BreadcrumbList">
                 {homePageRoute && <HomeBreadcrumbItem />}
-                {activeVersion && (
+                {versionMetadata && (
                     <li className="breadcrumbs__item">
                         {versionMainDocPath ? (
                             <Link className="breadcrumbs__link" href={versionMainDocPath}>
-                                {activeVersion.label}
+                                {versionMetadata.label}
                             </Link>
                         ) : (
-                            <span className="breadcrumbs__link">{activeVersion.label}</span>
+                            <span className="breadcrumbs__link">{versionMetadata.label}</span>
                         )}
                     </li>
                 )}

--- a/src/theme/DocBreadcrumbs/version-source.test.js
+++ b/src/theme/DocBreadcrumbs/version-source.test.js
@@ -1,0 +1,13 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const sourcePath = path.join(__dirname, 'index.tsx');
+
+test('doc breadcrumb version comes from the current docs page context', () => {
+    const source = fs.readFileSync(sourcePath, 'utf8');
+
+    assert.match(source, /useDocsVersion/);
+    assert.doesNotMatch(source, /useActivePluginAndVersion/);
+});


### PR DESCRIPTION
## Summary

- Use the current docs page version metadata for the docs breadcrumb version label.
- Keep the version breadcrumb link resolved through the matching global docs version.
- Add a small regression test to prevent falling back to pathname-based version inference.

## Test Plan

- `node --test src/theme/DocBreadcrumbs/version-source.test.js`
- `git diff --check -- src/theme/DocBreadcrumbs/index.tsx src/theme/DocBreadcrumbs/version-source.test.js`

## Notes

- `yarn typecheck` currently fails on existing unrelated repository-wide TypeScript issues, including JSX namespace errors, legacy Jest spec globals, and generated search module typings.
