### PR TITLE
[fix](docs) update removed BE /memz page reference to /profile in Jemalloc memory analysis

### DIFF
--- a/docs/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
+++ b/docs/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
@@ -6,7 +6,7 @@
 }
 ---
 
-Doris uses Jemalloc as the general memory allocator by default. The memory occupied by Jemalloc itself includes Cache and Metadata. Cache includes Thread Cache and Dirty Page. You can view the original profile of the memory allocator in real time at http://{be_host}:{be_web_server_port}/memz.
+Doris uses Jemalloc as the general memory allocator by default. The memory occupied by Jemalloc itself includes Cache and Metadata. Cache includes Thread Cache and Dirty Page. You can view the original profile of the memory allocator in real time in the **Jemalloc Profiles** section under **Memory Info** on Doris BE's Process Profile Web page http://{be_host}:{be_web_server_port}/profile.
 
 ## Jemalloc Cache Memory Analysis
 
@@ -26,7 +26,7 @@ During the running of the BE process, Jemalloc Cache consists of two parts.
 
 ### Jemalloc Cache View Method
 
-View Doris BE's Web page `http://{be_host}:{be_web_server_port}/memz` (webserver_port defaults to 8040) to obtain Jemalloc Profile, and interpret the use of Jemalloc Cache based on several sets of key information.
+View the **Jemalloc Profiles** section under **Memory Info** on Doris BE's Process Profile Web page `http://{be_host}:{be_web_server_port}/profile` (webserver_port defaults to 8040) to obtain the Jemalloc Profile, and interpret the use of Jemalloc Cache based on several sets of key information.
 
 - `tcache_bytes` in Jemalloc Profile is the total number of bytes of Jemalloc Thread Cache. If the `tcache_bytes` value is large, it means that the memory used by Jemalloc Thread Cache is too large.
 
@@ -82,7 +82,7 @@ MemTrackerLimiter Label=tc/jemalloc_metadata, Type=overview, Limit=-1.00 B(-1 B)
 
 ### How to view Jemalloc Metadata
 
-You can get the Jemalloc Profile by viewing the Doris BE web page `http://{be_host}:{be_web_server_port}/memz` (webserver_port defaults to 8040). Find the overall memory statistics of Jemalloc in the Jemalloc Profile as follows, where `metadata` is the memory size of Jemalloc Metadata.
+You can get the Jemalloc Profile from the **Jemalloc Profiles** section under **Memory Info** on the Doris BE Process Profile web page `http://{be_host}:{be_web_server_port}/profile` (webserver_port defaults to 8040). Find the overall memory statistics of Jemalloc in the Jemalloc Profile as follows, where `metadata` is the memory size of Jemalloc Metadata.
 
 `Allocated: 2401232080, active: 2526302208, metadata: 535979296 (n_thp 221), resident: 2995621888, mapped: 3221979136, retained: 131542581248`
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
@@ -6,7 +6,7 @@
 }
 ---
 
-Doris 默认使用 Jemalloc 作为通用内存分配器，Jemalloc 自身占用的内存包括 Cache 和 Metadata 两部分，其中 Cache 包括 Thread Cache 和 Dirty Page 两部分，在 http://{be_host}:{be_web_server_port}/memz 可以实时查看到内存分配器原始的 profile。
+Doris 默认使用 Jemalloc 作为通用内存分配器，Jemalloc 自身占用的内存包括 Cache 和 Metadata 两部分，其中 Cache 包括 Thread Cache 和 Dirty Page 两部分，在 Doris BE 的 Process Profile Web 页面 http://{be_host}:{be_web_server_port}/profile 中 **Memory Info** 的 **Jemalloc Profiles** 部分可以实时查看到内存分配器原始的 profile。
 
 ## Jemalloc Cache 内存分析
 
@@ -26,7 +26,7 @@ BE 进程运行过程中，Jemalloc Cache 包括两部分。
 
 ### Jemalloc Cache 查看方法
 
-查看 Doris BE 的 Web 页面 `http://{be_host}:{be_web_server_port}/memz`（webserver_port 默认 8040）可以获得 Jemalloc Profile，根据几组关键信息解读 Jemalloc Cache 的使用。
+查看 Doris BE 的 Process Profile Web 页面 `http://{be_host}:{be_web_server_port}/profile`（webserver_port 默认 8040）中 **Memory Info** 的 **Jemalloc Profiles** 部分可以获得 Jemalloc Profile，根据几组关键信息解读 Jemalloc Cache 的使用。
 
 - Jemalloc Profile 中的 `tcache_bytes`是 Jemalloc Thread Cache 的总字节数。如果 `tcache_bytes` 值较大，说明 Jemalloc Thread Cache 使用的内存过大。
 
@@ -83,7 +83,7 @@ MemTrackerLimiter Label=tc/jemalloc_metadata, Type=overview, Limit=-1.00 B(-1 B)
 
 ### Jemalloc Metadata 查看方法
 
-查看 Doris BE 的 Web 页面 `http://{be_host}:{be_web_server_port}/memz`（webserver_port 默认 8040）可以获得 Jemalloc Profile，查找 Jemalloc Profile 中关于 Jemalloc 整体的内存统计如下，其中 `metadata` 就是 Jemalloc Metadata 的内存大小。
+查看 Doris BE 的 Process Profile Web 页面 `http://{be_host}:{be_web_server_port}/profile`（webserver_port 默认 8040）中 **Memory Info** 的 **Jemalloc Profiles** 部分可以获得 Jemalloc Profile，查找 Jemalloc Profile 中关于 Jemalloc 整体的内存统计如下，其中 `metadata` 就是 Jemalloc Metadata 的内存大小。
 
 `Allocated: 2401232080, active: 2526302208, metadata: 535979296 (n_thp 221), resident: 2995621888, mapped: 3221979136, retained: 131542581248`
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
@@ -6,7 +6,7 @@
 }
 ---
 
-Doris 默认使用 Jemalloc 作为通用内存分配器，Jemalloc 自身占用的内存包括 Cache 和 Metadata 两部分，其中 Cache 包括 Thread Cache 和 Dirty Page 两部分，在 http://{be_host}:{be_web_server_port}/memz 可以实时查看到内存分配器原始的 profile。
+Doris 默认使用 Jemalloc 作为通用内存分配器，Jemalloc 自身占用的内存包括 Cache 和 Metadata 两部分，其中 Cache 包括 Thread Cache 和 Dirty Page 两部分，在 Doris BE 的 Process Profile Web 页面 http://{be_host}:{be_web_server_port}/profile 中 **Memory Info** 的 **Jemalloc Profiles** 部分可以实时查看到内存分配器原始的 profile。
 
 ## Jemalloc Cache 内存分析
 
@@ -26,7 +26,7 @@ BE 进程运行过程中，Jemalloc Cache 包括两部分。
 
 ### Jemalloc Cache 查看方法
 
-查看 Doris BE 的 Web 页面 `http://{be_host}:{be_web_server_port}/memz`（webserver_port 默认 8040）可以获得 Jemalloc Profile，根据几组关键信息解读 Jemalloc Cache 的使用。
+查看 Doris BE 的 Process Profile Web 页面 `http://{be_host}:{be_web_server_port}/profile`（webserver_port 默认 8040）中 **Memory Info** 的 **Jemalloc Profiles** 部分可以获得 Jemalloc Profile，根据几组关键信息解读 Jemalloc Cache 的使用。
 
 - Jemalloc Profile 中的 `tcache_bytes`是 Jemalloc Thread Cache 的总字节数。如果 `tcache_bytes` 值较大，说明 Jemalloc Thread Cache 使用的内存过大。
 
@@ -83,7 +83,7 @@ MemTrackerLimiter Label=tc/jemalloc_metadata, Type=overview, Limit=-1.00 B(-1 B)
 
 ### Jemalloc Metadata 查看方法
 
-查看 Doris BE 的 Web 页面 `http://{be_host}:{be_web_server_port}/memz`（webserver_port 默认 8040）可以获得 Jemalloc Profile，查找 Jemalloc Profile 中关于 Jemalloc 整体的内存统计如下，其中 `metadata` 就是 Jemalloc Metadata 的内存大小。
+查看 Doris BE 的 Process Profile Web 页面 `http://{be_host}:{be_web_server_port}/profile`（webserver_port 默认 8040）中 **Memory Info** 的 **Jemalloc Profiles** 部分可以获得 Jemalloc Profile，查找 Jemalloc Profile 中关于 Jemalloc 整体的内存统计如下，其中 `metadata` 就是 Jemalloc Metadata 的内存大小。
 
 `Allocated: 2401232080, active: 2526302208, metadata: 535979296 (n_thp 221), resident: 2995621888, mapped: 3221979136, retained: 131542581248`
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
@@ -6,7 +6,7 @@
 }
 ---
 
-Doris 默认使用 Jemalloc 作为通用内存分配器，Jemalloc 自身占用的内存包括 Cache 和 Metadata 两部分，其中 Cache 包括 Thread Cache 和 Dirty Page 两部分，在 http://{be_host}:{be_web_server_port}/memz 可以实时查看到内存分配器原始的 profile。
+Doris 默认使用 Jemalloc 作为通用内存分配器，Jemalloc 自身占用的内存包括 Cache 和 Metadata 两部分，其中 Cache 包括 Thread Cache 和 Dirty Page 两部分，在 Doris BE 的 Process Profile Web 页面 http://{be_host}:{be_web_server_port}/profile 中 **Memory Info** 的 **Jemalloc Profiles** 部分可以实时查看到内存分配器原始的 profile。
 
 ## Jemalloc Cache 内存分析
 
@@ -26,7 +26,7 @@ BE 进程运行过程中，Jemalloc Cache 包括两部分。
 
 ### Jemalloc Cache 查看方法
 
-查看 Doris BE 的 Web 页面 `http://{be_host}:{be_web_server_port}/memz`（webserver_port 默认 8040）可以获得 Jemalloc Profile，根据几组关键信息解读 Jemalloc Cache 的使用。
+查看 Doris BE 的 Process Profile Web 页面 `http://{be_host}:{be_web_server_port}/profile`（webserver_port 默认 8040）中 **Memory Info** 的 **Jemalloc Profiles** 部分可以获得 Jemalloc Profile，根据几组关键信息解读 Jemalloc Cache 的使用。
 
 - Jemalloc Profile 中的 `tcache_bytes`是 Jemalloc Thread Cache 的总字节数。如果 `tcache_bytes` 值较大，说明 Jemalloc Thread Cache 使用的内存过大。
 
@@ -83,7 +83,7 @@ MemTrackerLimiter Label=tc/jemalloc_metadata, Type=overview, Limit=-1.00 B(-1 B)
 
 ### Jemalloc Metadata 查看方法
 
-查看 Doris BE 的 Web 页面 `http://{be_host}:{be_web_server_port}/memz`（webserver_port 默认 8040）可以获得 Jemalloc Profile，查找 Jemalloc Profile 中关于 Jemalloc 整体的内存统计如下，其中 `metadata` 就是 Jemalloc Metadata 的内存大小。
+查看 Doris BE 的 Process Profile Web 页面 `http://{be_host}:{be_web_server_port}/profile`（webserver_port 默认 8040）中 **Memory Info** 的 **Jemalloc Profiles** 部分可以获得 Jemalloc Profile，查找 Jemalloc Profile 中关于 Jemalloc 整体的内存统计如下，其中 `metadata` 就是 Jemalloc Metadata 的内存大小。
 
 `Allocated: 2401232080, active: 2526302208, metadata: 535979296 (n_thp 221), resident: 2995621888, mapped: 3221979136, retained: 131542581248`
 

--- a/versioned_docs/version-3.x/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
+++ b/versioned_docs/version-3.x/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
@@ -6,7 +6,7 @@
 }
 ---
 
-Doris uses Jemalloc as the general memory allocator by default. The memory occupied by Jemalloc itself includes Cache and Metadata. Cache includes Thread Cache and Dirty Page. You can view the original profile of the memory allocator in real time at http://{be_host}:{be_web_server_port}/memz.
+Doris uses Jemalloc as the general memory allocator by default. The memory occupied by Jemalloc itself includes Cache and Metadata. Cache includes Thread Cache and Dirty Page. You can view the original profile of the memory allocator in real time in the **Jemalloc Profiles** section under **Memory Info** on Doris BE's Process Profile Web page http://{be_host}:{be_web_server_port}/profile.
 
 ## Jemalloc Cache Memory Analysis
 
@@ -26,7 +26,7 @@ During the running of the BE process, Jemalloc Cache consists of two parts.
 
 ### Jemalloc Cache View Method
 
-View Doris BE's Web page `http://{be_host}:{be_web_server_port}/memz` (webserver_port defaults to 8040) to obtain Jemalloc Profile, and interpret the use of Jemalloc Cache based on several sets of key information.
+View the **Jemalloc Profiles** section under **Memory Info** on Doris BE's Process Profile Web page `http://{be_host}:{be_web_server_port}/profile` (webserver_port defaults to 8040) to obtain the Jemalloc Profile, and interpret the use of Jemalloc Cache based on several sets of key information.
 
 - `tcache_bytes` in Jemalloc Profile is the total number of bytes of Jemalloc Thread Cache. If the `tcache_bytes` value is large, it means that the memory used by Jemalloc Thread Cache is too large.
 
@@ -82,7 +82,7 @@ MemTrackerLimiter Label=tc/jemalloc_metadata, Type=overview, Limit=-1.00 B(-1 B)
 
 ### How to view Jemalloc Metadata
 
-You can get the Jemalloc Profile by viewing the Doris BE web page `http://{be_host}:{be_web_server_port}/memz` (webserver_port defaults to 8040). Find the overall memory statistics of Jemalloc in the Jemalloc Profile as follows, where `metadata` is the memory size of Jemalloc Metadata.
+You can get the Jemalloc Profile from the **Jemalloc Profiles** section under **Memory Info** on the Doris BE Process Profile web page `http://{be_host}:{be_web_server_port}/profile` (webserver_port defaults to 8040). Find the overall memory statistics of Jemalloc in the Jemalloc Profile as follows, where `metadata` is the memory size of Jemalloc Metadata.
 
 `Allocated: 2401232080, active: 2526302208, metadata: 535979296 (n_thp 221), resident: 2995621888, mapped: 3221979136, retained: 131542581248`
 

--- a/versioned_docs/version-4.x/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
+++ b/versioned_docs/version-4.x/admin-manual/trouble-shooting/memory-management/memory-analysis/jemalloc-memory-analysis.md
@@ -6,7 +6,7 @@
 }
 ---
 
-Doris uses Jemalloc as the general memory allocator by default. The memory occupied by Jemalloc itself includes Cache and Metadata. Cache includes Thread Cache and Dirty Page. You can view the original profile of the memory allocator in real time at http://{be_host}:{be_web_server_port}/memz.
+Doris uses Jemalloc as the general memory allocator by default. The memory occupied by Jemalloc itself includes Cache and Metadata. Cache includes Thread Cache and Dirty Page. You can view the original profile of the memory allocator in real time in the **Jemalloc Profiles** section under **Memory Info** on Doris BE's Process Profile Web page http://{be_host}:{be_web_server_port}/profile.
 
 ## Jemalloc Cache Memory Analysis
 
@@ -26,7 +26,7 @@ During the running of the BE process, Jemalloc Cache consists of two parts.
 
 ### Jemalloc Cache View Method
 
-View Doris BE's Web page `http://{be_host}:{be_web_server_port}/memz` (webserver_port defaults to 8040) to obtain Jemalloc Profile, and interpret the use of Jemalloc Cache based on several sets of key information.
+View the **Jemalloc Profiles** section under **Memory Info** on Doris BE's Process Profile Web page `http://{be_host}:{be_web_server_port}/profile` (webserver_port defaults to 8040) to obtain the Jemalloc Profile, and interpret the use of Jemalloc Cache based on several sets of key information.
 
 - `tcache_bytes` in Jemalloc Profile is the total number of bytes of Jemalloc Thread Cache. If the `tcache_bytes` value is large, it means that the memory used by Jemalloc Thread Cache is too large.
 
@@ -82,7 +82,7 @@ MemTrackerLimiter Label=tc/jemalloc_metadata, Type=overview, Limit=-1.00 B(-1 B)
 
 ### How to view Jemalloc Metadata
 
-You can get the Jemalloc Profile by viewing the Doris BE web page `http://{be_host}:{be_web_server_port}/memz` (webserver_port defaults to 8040). Find the overall memory statistics of Jemalloc in the Jemalloc Profile as follows, where `metadata` is the memory size of Jemalloc Metadata.
+You can get the Jemalloc Profile from the **Jemalloc Profiles** section under **Memory Info** on the Doris BE Process Profile web page `http://{be_host}:{be_web_server_port}/profile` (webserver_port defaults to 8040). Find the overall memory statistics of Jemalloc in the Jemalloc Profile as follows, where `metadata` is the memory size of Jemalloc Metadata.
 
 `Allocated: 2401232080, active: 2526302208, metadata: 535979296 (n_thp 221), resident: 2995621888, mapped: 3221979136, retained: 131542581248`
 


### PR DESCRIPTION
## Purpose

The BE `/memz` web page was **removed** in [#41310](https://github.com/apache/doris/pull/41310) (`[opt](memory) Support Memory Profile`), which has been in Doris since **3.0.4** (picked to branch-3.0 via #44945). The current BE code registers no `/memz` page — the raw Jemalloc profile (`tcache_bytes`, the `extents` table, `Allocated/active/metadata/resident/retained`, etc.) is now produced by `jemalloc_stats_print(...)` in the **Jemalloc Profiles** section under **Memory Info** on the Process Profile page `/profile` (`be/src/service/http/default_path_handlers.cpp`).

The Jemalloc memory analysis doc still tells users to open `http://{be_host}:{be_web_server_port}/memz`, which no longer exists (the page is gone; `/mem_tracker` prints an "offline, please use Process Profile" notice).

## What changed

Redirect every `/memz` reference in the Jemalloc memory analysis doc to `/profile`, pointing at the **Memory Info → Jemalloc Profiles** section. All surrounding explanatory content is unchanged.

Files updated (3 occurrences each):

- `docs/.../memory-analysis/jemalloc-memory-analysis.md` (English, dev)
- `versioned_docs/version-4.x/.../jemalloc-memory-analysis.md`
- `versioned_docs/version-3.x/.../jemalloc-memory-analysis.md`
- `i18n/zh-CN/.../current/.../jemalloc-memory-analysis.md`
- `i18n/zh-CN/.../version-4.x/.../jemalloc-memory-analysis.md`
- `i18n/zh-CN/.../version-3.x/.../jemalloc-memory-analysis.md`

The `version-2.1` docs are intentionally left unchanged: `/memz` still exists in 2.1.

## Notes

The `overview.md` and `global/query/load-memory-analysis.md` docs in the same directory still reference the removed `/mem_tracker?type=*` pages. Those require a larger, version-aware rewrite against the new `MemoryProfile` hierarchy (which differs between 3.x and 4.x) and are intentionally out of scope for this PR.