### PR TITLE
[doc](arrow-flight-sql) add production warning and tracking issue

### DIFF
--- a/docs/connection-integration/arrow-flight-sql.md
+++ b/docs/connection-integration/arrow-flight-sql.md
@@ -23,7 +23,7 @@
 <!-- Applicable scenarios: High-speed read of Doris data / Python/Java integration / BI tool integration / Troubleshooting -->
 
 :::caution Experimental feature
-The Arrow Flight SQL high-speed data transmission capability described in this document is currently an **experimental feature**. If you encounter any issues during use, please report them through the mailing list or [GitHub Issue](https://github.com/apache/doris/issues).
+The Arrow Flight SQL high-speed data transmission capability described in this document is currently an **experimental feature**. It is not recommended for production use. If you encounter any issues during use, please report them through the mailing list or [GitHub Issue](https://github.com/apache/doris/issues/65615).
 :::
 
 Starting from Doris 2.1, a high-speed data transmission link based on the Arrow Flight SQL protocol has been implemented, allowing multiple languages to read large batches of data from Doris at high speed using SQL. Compared with the MySQL Client or JDBC/ODBC driver solutions, performance improves by tens to hundreds of times in some scenarios. Arrow Flight SQL also provides a generic JDBC driver that can interact seamlessly with databases that follow the same protocol.

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/arrow-flight-sql.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/arrow-flight-sql.md
@@ -23,7 +23,7 @@
 <!-- 适用场景: 高速读取 Doris 数据 / Python/Java 接入 / BI 工具集成 / 故障排查 -->
 
 :::caution 实验特性
-本文所述的 Arrow Flight SQL 高速数据传输能力目前为**实验特性**，使用过程中如遇到问题，欢迎通过邮件组或 [GitHub Issue](https://github.com/apache/doris/issues) 反馈。
+本文所述的 Arrow Flight SQL 高速数据传输能力目前为**实验特性**。不建议在生产环境中使用。使用过程中如遇到问题，欢迎通过邮件组或 [GitHub Issue](https://github.com/apache/doris/issues/65615) 反馈。
 :::
 
 自 Doris 2.1 版本起，基于 Arrow Flight SQL 协议实现了高速数据传输链路，支持多种语言使用 SQL 从 Doris 高速读取大批量数据。相比 MySQL Client 或 JDBC/ODBC 驱动方案，部分场景性能提升数十倍至百倍。Arrow Flight SQL 还提供通用 JDBC 驱动，可与同样遵循该协议的数据库无缝交互。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/arrow-flight-sql.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/arrow-flight-sql.md
@@ -23,7 +23,7 @@
 <!-- 适用场景: 高速读取 Doris 数据 / Python/Java 接入 / BI 工具集成 / 故障排查 -->
 
 :::caution 实验特性
-本文所述的 Arrow Flight SQL 高速数据传输能力目前为**实验特性**，使用过程中如遇到问题，欢迎通过邮件组或 [GitHub Issue](https://github.com/apache/doris/issues) 反馈。
+本文所述的 Arrow Flight SQL 高速数据传输能力目前为**实验特性**。不建议在生产环境中使用。使用过程中如遇到问题，欢迎通过邮件组或 [GitHub Issue](https://github.com/apache/doris/issues/65615) 反馈。
 :::
 
 自 Doris 2.1 版本起，基于 Arrow Flight SQL 协议实现了高速数据传输链路，支持多种语言使用 SQL 从 Doris 高速读取大批量数据。相比 MySQL Client 或 JDBC/ODBC 驱动方案，部分场景性能提升数十倍至百倍。Arrow Flight SQL 还提供通用 JDBC 驱动，可与同样遵循该协议的数据库无缝交互。

--- a/versioned_docs/version-4.x/connection-integration/arrow-flight-sql.md
+++ b/versioned_docs/version-4.x/connection-integration/arrow-flight-sql.md
@@ -23,7 +23,7 @@
 <!-- Applicable scenarios: High-speed read of Doris data / Python/Java integration / BI tool integration / Troubleshooting -->
 
 :::caution Experimental feature
-The Arrow Flight SQL high-speed data transmission capability described in this document is currently an **experimental feature**. If you encounter any issues during use, please report them through the mailing list or [GitHub Issue](https://github.com/apache/doris/issues).
+The Arrow Flight SQL high-speed data transmission capability described in this document is currently an **experimental feature**. It is not recommended for production use. If you encounter any issues during use, please report them through the mailing list or [GitHub Issue](https://github.com/apache/doris/issues/65615).
 :::
 
 Starting from Doris 2.1, a high-speed data transmission link based on the Arrow Flight SQL protocol has been implemented, allowing multiple languages to read large batches of data from Doris at high speed using SQL. Compared with the MySQL Client or JDBC/ODBC driver solutions, performance improves by tens to hundreds of times in some scenarios. Arrow Flight SQL also provides a generic JDBC driver that can interact seamlessly with databases that follow the same protocol.


### PR DESCRIPTION
## Summary

- clarify that the experimental Arrow Flight SQL feature is not recommended for production use
- direct user feedback to the Arrow Flight SQL tracking issue, apache/doris#65615
- keep the current and 4.x English and Chinese documentation in sync

## Validation

- `node scripts/docs-governance/report.js --files <four Arrow Flight SQL docs> --format github`
- `git diff --check upstream-apache/master...HEAD`