### PR TITLE
[fix](docs) Correct NULL behavior for vector distance functions

### DIFF
--- a/docs/sql-manual/sql-functions/ai-functions/distance-functions/cosine-distance.md
+++ b/docs/sql-manual/sql-functions/ai-functions/distance-functions/cosine-distance.md
@@ -25,7 +25,9 @@ COSINE_DISTANCE(<array1>, <array2>)
 
 ## Return Value
 
-Returns the cosine distance between two vectors (where the vector values are coordinates). If the input array is NULL, or any element in the array is NULL, then NULL is returned.
+Returns the cosine distance between two vectors (where the vector values are coordinates). The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Example
 
@@ -39,4 +41,24 @@ SELECT COSINE_DISTANCE([1, 2], [2, 3]),COSINE_DISTANCE([3, 6], [4, 7]);
 +---------------------------------+---------------------------------+
 |                     0.007722139 |                     0.001539648 |
 +---------------------------------+---------------------------------+
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT COSINE_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function cosine_distance cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT COSINE_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function cosine_distance cannot have null
 ```

--- a/docs/sql-manual/sql-functions/ai-functions/distance-functions/inner-product-approximate.md
+++ b/docs/sql-manual/sql-functions/ai-functions/distance-functions/inner-product-approximate.md
@@ -25,7 +25,9 @@ INNER_PRODUCT_APPROXIMATE(<array1>, <array2>)
 
 ## Return Value
 
-Returns the scalar product of two vectors of the same size. If the input array is NULL, or any element in array is NULL, then NULL is returned.
+Returns the scalar product of two vectors of the same size. The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Examples
 
@@ -84,4 +86,24 @@ Result
 | 153488 |   231871 |
 +--------+----------+
 10 rows in set (0.04 sec)
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT INNER_PRODUCT_APPROXIMATE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product_approximate cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT INNER_PRODUCT_APPROXIMATE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product_approximate cannot have null
 ```

--- a/docs/sql-manual/sql-functions/ai-functions/distance-functions/inner-product.md
+++ b/docs/sql-manual/sql-functions/ai-functions/distance-functions/inner-product.md
@@ -25,7 +25,9 @@ INNER_PRODUCT(<array1>, <array2>)
 
 ## Return Value
 
-Returns the scalar product of two vectors of the same size. If the input array is NULL, or any element in array is NULL, then NULL is returned.
+Returns the scalar product of two vectors of the same size. The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Examples
 
@@ -39,4 +41,24 @@ SELECT INNER_PRODUCT([1, 2], [2, 3]),INNER_PRODUCT([3, 6], [4, 7]);
 +-------------------------------+-------------------------------+
 |                             8 |                            54 |
 +-------------------------------+-------------------------------+
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT INNER_PRODUCT(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT INNER_PRODUCT([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product cannot have null
 ```

--- a/docs/sql-manual/sql-functions/ai-functions/distance-functions/l1-distance.md
+++ b/docs/sql-manual/sql-functions/ai-functions/distance-functions/l1-distance.md
@@ -25,7 +25,9 @@ L1_DISTANCE(<array1>, <array2>)
 
 ## Return Value
 
-Returns the distance between two points (vector values are coordinates) in L1 space. If the input array is NULL, or any element in the array is NULL, then NULL is returned.
+Returns the distance between two points (vector values are coordinates) in L1 space. The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Example
 
@@ -39,4 +41,24 @@ SELECT L1_DISTANCE([4, 5], [6, 8]),L1_DISTANCE([3, 6], [4, 5]);
 +-----------------------------+-----------------------------+
 |                           5 |                           2 |
 +-----------------------------+-----------------------------+
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT L1_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l1_distance cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT L1_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l1_distance cannot have null
 ```

--- a/docs/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance-approximate.md
+++ b/docs/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance-approximate.md
@@ -25,7 +25,9 @@ L2_DISTANCE_APPROXIMATE(<array1>, <array2>)
 
 ## Return Value
 
-Returns the distance between two points (vector values are coordinates) in Euclidean space. If the input array is NULL, or any element in the array is NULL, then NULL is returned.
+Returns the distance between two points (vector values are coordinates) in Euclidean space. The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Example
 
@@ -84,4 +86,24 @@ Result
 | 866737 | 231.6441 |
 +--------+----------+
 10 rows in set (0.08 sec)
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT L2_DISTANCE_APPROXIMATE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance_approximate cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT L2_DISTANCE_APPROXIMATE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance_approximate cannot have null
 ```

--- a/docs/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance.md
+++ b/docs/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance.md
@@ -25,7 +25,9 @@ L2_DISTANCE(<array1>, <array2>)
 
 ## Return Value
 
-Returns the distance between two points (vector values are coordinates) in Euclidean space. If the input array is NULL, or any element in the array is NULL, then NULL is returned.
+Returns the distance between two points (vector values are coordinates) in Euclidean space. The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Example
 
@@ -39,4 +41,24 @@ SELECT L2_DISTANCE([4, 5], [6, 8]),L2_DISTANCE([3, 6], [4, 5]);
 +-----------------------------+-----------------------------+
 |                    3.605551 |                    1.414214 |
 +-----------------------------+-----------------------------+
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT L2_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT L2_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/cosine-distance.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/cosine-distance.md
@@ -25,7 +25,9 @@ COSINE_DISTANCE(<array1>, <array2>)
 
 ## 返回值
 
-返回两个向量（向量值为坐标）之间的余弦距离。如果输入 array 为 NULL，或者 array 中任何元素为 NULL，则返回 NULL。
+返回两个向量（向量值为坐标）之间的余弦距离，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 举例
 
@@ -39,4 +41,24 @@ SELECT COSINE_DISTANCE([1, 2], [2, 3]),COSINE_DISTANCE([3, 6], [4, 7]);
 +---------------------------------+---------------------------------+
 |                     0.007722139 |                     0.001539648 |
 +---------------------------------+---------------------------------+
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT COSINE_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function cosine_distance cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT COSINE_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function cosine_distance cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/inner-product-approximate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/inner-product-approximate.md
@@ -25,7 +25,9 @@ INNER_PRODUCT_APPROXIMATE(<array1>, <array2>)
 
 ## 返回值
 
-返回两个相同大小向量的标量积。如果输入数组为 NULL，或数组中的任一元素为 NULL，则返回 NULL。
+返回两个相同大小向量的标量积，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 示例
 
@@ -84,4 +86,24 @@ LIMIT  10
 | 153488 |   231871 |
 +--------+----------+
 10 rows in set (0.04 sec)
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT INNER_PRODUCT_APPROXIMATE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product_approximate cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT INNER_PRODUCT_APPROXIMATE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product_approximate cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/inner-product.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/inner-product.md
@@ -25,7 +25,9 @@ INNER_PRODUCT(<array1>, <array2>)
 
 ## 返回值
 
-返回两个大小相同的向量的标量积。如果输入 array 为 NULL，或者 array 中任何元素为 NULL，则返回 NULL。
+返回两个大小相同的向量的标量积，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 举例
 
@@ -39,4 +41,24 @@ SELECT INNER_PRODUCT([1, 2], [2, 3]),INNER_PRODUCT([3, 6], [4, 7]);
 +-------------------------------+-------------------------------+
 |                             8 |                            54 |
 +-------------------------------+-------------------------------+
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT INNER_PRODUCT(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT INNER_PRODUCT([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/l1-distance.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/l1-distance.md
@@ -25,7 +25,9 @@ L1_DISTANCE(<array1>, <array2>)
 
 ## 返回值
 
-返回 L1 空间中两点（向量值为坐标）之间的距离。如果输入 array 为 NULL，或者 array 中任何元素为 NULL，则返回 NULL。
+返回 L1 空间中两点（向量值为坐标）之间的距离，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 举例
 
@@ -39,4 +41,24 @@ SELECT L1_DISTANCE([4, 5], [6, 8]),L1_DISTANCE([3, 6], [4, 5]);
 +-----------------------------+-----------------------------+
 |                           5 |                           2 |
 +-----------------------------+-----------------------------+
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT L1_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l1_distance cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT L1_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l1_distance cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance-approximate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance-approximate.md
@@ -25,7 +25,9 @@ L2_DISTANCE_APPROXIMATE(<array1>, <array2>)
 
 ## 返回值
 
-返回欧氏空间中两个点（向量值为坐标）之间的距离。如果输入数组为 NULL，或数组中的任一元素为 NULL，则返回 NULL。
+返回欧氏空间中两个点（向量值为坐标）之间的距离，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 示例
 
@@ -84,4 +86,24 @@ LIMIT  10
 | 866737 | 231.6441 |
 +--------+----------+
 10 rows in set (0.08 sec)
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT L2_DISTANCE_APPROXIMATE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance_approximate cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT L2_DISTANCE_APPROXIMATE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance_approximate cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance.md
@@ -25,7 +25,9 @@ L2_DISTANCE(<array1>, <array2>)
 
 ## 返回值
 
-返回欧几里得空间中两点（向量值为坐标）之间的距离。如果输入 array 为 NULL，或者 array 中任何元素为 NULL，则返回 NULL。
+返回欧几里得空间中两点（向量值为坐标）之间的距离，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 举例
 
@@ -39,4 +41,24 @@ SELECT L2_DISTANCE([4, 5], [6, 8]),L2_DISTANCE([3, 6], [4, 5]);
 +-----------------------------+-----------------------------+
 |                    3.605551 |                    1.414214 |
 +-----------------------------+-----------------------------+
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT L2_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT L2_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/cosine-distance.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/cosine-distance.md
@@ -25,7 +25,9 @@ COSINE_DISTANCE(<array1>, <array2>)
 
 ## 返回值
 
-返回两个向量（向量值为坐标）之间的余弦距离。如果输入 array 为 NULL，或者 array 中任何元素为 NULL，则返回 NULL。
+返回两个向量（向量值为坐标）之间的余弦距离，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 举例
 
@@ -39,4 +41,24 @@ SELECT COSINE_DISTANCE([1, 2], [2, 3]),COSINE_DISTANCE([3, 6], [4, 7]);
 +---------------------------------+---------------------------------+
 |                     0.007722139 |                     0.001539648 |
 +---------------------------------+---------------------------------+
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT COSINE_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function cosine_distance cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT COSINE_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function cosine_distance cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/inner-product-approximate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/inner-product-approximate.md
@@ -25,7 +25,9 @@ INNER_PRODUCT_APPROXIMATE(<array1>, <array2>)
 
 ## 返回值
 
-返回两个相同大小向量的标量积。如果输入数组为 NULL，或数组中的任一元素为 NULL，则返回 NULL。
+返回两个相同大小向量的标量积，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 示例
 
@@ -84,4 +86,24 @@ LIMIT  10
 | 153488 |   231871 |
 +--------+----------+
 10 rows in set (0.04 sec)
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT INNER_PRODUCT_APPROXIMATE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product_approximate cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT INNER_PRODUCT_APPROXIMATE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product_approximate cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/inner-product.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/inner-product.md
@@ -25,7 +25,9 @@ INNER_PRODUCT(<array1>, <array2>)
 
 ## 返回值
 
-返回两个大小相同的向量的标量积。如果输入 array 为 NULL，或者 array 中任何元素为 NULL，则返回 NULL。
+返回两个大小相同的向量的标量积，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 举例
 
@@ -39,4 +41,24 @@ SELECT INNER_PRODUCT([1, 2], [2, 3]),INNER_PRODUCT([3, 6], [4, 7]);
 +-------------------------------+-------------------------------+
 |                             8 |                            54 |
 +-------------------------------+-------------------------------+
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT INNER_PRODUCT(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT INNER_PRODUCT([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l1-distance.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l1-distance.md
@@ -25,7 +25,9 @@ L1_DISTANCE(<array1>, <array2>)
 
 ## 返回值
 
-返回 L1 空间中两点（向量值为坐标）之间的距离。如果输入 array 为 NULL，或者 array 中任何元素为 NULL，则返回 NULL。
+返回 L1 空间中两点（向量值为坐标）之间的距离，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 举例
 
@@ -39,4 +41,24 @@ SELECT L1_DISTANCE([4, 5], [6, 8]),L1_DISTANCE([3, 6], [4, 5]);
 +-----------------------------+-----------------------------+
 |                           5 |                           2 |
 +-----------------------------+-----------------------------+
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT L1_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l1_distance cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT L1_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l1_distance cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance-approximate.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance-approximate.md
@@ -25,7 +25,9 @@ L2_DISTANCE_APPROXIMATE(<array1>, <array2>)
 
 ## 返回值
 
-返回欧氏空间中两个点（向量值为坐标）之间的距离。如果输入数组为 NULL，或数组中的任一元素为 NULL，则返回 NULL。
+返回欧氏空间中两个点（向量值为坐标）之间的距离，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 示例
 
@@ -84,4 +86,24 @@ LIMIT  10
 | 866737 | 231.6441 |
 +--------+----------+
 10 rows in set (0.08 sec)
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT L2_DISTANCE_APPROXIMATE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance_approximate cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT L2_DISTANCE_APPROXIMATE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance_approximate cannot have null
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance.md
@@ -25,7 +25,9 @@ L2_DISTANCE(<array1>, <array2>)
 
 ## 返回值
 
-返回欧几里得空间中两点（向量值为坐标）之间的距离。如果输入 array 为 NULL，或者 array 中任何元素为 NULL，则返回 NULL。
+返回欧几里得空间中两点（向量值为坐标）之间的距离，返回类型为 `FLOAT`。
+
+如果任一输入数组为 `NULL`，或包含 `NULL` 元素，函数会报错。
 
 ## 举例
 
@@ -39,4 +41,24 @@ SELECT L2_DISTANCE([4, 5], [6, 8]),L2_DISTANCE([3, 6], [4, 5]);
 +-----------------------------+-----------------------------+
 |                    3.605551 |                    1.414214 |
 +-----------------------------+-----------------------------+
+```
+
+如果输入数组为 `NULL`，函数会报错：
+
+```sql
+SELECT L2_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance cannot be null
+```
+
+如果输入数组包含 `NULL` 元素，函数会报错：
+
+```sql
+SELECT L2_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance cannot have null
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/cosine-distance.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/cosine-distance.md
@@ -25,7 +25,9 @@ COSINE_DISTANCE(<array1>, <array2>)
 
 ## Return Value
 
-Returns the cosine distance between two vectors (where the vector values are coordinates). If the input array is NULL, or any element in the array is NULL, then NULL is returned.
+Returns the cosine distance between two vectors (where the vector values are coordinates). The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Example
 
@@ -39,4 +41,24 @@ SELECT COSINE_DISTANCE([1, 2], [2, 3]),COSINE_DISTANCE([3, 6], [4, 7]);
 +---------------------------------+---------------------------------+
 |                     0.007722139 |                     0.001539648 |
 +---------------------------------+---------------------------------+
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT COSINE_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function cosine_distance cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT COSINE_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function cosine_distance cannot have null
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/inner-product-approximate.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/inner-product-approximate.md
@@ -25,7 +25,9 @@ INNER_PRODUCT_APPROXIMATE(<array1>, <array2>)
 
 ## Return Value
 
-Returns the scalar product of two vectors of the same size. If the input array is NULL, or any element in array is NULL, then NULL is returned.
+Returns the scalar product of two vectors of the same size. The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Examples
 
@@ -84,4 +86,24 @@ Result
 | 153488 |   231871 |
 +--------+----------+
 10 rows in set (0.04 sec)
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT INNER_PRODUCT_APPROXIMATE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product_approximate cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT INNER_PRODUCT_APPROXIMATE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product_approximate cannot have null
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/inner-product.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/inner-product.md
@@ -25,7 +25,9 @@ INNER_PRODUCT(<array1>, <array2>)
 
 ## Return Value
 
-Returns the scalar product of two vectors of the same size. If the input array is NULL, or any element in array is NULL, then NULL is returned.
+Returns the scalar product of two vectors of the same size. The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Examples
 
@@ -39,4 +41,24 @@ SELECT INNER_PRODUCT([1, 2], [2, 3]),INNER_PRODUCT([3, 6], [4, 7]);
 +-------------------------------+-------------------------------+
 |                             8 |                            54 |
 +-------------------------------+-------------------------------+
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT INNER_PRODUCT(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT INNER_PRODUCT([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function inner_product cannot have null
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l1-distance.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l1-distance.md
@@ -25,7 +25,9 @@ L1_DISTANCE(<array1>, <array2>)
 
 ## Return Value
 
-Returns the distance between two points (vector values are coordinates) in L1 space. If the input array is NULL, or any element in the array is NULL, then NULL is returned.
+Returns the distance between two points (vector values are coordinates) in L1 space. The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Example
 
@@ -39,4 +41,24 @@ SELECT L1_DISTANCE([4, 5], [6, 8]),L1_DISTANCE([3, 6], [4, 5]);
 +-----------------------------+-----------------------------+
 |                           5 |                           2 |
 +-----------------------------+-----------------------------+
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT L1_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l1_distance cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT L1_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l1_distance cannot have null
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance-approximate.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance-approximate.md
@@ -25,7 +25,9 @@ L2_DISTANCE_APPROXIMATE(<array1>, <array2>)
 
 ## Return Value
 
-Returns the distance between two points (vector values are coordinates) in Euclidean space. If the input array is NULL, or any element in the array is NULL, then NULL is returned.
+Returns the distance between two points (vector values are coordinates) in Euclidean space. The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Example
 
@@ -84,4 +86,24 @@ Result
 | 866737 | 231.6441 |
 +--------+----------+
 10 rows in set (0.08 sec)
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT L2_DISTANCE_APPROXIMATE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance_approximate cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT L2_DISTANCE_APPROXIMATE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance_approximate cannot have null
 ```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/ai-functions/distance-functions/l2-distance.md
@@ -25,7 +25,9 @@ L2_DISTANCE(<array1>, <array2>)
 
 ## Return Value
 
-Returns the distance between two points (vector values are coordinates) in Euclidean space. If the input array is NULL, or any element in the array is NULL, then NULL is returned.
+Returns the distance between two points (vector values are coordinates) in Euclidean space. The return type is `FLOAT`.
+
+If either input array is `NULL`, or contains a `NULL` element, the function returns an error.
 
 ## Example
 
@@ -39,4 +41,24 @@ SELECT L2_DISTANCE([4, 5], [6, 8]),L2_DISTANCE([3, 6], [4, 5]);
 +-----------------------------+-----------------------------+
 |                    3.605551 |                    1.414214 |
 +-----------------------------+-----------------------------+
+```
+
+If an input array is `NULL`, the function returns an error:
+
+```sql
+SELECT L2_DISTANCE(NULL, [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance cannot be null
+```
+
+If an input array contains a `NULL` element, the function returns an error:
+
+```sql
+SELECT L2_DISTANCE([1, NULL], [1, 2]);
+```
+
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]First argument for function l2_distance cannot have null
 ```


### PR DESCRIPTION
## Summary

- Correct the documented NULL behavior of `l1_distance`, `l2_distance`, `cosine_distance`, `inner_product`, `l2_distance_approximate`, and `inner_product_approximate`.
- Clarify that a NULL array or a NULL array element raises an `INVALID_ARGUMENT` error instead of returning NULL, and add examples for both cases.
- Keep the current and 4.x English and Chinese pages synchronized. The behavior change was introduced in Doris PR #55631 and is not present in 3.x, so older versioned docs remain unchanged.

## Validation

- `git diff --check`
- `npm run docs:links:changed` (0 findings)
- `npm run docs:i18n-sync:changed` (Japanese candidate-translation notices only)
- `npm run docs:sql-functions:changed` (existing structural warnings in the touched legacy pages; no errors)
- `npx docusaurus build` compiled the documentation and then hit the repository's existing `build/blog.html/index.html` redirect collision during post-build.

## Versions 

- [x] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [x] Japanese candidate translation needed

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built (documentation-only change; the behavior is covered by Doris regression tests)
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync (not applicable; both English and Chinese were updated)
