### PR TITLE
fix(docs): correct Features and Architecture card links

### DIFF
--- a/docs/features-architecture/intro.mdx
+++ b/docs/features-architecture/intro.mdx
@@ -18,13 +18,13 @@ Welcome to Apache Doris! This section helps you understand the core features and
 <GettingStartedCard
     title="System Architecture"
     description="Learn about the architecture and components of Apache Doris"
-    link="/docs/features-architecture/system-architecture"
+    link="./system-architecture"
 />
 
 <GettingStartedCard
     title="Product Concepts"
     description="Learn about data models, table types, and data distribution"
-    link="/docs/features-architecture/product-concepts"
+    link="./product-concepts"
 />
 </div>
 
@@ -34,12 +34,12 @@ Welcome to Apache Doris! This section helps you understand the core features and
 <GettingStartedCard
     title="Feature Overview"
     description="Explore the core capabilities of Apache Doris"
-    link="/docs/features-architecture/feature-overview"
+    link="/why-doris/key-features"
 />
 
 <GettingStartedCard
     title="Release Notes"
     description="Learn about Apache Doris versions and release notes"
-    link="/docs/features-architecture/versioning"
+    link="/releases/all-release"
 />
 </div>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/features-architecture/intro.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/features-architecture/intro.mdx
@@ -18,13 +18,13 @@ import GettingStartedCard from '@site/src/components/getting-started-card/gettin
 <GettingStartedCard
     title="系统架构"
     description="了解 Apache Doris 的架构和组件"
-    link="/docs/features-architecture/system-architecture"
+    link="./system-architecture"
 />
 
 <GettingStartedCard
     title="产品概念"
     description="了解数据模型、表类型和数据分布"
-    link="/docs/features-architecture/product-concepts"
+    link="./product-concepts"
 />
 </div>
 
@@ -34,13 +34,13 @@ import GettingStartedCard from '@site/src/components/getting-started-card/gettin
 <GettingStartedCard
     title="功能概览"
     description="探索 Apache Doris 的核心能力"
-    link="/docs/features-architecture/feature-overview"
+    link="/why-doris/key-features"
 />
 
 <GettingStartedCard
     title="版本说明"
     description="了解 Apache Doris 的版本和发布说明"
-    link="/docs/features-architecture/versioning"
+    link="/releases/all-release"
 />
 </div>
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/features-architecture/intro.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/features-architecture/intro.mdx
@@ -18,13 +18,13 @@ import GettingStartedCard from '@site/src/components/getting-started-card/gettin
 <GettingStartedCard
     title="系统架构"
     description="了解 Apache Doris 的架构和组件"
-    link="/docs/features-architecture/system-architecture"
+    link="./system-architecture"
 />
 
 <GettingStartedCard
     title="产品概念"
     description="了解数据模型、表类型和数据分布"
-    link="/docs/features-architecture/product-concepts"
+    link="./product-concepts"
 />
 </div>
 
@@ -34,13 +34,13 @@ import GettingStartedCard from '@site/src/components/getting-started-card/gettin
 <GettingStartedCard
     title="功能概览"
     description="探索 Apache Doris 的核心能力"
-    link="/docs/features-architecture/feature-overview"
+    link="/why-doris/key-features"
 />
 
 <GettingStartedCard
     title="版本说明"
     description="了解 Apache Doris 的版本和发布说明"
-    link="/docs/features-architecture/versioning"
+    link="/releases/all-release"
 />
 </div>
 

--- a/versioned_docs/version-4.x/features-architecture/intro.mdx
+++ b/versioned_docs/version-4.x/features-architecture/intro.mdx
@@ -18,13 +18,13 @@ Welcome to Apache Doris! This section helps you understand the core features and
 <GettingStartedCard
     title="System Architecture"
     description="Learn about the architecture and components of Apache Doris"
-    link="/docs/features-architecture/system-architecture"
+    link="./system-architecture"
 />
 
 <GettingStartedCard
     title="Product Concepts"
     description="Learn about data models, table types, and data distribution"
-    link="/docs/features-architecture/product-concepts"
+    link="./product-concepts"
 />
 </div>
 
@@ -34,12 +34,12 @@ Welcome to Apache Doris! This section helps you understand the core features and
 <GettingStartedCard
     title="Feature Overview"
     description="Explore the core capabilities of Apache Doris"
-    link="/docs/features-architecture/feature-overview"
+    link="/why-doris/key-features"
 />
 
 <GettingStartedCard
     title="Release Notes"
     description="Learn about Apache Doris versions and release notes"
-    link="/docs/features-architecture/versioning"
+    link="/releases/all-release"
 />
 </div>


### PR DESCRIPTION
## Versions 

- [x] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [ ] Japanese candidate translation needed

## Docs Checklist

- [x] Checked by AI
- [x] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync
