### PR TITLE
docs: mark MySQL and PostgreSQL continuous load experimental

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -707,9 +707,9 @@
     "message": "更多",
     "description": "The label for category More in sidebar docs"
   },
-  "sidebar.docs.category.MySQL": {
-    "message": "MySQL",
-    "description": "The label for category MySQL in sidebar docs"
+  "sidebar.docs.category.MySQL (Experimental)": {
+    "message": "MySQL（实验性）",
+    "description": "The label for category MySQL (Experimental) in sidebar docs"
   },
   "sidebar.docs.category.Optimization Technology Principles": {
     "message": "优化技术原理",
@@ -723,9 +723,9 @@
     "message": "性能优化",
     "description": "The label for category Performance in sidebar docs"
   },
-  "sidebar.docs.category.PostgreSQL": {
-    "message": "PostgreSQL",
-    "description": "The label for category PostgreSQL in sidebar docs"
+  "sidebar.docs.category.PostgreSQL (Experimental)": {
+    "message": "PostgreSQL（实验性）",
+    "description": "The label for category PostgreSQL (Experimental) in sidebar docs"
   },
   "sidebar.docs.category.Query Performance": {
     "message": "查询性能",

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x.json
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x.json
@@ -707,9 +707,9 @@
     "message": "更多",
     "description": "The label for category More in sidebar docs"
   },
-  "sidebar.docs.category.MySQL": {
-    "message": "MySQL",
-    "description": "The label for category MySQL in sidebar docs"
+  "sidebar.docs.category.MySQL (Experimental)": {
+    "message": "MySQL（实验性）",
+    "description": "The label for category MySQL (Experimental) in sidebar docs"
   },
   "sidebar.docs.category.Optimization Technology Principles": {
     "message": "优化技术原理",
@@ -723,9 +723,9 @@
     "message": "性能优化",
     "description": "The label for category Performance in sidebar docs"
   },
-  "sidebar.docs.category.PostgreSQL": {
-    "message": "PostgreSQL",
-    "description": "The label for category PostgreSQL in sidebar docs"
+  "sidebar.docs.category.PostgreSQL (Experimental)": {
+    "message": "PostgreSQL（实验性）",
+    "description": "The label for category PostgreSQL (Experimental) in sidebar docs"
   },
   "sidebar.docs.category.Query Performance": {
     "message": "查询性能",

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -357,7 +357,7 @@ const sidebars: SidebarsConfig = {
                             items: [
                                 {
                                     type: 'category',
-                                    label: 'MySQL',
+                                    label: 'MySQL (Experimental)',
                                     items: [
                                         'data-operate/import/import-way/streaming-job/continuous-load-mysql-table',
                                         'data-operate/import/import-way/streaming-job/continuous-load-mysql-database',
@@ -374,7 +374,7 @@ const sidebars: SidebarsConfig = {
                                 },
                                 {
                                     type: 'category',
-                                    label: 'PostgreSQL',
+                                    label: 'PostgreSQL (Experimental)',
                                     items: [
                                         'data-operate/import/import-way/streaming-job/continuous-load-postgresql-table',
                                         'data-operate/import/import-way/streaming-job/continuous-load-postgresql-database',

--- a/versioned_sidebars/version-4.x-sidebars.json
+++ b/versioned_sidebars/version-4.x-sidebars.json
@@ -414,7 +414,7 @@
                   "items": [
                     {
                       "type": "category",
-                      "label": "MySQL",
+                      "label": "MySQL (Experimental)",
                       "items": [
                         "data-operate/import/import-way/streaming-job/continuous-load-mysql-table",
                         "data-operate/import/import-way/streaming-job/continuous-load-mysql-database",
@@ -431,7 +431,7 @@
                     },
                     {
                       "type": "category",
-                      "label": "PostgreSQL",
+                      "label": "PostgreSQL (Experimental)",
                       "items": [
                         "data-operate/import/import-way/streaming-job/continuous-load-postgresql-table",
                         "data-operate/import/import-way/streaming-job/continuous-load-postgresql-database",


### PR DESCRIPTION
## Summary

- Mark the MySQL and PostgreSQL categories under Continuous Load as experimental.
- Apply the labels to current and 4.x sidebars and their Chinese translations.
- Keep the parent Continuous Load category and S3 unchanged.

## Validation

- Parsed the changed JSON files and verified the expected current/4.x English and Chinese labels.