### PR TITLE
[doc] Add MySQL schema change synchronization documentation

### DIFF
--- a/docs/data-operate/import/import-way/streaming-job/continuous-load-overview.md
+++ b/docs/data-operate/import/import-way/streaming-job/continuous-load-overview.md
@@ -213,10 +213,9 @@ Only upstream tables **with a primary key** can be synchronized (both sync metho
 
 ### Schema Change (DDL)
 
-DDL sync applies **only to Auto Table Creation Sync**; SQL Mapping (TVF) does not sync any DDL.
+DDL sync applies **only to the [Auto Table Creation Sync method](#capability-comparison)**; the [SQL Mapping Sync method](#capability-comparison) does not sync any DDL.
 
-- **PostgreSQL** (supported since 4.1): only `ADD COLUMN` and `DROP COLUMN` are synced. **Column type changes, `RENAME COLUMN`, and constraint / index / partition changes are NOT synced** — apply them manually in Doris.
-- **MySQL**: upstream DDL is **not synced yet** — adjust the Doris table schema manually.
+- **MySQL and PostgreSQL**: only `ADD COLUMN` and `DROP COLUMN` are synced. **Column type changes, `RENAME COLUMN`, and primary key / constraint / index / partition changes are NOT synced** — apply them manually in Doris. For source-specific behavior and limitations, see [MySQL Schema Change Sync](./schema-change-mysql.md) and [PostgreSQL Schema Change Sync](./schema-change-postgresql.md).
 
 ## FAQ
 

--- a/docs/data-operate/import/import-way/streaming-job/schema-change-mysql.md
+++ b/docs/data-operate/import/import-way/streaming-job/schema-change-mysql.md
@@ -1,0 +1,42 @@
+---
+{
+    "title": "MySQL Schema Change Sync",
+    "language": "en",
+    "sidebar_label": "Schema Change Sync",
+    "description": "Describes the supported schema changes and synchronization behavior of MySQL CDC Auto Table Creation Sync.",
+    "keywords": [
+        "MySQL Schema Change",
+        "MySQL CDC",
+        "Auto Table Creation Sync",
+        "Continuous Load",
+        "Streaming Job",
+        "ADD COLUMN",
+        "DROP COLUMN"
+    ]
+}
+---
+
+<!-- Knowledge type: Concept -->
+<!-- Applicable scenario: Upstream schema changes during MySQL Auto Table Creation Sync -->
+
+MySQL Schema Change Sync automatically applies upstream MySQL column changes to Doris during continuous load. This capability applies only to [MySQL CDC with Auto Table Creation](./continuous-load-mysql-database.md). It is not supported by [MySQL CDC with SQL Mapping](./continuous-load-mysql-table.md).
+
+## Supported Schema Changes
+
+| MySQL operation | Doris behavior |
+| --- | --- |
+| `ADD COLUMN` | Adds a column with the same name and a type defined by the [MySQL Data Type Mapping](./data-type-mapping-mysql.md), and copies the column comment. DEFAULT and `NOT NULL` constraints are not copied, and historical rows are not backfilled. Subsequent rows use the actual values written by MySQL to the binlog. |
+| `DROP COLUMN` | Drops the column with the same name. |
+
+## Considerations
+
+- If an added column already exists or a dropped column does not exist, Doris skips the operation so that a retry does not fail the job.
+- Column positions specified by `FIRST` and `AFTER` are not synchronized to Doris. New columns are appended after the existing Doris columns.
+- `CHANGE COLUMN`, `MODIFY COLUMN`, `RENAME COLUMN`, DEFAULT changes, and `NULL` / `NOT NULL` constraint changes are not synchronized automatically. Before performing these operations, pause the continuous load job, change the Doris target table manually, verify that both schemas are compatible, and then resume the job.
+- Primary key, index, partition, table name, and other table-level schema changes are not synchronized automatically.
+
+## Related Docs
+
+- [MySQL CDC with Auto Table Creation](./continuous-load-mysql-database.md)
+- [MySQL Data Type Mapping](./data-type-mapping-mysql.md)
+- [Continuous Load Overview](./continuous-load-overview.md)

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/import-way/streaming-job/continuous-load-overview.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/import-way/streaming-job/continuous-load-overview.md
@@ -213,10 +213,9 @@ DROP JOB WHERE jobName = <job_name>;
 
 ### Schema Change（DDL）
 
-DDL 同步**仅适用于自动建表同步**；SQL 映射（TVF）不同步任何 DDL。
+DDL 同步**仅适用于[自动建表方式同步](#能力对比)**；[SQL 映射方式同步](#能力对比)不同步任何 DDL。
 
-- **PostgreSQL**（4.1 起支持）：仅 `ADD COLUMN` 和 `DROP COLUMN` 会同步。**列类型变更、`RENAME COLUMN`、约束 / 索引 / 分区变更不会同步**——需在 Doris 端手工处理。
-- **MySQL**：上游 DDL **暂不同步**——需手工调整 Doris 表结构。
+- **MySQL 和 PostgreSQL**：仅 `ADD COLUMN` 和 `DROP COLUMN` 会同步。**列类型变更、`RENAME COLUMN`、主键 / 约束 / 索引 / 分区变更不会同步**——需在 Doris 端手工处理。不同数据源的具体行为和限制详见 [MySQL Schema Change 同步](./schema-change-mysql.md)与 [PostgreSQL Schema Change 同步](./schema-change-postgresql.md)。
 
 ## FAQ
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/import-way/streaming-job/schema-change-mysql.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/import/import-way/streaming-job/schema-change-mysql.md
@@ -1,0 +1,42 @@
+---
+{
+    "title": "MySQL Schema Change 同步",
+    "language": "zh-CN",
+    "sidebar_label": "Schema Change 同步",
+    "description": "介绍 MySQL CDC 自动建表同步支持的 Schema Change 类型及其同步行为。",
+    "keywords": [
+        "MySQL Schema Change",
+        "MySQL CDC",
+        "自动建表同步",
+        "持续导入",
+        "Streaming Job",
+        "新增列",
+        "删除列"
+    ]
+}
+---
+
+<!-- 知识类型: 概念说明 -->
+<!-- 适用场景: MySQL 自动建表同步期间的上游表结构变更 -->
+
+MySQL Schema Change 同步用于在持续导入期间，将上游 MySQL 表的列结构变更自动应用到 Doris 目标表。该能力仅适用于 [MySQL CDC 自动建表同步](./continuous-load-mysql-database.md)，不适用于 [MySQL CDC SQL 映射同步](./continuous-load-mysql-table.md)。
+
+## 支持的 Schema Change
+
+| MySQL 操作 | Doris 行为 |
+| --- | --- |
+| `ADD COLUMN` | 新增同名列，类型遵循 [MySQL 数据类型映射](./data-type-mapping-mysql.md)，并复制列注释。不复制 DEFAULT 和 `NOT NULL` 约束，也不回填历史数据；后续数据使用 MySQL 写入 Binlog 的实际值。 |
+| `DROP COLUMN` | 删除同名列。 |
+
+## 注意事项
+
+- 如果新增列已存在或待删除列不存在，Doris 会跳过对应操作，避免作业因重试失败。
+- `FIRST` 和 `AFTER` 指定的列位置不会同步到 Doris。新增列会追加到 Doris 表的现有列之后。
+- `CHANGE COLUMN`、`MODIFY COLUMN`、`RENAME COLUMN`、DEFAULT 变更以及 `NULL` / `NOT NULL` 约束变更均不会自动同步。执行这些操作前，需要暂停持续导入作业并手动修改 Doris 目标表，确认两端结构兼容后再恢复作业。
+- 主键、索引、分区、表名以及其他表级结构变更不会自动同步。
+
+## 相关文档
+
+- [MySQL CDC 自动建表同步](./continuous-load-mysql-database.md)
+- [MySQL 数据类型映射](./data-type-mapping-mysql.md)
+- [持续导入概览](./continuous-load-overview.md)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -361,6 +361,7 @@ const sidebars: SidebarsConfig = {
                                     items: [
                                         'data-operate/import/import-way/streaming-job/continuous-load-mysql-table',
                                         'data-operate/import/import-way/streaming-job/continuous-load-mysql-database',
+                                        'data-operate/import/import-way/streaming-job/schema-change-mysql',
                                         'data-operate/import/import-way/streaming-job/data-type-mapping-mysql',
                                         {
                                             type: 'category',


### PR DESCRIPTION
## Proposed changes

- Add MySQL schema change synchronization documentation in English and Chinese.
- Add the new page to the current documentation sidebar.
- Update the continuous loading overview with unified schema change limitations and links.