### PR TITLE
feat: add Doris Operator 26.0.0 release

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/ecosystem/doris-operator.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/ecosystem/doris-operator.md
@@ -10,6 +10,43 @@
 
 本文按版本倒序列出 Doris Operator 的版本发布说明。
 
+## 26.0.0
+
+来源：[Release Notes 26.0.0](https://github.com/apache/doris-operator/issues/506)
+
+该版本改进了 DDC 生命周期管理与可靠性，包括计算组优雅停机滚动、可配置的就绪探针策略、DCR mTLS 支持以及更清晰的 DDC 健康状态上报。同时，该版本增强了 Helm chart 配置，并增加了多项校验和稳定性修复。
+
+### 功能与改进
+
+- DDC 计算组在滚动更新、缩容和删除操作中支持优雅停机滚动，提供 sentinel 兼容性开关，并在镜像不支持时回退到常规 StatefulSet 流程。[#502](https://github.com/apache/doris-operator/pull/502)
+- `DorisCluster` 和 `DorisDisaggregatedCluster` Pod 支持可配置的就绪探针策略。[#486](https://github.com/apache/doris-operator/pull/486)
+- DCR 支持 mTLS。[#483](https://github.com/apache/doris-operator/pull/483)
+- 将 DDC 计算组 Service 拆分为内部 headless Service 和外部 Service，使升级和流量切换更平滑。[#484](https://github.com/apache/doris-operator/pull/484)
+- Helm chart 增加组件级 Secret 支持。[#465](https://github.com/apache/doris-operator/pull/465)
+- Helm chart 暴露已部署 Pod 的 `serviceAccount` 配置。[#470](https://github.com/apache/doris-operator/pull/470)
+
+### Bug 修复
+
+- 修复 DDC MetaService 健康状态聚合，使 MetaService 降级能够反映到集群健康状态中。[#500](https://github.com/apache/doris-operator/pull/500)
+- 修复 `dcr.Annotations` 为 nil 时 `CompareConfigmapAndTriggerRestart` 中的 nil map panic。[#493](https://github.com/apache/doris-operator/pull/493)
+- 修复 FE endpoint 地址的 JSON tag，并重新生成 `DorisCluster` CRD。[#497](https://github.com/apache/doris-operator/pull/497)
+- 拒绝 `feSpec.replicas < feSpec.electionNumber` 的非法 `DorisDisaggregatedCluster` FE 配置。[#498](https://github.com/apache/doris-operator/pull/498)
+- 在应用不可变的 StatefulSet volume claim template 之前，拒绝 DDC 计算组存储模板变更。[#496](https://github.com/apache/doris-operator/pull/496)
+- 修复 `DorisDisaggregatedCluster` BE Helm 配置中的默认 `storage_root_path`。[#477](https://github.com/apache/doris-operator/pull/477)
+
+### 可靠性
+
+- 拒绝在 `DorisCluster` 和 `DorisDisaggregatedCluster` webhook 中使用内置 `admin` 账户作为 Operator 管理用户。[#499](https://github.com/apache/doris-operator/pull/499)
+- 增加针对 Go 格式化、vet/lint 检查、Operator 构建以及生成的 manifest 和 artifact 的 Pull Request 检查。[#501](https://github.com/apache/doris-operator/pull/501)
+
+### 致谢
+
+- [ecniiv](https://github.com/ecniiv)
+- [jonasbrami](https://github.com/jonasbrami)
+- [catpineapple](https://github.com/catpineapple)
+- [JinVei](https://github.com/JinVei)
+- [Al-assad](https://github.com/Al-assad)
+
 ## 25.8.0
 
 来源：[Release Notes 25.8.0](https://github.com/apache/doris-operator/issues/472)

--- a/releasenotes/ecosystem/doris-operator.md
+++ b/releasenotes/ecosystem/doris-operator.md
@@ -10,6 +10,43 @@
 
 This document lists Doris Operator release notes in reverse chronological order.
 
+## 26.0.0
+
+Source: [Release Notes 26.0.0](https://github.com/apache/doris-operator/issues/506)
+
+This version improves DDC lifecycle management and reliability, including graceful shutdown rollout for compute groups, configurable readiness probe policies, DCR mTLS support, and clearer DDC health reporting. It also enhances Helm chart configuration and adds several validation and stability fixes.
+
+### Features and Improvements
+
+- Added graceful shutdown rollout for DDC compute groups during rolling updates, scale-down, and delete operations, with a sentinel compatibility gate that falls back to the normal StatefulSet flow for unsupported images. [#502](https://github.com/apache/doris-operator/pull/502)
+- Supported a configurable readiness probe policy for `DorisCluster` and `DorisDisaggregatedCluster` pods. [#486](https://github.com/apache/doris-operator/pull/486)
+- Supported mTLS for DCR. [#483](https://github.com/apache/doris-operator/pull/483)
+- Split the DDC compute group service into an internal headless service and an external service for smoother upgrades and traffic switching. [#484](https://github.com/apache/doris-operator/pull/484)
+- Added component-level secret support to the Helm chart. [#465](https://github.com/apache/doris-operator/pull/465)
+- Exposed `serviceAccount` configuration for deployed pods in the Helm chart. [#470](https://github.com/apache/doris-operator/pull/470)
+
+### Bug Fixes
+
+- Fixed DDC MetaService health aggregation so MetaService degradation is reflected in the cluster health status. [#500](https://github.com/apache/doris-operator/pull/500)
+- Fixed a nil map panic in `CompareConfigmapAndTriggerRestart` when `dcr.Annotations` is nil. [#493](https://github.com/apache/doris-operator/pull/493)
+- Fixed the FE endpoint address JSON tag and regenerated `DorisCluster` CRDs. [#497](https://github.com/apache/doris-operator/pull/497)
+- Rejected invalid `DorisDisaggregatedCluster` FE specs where `feSpec.replicas < feSpec.electionNumber`. [#498](https://github.com/apache/doris-operator/pull/498)
+- Rejected DDC compute group storage template changes before applying immutable StatefulSet volume claim templates. [#496](https://github.com/apache/doris-operator/pull/496)
+- Fixed the default `storage_root_path` in the `DorisDisaggregatedCluster` BE Helm config. [#477](https://github.com/apache/doris-operator/pull/477)
+
+### Reliability
+
+- Rejected using the built-in `admin` account as the operator management user in the `DorisCluster` and `DorisDisaggregatedCluster` webhooks. [#499](https://github.com/apache/doris-operator/pull/499)
+- Added pull request checks for Go formatting, vet/lint checks, operator build, and generated manifests and artifacts. [#501](https://github.com/apache/doris-operator/pull/501)
+
+### Thanks
+
+- [ecniiv](https://github.com/ecniiv)
+- [jonasbrami](https://github.com/jonasbrami)
+- [catpineapple](https://github.com/catpineapple)
+- [JinVei](https://github.com/JinVei)
+- [Al-assad](https://github.com/Al-assad)
+
 ## 25.8.0
 
 Source: [Release Notes 25.8.0](https://github.com/apache/doris-operator/issues/472)

--- a/src/constant/download.data.ts
+++ b/src/constant/download.data.ts
@@ -2766,6 +2766,7 @@ const SPARK_SAME_SOURCE_2600 =
     'https://downloads.apache.org/doris/spark-connector/26.0.0/apache-doris-spark-connector-26.0.0-src.tgz';
 
 const DORIS_OPERATOR_SOURCE_VERSIONS = [
+    '26.0.0',
     '25.8.0',
     '25.7.0',
     '25.6.0',
@@ -2784,6 +2785,7 @@ const DORIS_OPERATOR_SOURCE_VERSIONS = [
 ];
 
 const DORIS_OPERATOR_BINARY_VERSIONS = [
+    '26.0.0',
     '25.8.0',
     '25.7.0',
     '25.6.0',


### PR DESCRIPTION
## What this PR does

Adds the **Doris Operator 26.0.0** release to the website.

### Release notes (both locales)

- `releasenotes/ecosystem/doris-operator.md`
- `i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/ecosystem/doris-operator.md`

Content is sourced from apache/doris-operator issue [#506](https://github.com/apache/doris-operator/issues/506) ("Release Notes 26.0.0"), normalized to this page's established house style (past tense, code spans, `#NNN` → `/pull/NNN` links, headings "Features and Improvements" / "Reliability"), matching how prior operator releases are rendered. English and zh-CN are structurally aligned: 4 subsections, 19 bullets, identical issue-reference sequence and acknowledgments.

### Download data

- `src/constant/download.data.ts`: registers `26.0.0` at the top of `DORIS_OPERATOR_SOURCE_VERSIONS` and `DORIS_OPERATOR_BINARY_VERSIONS` (newest-first).

### Artifacts verified

- Source: `apache-doris-operator-26.0.0-src.tar.gz` (+ `.asc`, `.sha512`) at `downloads.apache.org/doris/doris-operator/26.0.0/`
- Image: `apache/doris:operator-26.0.0` on Docker Hub (amd64 + arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
