### PR TITLE
[docs](variant) make reference page the navigation root

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1263,14 +1263,14 @@ const sidebars: SidebarsConfig = {
                                             label: 'VARIANT',
                                             link: {
                                                 type: 'doc',
-                                                id: 'sql-manual/basic-element/sql-data-types/semi-structured/variant-workload-guide',
+                                                id: 'sql-manual/basic-element/sql-data-types/semi-structured/VARIANT',
                                             },
                                             collapsed: true,
                                             items: [
                                                 {
                                                     type: 'doc',
-                                                    id: 'sql-manual/basic-element/sql-data-types/semi-structured/VARIANT',
-                                                    label: 'VARIANT Reference',
+                                                    id: 'sql-manual/basic-element/sql-data-types/semi-structured/variant-workload-guide',
+                                                    label: 'VARIANT Internal',
                                                 },
                                             ],
                                         },

--- a/versioned_sidebars/version-3.x-sidebars.json
+++ b/versioned_sidebars/version-3.x-sidebars.json
@@ -1116,14 +1116,14 @@
                                             "label": "VARIANT",
                                             "link": {
                                                 "type": "doc",
-                                                "id": "sql-manual/basic-element/sql-data-types/semi-structured/variant-workload-guide"
+                                                "id": "sql-manual/basic-element/sql-data-types/semi-structured/VARIANT"
                                             },
                                             "collapsed": false,
                                             "items": [
                                                 {
                                                     "type": "doc",
-                                                    "id": "sql-manual/basic-element/sql-data-types/semi-structured/VARIANT",
-                                                    "label": "VARIANT Reference"
+                                                    "id": "sql-manual/basic-element/sql-data-types/semi-structured/variant-workload-guide",
+                                                    "label": "VARIANT Internal"
                                                 }
                                             ]
                                         }

--- a/versioned_sidebars/version-4.x-sidebars.json
+++ b/versioned_sidebars/version-4.x-sidebars.json
@@ -1439,14 +1439,14 @@
                           "label": "VARIANT",
                           "link": {
                             "type": "doc",
-                            "id": "sql-manual/basic-element/sql-data-types/semi-structured/variant-workload-guide"
+                            "id": "sql-manual/basic-element/sql-data-types/semi-structured/VARIANT"
                           },
                           "collapsed": true,
                           "items": [
                             {
                               "type": "doc",
-                              "id": "sql-manual/basic-element/sql-data-types/semi-structured/VARIANT",
-                              "label": "VARIANT Reference"
+                              "id": "sql-manual/basic-element/sql-data-types/semi-structured/variant-workload-guide",
+                              "label": "VARIANT Internal"
                             }
                           ]
                         }


### PR DESCRIPTION
## Summary

- make the VARIANT reference page (`semi-structured/VARIANT`) the `VARIANT` navigation root
- move the workload/tuning guide (`variant-workload-guide`) under it as `VARIANT Internal`
- apply the same hierarchy to current, 4.x, and 3.x without changing either document route

## Validation

- `git diff --check origin/master...HEAD`
- parsed the 4.x and 3.x versioned sidebar JSON files
- asserted that each VARIANT root links to the reference page and its only child links to the workload guide

## Versions

- [x] dev
- [x] 4.x
- [x] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [ ] Chinese
- [x] English
- [ ] Japanese candidate translation needed

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

The hierarchy is defined in the shared sidebar configuration; no localized document content or routes changed.