### PR TITLE
add docs for aggregation function uniq_theta

### DIFF
--- a/docs/sql-manual/sql-functions/aggregate-functions/uniq-theta.md
+++ b/docs/sql-manual/sql-functions/aggregate-functions/uniq-theta.md
@@ -1,0 +1,168 @@
+---
+{
+    "title": "UNIQ_THETA",
+    "language": "en",
+    "description": "Returns the approximate number of distinct non-NULL elements, implemented with the Apache DataSketches Theta Sketch."
+}
+---
+
+## Description
+
+Returns the approximate number of distinct non-NULL elements.
+
+This function is implemented with the [Apache DataSketches](https://datasketches.apache.org/docs/Theta/ThetaSketches.html) Theta Sketch. Compared with the HyperLogLog based [APPROX_COUNT_DISTINCT](./approx-count-distinct), the Theta Sketch produces a mergeable sketch state that also supports set operations (union / intersect / difference), which makes it suitable for pre-aggregating detailed data into sketches that are later combined across partitions, dimensions, or time windows. It uses the KMV algorithm and, with the default 4096 nominal entries, has a relative error of 3.125% (95% confidence); the result is exact for small cardinalities.
+
+## Syntax
+
+```sql
+UNIQ_THETA(<expr>)
+```
+
+## Parameters
+
+| Parameters | Description |
+| -- | -- |
+| `<expr>` | The expression to get the value. Supported types are String, Date, DateTime, Timestamptz, IPv4, IPv6, TinyInt, Bool, SmallInt, Integer, BigInt, LargeInt, Float, Double, Decimal. |
+
+## Return Value
+
+Returns a value of type BIGINT.
+
+## Example
+
+```sql
+-- setup
+create table t1(
+        k1 int,
+        k_string varchar(100),
+        k_tinyint tinyint
+) distributed by hash (k1) buckets 1
+properties ("replication_num"="1");
+insert into t1 values
+    (1, 'apple', 10),
+    (1, 'banana', 20),
+    (1, 'apple', 10),
+    (2, 'orange', 30),
+    (2, 'orange', 40),
+    (2, 'grape', 50),
+    (3, null, null);
+```
+
+```sql
+select uniq_theta(k_string) from t1;
+```
+
+String type: Calculate the approximate distinct count of all k_string values, NULL values are not included in the calculation.
+
+```text
++----------------------+
+| uniq_theta(k_string) |
++----------------------+
+|                    4 |
++----------------------+
+```
+
+```sql
+select uniq_theta(k_tinyint) from t1;
+```
+
+TinyInt type: Calculate the approximate distinct count of all k_tinyint values.
+
+```text
++-----------------------+
+| uniq_theta(k_tinyint) |
++-----------------------+
+|                     5 |
++-----------------------+
+```
+
+```sql
+select k1, uniq_theta(k_string) from t1 group by k1 order by k1;
+```
+
+Group by k1 and calculate the approximate distinct count of k_string in each group. When all records in the group are NULL, returns 0.
+
+```text
++------+----------------------+
+| k1   | uniq_theta(k_string) |
++------+----------------------+
+|    1 |                    2 |
+|    2 |                    2 |
+|    3 |                    0 |
++------+----------------------+
+```
+
+```sql
+select uniq_theta(k_string) from t1 where k1 = 999;
+```
+
+When the query result is empty, returns 0.
+
+```text
++----------------------+
+| uniq_theta(k_string) |
++----------------------+
+|                    0 |
++----------------------+
+```
+
+### Mergeable sketch state
+
+Because `uniq_theta` is registered as a normal aggregate, the generic `agg_state` combinators `uniq_theta_state` / `uniq_theta_merge` / `uniq_theta_union` are available automatically. This lets you pre-compute sketches and later merge or union them without rescanning the raw data.
+
+```sql
+set enable_agg_state = true;
+
+-- uniq_theta_merge(uniq_theta_state(...)) equals a direct uniq_theta
+select uniq_theta_merge(uniq_theta_state(k_string)) from t1;
+```
+
+```text
++----------------------------------------------+
+| uniq_theta_merge(uniq_theta_state(k_string)) |
++----------------------------------------------+
+|                                            4 |
++----------------------------------------------+
+```
+
+```sql
+-- persist per-key sketches into an aggregate table, then merge/union later
+create table theta_agg(
+        k1 int,
+        s agg_state<uniq_theta(varchar(100))> generic
+)
+aggregate key(k1)
+distributed by hash(k1) buckets 1
+properties ("replication_num"="1");
+
+insert into theta_agg values
+    (1, uniq_theta_state(cast('apple' as varchar(100)))),
+    (1, uniq_theta_state(cast('banana' as varchar(100)))),
+    (2, uniq_theta_state(cast('orange' as varchar(100))));
+
+-- per-key cardinality
+select k1, uniq_theta_merge(s) from theta_agg group by k1 order by k1;
+```
+
+```text
++------+---------------------+
+| k1   | uniq_theta_merge(s) |
++------+---------------------+
+|    1 |                   2 |
+|    2 |                   1 |
++------+---------------------+
+```
+
+```sql
+-- union across keys, then merge for the global cardinality
+select uniq_theta_merge(u) from
+    (select uniq_theta_union(s) as u from theta_agg group by k1) t;
+```
+
+```text
++---------------------+
+| uniq_theta_merge(u) |
++---------------------+
+|                   3 |
++---------------------+
+```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/aggregate-functions/uniq-theta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/aggregate-functions/uniq-theta.md
@@ -1,0 +1,168 @@
+---
+{
+    "title": "UNIQ_THETA",
+    "language": "zh-CN",
+    "description": "返回非 NULL 的不同元素的近似数量，基于 Apache DataSketches Theta Sketch 实现。"
+}
+---
+
+## 描述
+
+返回非 NULL 的不同元素的近似数量。
+
+该函数基于 [Apache DataSketches](https://datasketches.apache.org/docs/Theta/ThetaSketches.html) 的 Theta Sketch 实现。与基于 HyperLogLog 的 [APPROX_COUNT_DISTINCT](./approx-count-distinct) 相比，Theta Sketch 产生的中间状态是可合并的，并且支持集合运算（并集 / 交集 / 差集），因此适合把明细数据预聚合为 sketch，之后再跨分区、跨维度或跨时间窗口合并。它采用 KMV 算法，在默认 4096 nominal entries 下相对误差为 3.125%（95% 置信度）；在小基数时结果是精确的。
+
+## 语法
+
+```sql
+UNIQ_THETA(<expr>)
+```
+
+## 参数说明
+
+| 参数 | 说明 |
+| -- | -- |
+| `<expr>` | 用于计算的表达式。支持的类型包括 String、Date、DateTime、Timestamptz、IPv4、IPv6、TinyInt、Bool、SmallInt、Integer、BigInt、LargeInt、Float、Double、Decimal。|
+
+## 返回值
+
+返回 BIGINT 类型的值。
+
+## 举例
+
+```sql
+-- 建表并写入数据
+create table t1(
+        k1 int,
+        k_string varchar(100),
+        k_tinyint tinyint
+) distributed by hash (k1) buckets 1
+properties ("replication_num"="1");
+insert into t1 values
+    (1, 'apple', 10),
+    (1, 'banana', 20),
+    (1, 'apple', 10),
+    (2, 'orange', 30),
+    (2, 'orange', 40),
+    (2, 'grape', 50),
+    (3, null, null);
+```
+
+```sql
+select uniq_theta(k_string) from t1;
+```
+
+String 类型：计算所有 k_string 值的近似去重数量，NULL 值不计入。
+
+```text
++----------------------+
+| uniq_theta(k_string) |
++----------------------+
+|                    4 |
++----------------------+
+```
+
+```sql
+select uniq_theta(k_tinyint) from t1;
+```
+
+TinyInt 类型：计算所有 k_tinyint 值的近似去重数量。
+
+```text
++-----------------------+
+| uniq_theta(k_tinyint) |
++-----------------------+
+|                     5 |
++-----------------------+
+```
+
+```sql
+select k1, uniq_theta(k_string) from t1 group by k1 order by k1;
+```
+
+按 k1 分组，计算每组内 k_string 的近似去重数量。当组内记录全为 NULL 时返回 0。
+
+```text
++------+----------------------+
+| k1   | uniq_theta(k_string) |
++------+----------------------+
+|    1 |                    2 |
+|    2 |                    2 |
+|    3 |                    0 |
++------+----------------------+
+```
+
+```sql
+select uniq_theta(k_string) from t1 where k1 = 999;
+```
+
+当查询结果为空时返回 0。
+
+```text
++----------------------+
+| uniq_theta(k_string) |
++----------------------+
+|                    0 |
++----------------------+
+```
+
+### 可合并的 sketch 中间状态
+
+由于 `uniq_theta` 是作为普通聚合函数注册的，通用的 `agg_state` 组合子 `uniq_theta_state` / `uniq_theta_merge` / `uniq_theta_union` 会自动可用。这样即可预计算 sketch，之后再合并或求并集，而无需重新扫描明细数据。
+
+```sql
+set enable_agg_state = true;
+
+-- uniq_theta_merge(uniq_theta_state(...)) 与直接 uniq_theta 结果一致
+select uniq_theta_merge(uniq_theta_state(k_string)) from t1;
+```
+
+```text
++----------------------------------------------+
+| uniq_theta_merge(uniq_theta_state(k_string)) |
++----------------------------------------------+
+|                                            4 |
++----------------------------------------------+
+```
+
+```sql
+-- 将每个 key 的 sketch 持久化到聚合表，之后再合并 / 求并集
+create table theta_agg(
+        k1 int,
+        s agg_state<uniq_theta(varchar(100))> generic
+)
+aggregate key(k1)
+distributed by hash(k1) buckets 1
+properties ("replication_num"="1");
+
+insert into theta_agg values
+    (1, uniq_theta_state(cast('apple' as varchar(100)))),
+    (1, uniq_theta_state(cast('banana' as varchar(100)))),
+    (2, uniq_theta_state(cast('orange' as varchar(100))));
+
+-- 每个 key 的基数
+select k1, uniq_theta_merge(s) from theta_agg group by k1 order by k1;
+```
+
+```text
++------+---------------------+
+| k1   | uniq_theta_merge(s) |
++------+---------------------+
+|    1 |                   2 |
+|    2 |                   1 |
++------+---------------------+
+```
+
+```sql
+-- 跨 key 求并集，再 merge 得到全局基数
+select uniq_theta_merge(u) from
+    (select uniq_theta_union(s) as u from theta_agg group by k1) t;
+```
+
+```text
++---------------------+
+| uniq_theta_merge(u) |
++---------------------+
+|                   3 |
++---------------------+
+```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/aggregate-functions/uniq-theta.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/aggregate-functions/uniq-theta.md
@@ -1,0 +1,168 @@
+---
+{
+    "title": "UNIQ_THETA",
+    "language": "zh-CN",
+    "description": "返回非 NULL 的不同元素的近似数量，基于 Apache DataSketches Theta Sketch 实现。"
+}
+---
+
+## 描述
+
+返回非 NULL 的不同元素的近似数量。
+
+该函数基于 [Apache DataSketches](https://datasketches.apache.org/docs/Theta/ThetaSketches.html) 的 Theta Sketch 实现。与基于 HyperLogLog 的 [APPROX_COUNT_DISTINCT](./approx-count-distinct) 相比，Theta Sketch 产生的中间状态是可合并的，并且支持集合运算（并集 / 交集 / 差集），因此适合把明细数据预聚合为 sketch，之后再跨分区、跨维度或跨时间窗口合并。它采用 KMV 算法，在默认 4096 nominal entries 下相对误差为 3.125%（95% 置信度）；在小基数时结果是精确的。
+
+## 语法
+
+```sql
+UNIQ_THETA(<expr>)
+```
+
+## 参数说明
+
+| 参数 | 说明 |
+| -- | -- |
+| `<expr>` | 用于计算的表达式。支持的类型包括 String、Date、DateTime、Timestamptz、IPv4、IPv6、TinyInt、Bool、SmallInt、Integer、BigInt、LargeInt、Float、Double、Decimal。|
+
+## 返回值
+
+返回 BIGINT 类型的值。
+
+## 举例
+
+```sql
+-- 建表并写入数据
+create table t1(
+        k1 int,
+        k_string varchar(100),
+        k_tinyint tinyint
+) distributed by hash (k1) buckets 1
+properties ("replication_num"="1");
+insert into t1 values
+    (1, 'apple', 10),
+    (1, 'banana', 20),
+    (1, 'apple', 10),
+    (2, 'orange', 30),
+    (2, 'orange', 40),
+    (2, 'grape', 50),
+    (3, null, null);
+```
+
+```sql
+select uniq_theta(k_string) from t1;
+```
+
+String 类型：计算所有 k_string 值的近似去重数量，NULL 值不计入。
+
+```text
++----------------------+
+| uniq_theta(k_string) |
++----------------------+
+|                    4 |
++----------------------+
+```
+
+```sql
+select uniq_theta(k_tinyint) from t1;
+```
+
+TinyInt 类型：计算所有 k_tinyint 值的近似去重数量。
+
+```text
++-----------------------+
+| uniq_theta(k_tinyint) |
++-----------------------+
+|                     5 |
++-----------------------+
+```
+
+```sql
+select k1, uniq_theta(k_string) from t1 group by k1 order by k1;
+```
+
+按 k1 分组，计算每组内 k_string 的近似去重数量。当组内记录全为 NULL 时返回 0。
+
+```text
++------+----------------------+
+| k1   | uniq_theta(k_string) |
++------+----------------------+
+|    1 |                    2 |
+|    2 |                    2 |
+|    3 |                    0 |
++------+----------------------+
+```
+
+```sql
+select uniq_theta(k_string) from t1 where k1 = 999;
+```
+
+当查询结果为空时返回 0。
+
+```text
++----------------------+
+| uniq_theta(k_string) |
++----------------------+
+|                    0 |
++----------------------+
+```
+
+### 可合并的 sketch 中间状态
+
+由于 `uniq_theta` 是作为普通聚合函数注册的，通用的 `agg_state` 组合子 `uniq_theta_state` / `uniq_theta_merge` / `uniq_theta_union` 会自动可用。这样即可预计算 sketch，之后再合并或求并集，而无需重新扫描明细数据。
+
+```sql
+set enable_agg_state = true;
+
+-- uniq_theta_merge(uniq_theta_state(...)) 与直接 uniq_theta 结果一致
+select uniq_theta_merge(uniq_theta_state(k_string)) from t1;
+```
+
+```text
++----------------------------------------------+
+| uniq_theta_merge(uniq_theta_state(k_string)) |
++----------------------------------------------+
+|                                            4 |
++----------------------------------------------+
+```
+
+```sql
+-- 将每个 key 的 sketch 持久化到聚合表，之后再合并 / 求并集
+create table theta_agg(
+        k1 int,
+        s agg_state<uniq_theta(varchar(100))> generic
+)
+aggregate key(k1)
+distributed by hash(k1) buckets 1
+properties ("replication_num"="1");
+
+insert into theta_agg values
+    (1, uniq_theta_state(cast('apple' as varchar(100)))),
+    (1, uniq_theta_state(cast('banana' as varchar(100)))),
+    (2, uniq_theta_state(cast('orange' as varchar(100))));
+
+-- 每个 key 的基数
+select k1, uniq_theta_merge(s) from theta_agg group by k1 order by k1;
+```
+
+```text
++------+---------------------+
+| k1   | uniq_theta_merge(s) |
++------+---------------------+
+|    1 |                   2 |
+|    2 |                   1 |
++------+---------------------+
+```
+
+```sql
+-- 跨 key 求并集，再 merge 得到全局基数
+select uniq_theta_merge(u) from
+    (select uniq_theta_union(s) as u from theta_agg group by k1) t;
+```
+
+```text
++---------------------+
+| uniq_theta_merge(u) |
++---------------------+
+|                   3 |
++---------------------+
+```

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -2014,6 +2014,7 @@ const sidebars: SidebarsConfig = {
                                 'sql-manual/sql-functions/aggregate-functions/ai-agg',
                                 'sql-manual/sql-functions/aggregate-functions/any-value',
                                 'sql-manual/sql-functions/aggregate-functions/approx-count-distinct',
+                                'sql-manual/sql-functions/aggregate-functions/uniq-theta',
                                 'sql-manual/sql-functions/aggregate-functions/array-agg',
                                 'sql-manual/sql-functions/aggregate-functions/avg',
                                 'sql-manual/sql-functions/aggregate-functions/avg-map',

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/uniq-theta.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/aggregate-functions/uniq-theta.md
@@ -1,0 +1,168 @@
+---
+{
+    "title": "UNIQ_THETA",
+    "language": "en",
+    "description": "Returns the approximate number of distinct non-NULL elements, implemented with the Apache DataSketches Theta Sketch."
+}
+---
+
+## Description
+
+Returns the approximate number of distinct non-NULL elements.
+
+This function is implemented with the [Apache DataSketches](https://datasketches.apache.org/docs/Theta/ThetaSketches.html) Theta Sketch. Compared with the HyperLogLog based [APPROX_COUNT_DISTINCT](./approx-count-distinct), the Theta Sketch produces a mergeable sketch state that also supports set operations (union / intersect / difference), which makes it suitable for pre-aggregating detailed data into sketches that are later combined across partitions, dimensions, or time windows. It uses the KMV algorithm and, with the default 4096 nominal entries, has a relative error of 3.125% (95% confidence); the result is exact for small cardinalities.
+
+## Syntax
+
+```sql
+UNIQ_THETA(<expr>)
+```
+
+## Parameters
+
+| Parameters | Description |
+| -- | -- |
+| `<expr>` | The expression to get the value. Supported types are String, Date, DateTime, Timestamptz, IPv4, IPv6, TinyInt, Bool, SmallInt, Integer, BigInt, LargeInt, Float, Double, Decimal. |
+
+## Return Value
+
+Returns a value of type BIGINT.
+
+## Example
+
+```sql
+-- setup
+create table t1(
+        k1 int,
+        k_string varchar(100),
+        k_tinyint tinyint
+) distributed by hash (k1) buckets 1
+properties ("replication_num"="1");
+insert into t1 values
+    (1, 'apple', 10),
+    (1, 'banana', 20),
+    (1, 'apple', 10),
+    (2, 'orange', 30),
+    (2, 'orange', 40),
+    (2, 'grape', 50),
+    (3, null, null);
+```
+
+```sql
+select uniq_theta(k_string) from t1;
+```
+
+String type: Calculate the approximate distinct count of all k_string values, NULL values are not included in the calculation.
+
+```text
++----------------------+
+| uniq_theta(k_string) |
++----------------------+
+|                    4 |
++----------------------+
+```
+
+```sql
+select uniq_theta(k_tinyint) from t1;
+```
+
+TinyInt type: Calculate the approximate distinct count of all k_tinyint values.
+
+```text
++-----------------------+
+| uniq_theta(k_tinyint) |
++-----------------------+
+|                     5 |
++-----------------------+
+```
+
+```sql
+select k1, uniq_theta(k_string) from t1 group by k1 order by k1;
+```
+
+Group by k1 and calculate the approximate distinct count of k_string in each group. When all records in the group are NULL, returns 0.
+
+```text
++------+----------------------+
+| k1   | uniq_theta(k_string) |
++------+----------------------+
+|    1 |                    2 |
+|    2 |                    2 |
+|    3 |                    0 |
++------+----------------------+
+```
+
+```sql
+select uniq_theta(k_string) from t1 where k1 = 999;
+```
+
+When the query result is empty, returns 0.
+
+```text
++----------------------+
+| uniq_theta(k_string) |
++----------------------+
+|                    0 |
++----------------------+
+```
+
+### Mergeable sketch state
+
+Because `uniq_theta` is registered as a normal aggregate, the generic `agg_state` combinators `uniq_theta_state` / `uniq_theta_merge` / `uniq_theta_union` are available automatically. This lets you pre-compute sketches and later merge or union them without rescanning the raw data.
+
+```sql
+set enable_agg_state = true;
+
+-- uniq_theta_merge(uniq_theta_state(...)) equals a direct uniq_theta
+select uniq_theta_merge(uniq_theta_state(k_string)) from t1;
+```
+
+```text
++----------------------------------------------+
+| uniq_theta_merge(uniq_theta_state(k_string)) |
++----------------------------------------------+
+|                                            4 |
++----------------------------------------------+
+```
+
+```sql
+-- persist per-key sketches into an aggregate table, then merge/union later
+create table theta_agg(
+        k1 int,
+        s agg_state<uniq_theta(varchar(100))> generic
+)
+aggregate key(k1)
+distributed by hash(k1) buckets 1
+properties ("replication_num"="1");
+
+insert into theta_agg values
+    (1, uniq_theta_state(cast('apple' as varchar(100)))),
+    (1, uniq_theta_state(cast('banana' as varchar(100)))),
+    (2, uniq_theta_state(cast('orange' as varchar(100))));
+
+-- per-key cardinality
+select k1, uniq_theta_merge(s) from theta_agg group by k1 order by k1;
+```
+
+```text
++------+---------------------+
+| k1   | uniq_theta_merge(s) |
++------+---------------------+
+|    1 |                   2 |
+|    2 |                   1 |
++------+---------------------+
+```
+
+```sql
+-- union across keys, then merge for the global cardinality
+select uniq_theta_merge(u) from
+    (select uniq_theta_union(s) as u from theta_agg group by k1) t;
+```
+
+```text
++---------------------+
+| uniq_theta_merge(u) |
++---------------------+
+|                   3 |
++---------------------+
+```

--- a/versioned_sidebars/version-4.x-sidebars.json
+++ b/versioned_sidebars/version-4.x-sidebars.json
@@ -2188,6 +2188,7 @@
                     "sql-manual/sql-functions/aggregate-functions/ai-agg",
                     "sql-manual/sql-functions/aggregate-functions/any-value",
                     "sql-manual/sql-functions/aggregate-functions/approx-count-distinct",
+                    "sql-manual/sql-functions/aggregate-functions/uniq-theta",
                     "sql-manual/sql-functions/aggregate-functions/array-agg",
                     "sql-manual/sql-functions/aggregate-functions/avg",
                     "sql-manual/sql-functions/aggregate-functions/avg-map",


### PR DESCRIPTION
Add documentation for the `uniq_theta` aggregate function (theta-sketch based approximate distinct count), following the pattern of #3711 (`datasketches_hll_union_agg`).

Corresponds to the BE/FE implementation PR that adds `uniq_theta` to Apache Doris.

Includes:
- EN + ZH docs for both `current` and `version-4.x`
- Sidebar entries in `sidebars.ts` and `versioned_sidebars/version-4.x-sidebars.json`

The docs cover the basic aggregate usage across types, NULL handling, GROUP BY, empty-result behavior, and the auto-derived `uniq_theta_state` / `uniq_theta_merge` / `uniq_theta_union` agg_state combinators.