### PR TITLE
[docs] update hive-catalog docs across locales and versions

### DIFF
--- a/docs/lakehouse/catalogs/hive-catalog.mdx
+++ b/docs/lakehouse/catalogs/hive-catalog.mdx
@@ -785,7 +785,7 @@ For partitioned tables, data will automatically be written to the corresponding 
 
 ### INSERT INTO
 
-The INSERT operation appends data to the target table. Specifying a partition for writing is currently not supported.
+The INSERT operation appends data to the target table.
 
 ```sql
 INSERT INTO hive_tbl VALUES (val1, val2, val3, val4);
@@ -795,13 +795,45 @@ INSERT INTO hive_tbl(col1, col2) VALUES (val1, val2);
 INSERT INTO hive_tbl(col1, col2, partition_col1, partition_col2) VALUES (1, 2, "beijing", "2023-12-12");
 ```
 
+Since version 4.2.0, support for writing data to static partition(or hybrid):
+
+```sql
+-- Full Static Partition
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
+```
+
 ### INSERT OVERWRITE
 
-INSERT OVERWRITE completely replaces the existing data in the table with new data. Specifying a partition for writing is currently not supported.
+INSERT OVERWRITE completely replaces the existing data in the table with new data.
 
 ```sql
 INSERT OVERWRITE TABLE hive_tbl VALUES (val1, val2, val3, val4);
 INSERT OVERWRITE TABLE hive_ctl.hive_db.hive_tbl(col1, col2) SELECT col1, col2 FROM internal.db1.tbl1;
+```
+
+Since version 4.2.0, support for writing data to static partition(or hybrid):
+
+```sql
+-- Full Static Partition
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
 ```
 
 The semantics of INSERT OVERWRITE are consistent with Hive, with the following behaviors:
@@ -810,7 +842,7 @@ The semantics of INSERT OVERWRITE are consistent with Hive, with the following b
 
 * If the target table is non-partitioned and the source table is empty, the target table will be cleared.
 
-* Since specifying a partition for writing is not supported, INSERT OVERWRITE automatically handles the relevant partitions in the target table based on the source table values. If the target table is partitioned, only the affected partitions will be overwritten; unaffected partitions remain unchanged.
+* Since version 4.2.0, specifying static partitions for writing is supported, as well as hybrid mode combining static and dynamic partitions. However, even when static partitions are specified, if the source query results are empty, the specified partitions will not be cleared.
 
 ### CTAS
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/hive-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/hive-catalog.mdx
@@ -796,23 +796,55 @@ Hive Transactional 表是 Hive 中支持 ACID 语义的表。详情可见 [Hive 
 
 ### INSERT INTO
 
-INSERT 操作会将数据以追加的方式写入到目标表中。当前不支持指定分区写入。
+INSERT 操作会将数据以追加的方式写入到目标表中。
 
 ```sql
-INSERT INTO hive_tbl values (val1, val2, val3, val4);
+INSERT INTO hive_tbl VALUES (val1, val2, val3, val4);
 INSERT INTO hive_ctl.hive_db.hive_tbl SELECT col1, col2 FROM internal.db1.tbl1;
 
-INSERT INTO hive_tbl(col1, col2) values (val1, val2);
-INSERT INTO hive_tbl(col1, col2, partition_col1, partition_col2) values (1, 2, "beijing", "2023-12-12");
+INSERT INTO hive_tbl(col1, col2) VALUES (val1, val2);
+INSERT INTO hive_tbl(col1, col2, partition_col1, partition_col2) VALUES (1, 2, "beijing", "2023-12-12");
+```
+
+自 4.2.0 版本，支持写入数据到静态分区，或者静态分区和动态分区混合使用：
+
+```sql
+-- Full Static Partition
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
 ```
 
 ### INSERT OVERWRITE
 
-INSERT OVERWRITE 会使用新的数据完全覆盖原有表中的数据。当前不支持指定分区写入。
+INSERT OVERWRITE 会使用新的数据完全覆盖原有表中的数据。
 
 ```sql
-INSERT OVERWRITE TABLE VALUES(val1, val2, val3, val4)
+INSERT OVERWRITE TABLE VALUES(val1, val2, val3, val4);
 INSERT OVERWRITE TABLE hive_ctl.hive_db.hive_tbl(col1, col2) SELECT col1, col2 FROM internal.db1.tbl1;
+```
+
+自 4.2.0 版本，支持写入数据到静态分区，或者静态分区和动态分区混合使用：
+
+```sql
+-- Full Static Partition
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
 ```
 
 INSERT OVERWRITE 的语义与 Hive 一致，有如下行为：
@@ -821,7 +853,7 @@ INSERT OVERWRITE 的语义与 Hive 一致，有如下行为：
 
 * 当目的表是非分区表，而源表是空表是，目的表会被清空。
 
-* 当前不支持指定分区写入，因此 INSERT OVERWRITE 为根据源表中的数值，自动处理对应的目的表分区。如果目的表是分区表，则只会覆盖涉及到的分区，不涉及的分区，数据无变化。
+* 自 4.2.0 版本开始，支持指定分区写入，以及指定分区和动态分区混合使用。但是即便指定了静态分区，如果查询内容为空，则指定的分区也不会被清理。
 
 ### CTAS
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/hive-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/hive-catalog.mdx
@@ -796,23 +796,55 @@ Hive Transactional 表是 Hive 中支持 ACID 语义的表。详情可见 [Hive 
 
 ### INSERT INTO
 
-INSERT 操作会将数据以追加的方式写入到目标表中。当前不支持指定分区写入。
+INSERT 操作会将数据以追加的方式写入到目标表中。
 
 ```sql
-INSERT INTO hive_tbl values (val1, val2, val3, val4);
+INSERT INTO hive_tbl VALUES (val1, val2, val3, val4);
 INSERT INTO hive_ctl.hive_db.hive_tbl SELECT col1, col2 FROM internal.db1.tbl1;
 
-INSERT INTO hive_tbl(col1, col2) values (val1, val2);
-INSERT INTO hive_tbl(col1, col2, partition_col1, partition_col2) values (1, 2, "beijing", "2023-12-12");
+INSERT INTO hive_tbl(col1, col2) VALUES (val1, val2);
+INSERT INTO hive_tbl(col1, col2, partition_col1, partition_col2) VALUES (1, 2, "beijing", "2023-12-12");
+```
+
+自 4.2.0 版本，支持写入数据到静态分区，或者静态分区和动态分区混合使用：
+
+```sql
+-- Full Static Partition
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
 ```
 
 ### INSERT OVERWRITE
 
-INSERT OVERWRITE 会使用新的数据完全覆盖原有表中的数据。当前不支持指定分区写入。
+INSERT OVERWRITE 会使用新的数据完全覆盖原有表中的数据。
 
 ```sql
-INSERT OVERWRITE TABLE VALUES(val1, val2, val3, val4)
+INSERT OVERWRITE TABLE VALUES(val1, val2, val3, val4);
 INSERT OVERWRITE TABLE hive_ctl.hive_db.hive_tbl(col1, col2) SELECT col1, col2 FROM internal.db1.tbl1;
+```
+
+自 4.2.0 版本，支持写入数据到静态分区，或者静态分区和动态分区混合使用：
+
+```sql
+-- Full Static Partition
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
 ```
 
 INSERT OVERWRITE 的语义与 Hive 一致，有如下行为：
@@ -821,7 +853,7 @@ INSERT OVERWRITE 的语义与 Hive 一致，有如下行为：
 
 * 当目的表是非分区表，而源表是空表是，目的表会被清空。
 
-* 当前不支持指定分区写入，因此 INSERT OVERWRITE 为根据源表中的数值，自动处理对应的目的表分区。如果目的表是分区表，则只会覆盖涉及到的分区，不涉及的分区，数据无变化。
+* 自 4.2.0 版本开始，支持指定分区写入，以及指定分区和动态分区混合使用。但是即便指定了静态分区，如果查询内容为空，则指定的分区也不会被清理。
 
 ### CTAS
 

--- a/ja-source/docusaurus-plugin-content-docs/current/lakehouse/catalogs/hive-catalog.mdx
+++ b/ja-source/docusaurus-plugin-content-docs/current/lakehouse/catalogs/hive-catalog.mdx
@@ -723,7 +723,7 @@ For partitioned tables, data will automatically be written to the corresponding 
 
 ### INSERT INTO
 
-The INSERT operation appends data to the target table. Specifying a partition for writing is currently not supported.
+The INSERT operation appends data to the target table.
 
 ```sql
 INSERT INTO hive_tbl VALUES (val1, val2, val3, val4);
@@ -731,17 +731,47 @@ INSERT INTO hive_ctl.hive_db.hive_tbl SELECT col1, col2 FROM internal.db1.tbl1;
 
 INSERT INTO hive_tbl(col1, col2) VALUES (val1, val2);
 INSERT INTO hive_tbl(col1, col2, partition_col1, partition_col2) VALUES (1, 2, "beijing", "2023-12-12");
+```
 
+Since version 4.2.0, support for writing data to static partition(or hybrid):
+
+```sql
+-- Full Static Partition
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
 ```
 
 ### INSERT OVERWRITE
 
-INSERT OVERWRITE completely replaces the existing data in the table with new data. Specifying a partition for writing is currently not supported.
+INSERT OVERWRITE completely replaces the existing data in the table with new data.
 
 ```sql
 INSERT OVERWRITE TABLE hive_tbl VALUES (val1, val2, val3, val4);
 INSERT OVERWRITE TABLE hive_ctl.hive_db.hive_tbl(col1, col2) SELECT col1, col2 FROM internal.db1.tbl1;
+```
 
+Since version 4.2.0, support for writing data to static partition(or hybrid):
+
+```sql
+-- Full Static Partition
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
 ```
 
 The semantics of INSERT OVERWRITE are consistent with Hive, with the following behaviors:
@@ -750,7 +780,7 @@ The semantics of INSERT OVERWRITE are consistent with Hive, with the following b
 
 * If the target table is non-partitioned and the source table is empty, the target table will be cleared.
 
-* Since specifying a partition for writing is not supported, INSERT OVERWRITE automatically handles the relevant partitions in the target table based on the source table values. If the target table is partitioned, only the affected partitions will be overwritten; unaffected partitions remain unchanged.
+* Since version 4.2.0, specifying static partitions for writing is supported, as well as hybrid mode combining static and dynamic partitions. However, even when static partitions are specified, if the source query results are empty, the specified partitions will not be cleared.
 
 ### CTAS
 

--- a/ja-source/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/hive-catalog.mdx
+++ b/ja-source/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/hive-catalog.mdx
@@ -724,7 +724,7 @@ For partitioned tables, data will automatically be written to the corresponding 
 
 ### INSERT INTO
 
-The INSERT operation appends data to the target table. Specifying a partition for writing is currently not supported.
+The INSERT operation appends data to the target table.
 
 ```sql
 INSERT INTO hive_tbl VALUES (val1, val2, val3, val4);
@@ -732,17 +732,47 @@ INSERT INTO hive_ctl.hive_db.hive_tbl SELECT col1, col2 FROM internal.db1.tbl1;
 
 INSERT INTO hive_tbl(col1, col2) VALUES (val1, val2);
 INSERT INTO hive_tbl(col1, col2, partition_col1, partition_col2) VALUES (1, 2, "beijing", "2023-12-12");
+```
 
+Since version 4.2.0, support for writing data to static partition(or hybrid):
+
+```sql
+-- Full Static Partition
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
 ```
 
 ### INSERT OVERWRITE
 
-INSERT OVERWRITE completely replaces the existing data in the table with new data. Specifying a partition for writing is currently not supported.
+INSERT OVERWRITE completely replaces the existing data in the table with new data.
 
 ```sql
 INSERT OVERWRITE TABLE hive_tbl VALUES (val1, val2, val3, val4);
 INSERT OVERWRITE TABLE hive_ctl.hive_db.hive_tbl(col1, col2) SELECT col1, col2 FROM internal.db1.tbl1;
+```
 
+Since version 4.2.0, support for writing data to static partition(or hybrid):
+
+```sql
+-- Full Static Partition
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
 ```
 
 The semantics of INSERT OVERWRITE are consistent with Hive, with the following behaviors:
@@ -751,7 +781,7 @@ The semantics of INSERT OVERWRITE are consistent with Hive, with the following b
 
 * If the target table is non-partitioned and the source table is empty, the target table will be cleared.
 
-* Since specifying a partition for writing is not supported, INSERT OVERWRITE automatically handles the relevant partitions in the target table based on the source table values. If the target table is partitioned, only the affected partitions will be overwritten; unaffected partitions remain unchanged.
+* Since version 4.2.0, specifying static partitions for writing is supported, as well as hybrid mode combining static and dynamic partitions. However, even when static partitions are specified, if the source query results are empty, the specified partitions will not be cleared.
 
 ### CTAS
 

--- a/versioned_docs/version-4.x/lakehouse/catalogs/hive-catalog.mdx
+++ b/versioned_docs/version-4.x/lakehouse/catalogs/hive-catalog.mdx
@@ -785,7 +785,7 @@ For partitioned tables, data will automatically be written to the corresponding 
 
 ### INSERT INTO
 
-The INSERT operation appends data to the target table. Specifying a partition for writing is currently not supported.
+The INSERT operation appends data to the target table.
 
 ```sql
 INSERT INTO hive_tbl VALUES (val1, val2, val3, val4);
@@ -795,13 +795,45 @@ INSERT INTO hive_tbl(col1, col2) VALUES (val1, val2);
 INSERT INTO hive_tbl(col1, col2, partition_col1, partition_col2) VALUES (1, 2, "beijing", "2023-12-12");
 ```
 
+Since version 4.2.0, support for writing data to static partition(or hybrid):
+
+```sql
+-- Full Static Partition
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT INTO hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
+```
+
 ### INSERT OVERWRITE
 
-INSERT OVERWRITE completely replaces the existing data in the table with new data. Specifying a partition for writing is currently not supported.
+INSERT OVERWRITE completely replaces the existing data in the table with new data.
 
 ```sql
 INSERT OVERWRITE TABLE hive_tbl VALUES (val1, val2, val3, val4);
 INSERT OVERWRITE TABLE hive_ctl.hive_db.hive_tbl(col1, col2) SELECT col1, col2 FROM internal.db1.tbl1;
+```
+
+Since version 4.2.0, support for writing data to static partition(or hybrid):
+
+```sql
+-- Full Static Partition
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+VALUES (val1, val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30', partition_col2='beijing')
+SELECT col1, col2 FROM source_table;
+
+-- Hybrid Partition Mode: "partition_col1" is static, "partition_col2" comes from SELECT dynamically
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+VALUES (val1, val2, partition_val2);
+INSERT OVERWRITE TABLE hive_tbl PARTITION (partition_col1='2026-07-30')
+SELECT col1, col2, partition_col2 FROM source_table;
 ```
 
 The semantics of INSERT OVERWRITE are consistent with Hive, with the following behaviors:
@@ -810,7 +842,7 @@ The semantics of INSERT OVERWRITE are consistent with Hive, with the following b
 
 * If the target table is non-partitioned and the source table is empty, the target table will be cleared.
 
-* Since specifying a partition for writing is not supported, INSERT OVERWRITE automatically handles the relevant partitions in the target table based on the source table values. If the target table is partitioned, only the affected partitions will be overwritten; unaffected partitions remain unchanged.
+* Since version 4.2.0, specifying static partitions for writing is supported, as well as hybrid mode combining static and dynamic partitions. However, even when static partitions are specified, if the source query results are empty, the specified partitions will not be cleared.
 
 ### CTAS
 


### PR DESCRIPTION
## Versions 

- [x] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [x] Japanese candidate translation needed

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
- [ ] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync
