### PR TITLE
[fix](doc) remove Routine Load flexible partial update from 3.x docs

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/import-way/routine-load-manual.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/import-way/routine-load-manual.md
@@ -420,7 +420,6 @@ job_properties 子句具体参数选项如下：
 | send_batch_parallelism    | 用于设置发送批量数据的并行度。如果并行度的值超过 BE 配置中的 `max_send_batch_parallelism_per_job`，那么作为协调点的 BE 将使用 `max_send_batch_parallelism_per_job` 的值。 |
 | load_to_single_tablet     | 支持一个任务只导入数据到对应分区的一个 tablet，默认值为 false，该参数只允许在对带有 random 分桶的 olap 表导数的时候设置。 |
 | partial_columns           | 指定是否开启部分列更新功能。默认值为 false。该参数只允许在表模型为 Unique 且采用 Merge on Write 时设置。一流多表不支持此参数。具体参考文档[部分列更新](../../../data-operate/update/partial-column-update.md) |
-| unique_key_update_mode    | 指定 Unique Key 表的更新模式。可选值：<ul><li>`UPSERT`（默认）：标准的整行插入或更新操作。</li><li>`UPDATE_FIXED_COLUMNS`：部分列更新，所有行更新相同的列。等同于 `partial_columns=true`。</li><li>`UPDATE_FLEXIBLE_COLUMNS`：灵活部分列更新，每行可以更新不同的列。需要 JSON 格式且表必须设置 `enable_unique_key_skip_bitmap_column=true`。不能与 `jsonpaths`、`fuzzy_parse`、`COLUMNS` 子句或 `WHERE` 子句一起使用。</li></ul>详情参考[部分列更新](../../../data-operate/update/partial-column-update#灵活部分列更新) |
 | partial_update_new_key_behavior | 在 Unique Merge on Write 表上进行部分列更新时，对新插入行的处理方式。有两种类型 `APPEND`、`ERROR`。<br/>- `APPEND`：允许插入新行数据<br/>- `ERROR`：插入新行时导入失败并报错 |
 | max_filter_ratio          | 采样窗口内，允许的最大过滤率。必须在大于等于 0 到小于等于 1 之间。默认值是 1.0，表示可以容忍任何错误行。采样窗口为 `max_batch_rows * 10`。即如果在采样窗口内，错误行数/总行数大于 `max_filter_ratio`，则会导致例行作业被暂停，需要人工介入检查数据质量问题。被 where 条件过滤掉的行不算错误行。 |
 | enclose                   | 指定包围符。当 CSV 数据字段中含有行分隔符或列分隔符时，为防止意外截断，可指定单字节字符作为包围符起到保护作用。例如列分隔符为 ","，包围符为 "'"，数据为 "a,'b,c'"，则 "b,c" 会被解析为一个字段。 |
@@ -1372,83 +1371,6 @@ ReasonOfStateChanged:
     +------+----------------+------+------+
     3 rows in set (0.01 sec)
     ```
-
-**灵活部分列更新**
-
-本示例演示如何使用灵活部分列更新，其中每行可以更新不同的列。这在 CDC 场景中非常有用，因为变更记录可能包含不同的字段。
-
-1. 导入数据样例（每条 JSON 记录更新不同的列）：
-
-    ```json
-    {"id": 1, "balance": 150.00, "last_active": "2024-01-15 10:30:00"}
-    {"id": 2, "city": "Shanghai", "age": 28}
-    {"id": 3, "name": "Alice", "balance": 500.00, "city": "Beijing"}
-    {"id": 1, "age": 30}
-    {"id": 4, "__DORIS_DELETE_SIGN__": 1}
-    ```
-
-2. 建表（必须启用 Merge-on-Write 和 skip bitmap 列）：
-
-    ```sql
-    CREATE TABLE demo.routine_test_flexible (
-        id           INT            NOT NULL  COMMENT "id",
-        name         VARCHAR(30)              COMMENT "姓名",
-        age          INT                      COMMENT "年龄",
-        city         VARCHAR(50)              COMMENT "城市",
-        balance      DECIMAL(10,2)            COMMENT "余额",
-        last_active  DATETIME                 COMMENT "最后活跃时间"
-    )
-    UNIQUE KEY(`id`)
-    DISTRIBUTED BY HASH(`id`) BUCKETS 1
-    PROPERTIES (
-        "replication_num" = "1",
-        "enable_unique_key_merge_on_write" = "true",
-        "enable_unique_key_skip_bitmap_column" = "true"
-    );
-    ```
-
-3. 插入初始数据：
-
-    ```sql
-    INSERT INTO demo.routine_test_flexible VALUES
-    (1, 'John', 25, 'Shenzhen', 100.00, '2024-01-01 08:00:00'),
-    (2, 'Jane', 30, 'Guangzhou', 200.00, '2024-01-02 09:00:00'),
-    (3, 'Bob', 35, 'Hangzhou', 300.00, '2024-01-03 10:00:00'),
-    (4, 'Tom', 40, 'Nanjing', 400.00, '2024-01-04 11:00:00');
-    ```
-
-4. 导入命令：
-
-    ```sql
-    CREATE ROUTINE LOAD demo.kafka_job_flexible ON routine_test_flexible
-            PROPERTIES
-            (
-                "format" = "json",
-                "unique_key_update_mode" = "UPDATE_FLEXIBLE_COLUMNS"
-            )
-            FROM KAFKA
-            (
-                "kafka_broker_list" = "10.16.10.6:9092",
-                "kafka_topic" = "routineLoadFlexible",
-                "property.kafka_default_offsets" = "OFFSET_BEGINNING"
-            );
-    ```
-
-5. 导入结果：
-
-    ```sql
-    mysql> SELECT * FROM demo.routine_test_flexible ORDER BY id;
-    +------+-------+------+-----------+---------+---------------------+
-    | id   | name  | age  | city      | balance | last_active         |
-    +------+-------+------+-----------+---------+---------------------+
-    |    1 | John  |   30 | Shenzhen  |  150.00 | 2024-01-15 10:30:00 |
-    |    2 | Jane  |   28 | Shanghai  |  200.00 | 2024-01-02 09:00:00 |
-    |    3 | Alice |   35 | Beijing   |  500.00 | 2024-01-03 10:00:00 |
-    +------+-------+------+-----------+---------+---------------------+
-    3 rows in set (0.01 sec)
-    ```
-
-    注意：`id=4` 的行因为 `__DORIS_DELETE_SIGN__` 被删除，每行只更新了其对应 JSON 记录中包含的列。
 
 ### 导入复杂类型
 

--- a/ja-source/docusaurus-plugin-content-docs/version-3.x/data-operate/import/import-way/routine-load-manual.md
+++ b/ja-source/docusaurus-plugin-content-docs/version-3.x/data-operate/import/import-way/routine-load-manual.md
@@ -405,7 +405,6 @@ job_properties句の具体的なパラメータオプションは以下の通り
 | send_batch_parallelism    | バッチデータ送信の並列度を設定するために使用されます。並列度の値がBE設定の`max_send_batch_parallelism_per_job`を超える場合、コーディネーターとして機能するBEは`max_send_batch_parallelism_per_job`の値を使用します。 |
 | load_to_single_tablet     | タスクごとに対応するパーティションの1つのタブレットのみにデータをインポートすることをサポートします。デフォルト値はfalseです。このパラメータは、ランダムバケティングを使用するolapTableにデータをインポートする場合にのみ許可されます。 |
 | partial_columns           | 部分列更新を有効にするかどうかを指定します。デフォルト値はfalseです。このパラメータは、TableモデルがUniqueでMerge on Writeを使用する場合にのみ許可されます。マルチTableストリーミングはこのパラメータをサポートしていません。詳細については、[Partial Column アップデート](../../../data-operate/update/partial-column-update.md)を参照してください |
-| unique_key_update_mode    | Unique KeyTableの更新モードを指定します。オプション値：<ul><li>`UPSERT`（デフォルト）：標準的な全行挿入または更新操作。</li><li>`UPDATE_FIXED_COLUMNS`：部分列更新、すべての行が同じ列を更新。`partial_columns=true`と同等。</li><li>`UPDATE_FLEXIBLE_COLUMNS`：柔軟な部分列更新、各行が異なる列を更新可能。JSON形式が必要で、Tableに`enable_unique_key_skip_bitmap_column=true`が必要。`jsonpaths`、`fuzzy_parse`、`COLUMNS`句、または`WHERE`句と併用不可。</li></ul>詳細については、[Partial Column アップデート](../../../data-operate/update/partial-column-update#flexible-partial-column-update)を参照してください |
 | partial_update_new_key_behavior | Unique Merge on WriteTableで部分列更新を実行する際の新しく挿入された行の処理方法。2つのタイプ：`APPEND`、`ERROR`。<br/>- `APPEND`：新しい行データの挿入を許可<br/>- `ERROR`：新しい行を挿入する際にインポートが失敗してエラーを報告 |
 | max_filter_ratio          | サンプリングウィンドウ内で許可される最大フィルタリング率。0以上1以下である必要があります。デフォルト値は1.0で、任意のエラー行を許容できることを意味します。サンプリングウィンドウは`max_batch_rows * 10`です。サンプリングウィンドウ内のエラー行/総行数が`max_filter_ratio`より大きい場合、routineジョブは一時停止され、データ品質の問題を手動で確認する必要があります。where条件によってフィルタリングされた行はエラー行としてカウントされません。 |
 | enclose                   | 囲み文字を指定します。CSVデータフィールドに行または列の区切り文字が含まれる場合、保護のために単一バイト文字を囲み文字として指定できます。例えば、列区切り文字が","で囲み文字が"'"の場合、データ"a,'b,c'"について、"b,c"が1つのフィールドとして解析されます。 |
@@ -1293,77 +1292,6 @@ Table内のインポート前のデータ:
     +------+----------------+------+------+
     3 rows in set (0.01 sec)
     ```
-**Flexible Partial Column アップデート**
-
-この例では、各行が異なる列を更新できる柔軟な部分列更新の使用方法を示します。これは、変更レコードが異なるフィールドを含む可能性があるCDCシナリオで非常に有用です。
-
-1. サンプルインポートデータ（各JSONレコードは異なる列を更新します）：
-
-    ```json
-    {"id": 1, "balance": 150.00, "last_active": "2024-01-15 10:30:00"}
-    {"id": 2, "city": "Shanghai", "age": 28}
-    {"id": 3, "name": "Alice", "balance": 500.00, "city": "Beijing"}
-    {"id": 1, "age": 30}
-    {"id": 4, "__DORIS_DELETE_SIGN__": 1}
-    ```
-2. Tableの作成（Merge-on-Writeを有効にし、bitmapカラムをスキップする必要があります）：
-
-    ```sql
-    CREATE TABLE demo.routine_test_flexible (
-        id           INT            NOT NULL  COMMENT "id",
-        name         VARCHAR(30)              COMMENT "Name",
-        age          INT                      COMMENT "Age",
-        city         VARCHAR(50)              COMMENT "City",
-        balance      DECIMAL(10,2)            COMMENT "Balance",
-        last_active  DATETIME                 COMMENT "Last Active Time"
-    )
-    UNIQUE KEY(`id`)
-    DISTRIBUTED BY HASH(`id`) BUCKETS 1
-    PROPERTIES (
-        "replication_num" = "1",
-        "enable_unique_key_merge_on_write" = "true",
-        "enable_unique_key_skip_bitmap_column" = "true"
-    );
-    ```
-3. 初期データを挿入する:
-
-    ```sql
-    INSERT INTO demo.routine_test_flexible VALUES
-    (1, 'John', 25, 'Shenzhen', 100.00, '2024-01-01 08:00:00'),
-    (2, 'Jane', 30, 'Guangzhou', 200.00, '2024-01-02 09:00:00'),
-    (3, 'Bob', 35, 'Hangzhou', 300.00, '2024-01-03 10:00:00'),
-    (4, 'Tom', 40, 'Nanjing', 400.00, '2024-01-04 11:00:00');
-    ```
-4. Importコマンド:
-
-    ```sql
-    CREATE ROUTINE LOAD demo.kafka_job_flexible ON routine_test_flexible
-            PROPERTIES
-            (
-                "format" = "json",
-                "unique_key_update_mode" = "UPDATE_FLEXIBLE_COLUMNS"
-            )
-            FROM KAFKA
-            (
-                "kafka_broker_list" = "10.16.10.6:9092",
-                "kafka_topic" = "routineLoadFlexible",
-                "property.kafka_default_offsets" = "OFFSET_BEGINNING"
-            );
-    ```
-5. インポート結果：
-
-    ```sql
-    mysql> SELECT * FROM demo.routine_test_flexible ORDER BY id;
-    +------+-------+------+-----------+---------+---------------------+
-    | id   | name  | age  | city      | balance | last_active         |
-    +------+-------+------+-----------+---------+---------------------+
-    |    1 | John  |   30 | Shenzhen  |  150.00 | 2024-01-15 10:30:00 |
-    |    2 | Jane  |   28 | Shanghai  |  200.00 | 2024-01-02 09:00:00 |
-    |    3 | Alice |   35 | Beijing   |  500.00 | 2024-01-03 10:00:00 |
-    +------+-------+------+-----------+---------+---------------------+
-    3 rows in set (0.01 sec)
-    ```
-注意: `id=4`の行は`__DORIS_DELETE_SIGN__`により削除され、各行は対応するJSONレコードに含まれる列のみを更新しました。
 
 ### 複合型のインポート
 

--- a/versioned_docs/version-3.x/data-operate/import/import-way/routine-load-manual.md
+++ b/versioned_docs/version-3.x/data-operate/import/import-way/routine-load-manual.md
@@ -420,7 +420,6 @@ Specific parameter options for the job_properties clause are as follows:
 | send_batch_parallelism    | Used to set the parallelism for sending batch data. If the parallelism value exceeds `max_send_batch_parallelism_per_job` in the BE configuration, the BE serving as coordinator will use the value of `max_send_batch_parallelism_per_job`. |
 | load_to_single_tablet     | Supports importing data to only one tablet of the corresponding partition per task. Default value is false. This parameter is only allowed when importing data to olap tables with random bucketing. |
 | partial_columns           | Specifies whether to enable partial column update. Default value is false. This parameter is only allowed when the table model is Unique and uses Merge on Write. Multi-table streaming does not support this parameter. For details, refer to [Partial Column Update](../../../data-operate/update/partial-column-update.md) |
-| unique_key_update_mode    | Specifies the update mode for Unique Key tables. Optional values: <ul><li>`UPSERT` (default): Standard full-row insert or update operation.</li><li>`UPDATE_FIXED_COLUMNS`: Partial column update, all rows update the same columns. Equivalent to `partial_columns=true`.</li><li>`UPDATE_FLEXIBLE_COLUMNS`: Flexible partial column update, each row can update different columns. Requires JSON format and table must have `enable_unique_key_skip_bitmap_column=true`. Cannot be used with `jsonpaths`, `fuzzy_parse`, `COLUMNS` clause, or `WHERE` clause.</li></ul>For details, refer to [Partial Column Update](../../../data-operate/update/partial-column-update#flexible-partial-column-updates) |
 | partial_update_new_key_behavior | Handling method for newly inserted rows when performing partial column updates on Unique Merge on Write tables. Two types: `APPEND`, `ERROR`.<br/>- `APPEND`: Allow insertion of new row data<br/>- `ERROR`: Import fails and reports an error when inserting new rows |
 | max_filter_ratio          | Maximum allowed filtering rate within the sampling window. Must be between greater than or equal to 0 and less than or equal to 1. Default value is 1.0, meaning any error rows can be tolerated. The sampling window is `max_batch_rows * 10`. If the error rows/total rows in the sampling window is greater than `max_filter_ratio`, the routine job will be paused, requiring manual intervention to check data quality issues. Rows filtered by where conditions are not counted as error rows. |
 | enclose                   | Specifies the enclosing character. When CSV data fields contain row or column separators, a single-byte character can be specified as an enclosing character for protection. For example, if the column separator is "," and the enclosing character is "'", for data "a,'b,c'", "b,c" will be parsed as one field. |
@@ -1373,83 +1372,6 @@ Specific display result descriptions are as follows:
     +------+----------------+------+------+
     3 rows in set (0.01 sec)
     ```
-
-**Flexible Partial Column Update**
-
-This example demonstrates how to use flexible partial column update, where each row can update different columns. This is very useful in CDC scenarios where change records may contain different fields.
-
-1. Sample import data (each JSON record updates different columns):
-
-    ```json
-    {"id": 1, "balance": 150.00, "last_active": "2024-01-15 10:30:00"}
-    {"id": 2, "city": "Shanghai", "age": 28}
-    {"id": 3, "name": "Alice", "balance": 500.00, "city": "Beijing"}
-    {"id": 1, "age": 30}
-    {"id": 4, "__DORIS_DELETE_SIGN__": 1}
-    ```
-
-2. Create table (must enable Merge-on-Write and skip bitmap column):
-
-    ```sql
-    CREATE TABLE demo.routine_test_flexible (
-        id           INT            NOT NULL  COMMENT "id",
-        name         VARCHAR(30)              COMMENT "Name",
-        age          INT                      COMMENT "Age",
-        city         VARCHAR(50)              COMMENT "City",
-        balance      DECIMAL(10,2)            COMMENT "Balance",
-        last_active  DATETIME                 COMMENT "Last Active Time"
-    )
-    UNIQUE KEY(`id`)
-    DISTRIBUTED BY HASH(`id`) BUCKETS 1
-    PROPERTIES (
-        "replication_num" = "1",
-        "enable_unique_key_merge_on_write" = "true",
-        "enable_unique_key_skip_bitmap_column" = "true"
-    );
-    ```
-
-3. Insert initial data:
-
-    ```sql
-    INSERT INTO demo.routine_test_flexible VALUES
-    (1, 'John', 25, 'Shenzhen', 100.00, '2024-01-01 08:00:00'),
-    (2, 'Jane', 30, 'Guangzhou', 200.00, '2024-01-02 09:00:00'),
-    (3, 'Bob', 35, 'Hangzhou', 300.00, '2024-01-03 10:00:00'),
-    (4, 'Tom', 40, 'Nanjing', 400.00, '2024-01-04 11:00:00');
-    ```
-
-4. Import command:
-
-    ```sql
-    CREATE ROUTINE LOAD demo.kafka_job_flexible ON routine_test_flexible
-            PROPERTIES
-            (
-                "format" = "json",
-                "unique_key_update_mode" = "UPDATE_FLEXIBLE_COLUMNS"
-            )
-            FROM KAFKA
-            (
-                "kafka_broker_list" = "10.16.10.6:9092",
-                "kafka_topic" = "routineLoadFlexible",
-                "property.kafka_default_offsets" = "OFFSET_BEGINNING"
-            );
-    ```
-
-5. Import result:
-
-    ```sql
-    mysql> SELECT * FROM demo.routine_test_flexible ORDER BY id;
-    +------+-------+------+-----------+---------+---------------------+
-    | id   | name  | age  | city      | balance | last_active         |
-    +------+-------+------+-----------+---------+---------------------+
-    |    1 | John  |   30 | Shenzhen  |  150.00 | 2024-01-15 10:30:00 |
-    |    2 | Jane  |   28 | Shanghai  |  200.00 | 2024-01-02 09:00:00 |
-    |    3 | Alice |   35 | Beijing   |  500.00 | 2024-01-03 10:00:00 |
-    +------+-------+------+-----------+---------+---------------------+
-    3 rows in set (0.01 sec)
-    ```
-
-    Note: The row with `id=4` was deleted due to `__DORIS_DELETE_SIGN__`, and each row only updated the columns contained in its corresponding JSON record.
 
 ### Import Complex Types
 


### PR DESCRIPTION
The version-3.x Routine Load manual documents `unique_key_update_mode` (including `UPDATE_FLEXIBLE_COLUMNS`) as a job property and ships a full "Flexible Partial Column Update" CREATE ROUTINE LOAD example. This feature does not exist in any 3.x release.

On Doris 3.1.4, creating such a job fails at property validation:

    ERROR 1105 (HY000): errCode = 2, detailMessage = unique_key_update_mode is invalid property

`unique_key_update_mode` was added to Routine Load by apache/doris #59896 and #60128, merged to master in January 2026 and never backported to branch-3.1. On branch-3.1 the property is absent from the Routine Load whitelist (CreateRoutineLoadStmt.PROPERTIES_SET), so it is rejected at CREATE before any BE involvement. The property exists only on the Stream Load path in 3.x (StreamLoadTask), which is why the Stream Load and partial-column-update docs are unaffected.

Remove, from the English, Chinese, and Japanese version-3.x copies:
- the `unique_key_update_mode` row in the job_properties table
- the "Flexible Partial Column Update" example section

`partial_columns` (fixed-column partial update) is supported in 3.x Routine Load and is left in place. The dev and 4.x docs are unchanged because the feature exists there.

## Versions 

- [ ] dev
- [ ] 4.x
- [x] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [x] Japanese candidate translation needed

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
- [ ] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync
