### PR TITLE
[fix](doc)fix wrong description of unnest function

### DIFF
--- a/docs/sql-manual/sql-functions/table-functions/unnest.md
+++ b/docs/sql-manual/sql-functions/table-functions/unnest.md
@@ -22,7 +22,7 @@ UNNEST(<expr>[, ...]) [WITH ORDINALITY] [AS alias [(col1, col2, ...)]]
 - Multiple ARRAY parameters: Combines the elements expanded each time into multiple columns (or as a Struct) by position. The expansion length is determined by the longest input, and shorter columns are padded with NULL.
 - MAP parameter: Returns two columns (Struct) (key, value); NULL keys/values remain NULL.
 - BITMAP parameter: Returns integer values by element.
-- WITH ORDINALITY: Appends a sequence number column starting from 1 to the output (as the last column or specified by an alias).
+- WITH ORDINALITY: Appends a sequence number column starting from 0 to the output (as the first column or specified by an alias).
 - Empty array or NULL:
   - When generating an independent table (SELECT list or FROM ... UNNEST), if the parameter is NULL or an empty array, no rows are generated (0 rows).
   - When used in combination with FROM/LATERAL and LEFT JOIN (i.e., generating outer row semantics), if all expanded rows of a parent row are filtered or have no output, a row is inserted for the parent row, with the UNNEST output columns set to NULL (to retain the left table row).
@@ -34,7 +34,7 @@ UNNEST(<expr>[, ...]) [WITH ORDINALITY] [AS alias [(col1, col2, ...)]]
 4. In JOIN scenarios:
    - INNER / CROSS JOIN: Performs Cartesian product or matching based on the expanded results.
    - LEFT JOIN LATERAL: Implements outer row semantics — if there are no matches or all expanded results are filtered by ON/filter conditions, a row with NULL values is generated (to retain the left table row).
-5. WITH ORDINALITY adds a sequence number (starting from 1) to the expanded rows.
+5. WITH ORDINALITY adds a sequence number (starting from 0) to the expanded rows.
 6. When UNNEST(...) is used directly in the SELECT list, it is equivalent to applying the table-generating function to a single-row source, expanding the expression into multiple rows of output.
 
 ## Examples
@@ -102,14 +102,14 @@ Output (example):
 ```
 3. WITH ORDINALITY：
 ```sql
-SELECT i.id, t.ord, t.tag
-FROM items i, unnest(i.tags) WITH ORDINALITY AS t(tag, ord)
+SELECT i.id, t.tag, t.ord
+FROM items i, unnest(i.tags) WITH ORDINALITY AS t(ord, tag)
 ORDER BY i.id, t.ord;
 ```
 Output (example):
 ```sql
 +------+-------------+------+
-| id   | ord         | tag  |
+| id   | tag         | ord  |
 +------+-------------+------+
 |    1 | Electronics |    0 |
 |    1 | High-End    |    2 |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/table-functions/unnest.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/table-functions/unnest.md
@@ -22,7 +22,7 @@ UNNEST(<expr>[, ...]) [WITH ORDINALITY] [AS alias [(col1, col2, ...)]]
 - 多个 ARRAY 参数：将每次展开的元素按位置组合为多列（或作为 Struct），展开长度由最长输入决定，短列用 NULL 补齐。
 - MAP 参数：返回 (key, value) 两列（Struct）；NULL key/value 保持 NULL。
 - BITMAP 参数：按元素返回整型。
-- WITH ORDINALITY：在输出中附加一个从 1 开始的序号列（作为最后一列或由别名指定）。
+- WITH ORDINALITY：在输出中附加一个从 0 开始的序号列（作为第一列或由别名指定）。
 - 空数组或 NULL：
   - 作为独立表生成（SELECT 列表或 FROM ... UNNEST）时，若参数为 NULL 或空数组，不产生行（0 行）。
   - 在 FROM/LATERAL 与 LEFT JOIN 联合使用时（即产生 outer 行语义），若某个父行的所有展开行被过滤或无输出，会为该父行插入一行，其中 UNNEST 输出列为 NULL（以保留左表行）。
@@ -34,7 +34,7 @@ UNNEST(<expr>[, ...]) [WITH ORDINALITY] [AS alias [(col1, col2, ...)]]
 4. 在 JOIN 场景：
    - INNER / CROSS JOIN：按展开结果做笛卡尔或匹配。
    - LEFT JOIN LATERAL：实现 outer 行语义——若没有匹配或展开结果被 ON/过滤条件全部过滤，会产生一行 NULL（保持左表行）。
-5. WITH ORDINALITY 为展开行增加序号（1 起）。
+5. WITH ORDINALITY 为展开行增加序号（0 起）。
 6. 在 SELECT 列表直接使用 `UNNEST(...)` 时，等价于对一个单行源应用表生成函数，会把该表达式展开为多行输出。
 
 ## 示例
@@ -102,14 +102,14 @@ ORDER BY i.id, t.tag;
 ```
 3. WITH ORDINALITY：
 ```sql
-SELECT i.id, t.ord, t.tag
-FROM items i, unnest(i.tags) WITH ORDINALITY AS t(tag, ord)
+SELECT i.id, t.tag, t.ord
+FROM items i, unnest(i.tags) WITH ORDINALITY AS t(ord, tag)
 ORDER BY i.id, t.ord;
 ```
 输出（示例）：
 ```sql
 +------+-------------+------+
-| id   | ord         | tag  |
+| id   | tag         | ord  |
 +------+-------------+------+
 |    1 | Electronics |    0 |
 |    1 | High-End    |    2 |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/table-functions/unnest.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/table-functions/unnest.md
@@ -22,7 +22,7 @@ UNNEST(<expr>[, ...]) [WITH ORDINALITY] [AS alias [(col1, col2, ...)]]
 - 多个 ARRAY 参数：将每次展开的元素按位置组合为多列（或作为 Struct），展开长度由最长输入决定，短列用 NULL 补齐。
 - MAP 参数：返回 (key, value) 两列（Struct）；NULL key/value 保持 NULL。
 - BITMAP 参数：按元素返回整型。
-- WITH ORDINALITY：在输出中附加一个从 1 开始的序号列（作为最后一列或由别名指定）。
+- WITH ORDINALITY：在输出中附加一个从 0 开始的序号列（作为第一列或由别名指定）。
 - 空数组或 NULL：
   - 作为独立表生成（SELECT 列表或 FROM ... UNNEST）时，若参数为 NULL 或空数组，不产生行（0 行）。
   - 在 FROM/LATERAL 与 LEFT JOIN 联合使用时（即产生 outer 行语义），若某个父行的所有展开行被过滤或无输出，会为该父行插入一行，其中 UNNEST 输出列为 NULL（以保留左表行）。
@@ -34,7 +34,7 @@ UNNEST(<expr>[, ...]) [WITH ORDINALITY] [AS alias [(col1, col2, ...)]]
 4. 在 JOIN 场景：
    - INNER / CROSS JOIN：按展开结果做笛卡尔或匹配。
    - LEFT JOIN LATERAL：实现 outer 行语义——若没有匹配或展开结果被 ON/过滤条件全部过滤，会产生一行 NULL（保持左表行）。
-5. WITH ORDINALITY 为展开行增加序号（1 起）。
+5. WITH ORDINALITY 为展开行增加序号（0 起）。
 6. 在 SELECT 列表直接使用 `UNNEST(...)` 时，等价于对一个单行源应用表生成函数，会把该表达式展开为多行输出。
 
 ## 示例
@@ -102,14 +102,14 @@ ORDER BY i.id, t.tag;
 ```
 3. WITH ORDINALITY：
 ```sql
-SELECT i.id, t.ord, t.tag
-FROM items i, unnest(i.tags) WITH ORDINALITY AS t(tag, ord)
+SELECT i.id, t.tag, t.ord
+FROM items i, unnest(i.tags) WITH ORDINALITY AS t(ord, tag)
 ORDER BY i.id, t.ord;
 ```
 输出（示例）：
 ```sql
 +------+-------------+------+
-| id   | ord         | tag  |
+| id   | tag         | ord  |
 +------+-------------+------+
 |    1 | Electronics |    0 |
 |    1 | High-End    |    2 |

--- a/ja-source/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/table-functions/unnest.md
+++ b/ja-source/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/table-functions/unnest.md
@@ -21,7 +21,7 @@ UNNEST(<expr>[, ...]) [WITH ORDINALITY] [AS alias [(col1, col2, ...)]]
 - 複数のARRAYパラメータ：位置によって各回展開された要素を複数列（またはStruct）に結合する。展開の長さは最も長い入力によって決定され、短い列はNULLでパディングされる。
 - MAPパラメータ：2列（Struct）（key、value）を返す；NULLキー/値はNULLのまま。
 - BITMAPパラメータ：要素ごとに整数値を返す。
-- WITH ORDINALITY：1から始まるシーケンス番号列を出力に追加する（最後の列として、またはエイリアスで指定された位置に）。
+- WITH ORDINALITY：0から始まるシーケンス番号列を出力に追加する（最初の列として、またはエイリアスで指定された位置に）。
 - 空配列またはNULL：
   - 独立したテーブルを生成する場合（SELECTリストまたはFROM ... UNNEST）、パラメータがNULLまたは空配列の場合、行は生成されない（0行）。
   - FROM/LATERALとLEFT JOINの組み合わせで使用される場合（つまり、外部行セマンティクスを生成）、親行の展開された行がすべてフィルタリングされるか出力がない場合、親行のために行が挿入され、UNNEST出力列はNULLに設定される（左テーブル行を保持するため）。
@@ -33,7 +33,7 @@ UNNEST(<expr>[, ...]) [WITH ORDINALITY] [AS alias [(col1, col2, ...)]]
 4. JOINシナリオにおいて：
    - INNER / CROSS JOIN：展開結果に基づいてデカルト積またはマッチングを実行する。
    - LEFT JOIN LATERAL：外部行セマンティクスを実装する — マッチがないか、すべての展開結果がON/フィルタ条件によってフィルタリングされた場合、NULL値を持つ行が生成される（左テーブル行を保持するため）。
-5. WITH ORDINALITYは展開された行にシーケンス番号（1から開始）を追加する。
+5. WITH ORDINALITYは展開された行にシーケンス番号（0から開始）を追加する。
 6. UNNEST(...)がSELECTリストで直接使用される場合、単一行ソースにテーブル生成関数を適用することと同等であり、式を複数行の出力に展開する。
 
 ## 例
@@ -107,15 +107,15 @@ ORDER BY i.id, t.tag;
 3. WITH ORDINALITY：
 
 ```sql
-SELECT i.id, t.ord, t.tag
-FROM items i, unnest(i.tags) WITH ORDINALITY AS t(tag, ord)
+SELECT i.id, t.tag, t.ord
+FROM items i, unnest(i.tags) WITH ORDINALITY AS t(ord, tag)
 ORDER BY i.id, t.ord;
 ```
 出力（例）：
 
 ```sql
 +------+-------------+------+
-| id   | ord         | tag  |
+| id   | tag         | ord  |
 +------+-------------+------+
 |    1 | Electronics |    0 |
 |    1 | High-End    |    2 |

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/table-functions/unnest.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/table-functions/unnest.md
@@ -22,7 +22,7 @@ UNNEST(<expr>[, ...]) [WITH ORDINALITY] [AS alias [(col1, col2, ...)]]
 - Multiple ARRAY parameters: Combines the elements expanded each time into multiple columns (or as a Struct) by position. The expansion length is determined by the longest input, and shorter columns are padded with NULL.
 - MAP parameter: Returns two columns (Struct) (key, value); NULL keys/values remain NULL.
 - BITMAP parameter: Returns integer values by element.
-- WITH ORDINALITY: Appends a sequence number column starting from 1 to the output (as the last column or specified by an alias).
+- WITH ORDINALITY: Appends a sequence number column starting from 0 to the output (as the first column or specified by an alias).
 - Empty array or NULL:
   - When generating an independent table (SELECT list or FROM ... UNNEST), if the parameter is NULL or an empty array, no rows are generated (0 rows).
   - When used in combination with FROM/LATERAL and LEFT JOIN (i.e., generating outer row semantics), if all expanded rows of a parent row are filtered or have no output, a row is inserted for the parent row, with the UNNEST output columns set to NULL (to retain the left table row).
@@ -34,7 +34,7 @@ UNNEST(<expr>[, ...]) [WITH ORDINALITY] [AS alias [(col1, col2, ...)]]
 4. In JOIN scenarios:
    - INNER / CROSS JOIN: Performs Cartesian product or matching based on the expanded results.
    - LEFT JOIN LATERAL: Implements outer row semantics — if there are no matches or all expanded results are filtered by ON/filter conditions, a row with NULL values is generated (to retain the left table row).
-5. WITH ORDINALITY adds a sequence number (starting from 1) to the expanded rows.
+5. WITH ORDINALITY adds a sequence number (starting from 0) to the expanded rows.
 6. When UNNEST(...) is used directly in the SELECT list, it is equivalent to applying the table-generating function to a single-row source, expanding the expression into multiple rows of output.
 
 ## Examples
@@ -102,14 +102,14 @@ Output (example):
 ```
 3. WITH ORDINALITY：
 ```sql
-SELECT i.id, t.ord, t.tag
-FROM items i, unnest(i.tags) WITH ORDINALITY AS t(tag, ord)
+SELECT i.id, t.tag, t.ord
+FROM items i, unnest(i.tags) WITH ORDINALITY AS t(ord, tag)
 ORDER BY i.id, t.ord;
 ```
 Output (example):
 ```sql
 +------+-------------+------+
-| id   | ord         | tag  |
+| id   | tag         | ord  |
 +------+-------------+------+
 |    1 | Electronics |    0 |
 |    1 | High-End    |    2 |


### PR DESCRIPTION
## Versions 

- [x] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [ ] Chinese
- [ ] English
- [ ] Japanese candidate translation needed

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
- [ ] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync
