### PR TITLE
[doc](lance) add version note

### DIFF
--- a/docs/lakehouse/catalogs/lance-catalog.mdx
+++ b/docs/lakehouse/catalogs/lance-catalog.mdx
@@ -6,6 +6,10 @@
 }
 ---
 
+:::note
+Lance Catalog is supported starting from Apache Doris 4.2.
+:::
+
 Lance is a columnar data format designed for analytics and AI workloads. Doris can use a Lance Catalog to discover databases and tables in a Lance Namespace and directly query Lance datasets stored on a local file system or S3-compatible object storage.
 
 Doris currently provides read-only access to Lance. Creating, writing, updating, or deleting Lance tables is not supported.

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/lance-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/lance-catalog.mdx
@@ -6,6 +6,10 @@
 }
 ---
 
+:::note
+Lance Catalog 自 Apache Doris 4.2 版本开始支持。
+:::
+
 Lance 是面向分析和 AI 场景的列式数据格式。Doris 可以通过 Lance Catalog 发现 Lance Namespace 中的数据库和表，并直接查询存储在本地文件系统或 S3 兼容对象存储中的 Lance 数据集。
 
 当前 Doris 对 Lance 提供只读能力，不支持创建、写入、更新或删除 Lance 表。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/lance-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/lance-catalog.mdx
@@ -6,6 +6,10 @@
 }
 ---
 
+:::note
+Lance Catalog 自 Apache Doris 4.2 版本开始支持。
+:::
+
 Lance 是面向分析和 AI 场景的列式数据格式。Doris 可以通过 Lance Catalog 发现 Lance Namespace 中的数据库和表，并直接查询存储在本地文件系统或 S3 兼容对象存储中的 Lance 数据集。
 
 当前 Doris 对 Lance 提供只读能力，不支持创建、写入、更新或删除 Lance 表。

--- a/versioned_docs/version-4.x/lakehouse/catalogs/lance-catalog.mdx
+++ b/versioned_docs/version-4.x/lakehouse/catalogs/lance-catalog.mdx
@@ -6,6 +6,10 @@
 }
 ---
 
+:::note
+Lance Catalog is supported starting from Apache Doris 4.2.
+:::
+
 Lance is a columnar data format designed for analytics and AI workloads. Doris can use a Lance Catalog to discover databases and tables in a Lance Namespace and directly query Lance datasets stored on a local file system or S3-compatible object storage.
 
 Doris currently provides read-only access to Lance. Creating, writing, updating, or deleting Lance tables is not supported.


### PR DESCRIPTION
## Versions 

- [x] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [ ] Japanese candidate translation needed

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
- [ ] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync
