### PR TITLE
feat: link Profile Analysis from the Resources nav

### DIFF
--- a/src/components/home-next/NavbarNext.tsx
+++ b/src/components/home-next/NavbarNext.tsx
@@ -67,6 +67,7 @@ function buildNavItems(
                 { label: 'Blogs', href: '/blog' },
                 { label: 'News and Events', href: '/events' },
                 { label: 'Course', href: '/course' },
+                { label: 'Profile Analysis', href: '/profile-analysis' },
             ],
         },
         {

--- a/src/components/profile-analysis/ProfileAnalysis.scss
+++ b/src/components/profile-analysis/ProfileAnalysis.scss
@@ -421,7 +421,8 @@
         }
     }
 
-    &__ai-warning {
+    &__ai-warning,
+    &__version-notice {
         margin-bottom: 1rem;
         padding: 0.9rem 1rem;
         border-left: 4px solid var(--ifm-color-warning);

--- a/src/components/profile-analysis/ProfileUploader.tsx
+++ b/src/components/profile-analysis/ProfileUploader.tsx
@@ -89,6 +89,11 @@ export function ProfileUploader({ file, disabled, onFileChange }: ProfileUploade
                 Profile sections before local visualization or AI upload.
             </p>
 
+            <div className="profile-analysis__version-notice" role="note">
+                Use a Profile produced by Apache Doris 4.1 or later. Profiles from earlier versions may fail to
+                parse.
+            </div>
+
             <label
                 className={`profile-analysis__drop-zone${
                     disabled ? ' profile-analysis__drop-zone--disabled' : ''

--- a/src/components/profile-analysis/profile-analysis.components.test.js
+++ b/src/components/profile-analysis/profile-analysis.components.test.js
@@ -84,6 +84,19 @@ test('explains the raw file limit and large-profile reduction in English', () =>
     assert.match(markup, /Files over 10 MiB are reduced to their aggregated Profile sections/);
 });
 
+test('states the supported Doris version before a Profile is chosen', () => {
+    const markup = renderUploader();
+
+    assert.match(markup, /profile-analysis__version-notice/);
+    assert.match(markup, /Apache Doris 4\.1 or later/);
+    assert.match(markup, /Profiles from earlier versions may fail to parse/);
+    // The notice must precede the drop zone so it is read before a file is picked.
+    assert.ok(markup.indexOf('__version-notice') < markup.indexOf('__drop-zone'));
+
+    const styles = fs.readFileSync(path.join(__dirname, 'ProfileAnalysis.scss'), 'utf8');
+    assert.match(styles, /&__version-notice[\s\S]*?{[^}]*border-left:\s*4px solid var\(--ifm-color-warning\)/);
+});
+
 test('disables both tab actions without a file and keeps visualization available during AI processing', () => {
     const analyzerSource = fs.readFileSync(path.join(__dirname, 'ProfileAnalyzer.tsx'), 'utf8');
 


### PR DESCRIPTION
## Purpose

Bring the Profile Analysis page online.

`/profile-analysis` shipped in #4043 but nothing on the site links to it, so the page is only reachable by typing the URL. This adds the missing navigation entry, plus a version notice the page needs before users start feeding it Profiles.

## Changes

**1. Resources nav entry** — `src/components/home-next/NavbarNext.tsx`

Adds `Profile Analysis` to the Resources dropdown. `buildNavItems` drives both the desktop dropdown and the mobile panel, so the single entry covers both. The `href` omits the locale prefix, matching the neighbouring `/blog`, `/events`, and `/course` entries — Docusaurus `Link` resolves it against the localized baseUrl.

**2. Supported-version notice** — `src/components/profile-analysis/ProfileUploader.tsx`

> Use a Profile produced by Apache Doris 4.1 or later. Profiles from earlier versions may fail to parse.

Placed in the "Choose a Query Profile" section directly above the drop zone, so it is read before a file is picked and stays visible on both the Visualize Execution and AI-assisted analysis tabs.

The callout reuses the existing `__ai-warning` rule in `ProfileAnalysis.scss` — the selector is widened to `&__ai-warning, &__version-notice` rather than duplicating the block. No new colors; it keeps using the existing Infima warning tokens.

## Notes

The page text is hard-coded English throughout (the privacy notice, the tab labels, the uploader help text), so the notice is English too. Localizing it would mean routing the whole component through `<Translate>`, which is out of scope here.

## Testing

Extended `profile-analysis.components.test.js` with a case covering the notice text, its DOM position relative to the drop zone, and the style rule. Full file passes:

```
$ node --test src/components/profile-analysis/profile-analysis.components.test.js
ℹ tests 15
ℹ pass 15
ℹ fail 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)