### PR TITLE
[doc](lakehouse) Add ADBC Catalog documentation

### DIFF
--- a/docs/connection-integration/data-integration/metabase.md
+++ b/docs/connection-integration/data-integration/metabase.md
@@ -12,8 +12,8 @@
 }
 ---
 
-{/* Knowledge type: Procedure */}
-{/* Applicable scenario: Connect to Apache Doris in Metabase and build visualization dashboards */}
+<!-- Knowledge type: Procedure -->
+<!-- Applicable scenario: Connect to Apache Doris in Metabase and build visualization dashboards -->
 
 Metabase is an open source business intelligence tool that provides data analysis, data visualization, interactive dashboards, data drill-down, SQL query editing, and data export. With the Metabase Apache Doris Driver, Metabase can integrate Apache Doris databases and tables as data sources to query Doris internal data and external data, and to build visualization dashboards.
 
@@ -101,8 +101,8 @@ If you start Metabase with Docker, you are recommended to start it by mounting `
 
 ## Configure the Doris data source
 
-{/* Knowledge type: Configuration parameters */}
-{/* Applicable scenario: Add an Apache Doris database connection on the Metabase admin page */}
+<!-- Knowledge type: Configuration parameters -->
+<!-- Applicable scenario: Add an Apache Doris database connection on the Metabase admin page -->
 
 After installing Metabase and `metabase-doris-driver`, you can add a data source in Metabase that connects to the Doris `tpch` database.
 
@@ -172,8 +172,8 @@ After the data source configuration is complete, you can build visualizations in
 
 ## Build a visualization dashboard
 
-{/* Knowledge type: Procedure */}
-{/* Applicable scenario: Use Doris TPC-H data to create a Question and a Dashboard in Metabase */}
+<!-- Knowledge type: Procedure -->
+<!-- Applicable scenario: Use Doris TPC-H data to create a Question and a Dashboard in Metabase -->
 
 This example uses TPC-H data as the data source. For how to build the Doris TPC-H data source, see the [Doris TPC-H benchmark documentation](../../lakehouse/best-practices/tpch.md).
 
@@ -280,8 +280,8 @@ The following table summarizes the driver capabilities and current support bound
 
 ## Advanced scenarios
 
-{/* Knowledge type: Feature description */}
-{/* Applicable scenario: Access external data sources, create interactive dashboards, and optimize query performance */}
+<!-- Knowledge type: Feature description -->
+<!-- Applicable scenario: Access external data sources, create interactive dashboards, and optimize query performance -->
 
 ### Use Catalog to access external data
 

--- a/docs/lakehouse/catalogs/adbc-catalog.md
+++ b/docs/lakehouse/catalogs/adbc-catalog.md
@@ -2,13 +2,31 @@
 {
     "title": "ADBC Catalog",
     "language": "en",
-    "description": "Apache Doris ADBC Catalog guide: query Arrow Flight SQL and other external data sources through an Arrow Database Connectivity driver, with Arrow-native transfer, parallel reads across BE nodes, and predicate pushdown."
+    "description": "Query Arrow Flight SQL and other external sources through an ADBC driver: Arrow-format transfer and parallel BE reads.",
+    "keywords": [
+        "ADBC Catalog",
+        "Arrow Database Connectivity",
+        "Arrow Flight SQL",
+        "ADBC driver",
+        "driver_url",
+        "partitioned_read",
+        "parallel reads",
+        "predicate pushdown",
+        "cross-cluster federated query",
+        "Doris data integration",
+        "ADBC vs JDBC"
+    ]
 }
 ---
 
+<!-- Knowledge Type: Capability Definition + Configuration Reference -->
+<!-- Applicable Scenarios: Cross-cluster federated query / External data source access / Data integration -->
+
 ## Overview
 
-ADBC ([Arrow Database Connectivity](https://arrow.apache.org/adbc/)) is a database access interface defined by the Arrow ecosystem. An ADBC Catalog reads an external data source through an ADBC driver. Two things work differently than in a JDBC Catalog:
+ADBC ([Arrow Database Connectivity](https://arrow.apache.org/adbc/)) is a database access interface defined by the Arrow ecosystem. **An ADBC Catalog reads an external data source through an ADBC driver: data crosses the network in Arrow format, and several BE nodes read it in parallel.**
+
+Two things work differently than in a JDBC Catalog:
 
 - Arrow-native transfer. Data crosses the network in Arrow format and Doris reads it directly, without the row-by-row, value-by-value conversion a JDBC catalog performs.
 - Parallel reads. One scan is split by the driver's own result partitions and read by several BE nodes at once, instead of by a single BE node over one connection.
@@ -39,24 +57,28 @@ The current phase targets Arrow Flight SQL data sources, including another Doris
 
 ## Feature Overview
 
-| Feature | Support |
-| --- | --- |
-| Metadata access | `SHOW DATABASES`, `SHOW TABLES`, `DESC`, `SHOW CREATE TABLE` and `information_schema` |
-| Data query | Queries against external tables, plus joins, aggregation, `ORDER BY`, `UNION` and subqueries with internal tables and tables in other catalogs |
-| Column pruning | Supported. Only the columns a query needs are requested from the data source |
-| Predicate pushdown | Some scalar predicates become the remote `WHERE` clause |
-| `LIMIT` pushdown | Supported once the whole `WHERE` clause has been pushed down |
-| `COUNT(*)` optimization | Supported. No column data is read |
-| Parallel reads | A scan is split by the driver's result partitions and read by several BE nodes |
-| Type mapping | Automatic, including `ARRAY`, `MAP`, `STRUCT`, `DECIMAL`, dates, and timestamps with and without a time zone |
-| Metadata cache | Supported. Cached for 10 minutes by default, cleared by any `REFRESH` statement |
-| `SELECT INTO OUTFILE` | Supported |
-| Materialized views (MTMV) | An MTMV can be built and refreshed on an ADBC table |
-| Writing to the data source | `INSERT`, `CREATE TABLE`, `DROP TABLE` and other write statements are not supported yet |
-| Statistics | Not supported yet |
-| Aggregate pushdown | Not supported yet |
+<!-- Knowledge Type: Capability Matrix -->
+
+| Feature | Support | Description |
+| --- | --- | --- |
+| Metadata access | Supported | `SHOW DATABASES`, `SHOW TABLES`, `DESC`, `SHOW CREATE TABLE` and `information_schema` |
+| Data query | Supported | Queries against external tables, plus joins, aggregation, `ORDER BY`, `UNION` and subqueries with internal tables and tables in other catalogs |
+| Column pruning | Supported | Only the columns a query needs are requested from the data source |
+| Predicate pushdown | Supported | Some scalar predicates become the remote `WHERE` clause |
+| `LIMIT` pushdown | Supported | Applies once the whole `WHERE` clause has been pushed down |
+| `COUNT(*)` optimization | Supported | No column data is read |
+| Parallel reads | Supported | A scan is split by the driver's result partitions and read by several BE nodes |
+| Type mapping | Supported | Automatic, including `ARRAY`, `MAP`, `STRUCT`, `DECIMAL`, dates, and timestamps with and without a time zone |
+| Metadata cache | Supported | Cached for 10 minutes by default, cleared by any `REFRESH` statement |
+| `SELECT INTO OUTFILE` | Supported | Query results can be exported to a file |
+| Materialized views (MTMV) | Supported | An MTMV can be built and refreshed on an ADBC table |
+| Writing to the data source | Not supported yet | `INSERT`, `CREATE TABLE`, `DROP TABLE` and other write statements are rejected |
+| Statistics | Not supported yet | Statistics collection is unavailable |
+| Aggregate pushdown | Not supported yet | Aggregation runs in Doris |
 
 ## Deploying the ADBC Driver
+
+<!-- Knowledge Type: Deployment Steps -->
 
 Doris ships no ADBC driver, so deploy the driver library to the cluster nodes before you create a catalog.
 
@@ -94,6 +116,8 @@ driver_secure_path=/opt/doris/adbc_drivers
 
 ## Configuring Catalog
 
+<!-- Knowledge Type: Configuration Parameters -->
+
 ### Syntax
 
 ```sql
@@ -111,15 +135,13 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
 
 * `<driver_url>`
 
-    Required. The ADBC driver shared library.
+    Required. The ADBC driver shared library, given as a **local reference only**. Three forms are accepted:
 
-    **Local references only.** Three forms are accepted:
-
-    * A bare file name, resolved under the `drivers_dir` directory from `adbc.conf`. The name must match `[A-Za-z0-9._-]+.so`, optionally with a version suffix such as `.so.1`, and cannot contain a path separator.
-
-    * A `file://` URL carrying no authority, query or fragment.
-
-    * An absolute path.
+    | Form | Description |
+    | --- | --- |
+    | A bare file name | Resolved under the `drivers_dir` directory from `adbc.conf`. The name must match `[A-Za-z0-9._-]+.so`, optionally with a version suffix such as `.so.1`, and cannot contain a path separator. |
+    | A `file://` URL | Carries no authority, query or fragment. |
+    | An absolute path | The FE and every BE load the driver library from that path. |
 
     Remote schemes such as `http://` are rejected, because a per-node download cannot promise that every node ends up with the same driver build.
 
@@ -127,67 +149,58 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
 
     Required. The ADBC connection string.
 
-    It **must pin one remote catalog**, for example `postgresql://host:5432/mydb`, because Doris maps ADBC's three naming levels onto its own two. Refer to the section on [Namespace Mapping] for details.
+    It **must pin one remote catalog**, for example `postgresql://host:5432/mydb`, because Doris maps ADBC's three naming levels onto its own two. See [Namespace Mapping](#namespace-mapping) for details.
 
 * `{DriverProperties}`
 
     The DriverProperties section holds optional properties that control how the driver is loaded.
 
-    - `driver_checksum`
+    | Property | Default | Description |
+    | --- | --- | --- |
+    | `driver_checksum` | Nothing is verified | MD5 of the driver library file, verified at `CREATE CATALOG`. |
+    | `driver_entrypoint` | Empty | The driver's entry point symbol. When empty, the driver infers it. |
 
-        MD5 of the driver library file, verified at `CREATE CATALOG`. Nothing is verified by default.
+    `driver_checksum` catches the wrong driver build, or a stale copy on one node. Such a file usually loads without complaint and surfaces much later as a query failure that says nothing about a driver.
 
-        It catches a mistake that is easy to make here: the wrong driver build, or a stale copy on one node. Such a file usually loads without complaint and surfaces much later as a query failure that says nothing about a driver.
-
-        This verifies the FE's copy only, not the copies on the BEs.
-
-    - `driver_entrypoint`
-
-        The driver's entry point symbol. Empty by default, in which case the driver infers it.
+    :::caution
+    `driver_checksum` verifies the FE's copy only, not the copies on the BEs.
+    :::
 
 * `{ConnectionProperties}`
 
     The ConnectionProperties section holds the credentials for the data source and the dialect used to generate pushdown SQL.
 
-    - `user`
+    | Property | Default | Description |
+    | --- | --- | --- |
+    | `user` | None | User name, passed to the driver as written. Whether it is required depends on the data source. |
+    | `password` | None | Password, passed to the driver as written. Whether it is required depends on the data source. |
+    | `sql_dialect` | Auto-detected | The dialect used to generate pushdown SQL. By default the driver reports the data source's vendor name and Doris picks a dialect from it. An unrecognized name gets `ansi`. |
 
-        User name. Passed to the driver as written. Whether it is required depends on the data source.
+    Set `sql_dialect` explicitly when the vendor name a data source reports is unhelpful, or when its SQL does not match what that name implies. Two dialects are built in:
 
-    - `password`
-
-        Password. Passed to the driver as written. Whether it is required depends on the data source.
-
-    - `sql_dialect`
-
-        The dialect used to generate pushdown SQL. Auto-detected by default: the driver reports the data source's vendor name and Doris picks a dialect from it. An unrecognized name gets `ansi`.
-
-        Set it explicitly when the vendor name a data source reports is unhelpful, or when its SQL does not match what that name implies. Two dialects are built in:
-
-        * `ansi`: standard SQL. The default, and what an unrecognized data source gets.
-
-        * `doris`: identical to `ansi` except that identifiers are quoted with backticks (`` ` ``). Doris reads a double-quoted name as a string literal, so ANSI quoting does not parse against a Doris data source at all. A data source whose vendor name starts with `doris`, case-insensitively, selects this dialect automatically.
+    | Value | Description |
+    | --- | --- |
+    | `ansi` | Standard SQL. The default, and what an unrecognized data source gets. |
+    | `doris` | Identical to `ansi` except that identifiers are quoted with backticks (`` ` ``). Doris reads a double-quoted name as a string literal, so ANSI quoting does not parse against a Doris data source at all. A data source whose vendor name starts with `doris`, case-insensitively, selects this dialect automatically. |
 
 * `{ReadProperties}`
 
     The ReadProperties section controls parallel reads.
 
-    - `partitioned_read`
+    | Property | Default | Description |
+    | --- | --- | --- |
+    | `partitioned_read` | `auto` | Parallel read mode. An invalid value raises an error rather than falling back to the default. |
+    | `max_partitions` | `1024` | The largest number of partitions one scan may plan. |
 
-        Parallel read mode, `auto` by default. An invalid value raises an error rather than falling back to the default. Three values are accepted:
+    `partitioned_read` accepts three values:
 
-        * `auto`: the default. Split the scan when the driver can partition it, and read it as a single statement when it cannot.
+    | Value | Description |
+    | --- | --- |
+    | `auto` | The default. Splits the scan when the driver can partition it, and reads it as a single statement when it cannot. |
+    | `disabled` | Never asks for partitions. Asking is not free: on an Arrow Flight SQL data source the call that returns partitions **is** the query's execution, so planning costs one more remote round trip and the data source starts working before Doris has committed to running the query. Use this value to get back to single-statement reads when a data source pays too much for that, or when Doris cannot read the partitions it returns. |
+    | `required` | The scan must be split, or the query fails and says why. Use it where parallelism must not be lost quietly. Under `auto`, a driver that stops partitioning still returns a successful query, and nothing in the result shows that it took the fallback path. |
 
-        * `disabled`: never ask for partitions. Asking is not free. On an Arrow Flight SQL data source the call that returns partitions **is** the query's execution, so planning costs one more remote round trip and the data source starts working before Doris has committed to running the query. Use this value to get back to single-statement reads when a data source pays too much for that, or when Doris cannot read the partitions it returns.
-
-        * `required`: the scan must be split, or the query fails and says why. Use it where parallelism must not be lost quietly. Under `auto`, a driver that stops partitioning still returns a successful query, and nothing in the result shows that it took the fallback path.
-
-    - `max_partitions`
-
-        The largest number of partitions one scan may plan, `1024` by default.
-
-        This is a guard rail against a pathological data source, not a tuning knob. Every partition costs some planning resource, and enough of them will exhaust the FE.
-
-        Exceeding the limit fails the query instead of falling back to a single-statement read. By that point the data source has already executed the query, and a fallback would make it execute a second time.
+    `max_partitions` is a guard rail against a pathological data source, not a tuning knob. Every partition costs some planning resource, and enough of them will exhaust the FE. Exceeding the limit fails the query instead of falling back to a single-statement read, because by that point the data source has already executed the query and a fallback would make it execute a second time.
 
 * `{DriverOptions}`
 
@@ -203,11 +216,13 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
 
 * `{CommonProperties}`
 
-    The CommonProperties section is used to fill in common properties. Please refer to the [Catalog Overview](../catalog-overview.md) section on [Common Properties].
+    The CommonProperties section is used to fill in common properties. Refer to the Common Properties section of [Catalog Overview](../catalog-overview.md).
 
-    For metadata cache properties, refer to the section on [Metadata Cache].
+    For metadata cache properties, see [Metadata Cache](#meta-cache).
 
 ## Examples
+
+<!-- Knowledge Type: Operational Examples -->
 
 ### Querying Another Doris Cluster
 
@@ -229,6 +244,8 @@ SELECT id, name FROM remote_doris.some_db.some_table ORDER BY id LIMIT 10;
 
 ### Using an Absolute Path and Pinning the Driver Build
 
+Reference the driver by absolute path, and pin the FE's copy with `driver_checksum`:
+
 ```sql
 CREATE CATALOG remote_source PROPERTIES (
     'type' = 'adbc',
@@ -241,6 +258,8 @@ CREATE CATALOG remote_source PROPERTIES (
 ```
 
 ### Setting the Dialect and Requiring Parallel Reads
+
+Use the `doris` dialect against a Doris data source, and require the scan to be split so that parallelism is never lost quietly:
 
 ```sql
 CREATE CATALOG remote_doris_parallel PROPERTIES (
@@ -272,6 +291,8 @@ CREATE CATALOG remote_source_single PROPERTIES (
 
 ## Namespace Mapping
 
+<!-- Knowledge Type: Behavior Rules -->
+
 ADBC names objects in three levels (catalog / db_schema / table), while a Doris external table has two (database / table). The outermost name is already spent on the catalog you created, so one remote level has to be dropped from the name:
 
 - `uri` must pin one remote catalog. At most one of the two remote levels then varies, and Doris never has to join two names into a single database name.
@@ -287,6 +308,8 @@ If the data source reports an object with neither a catalog name nor a db_schema
 If `uri` does not pin a remote catalog, Doris reports this at `CREATE CATALOG` and asks you to name the remote catalog in the uri, such as `postgresql://host:5432/mydb`, or through a driver option. Some drivers do not implement the interface Doris uses for that check. Their catalogs are accepted as written, and the problem surfaces at the first `SHOW DATABASES`.
 
 ## Column Type Mapping
+
+<!-- Knowledge Type: Type Reference -->
 
 Doris maps the Arrow types the data source returns.
 
@@ -320,15 +343,15 @@ Doris maps the Arrow types the data source returns.
 | `run_end_encoded` | Mapped by the value type | |
 | Others | Unsupported | |
 
-> Note:
->
-> Doris has no unsigned integer types, so an unsigned type widens by one step. `uint32` maps to `BIGINT` rather than `INT`, because the narrower type would silently wrap every value above 2^31 into a negative number.
->
-> When a type cannot be mapped, Doris raises an error while describing the table and names the column and its Arrow type, rather than mapping it to something lossy. Cast the column on the source side, or leave it out of the query.
->
-> Reading from a Doris data source, an `IPV4` column arrives as `INT` because both sides encode it as int32, and a source `DATETIME` column arrives as `TIMESTAMPTZ`.
+:::note
+- Doris has no unsigned integer types, so an unsigned type widens by one step. `uint32` maps to `BIGINT` rather than `INT`, because the narrower type would silently wrap every value above 2^31 into a negative number.
+- When a type cannot be mapped, Doris raises an error while describing the table and names the column and its Arrow type, rather than mapping it to something lossy. Cast the column on the source side, or leave it out of the query.
+- Reading from a Doris data source, an `IPV4` column arrives as `INT` because both sides encode it as int32, and a source `DATETIME` column arrives as `TIMESTAMPTZ`.
+:::
 
 ## Query Operations
+
+<!-- Knowledge Type: Operational Examples + Behavior Rules -->
 
 ### Basic Query
 
@@ -360,9 +383,11 @@ DESC adbc_ctl.adbc_db.adbc_tbl;
 SHOW CREATE TABLE adbc_ctl.adbc_db.adbc_tbl;
 ```
 
-Database and table listings are always read live, so a table created on the data source is visible without any `REFRESH`. Table schemas are cached; refer to the section on [Metadata Cache].
+Database and table listings are always read live, so a table created on the data source is visible without any `REFRESH`. Table schemas are cached; see [Metadata Cache](#meta-cache).
 
-> Note: Views on the data source are not listed as tables.
+:::note
+Views on the data source are not listed as tables.
+:::
 
 ### Data Integration
 
@@ -433,6 +458,8 @@ A partition count above `max_partitions` fails the query.
 
 ## Metadata Cache {#meta-cache}
 
+<!-- Knowledge Type: Configuration Parameters + Usage Guidance -->
+
 To speed up access to an external data source, Doris caches part of an ADBC catalog's metadata: database name resolution, table name resolution, and table schemas.
 
 Database and table listings are **not cached**. They are always read live, so a table created on the data source is reachable without a `REFRESH`.
@@ -502,6 +529,8 @@ An ADBC connection reaches the data source as the single identity configured on 
 
 ## Limitations
 
+<!-- Knowledge Type: Limitations -->
+
 - Read only. `INSERT`, `CREATE TABLE`, `DROP TABLE` and other write statements against the data source are rejected.
 - Statistics collection and aggregate pushdown are not supported.
 - Views on the data source are not listed as tables.
@@ -513,33 +542,14 @@ An ADBC connection reaches the data source as the single identity configured on 
 
 ### FAQ
 
-1. `Driver file not found`
+<!-- Knowledge Type: Troubleshooting -->
 
-    The FE cannot find the driver file at the path it resolved. Check that:
-
-    - a bare file name in `driver_url` is present in the `drivers_dir` directory from `adbc.conf`;
-    - an absolute path or `file://` URL exists and is readable on the FE node.
-
-2. `Driver path does not match any path allowed by driver_secure_path`
-
-    The driver path falls outside the allow list in `adbc.conf`. Move the driver into an allowed directory, or change `driver_secure_path` and restart the FE.
-
-3. `scheme 'xxx' is not supported, only a local file is`
-
-    `driver_url` uses a remote scheme such as `http://`. An ADBC driver is not downloaded per node. Place the driver file on the FE and on all BEs, then reference it by bare name, absolute path or `file://` URL.
-
-4. `The ADBC source reports no current catalog, so 'uri' does not pin one`
-
-    `uri` does not pin a remote catalog. Name the remote catalog in the uri, such as `postgresql://host:5432/mydb`, or set it through a driver option with the `adbc.` prefix.
-
-5. A query fails saying a column's Arrow type has no Doris equivalent
-
-    That column's type cannot be mapped. Cast it to a mappable type on the data source, or leave it out of the query rather than using `SELECT *`.
-
-6. Query results look wrong, but nothing reports an error
-
-    Check that the driver file is the same build on the FE and on every BE. ADBC describes partition information in a driver-private format, and different implementations can misread each other's without raising anything. Use `driver_checksum` to pin the FE's build, and compare the MD5 of the driver file on each BE by hand.
-
-7. The remote SQL fails with a syntax error
-
-    The data source's SQL dialect does not match the one in use. Set `sql_dialect` explicitly, for example `'sql_dialect' = 'doris'` against a Doris data source.
+| Symptom or error | Cause | What to do |
+| --- | --- | --- |
+| `Driver file not found` | The FE cannot find the driver file at the path it resolved. | Check that a bare file name in `driver_url` is present in the `drivers_dir` directory from `adbc.conf`, and that an absolute path or `file://` URL exists and is readable on the FE node. |
+| `Driver path does not match any path allowed by driver_secure_path` | The driver path falls outside the allow list in `adbc.conf`. | Move the driver into an allowed directory, or change `driver_secure_path` and restart the FE. |
+| `scheme 'xxx' is not supported, only a local file is` | `driver_url` uses a remote scheme such as `http://`. | An ADBC driver is not downloaded per node. Place the driver file on the FE and on all BEs, then reference it by bare name, absolute path or `file://` URL. |
+| `The ADBC source reports no current catalog, so 'uri' does not pin one` | `uri` does not pin a remote catalog. | Name the remote catalog in the uri, such as `postgresql://host:5432/mydb`, or set it through a driver option with the `adbc.` prefix. |
+| A query fails saying a column's Arrow type has no Doris equivalent | That column's type cannot be mapped. | Cast it to a mappable type on the data source, or leave it out of the query rather than using `SELECT *`. |
+| Query results look wrong, but nothing reports an error | The driver file may not be the same build on the FE and on every BE. ADBC describes partition information in a driver-private format, and different implementations can misread each other's without raising anything. | Use `driver_checksum` to pin the FE's build, and compare the MD5 of the driver file on each BE by hand. |
+| The remote SQL fails with a syntax error | The data source's SQL dialect does not match the one in use. | Set `sql_dialect` explicitly, for example `'sql_dialect' = 'doris'` against a Doris data source. |

--- a/docs/lakehouse/catalogs/adbc-catalog.md
+++ b/docs/lakehouse/catalogs/adbc-catalog.md
@@ -1,0 +1,545 @@
+---
+{
+    "title": "ADBC Catalog",
+    "language": "en",
+    "description": "Apache Doris ADBC Catalog guide: query Arrow Flight SQL and other external data sources through an Arrow Database Connectivity driver, with Arrow-native transfer, parallel reads across BE nodes, and predicate pushdown."
+}
+---
+
+## Overview
+
+ADBC ([Arrow Database Connectivity](https://arrow.apache.org/adbc/)) is a database access interface defined by the Arrow ecosystem. An ADBC Catalog reads an external data source through an ADBC driver. Two things work differently than in a JDBC Catalog:
+
+- Arrow-native transfer. Data crosses the network in Arrow format and Doris reads it directly, without the row-by-row, value-by-value conversion a JDBC catalog performs.
+- Parallel reads. One scan is split by the driver's own result partitions and read by several BE nodes at once, instead of by a single BE node over one connection.
+
+:::note
+- This is an experimental feature, supported since version 5.0.0.
+- Only read operations are supported. Writing to the external data source is not supported.
+- Doris ships no ADBC driver. You deploy the driver library yourself, to the FE and to every BE node.
+:::
+
+The current phase targets Arrow Flight SQL data sources, including another Doris cluster, and replaces the [Doris Catalog](./doris-catalog.mdx). Another data source needs only its own ADBC driver library, plus a dialect implementation where its SQL differs from ANSI SQL.
+
+### Differences from a JDBC Catalog
+
+| Aspect | JDBC Catalog | ADBC Catalog |
+| --- | --- | --- |
+| Data transfer | Source rows become JDBC objects, then Doris data one value at a time | Data is transferred in Arrow format and read directly, with no per-value conversion |
+| Read parallelism | One BE node over a single connection | Split by the driver's result partitions and read by several BE nodes |
+| Driver form | A JDBC driver JAR, downloadable from a remote URL | An ADBC driver shared library (`.so`), referenced as a local file only |
+| Write support | Write-back supported | Not supported yet |
+
+## Applicable Scenarios
+
+| Scenario | Description |
+| --- | --- |
+| Data integration | Read from the external data source into a Doris internal table, or run federated queries across internal tables and tables in other catalogs. Data is transferred in Arrow format and read in parallel by several BE nodes, which performs better than the JDBC path. |
+| Writing back | Not supported. |
+
+## Feature Overview
+
+| Feature | Support |
+| --- | --- |
+| Metadata access | `SHOW DATABASES`, `SHOW TABLES`, `DESC`, `SHOW CREATE TABLE` and `information_schema` |
+| Data query | Queries against external tables, plus joins, aggregation, `ORDER BY`, `UNION` and subqueries with internal tables and tables in other catalogs |
+| Column pruning | Supported. Only the columns a query needs are requested from the data source |
+| Predicate pushdown | Some scalar predicates become the remote `WHERE` clause |
+| `LIMIT` pushdown | Supported once the whole `WHERE` clause has been pushed down |
+| `COUNT(*)` optimization | Supported. No column data is read |
+| Parallel reads | A scan is split by the driver's result partitions and read by several BE nodes |
+| Type mapping | Automatic, including `ARRAY`, `MAP`, `STRUCT`, `DECIMAL`, dates, and timestamps with and without a time zone |
+| Metadata cache | Supported. Cached for 10 minutes by default, cleared by any `REFRESH` statement |
+| `SELECT INTO OUTFILE` | Supported |
+| Materialized views (MTMV) | An MTMV can be built and refreshed on an ADBC table |
+| Writing to the data source | `INSERT`, `CREATE TABLE`, `DROP TABLE` and other write statements are not supported yet |
+| Statistics | Not supported yet |
+| Aggregate pushdown | Not supported yet |
+
+## Deploying the ADBC Driver
+
+Doris ships no ADBC driver, so deploy the driver library to the cluster nodes before you create a catalog.
+
+### Driver Placement Requirements
+
+:::caution
+At `CREATE CATALOG` the FE resolves `driver_url` into an absolute path and sends that path to the BEs unchanged. Each BE loads the driver from exactly that path. Therefore:
+
+- The driver file must exist at the **same absolute path** on the FE and on **every** BE node.
+- The FE and all BEs must load the **same build**. ADBC describes partition information in a driver-private format with no interoperability guarantee across driver implementations. Mixing driver versions may not raise an error at all; it may simply produce wrong results.
+:::
+
+The build output creates two driver directories:
+
+- FE: `<FE_HOME>/plugins/adbc_drivers`
+- BE: `<BE_HOME>/plugins/adbc_drivers`
+
+FE and BE usually live under different deployment directories, so these two absolute paths are not the same. In a multi-node deployment, put the driver at one shared absolute path on every FE and BE node, for example `/opt/doris/adbc_drivers`, and point `drivers_dir` in the FE's `adbc.conf` at that directory.
+
+### adbc.conf
+
+The ADBC connector plugin reads its settings from `<DORIS_HOME>/plugins/connector/adbc/adbc.conf` on the FE. This file must exist on **every FE node**. Doris does not replicate it through catalog metadata, and an edit takes effect after an FE restart.
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `drivers_dir` | `<DORIS_HOME>/plugins/adbc_drivers` | The directory a bare file name in `driver_url` resolves under. |
+| `driver_secure_path` | `*` | Directories a driver may be loaded from, separated by semicolons (`;`). `*` or blank allows any directory. When set to concrete paths, a driver path is matched component by component, so neither path traversal nor prefix confusion (`/opt/drv` against `/opt/drv-evil`) can get around it. |
+
+Example configuration:
+
+```properties
+drivers_dir=/opt/doris/adbc_drivers
+driver_secure_path=/opt/doris/adbc_drivers
+```
+
+## Configuring Catalog
+
+### Syntax
+
+```sql
+CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
+    'type' = 'adbc',
+    'driver_url' = '<driver_url>',
+    'uri' = '<connection_uri>',
+    {DriverProperties},
+    {ConnectionProperties},
+    {ReadProperties},
+    {DriverOptions},
+    {CommonProperties}
+);
+```
+
+* `<driver_url>`
+
+    Required. The ADBC driver shared library.
+
+    **Local references only.** Three forms are accepted:
+
+    * A bare file name, resolved under the `drivers_dir` directory from `adbc.conf`. The name must match `[A-Za-z0-9._-]+.so`, optionally with a version suffix such as `.so.1`, and cannot contain a path separator.
+
+    * A `file://` URL carrying no authority, query or fragment.
+
+    * An absolute path.
+
+    Remote schemes such as `http://` are rejected, because a per-node download cannot promise that every node ends up with the same driver build.
+
+* `<connection_uri>`
+
+    Required. The ADBC connection string.
+
+    It **must pin one remote catalog**, for example `postgresql://host:5432/mydb`, because Doris maps ADBC's three naming levels onto its own two. Refer to the section on [Namespace Mapping] for details.
+
+* `{DriverProperties}`
+
+    The DriverProperties section holds optional properties that control how the driver is loaded.
+
+    - `driver_checksum`
+
+        MD5 of the driver library file, verified at `CREATE CATALOG`. Nothing is verified by default.
+
+        It catches a mistake that is easy to make here: the wrong driver build, or a stale copy on one node. Such a file usually loads without complaint and surfaces much later as a query failure that says nothing about a driver.
+
+        This verifies the FE's copy only, not the copies on the BEs.
+
+    - `driver_entrypoint`
+
+        The driver's entry point symbol. Empty by default, in which case the driver infers it.
+
+* `{ConnectionProperties}`
+
+    The ConnectionProperties section holds the credentials for the data source and the dialect used to generate pushdown SQL.
+
+    - `user`
+
+        User name. Passed to the driver as written. Whether it is required depends on the data source.
+
+    - `password`
+
+        Password. Passed to the driver as written. Whether it is required depends on the data source.
+
+    - `sql_dialect`
+
+        The dialect used to generate pushdown SQL. Auto-detected by default: the driver reports the data source's vendor name and Doris picks a dialect from it. An unrecognized name gets `ansi`.
+
+        Set it explicitly when the vendor name a data source reports is unhelpful, or when its SQL does not match what that name implies. Two dialects are built in:
+
+        * `ansi`: standard SQL. The default, and what an unrecognized data source gets.
+
+        * `doris`: identical to `ansi` except that identifiers are quoted with backticks (`` ` ``). Doris reads a double-quoted name as a string literal, so ANSI quoting does not parse against a Doris data source at all. A data source whose vendor name starts with `doris`, case-insensitively, selects this dialect automatically.
+
+* `{ReadProperties}`
+
+    The ReadProperties section controls parallel reads.
+
+    - `partitioned_read`
+
+        Parallel read mode, `auto` by default. An invalid value raises an error rather than falling back to the default. Three values are accepted:
+
+        * `auto`: the default. Split the scan when the driver can partition it, and read it as a single statement when it cannot.
+
+        * `disabled`: never ask for partitions. Asking is not free. On an Arrow Flight SQL data source the call that returns partitions **is** the query's execution, so planning costs one more remote round trip and the data source starts working before Doris has committed to running the query. Use this value to get back to single-statement reads when a data source pays too much for that, or when Doris cannot read the partitions it returns.
+
+        * `required`: the scan must be split, or the query fails and says why. Use it where parallelism must not be lost quietly. Under `auto`, a driver that stops partitioning still returns a successful query, and nothing in the result shows that it took the fallback path.
+
+    - `max_partitions`
+
+        The largest number of partitions one scan may plan, `1024` by default.
+
+        This is a guard rail against a pathological data source, not a tuning knob. Every partition costs some planning resource, and enough of them will exhaust the FE.
+
+        Exceeding the limit fails the query instead of falling back to a single-statement read. By that point the data source has already executed the query, and a fallback would make it execute a second time.
+
+* `{DriverOptions}`
+
+    The DriverOptions section holds options passed straight through to the driver, written with an `adbc.` prefix.
+
+    :::caution
+    **The prefix is part of the option name and is not stripped.** ADBC's own option names already start with `adbc.`, for example `adbc.snowflake.sql.db`, so in `CREATE CATALOG` you write `adbc.adbc.snowflake.sql.db`.
+    :::
+
+    ```sql
+    'adbc.adbc.snowflake.sql.db' = 'my_database'
+    ```
+
+* `{CommonProperties}`
+
+    The CommonProperties section is used to fill in common properties. Please refer to the [Catalog Overview](../catalog-overview.md) section on [Common Properties].
+
+    For metadata cache properties, refer to the section on [Metadata Cache].
+
+## Examples
+
+### Querying Another Doris Cluster
+
+Read another Doris cluster through the Arrow Flight SQL driver. `uri` points at the Arrow Flight port of the target cluster's FE:
+
+```sql
+CREATE CATALOG remote_doris PROPERTIES (
+    'type' = 'adbc',
+    'driver_url' = 'libadbc_driver_flightsql.so',
+    'uri' = 'grpc://remote-doris-fe:8070',
+    'user' = 'root',
+    'password' = '<password>'
+);
+
+SELECT id, name FROM remote_doris.some_db.some_table ORDER BY id LIMIT 10;
+```
+
+`driver_url` here is a bare file name, resolved under `drivers_dir` from `adbc.conf`.
+
+### Using an Absolute Path and Pinning the Driver Build
+
+```sql
+CREATE CATALOG remote_source PROPERTIES (
+    'type' = 'adbc',
+    'driver_url' = '/opt/doris/adbc_drivers/libadbc_driver_flightsql.so',
+    'driver_checksum' = 'd41d8cd98f00b204e9800998ecf8427e',
+    'uri' = 'grpc+tls://remote-host:8070',
+    'user' = 'analyst',
+    'password' = '<password>'
+);
+```
+
+### Setting the Dialect and Requiring Parallel Reads
+
+```sql
+CREATE CATALOG remote_doris_parallel PROPERTIES (
+    'type' = 'adbc',
+    'driver_url' = 'libadbc_driver_flightsql.so',
+    'uri' = 'grpc://remote-doris-fe:8070',
+    'user' = 'root',
+    'password' = '<password>',
+    'sql_dialect' = 'doris',
+    'partitioned_read' = 'required',
+    'max_partitions' = '256'
+);
+```
+
+### Disabling Parallel Reads
+
+Turn parallel reads off when the data source pays too much for the partition request that happens before the query runs:
+
+```sql
+CREATE CATALOG remote_source_single PROPERTIES (
+    'type' = 'adbc',
+    'driver_url' = 'libadbc_driver_flightsql.so',
+    'uri' = 'grpc://remote-host:8070',
+    'user' = 'root',
+    'password' = '<password>',
+    'partitioned_read' = 'disabled'
+);
+```
+
+## Namespace Mapping
+
+ADBC names objects in three levels (catalog / db_schema / table), while a Doris external table has two (database / table). The outermost name is already spent on the catalog you created, so one remote level has to be dropped from the name:
+
+- `uri` must pin one remote catalog. At most one of the two remote levels then varies, and Doris never has to join two names into a single database name.
+- When the remote `db_schema` is non-empty, the Doris database name is that `db_schema`. Otherwise it is the remote catalog name.
+
+| Remote (catalog, db_schema) | Doris database name |
+| --- | --- |
+| `mydb`, `public` | `public` |
+| `mydb`, empty | `mydb` |
+
+If the data source reports an object with neither a catalog name nor a db_schema name, Doris cannot address it as a database and raises an error.
+
+If `uri` does not pin a remote catalog, Doris reports this at `CREATE CATALOG` and asks you to name the remote catalog in the uri, such as `postgresql://host:5432/mydb`, or through a driver option. Some drivers do not implement the interface Doris uses for that check. Their catalogs are accepted as written, and the problem surfaces at the first `SHOW DATABASES`.
+
+## Column Type Mapping
+
+Doris maps the Arrow types the data source returns.
+
+| Arrow type | Doris type | Comment |
+| --- | --- | --- |
+| `bool` | `BOOLEAN` | |
+| `int8` | `TINYINT` | |
+| `int16` | `SMALLINT` | |
+| `int32` | `INT` | |
+| `int64` | `BIGINT` | |
+| `uint8` | `SMALLINT` | Unsigned integers widen by one step |
+| `uint16` | `INT` | Unsigned integers widen by one step |
+| `uint32` | `BIGINT` | Unsigned integers widen by one step |
+| `uint64` | `LARGEINT` | Unsigned integers widen by one step |
+| `float16`, `float32` | `FLOAT` | |
+| `float64` | `DOUBLE` | |
+| `decimal128(P,S)` | `DECIMAL(P,S)` | Maximum precision 38; beyond that the column is rejected |
+| `decimal256(P,S)` | `DECIMAL(P,S)` | Maximum precision 76; beyond that the column is rejected |
+| `date32(day)` | `DATE` | |
+| `date64(ms)` | `DATETIME(3)` | `date64` carries a time of day, which `DATE` would drop |
+| `timestamp(s)` without time zone | `DATETIME(0)` | |
+| `timestamp(ms)` without time zone | `DATETIME(3)` | |
+| `timestamp(us)`, `timestamp(ns)` without time zone | `DATETIME(6)` | Nanosecond precision is truncated to microseconds |
+| `timestamp` with time zone | `TIMESTAMPTZ(0-6)` | Same precision rules. A zoned Arrow timestamp is an instant, and `DATETIME` would drop the zone |
+| `utf8`, `large_utf8`, `utf8_view` | `STRING` | |
+| `binary`, `large_binary`, `binary_view`, `fixed_size_binary` | `STRING` | Doris has no general binary column type on the external table path |
+| `list`, `large_list`, `fixed_size_list`, `list_view`, `large_list_view` | `ARRAY` | Element type is mapped recursively |
+| `struct` | `STRUCT` | Field types are mapped recursively, and **field names are lowercased** |
+| `map` | `MAP` | Key and value types are mapped recursively |
+| `dictionary` | Mapped by the dictionary's value type | |
+| `run_end_encoded` | Mapped by the value type | |
+| Others | Unsupported | |
+
+> Note:
+>
+> Doris has no unsigned integer types, so an unsigned type widens by one step. `uint32` maps to `BIGINT` rather than `INT`, because the narrower type would silently wrap every value above 2^31 into a negative number.
+>
+> When a type cannot be mapped, Doris raises an error while describing the table and names the column and its Arrow type, rather than mapping it to something lossy. Cast the column on the source side, or leave it out of the query.
+>
+> Reading from a Doris data source, an `IPV4` column arrives as `INT` because both sides encode it as int32, and a source `DATETIME` column arrives as `TIMESTAMPTZ`.
+
+## Query Operations
+
+### Basic Query
+
+Once the catalog is configured, query its tables in any of these ways:
+
+```sql
+-- 1. switch to catalog, use database and query
+SWITCH adbc_ctl;
+USE adbc_db;
+SELECT * FROM adbc_tbl LIMIT 10;
+
+-- 2. use adbc database directly
+USE adbc_ctl.adbc_db;
+SELECT * FROM adbc_tbl LIMIT 10;
+
+-- 3. use full qualified name to query
+SELECT * FROM adbc_ctl.adbc_db.adbc_tbl LIMIT 10;
+```
+
+### Metadata Operations
+
+```sql
+SHOW DATABASES FROM adbc_ctl;
+
+SHOW TABLES FROM adbc_ctl.adbc_db;
+
+DESC adbc_ctl.adbc_db.adbc_tbl;
+
+SHOW CREATE TABLE adbc_ctl.adbc_db.adbc_tbl;
+```
+
+Database and table listings are always read live, so a table created on the data source is visible without any `REFRESH`. Table schemas are cached; refer to the section on [Metadata Cache].
+
+> Note: Views on the data source are not listed as tables.
+
+### Data Integration
+
+You can write data from the external source into a Doris internal table:
+
+```sql
+INSERT INTO internal.demo.local_tbl
+SELECT * FROM adbc_ctl.adbc_db.adbc_tbl;
+```
+
+Federated queries with internal tables and tables in other catalogs also work, as do `SELECT ... INTO OUTFILE` and materialized views (MTMV) built on ADBC tables.
+
+### Column Pruning
+
+Doris requests only the columns a query needs. Unused columns do not appear in the generated remote SQL.
+
+### Predicate Pushdown
+
+The following predicates become the remote SQL `WHERE` clause:
+
+| Category | Supported forms |
+| --- | --- |
+| Comparison | `=`, `!=`, `<`, `<=`, `>`, `>=` |
+| Null tests | `IS NULL`, `IS NOT NULL` |
+| Sets | `IN`, `NOT IN` |
+| Logical operators | `AND`, `OR`, `NOT` over the predicates above |
+
+Function calls, arithmetic expressions, `LIKE` and `BETWEEN` are not pushed down and stay in Doris.
+
+Each top-level `AND` conjunct is pushed all or not at all. **Doris re-applies every predicate regardless**, so pushdown affects query speed and never changes which rows come back.
+
+### LIMIT Pushdown
+
+`LIMIT` is pushed down only after the whole `WHERE` clause has been pushed down, so the data source never truncates ahead of a filter Doris still has to apply.
+
+### COUNT(*) Optimization
+
+`COUNT(*)` reads no column data from the data source.
+
+### Inspecting the Generated Remote SQL
+
+`EXPLAIN` shows the SQL statement actually sent to the data source:
+
+```sql
+EXPLAIN
+SELECT id, name
+FROM adbc_ctl.adbc_db.adbc_tbl
+WHERE id > 100 AND name IS NOT NULL
+LIMIT 10;
+```
+
+The `QUERY:` line in the output is the pushed-down remote statement, and its columns match the ones the scan actually requests.
+
+:::tip
+On an Arrow Flight SQL data source, the call that asks for partitions is itself the query's execution. So when you run `EXPLAIN` on an ADBC table, Doris does not ask the data source for partitions, and the data source does not actually execute the query.
+:::
+
+### Parallel Reads
+
+When `partitioned_read` is `auto` (the default) or `required`, Doris asks the driver to split one scan into several result partitions. One BE node reads each partition, and the nodes work in parallel.
+
+When the data source cannot partition a scan:
+
+- `auto`: falls back to a single-statement read on one BE node.
+- `required`: the query fails and says why.
+
+A partition count above `max_partitions` fails the query.
+
+## Metadata Cache {#meta-cache}
+
+To speed up access to an external data source, Doris caches part of an ADBC catalog's metadata: database name resolution, table name resolution, and table schemas.
+
+Database and table listings are **not cached**. They are always read live, so a table created on the data source is reachable without a `REFRESH`.
+
+### Cache Property Configuration {#meta-cache-unified-model}
+
+An ADBC catalog's metadata cache is configured through the unified keys `meta.cache.<engine>.<entry>.{enable,ttl-second,capacity}`.
+
+| Property | Default | Meaning |
+| --- | --- | --- |
+| `meta.cache.adbc.metadata.enable` | `true` | Whether the metadata cache is enabled. |
+| `meta.cache.adbc.metadata.ttl-second` | `600` | `0` disables the cache, which takes effect immediately and can be used to see the latest metadata; `-1` never expires; other positive integers are a TTL in seconds based on access time. |
+| `meta.cache.adbc.metadata.capacity` | `1000` | Maximum number of cache entries. `0` disables the cache. |
+
+**How it takes effect:** the cache is active only when `enable=true`, `ttl-second != 0` and `capacity > 0`.
+
+:::tip
+The default TTL of 10 minutes is well below the default for other catalogs. An ADBC data source is another live database: its tables are altered by other people's DDL at any time, and nothing tells Doris when. This value is the ceiling on how long someone who forgot to `REFRESH` keeps seeing the old table schema.
+:::
+
+### Cache Modules {#meta-cache-unified-modules}
+
+Database resolution, table name resolution and table schemas share one set of settings. They are read together and dropped together, and they describe the same thing: the shape of the remote data source.
+
+| Module (`<entry>`) | Property key prefix | Cached content and impact |
+| --- | --- | --- |
+| `metadata` | `meta.cache.adbc.metadata.` | Caches database name resolution, table name resolution and table schemas. Impact: how soon an added, dropped or retyped column on the source becomes visible in Doris. |
+
+### Manual Refresh
+
+Each of these statements drops the cache for its own scope:
+
+```sql
+REFRESH CATALOG adbc_ctl;
+REFRESH DATABASE adbc_ctl.adbc_db;
+REFRESH TABLE adbc_ctl.adbc_db.adbc_tbl;
+```
+
+### Best Practices {#meta-cache-best-practices}
+
+* **Real-time access to the latest metadata**: if you want every query to read the data source's current table schema, set `ttl-second` to `0`:
+
+  ```sql
+  ALTER CATALOG adbc_ctl SET PROPERTIES ("meta.cache.adbc.metadata.ttl-second" = "0");
+  ```
+
+* **Data sources whose schemas change often**: lower `ttl-second`, or run a `REFRESH` once you know a change has happened.
+
+### Observability {#meta-cache-unified-observability}
+
+Cache metrics are available from the `information_schema.catalog_meta_cache_statistics` system table:
+
+```sql
+SELECT catalog_name, engine_name, entry_name,
+       effective_enabled, ttl_second, capacity,
+       estimated_size, hit_rate, load_failure_count, last_error
+FROM information_schema.catalog_meta_cache_statistics
+WHERE catalog_name = 'adbc_ctl' AND engine_name = 'adbc'
+ORDER BY entry_name;
+```
+
+The system table is documented at [catalog_meta_cache_statistics](../../admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md).
+
+:::caution
+An ADBC connection reaches the data source as the single identity configured on the catalog, whoever runs the query. Cache entries are therefore shared across all users.
+:::
+
+## Limitations
+
+- Read only. `INSERT`, `CREATE TABLE`, `DROP TABLE` and other write statements against the data source are rejected.
+- Statistics collection and aggregate pushdown are not supported.
+- Views on the data source are not listed as tables.
+- `driver_checksum` verifies the FE's copy of the driver only. The BE copies are not verified, and the FE and BE files are not compared against each other.
+- `driver_url` accepts local references only. Doris will not download a driver from a remote URL.
+- Reading from a Doris data source, an `IPV4` column arrives as `INT` and a source `DATETIME` column arrives as `TIMESTAMPTZ`.
+
+## Appendix
+
+### FAQ
+
+1. `Driver file not found`
+
+    The FE cannot find the driver file at the path it resolved. Check that:
+
+    - a bare file name in `driver_url` is present in the `drivers_dir` directory from `adbc.conf`;
+    - an absolute path or `file://` URL exists and is readable on the FE node.
+
+2. `Driver path does not match any path allowed by driver_secure_path`
+
+    The driver path falls outside the allow list in `adbc.conf`. Move the driver into an allowed directory, or change `driver_secure_path` and restart the FE.
+
+3. `scheme 'xxx' is not supported, only a local file is`
+
+    `driver_url` uses a remote scheme such as `http://`. An ADBC driver is not downloaded per node. Place the driver file on the FE and on all BEs, then reference it by bare name, absolute path or `file://` URL.
+
+4. `The ADBC source reports no current catalog, so 'uri' does not pin one`
+
+    `uri` does not pin a remote catalog. Name the remote catalog in the uri, such as `postgresql://host:5432/mydb`, or set it through a driver option with the `adbc.` prefix.
+
+5. A query fails saying a column's Arrow type has no Doris equivalent
+
+    That column's type cannot be mapped. Cast it to a mappable type on the data source, or leave it out of the query rather than using `SELECT *`.
+
+6. Query results look wrong, but nothing reports an error
+
+    Check that the driver file is the same build on the FE and on every BE. ADBC describes partition information in a driver-private format, and different implementations can misread each other's without raising anything. Use `driver_checksum` to pin the FE's build, and compare the MD5 of the driver file on each BE by hand.
+
+7. The remote SQL fails with a syntax error
+
+    The data source's SQL dialect does not match the one in use. Set `sql_dialect` explicitly, for example `'sql_dialect' = 'doris'` against a Doris data source.

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/data-integration/metabase.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/data-integration/metabase.md
@@ -12,8 +12,8 @@
 }
 ---
 
-{/* 知识类型: 操作步骤 */}
-{/* 适用场景: 在 Metabase 中连接 Apache Doris 并构建可视化仪表盘 */}
+<!-- 知识类型: 操作步骤 -->
+<!-- 适用场景: 在 Metabase 中连接 Apache Doris 并构建可视化仪表盘 -->
 
 Metabase 是一个开源商业智能工具，提供数据分析、数据可视化、交互式仪表盘、数据钻取、SQL 查询编辑和数据导出等能力。通过 Metabase Apache Doris Driver，Metabase 可以将 Apache Doris 数据库和表集成为数据源，用于查询 Doris 内部数据和外部数据，并构建可视化看板。
 
@@ -101,8 +101,8 @@ b23e82f19a7f9226343e42566e1e192b6df7a0dfc48a73d2101fc74bfec243f3
 
 ## 配置 Doris 数据源
 
-{/* 知识类型: 配置参数 */}
-{/* 适用场景: 在 Metabase 管理页面新增 Apache Doris 数据库连接 */}
+<!-- 知识类型: 配置参数 -->
+<!-- 适用场景: 在 Metabase 管理页面新增 Apache Doris 数据库连接 -->
 
 安装 Metabase 和 `metabase-doris-driver` 后，可以在 Metabase 中新增一个连接到 Doris `tpch` 数据库的数据源。
 
@@ -172,8 +172,8 @@ b23e82f19a7f9226343e42566e1e192b6df7a0dfc48a73d2101fc74bfec243f3
 
 ## 构建可视化仪表盘
 
-{/* 知识类型: 操作步骤 */}
-{/* 适用场景: 使用 Doris TPC-H 数据在 Metabase 中创建 Question 和 Dashboard */}
+<!-- 知识类型: 操作步骤 -->
+<!-- 适用场景: 使用 Doris TPC-H 数据在 Metabase 中创建 Question 和 Dashboard -->
 
 本示例使用 TPC-H 数据作为数据源。Doris TPC-H 数据源构建方式请参见 [Doris TPC-H 基准测试文档](../../lakehouse/best-practices/tpch.md)。
 
@@ -280,8 +280,8 @@ b23e82f19a7f9226343e42566e1e192b6df7a0dfc48a73d2101fc74bfec243f3
 
 ## 高级使用场景
 
-{/* 知识类型: 功能说明 */}
-{/* 适用场景: 访问外部数据源、创建交互式仪表盘和优化查询性能 */}
+<!-- 知识类型: 功能说明 -->
+<!-- 适用场景: 访问外部数据源、创建交互式仪表盘和优化查询性能 -->
 
 ### 使用 Catalog 访问外部数据
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/adbc-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/adbc-catalog.md
@@ -2,13 +2,31 @@
 {
     "title": "ADBC Catalog",
     "language": "zh-CN",
-    "description": "Apache Doris ADBC Catalog 使用指南：通过 Arrow Database Connectivity 驱动访问 Arrow Flight SQL 等外部数据源，数据以 Arrow 格式传输并由多个 BE 节点并行读取，支持谓词下推、列裁剪、类型映射和元数据缓存，实现高性能的跨集群联邦查询与数据集成。"
+    "description": "Doris ADBC Catalog 通过 ADBC 驱动以 Arrow 格式读取 Arrow Flight SQL 等外部数据源，支持多 BE 并行读取、谓词下推和联邦查询。",
+    "keywords": [
+        "ADBC Catalog",
+        "Arrow Database Connectivity",
+        "Arrow Flight SQL",
+        "ADBC 驱动",
+        "driver_url",
+        "partitioned_read",
+        "并行读取",
+        "谓词下推",
+        "跨集群联邦查询",
+        "Doris 数据集成",
+        "ADBC 与 JDBC 区别"
+    ]
 }
 ---
 
+<!-- 知识类型: 能力定义 + 配置参考 -->
+<!-- 适用场景: 跨集群联邦查询 / 外部数据源接入 / 数据集成 -->
+
 ## 概述
 
-ADBC（[Arrow Database Connectivity](https://arrow.apache.org/adbc/)）是 Arrow 生态定义的一套数据库访问接口。ADBC Catalog 通过 ADBC 驱动访问外部数据源，与 JDBC Catalog 相比有两点不同：
+ADBC（[Arrow Database Connectivity](https://arrow.apache.org/adbc/)）是 Arrow 生态定义的一套数据库访问接口。**ADBC Catalog 通过 ADBC 驱动访问外部数据源，数据以 Arrow 格式传输，并由多个 BE 节点并行读取。**
+
+与 JDBC Catalog 相比，有两点不同：
 
 - **Arrow 原生传输**：数据以 Arrow 格式在网络上传输并被 Doris 直接读取，无需逐行逐值的格式转换。
 - **多 BE 并行读取**：一次扫描会按驱动自身的结果分区（Partition）拆分，由多个 BE 节点同时读取，而不是由单个 BE 节点通过单条连接读取。
@@ -34,29 +52,33 @@ ADBC（[Arrow Database Connectivity](https://arrow.apache.org/adbc/)）是 Arrow
 
 | 场景 | 说明 |
 | --- | --- |
-| 数据集成 | 读取外部数据源的数据并写入到 Doris 内表，或与内表、其他 Catalog 的表进行联邦查询。数据以 Arrow 格式传输，并由多个 BE 节点并行读取，相比 JDBC 方式可以获得更高性能的数据交互。 |
+| 数据集成 | 读取外部数据源的数据并写入 Doris 内表，或与内表、其他 Catalog 的表进行联邦查询。数据以 Arrow 格式传输，并由多个 BE 节点并行读取，相比 JDBC 方式可以获得更高性能的数据交互。 |
 | 数据写回 | 暂不支持。 |
 
 ## 功能概览
 
-| 功能 | 支持情况 |
-| --- | --- |
-| 元数据访问 | 支持 `SHOW DATABASES`、`SHOW TABLES`、`DESC`、`SHOW CREATE TABLE` 以及 `information_schema` |
-| 数据查询 | 支持对外部表的查询，以及与内表、其他 Catalog 表的 Join、聚合、`ORDER BY`、`UNION` 和子查询 |
-| 列裁剪 | 支持，只向数据源请求查询实际需要的列 |
-| 谓词下推 | 支持将部分标量谓词下推为远端 `WHERE` 条件 |
-| `LIMIT` 下推 | 支持，在 `WHERE` 条件被完整下推后生效 |
-| `COUNT(*)` 优化 | 支持，不读取任何列数据 |
-| 并行读取 | 支持按驱动的结果分区拆分扫描，由多个 BE 并行读取 |
-| 类型映射 | 支持包括 `ARRAY`、`MAP`、`STRUCT`、`DECIMAL`、日期和带/不带时区时间戳在内的自动映射 |
-| 元数据缓存 | 支持，默认缓存 10 分钟，可通过 `REFRESH` 语句清除 |
-| `SELECT INTO OUTFILE` | 支持 |
-| 物化视图（MTMV） | 支持基于 ADBC 表构建和刷新 |
-| 写入数据源 | 暂不支持 `INSERT`、`CREATE TABLE`、`DROP TABLE` 等写操作 |
-| 统计信息 | 暂不支持 |
-| 聚合下推 | 暂不支持 |
+<!-- 知识类型: 能力清单 -->
+
+| 功能 | 支持情况 | 说明 |
+| --- | --- | --- |
+| 元数据访问 | 支持 | `SHOW DATABASES`、`SHOW TABLES`、`DESC`、`SHOW CREATE TABLE` 以及 `information_schema` |
+| 数据查询 | 支持 | 对外部表的查询，以及与内表、其他 Catalog 表的 Join、聚合、`ORDER BY`、`UNION` 和子查询 |
+| 列裁剪 | 支持 | 只向数据源请求查询实际需要的列 |
+| 谓词下推 | 支持 | 将部分标量谓词下推为远端 `WHERE` 条件 |
+| `LIMIT` 下推 | 支持 | 在 `WHERE` 条件被完整下推后生效 |
+| `COUNT(*)` 优化 | 支持 | 不读取任何列数据 |
+| 并行读取 | 支持 | 按驱动的结果分区拆分扫描，由多个 BE 并行读取 |
+| 类型映射 | 支持 | 自动映射，包括 `ARRAY`、`MAP`、`STRUCT`、`DECIMAL`、日期和带/不带时区时间戳 |
+| 元数据缓存 | 支持 | 默认缓存 10 分钟，可通过 `REFRESH` 语句清除 |
+| `SELECT INTO OUTFILE` | 支持 | 可将查询结果导出到文件 |
+| 物化视图（MTMV） | 支持 | 可基于 ADBC 表构建和刷新 |
+| 写入数据源 | 暂不支持 | `INSERT`、`CREATE TABLE`、`DROP TABLE` 等写操作 |
+| 统计信息 | 暂不支持 | 不支持统计信息收集 |
+| 聚合下推 | 暂不支持 | 聚合运算由 Doris 完成 |
 
 ## 部署 ADBC 驱动
+
+<!-- 知识类型: 部署步骤 -->
 
 Doris 不附带任何 ADBC 驱动，使用前需要先将驱动动态库部署到集群节点上。
 
@@ -94,6 +116,8 @@ driver_secure_path=/opt/doris/adbc_drivers
 
 ## 配置 Catalog
 
+<!-- 知识类型: 配置参数 -->
+
 ### 语法
 
 ```sql
@@ -111,15 +135,13 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
 
 * `<driver_url>`
 
-    必填。ADBC 驱动动态库。
+    必填。ADBC 驱动动态库，**只支持本地引用**，可以填写以下三种形式：
 
-    **只支持本地引用**，可以填写以下三种形式：
-
-    * 纯文件名：在 `adbc.conf` 的 `drivers_dir` 目录下解析。文件名必须匹配 `[A-Za-z0-9._-]+.so`（允许带版本号后缀，如 `.so.1`），不能包含路径分隔符。
-
-    * `file://` URL：不能带有 authority、query 或 fragment。
-
-    * 绝对路径。
+    | 形式 | 说明 |
+    | --- | --- |
+    | 纯文件名 | 在 `adbc.conf` 的 `drivers_dir` 目录下解析。文件名必须匹配 `[A-Za-z0-9._-]+.so`（允许带版本号后缀，如 `.so.1`），不能包含路径分隔符。 |
+    | `file://` URL | 不能带有 authority、query 或 fragment。 |
+    | 绝对路径 | FE 和所有 BE 都按该路径加载驱动库。 |
 
     不支持 `http://` 等远程协议，因为逐节点下载无法保证各节点拿到同一个驱动构建。
 
@@ -127,67 +149,58 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
 
     必填。ADBC 连接串。
 
-    **必须指向一个确定的远端 Catalog**（例如 `postgresql://host:5432/mydb`），因为 Doris 需要把 ADBC 的三级命名空间映射到自身的两级命名空间。详情可参阅【命名空间映射】部分。
+    **必须指向一个确定的远端 Catalog**（例如 `postgresql://host:5432/mydb`），因为 Doris 需要把 ADBC 的三级命名空间映射到自身的两级命名空间。详情可参阅[命名空间映射](#命名空间映射)部分。
 
 * `{DriverProperties}`
 
     DriverProperties 部分用于填写驱动加载相关的可选属性。
 
-    - `driver_checksum`
+    | 属性名 | 默认值 | 说明 |
+    | --- | --- | --- |
+    | `driver_checksum` | 不校验 | 驱动库文件的 MD5 值，在 `CREATE CATALOG` 时校验。 |
+    | `driver_entrypoint` | 空 | 驱动的入口函数符号名。为空时由驱动自行推断。 |
 
-        驱动库文件的 MD5 值，在 `CREATE CATALOG` 时校验。默认不校验。
+    `driver_checksum` 用于避免放错驱动版本，或某个节点上是旧副本这类问题。这类问题通常可以正常加载驱动，但会在很久之后表现为一个看起来与驱动文件无关的查询失败。
 
-        用于避免放错驱动版本，或某个节点上是旧副本这类问题。这类问题通常可以正常加载驱动，但会在很久之后表现为一个看起来与驱动文件无关的查询失败。
-
-        注意：该校验只作用于 FE 上的驱动副本，不会校验 BE 上的副本。
-
-    - `driver_entrypoint`
-
-        驱动的入口函数符号名。默认为空，此时由驱动自行推断。
+    :::caution
+    `driver_checksum` 只作用于 FE 上的驱动副本，不会校验 BE 上的副本。
+    :::
 
 * `{ConnectionProperties}`
 
     ConnectionProperties 部分用于填写数据源的认证信息，以及生成下推 SQL 时使用的方言。
 
-    - `user`
+    | 属性名 | 默认值 | 说明 |
+    | --- | --- | --- |
+    | `user` | 无 | 用户名。会原样传递给驱动，是否必填取决于数据源。 |
+    | `password` | 无 | 密码。会原样传递给驱动，是否必填取决于数据源。 |
+    | `sql_dialect` | 自动探测 | 生成下推 SQL 时使用的方言。默认由驱动上报数据源的 Vendor 名称来选择方言，无法识别时使用 `ansi`。 |
 
-        用户名。会原样传递给驱动，是否必填取决于数据源。
+    当数据源上报的 Vendor 名称不可用，或其 SQL 与 Vendor 名称暗示的不一致时，可以显式指定 `sql_dialect`。当前内置两种方言：
 
-    - `password`
-
-        密码。会原样传递给驱动，是否必填取决于数据源。
-
-    - `sql_dialect`
-
-        生成下推 SQL 时使用的方言。默认自动探测：由驱动上报数据源的 Vendor 名称来选择方言，无法识别时使用 `ansi`。
-
-        当数据源上报的 Vendor 名称不可用，或其 SQL 与 Vendor 名称暗示的不一致时，可以显式指定。当前内置两种方言：
-
-        * `ansi`：标准 SQL。默认值，也是无法识别的数据源所使用的方言。
-
-        * `doris`：与 `ansi` 的唯一区别是标识符使用反引号（`` ` ``）引用。Doris 会把双引号解析为字符串字面量，因此 ANSI 的引用方式在 Doris 数据源上无法解析。Vendor 名称以 `doris` 开头（不区分大小写）的数据源会自动选中该方言。
+    | 取值 | 说明 |
+    | --- | --- |
+    | `ansi` | 标准 SQL。默认值，也是无法识别的数据源所使用的方言。 |
+    | `doris` | 与 `ansi` 的唯一区别是标识符使用反引号（`` ` ``）引用。Doris 会把双引号解析为字符串字面量，因此 ANSI 的引用方式在 Doris 数据源上无法解析。Vendor 名称以 `doris` 开头（不区分大小写）的数据源会自动选中该方言。 |
 
 * `{ReadProperties}`
 
     ReadProperties 部分用于控制并行读取行为。
 
-    - `partitioned_read`
+    | 属性名 | 默认值 | 说明 |
+    | --- | --- | --- |
+    | `partitioned_read` | `auto` | 并行读取模式。取值非法时直接报错，不会回退到默认值。 |
+    | `max_partitions` | `1024` | 一次扫描最多可以规划的分区数。 |
 
-        并行读取模式，默认为 `auto`。取值非法时直接报错，不会回退到默认值。支持以下三种取值：
+    `partitioned_read` 支持以下三种取值：
 
-        * `auto`：默认值。驱动支持分区时拆分扫描，不支持时回退为单条语句读取。
+    | 取值 | 说明 |
+    | --- | --- |
+    | `auto` | 默认值。驱动支持分区时拆分扫描，不支持时回退为单条语句读取。 |
+    | `disabled` | 从不请求分区。请求分区并非零开销：在 Arrow Flight SQL 数据源上，返回分区的调用**就是**查询的执行，因此会多一次远程交互，并且数据源会在 Doris 决定执行该查询之前就开始工作。当数据源为此付出的代价过高，或其分区 Doris 无法读取时，可以用该值回到单条语句读取的方式。 |
+    | `required` | 必须拆分扫描，否则查询报错并说明原因。适用于不允许静默丢失并行度的场景：在 `auto` 下，驱动一旦停止分区，查询仍然会成功，只是悄悄走了回退路径。 |
 
-        * `disabled`：从不请求分区。请求分区并非零开销：在 Arrow Flight SQL 数据源上，返回分区的调用**就是**查询的执行，因此会多一次远程交互，并且数据源会在 Doris 决定执行该查询之前就开始工作。当数据源为此付出的代价过高，或其分区 Doris 无法读取时，可以用该值回到单条语句读取的方式。
-
-        * `required`：必须拆分扫描，否则查询报错并说明原因。适用于不允许静默丢失并行度的场景：在 `auto` 下，驱动一旦停止分区，查询仍然会成功，只是悄悄走了回退路径。
-
-    - `max_partitions`
-
-        一次扫描最多可以规划的分区数，默认为 `1024`。
-
-        这是防止异常数据源的保护阈值，不是调优参数：每个分区都会占用一定的规划开销，分区过多会耗尽 FE 资源。
-
-        超过该值时查询直接失败，而不是回退为单条语句读取。因为此时数据源已经执行过该查询，回退会导致它再执行一次。
+    `max_partitions` 是防止异常数据源的保护阈值，不是调优参数：每个分区都会占用一定的规划开销，分区过多会耗尽 FE 资源。超过该值时查询直接失败，而不是回退为单条语句读取，因为此时数据源已经执行过该查询，回退会导致它再执行一次。
 
 * `{DriverOptions}`
 
@@ -205,9 +218,11 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
 
     CommonProperties 部分用于填写通用属性。请参阅[数据目录概述](../catalog-overview.md)中【通用属性】部分。
 
-    元数据缓存相关的属性请参阅【元数据缓存】部分。
+    元数据缓存相关的属性请参阅[元数据缓存](#meta-cache)部分。
 
 ## 基础示例
+
+<!-- 知识类型: 操作示例 -->
 
 ### 访问另一个 Doris 集群
 
@@ -229,6 +244,8 @@ SELECT id, name FROM remote_doris.some_db.some_table ORDER BY id LIMIT 10;
 
 ### 使用绝对路径并校验驱动版本
 
+`driver_url` 使用绝对路径引用驱动，并通过 `driver_checksum` 固定 FE 侧的驱动版本：
+
 ```sql
 CREATE CATALOG remote_source PROPERTIES (
     'type' = 'adbc',
@@ -241,6 +258,8 @@ CREATE CATALOG remote_source PROPERTIES (
 ```
 
 ### 显式指定方言并强制并行读取
+
+访问 Doris 数据源时指定 `doris` 方言，并要求扫描必须拆分为分区，避免静默丢失并行度：
 
 ```sql
 CREATE CATALOG remote_doris_parallel PROPERTIES (
@@ -272,6 +291,8 @@ CREATE CATALOG remote_source_single PROPERTIES (
 
 ## 命名空间映射
 
+<!-- 知识类型: 行为规则 -->
+
 ADBC 使用三级命名（catalog / db_schema / table），而 Doris 外部表只有两级（database / table）——最外层的名字已经被用户创建的 Catalog 占用。因此：
 
 - `uri` 必须指向一个确定的远端 Catalog。这样两个远端层级中最多只有一个是变化的，无需将两级名字拼接成一个数据库名。
@@ -287,6 +308,8 @@ ADBC 使用三级命名（catalog / db_schema / table），而 Doris 外部表�
 如果 `uri` 没有指向确定的远端 Catalog，Doris 会在 `CREATE CATALOG` 时报错，提示在 `uri` 中指定远端 Catalog 名（如 `postgresql://host:5432/mydb`），或通过驱动选项指定。部分驱动不实现相关的查询接口，此时 Doris 会接受该 `uri`，问题会在第一次 `SHOW DATABASES` 时暴露。
 
 ## 列类型映射
+
+<!-- 知识类型: 类型参考 -->
 
 Doris 按数据源返回的 Arrow 类型进行映射。
 
@@ -306,7 +329,7 @@ Doris 按数据源返回的 Arrow 类型进行映射。
 | `decimal128(P,S)` | `DECIMAL(P,S)` | 精度上限为 38，超出则报错 |
 | `decimal256(P,S)` | `DECIMAL(P,S)` | 精度上限为 76，超出则报错 |
 | `date32(day)` | `DATE` | |
-| `date64(ms)` | `DATETIME(3)` | `date64` 带有时间部分，映射为 `DATE` 会丢失 |
+| `date64(ms)` | `DATETIME(3)` | `date64` 带有时间部分，映射为 `DATE` 会丢失时间部分 |
 | 无时区 `timestamp(s)` | `DATETIME(0)` | |
 | 无时区 `timestamp(ms)` | `DATETIME(3)` | |
 | 无时区 `timestamp(us)`、`timestamp(ns)` | `DATETIME(6)` | 纳秒精度截断为微秒 |
@@ -320,15 +343,15 @@ Doris 按数据源返回的 Arrow 类型进行映射。
 | `run_end_encoded` | 按值类型映射 | |
 | 其他 | 不支持 | |
 
-> 注：
->
-> Doris 没有无符号整数类型，因此无符号类型会提升一级映射。例如 `uint32` 映射为 `BIGINT` 而不是 `INT`，否则超过 2^31 的值会静默回绕为负数。
->
-> 遇到无法映射的类型时，Doris 会在描述表结构时直接报错，并指出具体的列名和 Arrow 类型，而不是映射为一个有损的类型。可以在源端将该列 CAST 为可映射的类型，或在查询中排除该列。
->
-> 从 Doris 数据源读取时，`IPV4` 列会以 `INT` 返回（两端都按 int32 编码），源端的 `DATETIME` 列会以 `TIMESTAMPTZ` 返回。
+:::note
+- Doris 没有无符号整数类型，因此无符号类型会提升一级映射。例如 `uint32` 映射为 `BIGINT` 而不是 `INT`，否则超过 2^31 的值会静默回绕为负数。
+- 遇到无法映射的类型时，Doris 会在描述表结构时直接报错，并指出具体的列名和 Arrow 类型，而不是映射为一个有损的类型。可以在源端将该列 CAST 为可映射的类型，或在查询中排除该列。
+- 从 Doris 数据源读取时，`IPV4` 列会以 `INT` 返回（两端都按 int32 编码），源端的 `DATETIME` 列会以 `TIMESTAMPTZ` 返回。
+:::
 
 ## 查询操作
+
+<!-- 知识类型: 操作示例 + 行为规则 -->
 
 ### 基础查询
 
@@ -360,9 +383,11 @@ DESC adbc_ctl.adbc_db.adbc_tbl;
 SHOW CREATE TABLE adbc_ctl.adbc_db.adbc_tbl;
 ```
 
-数据库列表和表列表始终实时读取，因此在数据源上新建的表无需执行任何 `REFRESH` 即可看到。表结构（Schema）会被缓存，详见【元数据缓存】。
+数据库列表和表列表始终实时读取，因此在数据源上新建的表无需执行任何 `REFRESH` 即可看到。表结构（Schema）会被缓存，详见[元数据缓存](#meta-cache)。
 
-> 注：数据源上的视图不会作为表列出。
+:::note
+数据源上的视图不会作为表列出。
+:::
 
 ### 数据集成
 
@@ -433,6 +458,8 @@ LIMIT 10;
 
 ## 元数据缓存 {#meta-cache}
 
+<!-- 知识类型: 配置参数 + 使用建议 -->
+
 为了提升访问外部数据源的性能，Doris 会缓存 ADBC Catalog 的部分元数据，包括数据库名解析、表名解析和表结构（Schema）。
 
 数据库列表和表列表**不做缓存**，始终实时读取，因此数据源上新建的表无需 `REFRESH` 即可访问。
@@ -502,6 +529,8 @@ ADBC 连接使用 Catalog 中配置的固定身份访问数据源，与发起查
 
 ## 使用限制
 
+<!-- 知识类型: 使用限制 -->
+
 - **只读**：不支持 `INSERT`、`CREATE TABLE`、`DROP TABLE` 等针对数据源的写操作。
 - 不支持统计信息收集和聚合下推。
 - 数据源上的视图不会作为表列出。
@@ -513,33 +542,14 @@ ADBC 连接使用 Catalog 中配置的固定身份访问数据源，与发起查
 
 ### FAQ
 
-1. `Driver file not found`
+<!-- 知识类型: 故障排查 -->
 
-    FE 无法在解析出的路径上找到驱动文件。请检查：
-
-    - `driver_url` 填写的纯文件名是否位于 `adbc.conf` 的 `drivers_dir` 目录下；
-    - 使用绝对路径或 `file://` URL 时，该路径在 FE 节点上是否存在且可读。
-
-2. `Driver path does not match any path allowed by driver_secure_path`
-
-    驱动路径不在 `adbc.conf` 的 `driver_secure_path` 白名单内。将驱动移动到白名单目录下，或调整 `driver_secure_path` 配置后重启 FE。
-
-3. `scheme 'xxx' is not supported, only a local file is`
-
-    `driver_url` 使用了 `http://` 等远程协议。ADBC 驱动不支持逐节点下载，请将驱动文件放置到 FE 和所有 BE 上，并通过纯文件名、绝对路径或 `file://` URL 引用。
-
-4. `The ADBC source reports no current catalog, so 'uri' does not pin one`
-
-    `uri` 没有指向一个确定的远端 Catalog。请在 `uri` 中指定远端 Catalog 名（如 `postgresql://host:5432/mydb`），或通过 `adbc.` 前缀的驱动选项指定。
-
-5. 查询报错提示某列的 Arrow 类型没有对应的 Doris 类型
-
-    该列的类型当前不支持映射。可以在数据源侧将该列 CAST 为可映射的类型，或在查询中排除该列（不要使用 `SELECT *`）。
-
-6. 查询结果异常，但没有报错
-
-    请确认 FE 和所有 BE 上的驱动文件是同一个构建产物。ADBC 的分区信息使用驱动私有的格式描述，不同实现之间可能会错误解析而不报错。可以通过 `driver_checksum` 固定 FE 侧的驱动版本，并人工核对各 BE 上驱动文件的 MD5。
-
-7. 远端 SQL 报语法错误
-
-    数据源的 SQL 方言与当前使用的方言不匹配。可以通过 `sql_dialect` 显式指定方言，例如访问 Doris 数据源时指定 `'sql_dialect' = 'doris'`。
+| 现象 / 报错 | 原因 | 处理方法 |
+| --- | --- | --- |
+| `Driver file not found` | FE 无法在解析出的路径上找到驱动文件。 | 检查 `driver_url` 填写的纯文件名是否位于 `adbc.conf` 的 `drivers_dir` 目录下；使用绝对路径或 `file://` URL 时，检查该路径在 FE 节点上是否存在且可读。 |
+| `Driver path does not match any path allowed by driver_secure_path` | 驱动路径不在 `adbc.conf` 的 `driver_secure_path` 白名单内。 | 将驱动移动到白名单目录下，或调整 `driver_secure_path` 配置后重启 FE。 |
+| `scheme 'xxx' is not supported, only a local file is` | `driver_url` 使用了 `http://` 等远程协议。 | ADBC 驱动不支持逐节点下载。请将驱动文件放置到 FE 和所有 BE 上，并通过纯文件名、绝对路径或 `file://` URL 引用。 |
+| `The ADBC source reports no current catalog, so 'uri' does not pin one` | `uri` 没有指向一个确定的远端 Catalog。 | 在 `uri` 中指定远端 Catalog 名（如 `postgresql://host:5432/mydb`），或通过 `adbc.` 前缀的驱动选项指定。 |
+| 查询报错提示某列的 Arrow 类型没有对应的 Doris 类型 | 该列的类型当前不支持映射。 | 在数据源侧将该列 CAST 为可映射的类型，或在查询中排除该列（不要使用 `SELECT *`）。 |
+| 查询结果异常，但没有报错 | FE 和 BE 上的驱动文件可能不是同一个构建产物。ADBC 的分区信息使用驱动私有的格式描述，不同实现之间可能会错误解析而不报错。 | 通过 `driver_checksum` 固定 FE 侧的驱动版本，并人工核对各 BE 上驱动文件的 MD5。 |
+| 远端 SQL 报语法错误 | 数据源的 SQL 方言与当前使用的方言不匹配。 | 通过 `sql_dialect` 显式指定方言，例如访问 Doris 数据源时指定 `'sql_dialect' = 'doris'`。 |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/adbc-catalog.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/adbc-catalog.md
@@ -1,0 +1,545 @@
+---
+{
+    "title": "ADBC Catalog",
+    "language": "zh-CN",
+    "description": "Apache Doris ADBC Catalog 使用指南：通过 Arrow Database Connectivity 驱动访问 Arrow Flight SQL 等外部数据源，数据以 Arrow 格式传输并由多个 BE 节点并行读取，支持谓词下推、列裁剪、类型映射和元数据缓存，实现高性能的跨集群联邦查询与数据集成。"
+}
+---
+
+## 概述
+
+ADBC（[Arrow Database Connectivity](https://arrow.apache.org/adbc/)）是 Arrow 生态定义的一套数据库访问接口。ADBC Catalog 通过 ADBC 驱动访问外部数据源，与 JDBC Catalog 相比有两点不同：
+
+- **Arrow 原生传输**：数据以 Arrow 格式在网络上传输并被 Doris 直接读取，无需逐行逐值的格式转换。
+- **多 BE 并行读取**：一次扫描会按驱动自身的结果分区（Partition）拆分，由多个 BE 节点同时读取，而不是由单个 BE 节点通过单条连接读取。
+
+:::note
+- 该功能为实验功能，自 5.0.0 版本开始支持。
+- 当前仅支持读操作，不支持写入外部数据源。
+- Doris 不附带任何 ADBC 驱动，驱动库文件需要由用户自行部署到 FE 和所有 BE 节点上。
+:::
+
+当前阶段以 Arrow Flight SQL 数据源为目标（包括另一个 Doris 集群），是 [Doris Catalog](./doris-catalog.mdx) 的替代方案。其他数据源只需提供对应的 ADBC 驱动动态库，以及在其 SQL 与 ANSI SQL 存在差异时提供方言实现。
+
+### 与 JDBC Catalog 的区别
+
+| 对比项 | JDBC Catalog | ADBC Catalog |
+| --- | --- | --- |
+| 数据传输 | 源端数据先转为 JDBC 对象，再逐行逐值转换为 Doris 数据格式 | 数据以 Arrow 格式传输并被直接读取，无需逐行逐值转换 |
+| 读取并行度 | 由单个 BE 节点通过单条连接读取 | 按驱动的结果分区拆分，由多个 BE 节点并行读取 |
+| 驱动形式 | JDBC 驱动 JAR，可从远程 URL 下载 | ADBC 驱动动态库（`.so`），只能引用本地文件 |
+| 写入能力 | 支持写回 | 暂不支持 |
+
+## 适用场景
+
+| 场景 | 说明 |
+| --- | --- |
+| 数据集成 | 读取外部数据源的数据并写入到 Doris 内表，或与内表、其他 Catalog 的表进行联邦查询。数据以 Arrow 格式传输，并由多个 BE 节点并行读取，相比 JDBC 方式可以获得更高性能的数据交互。 |
+| 数据写回 | 暂不支持。 |
+
+## 功能概览
+
+| 功能 | 支持情况 |
+| --- | --- |
+| 元数据访问 | 支持 `SHOW DATABASES`、`SHOW TABLES`、`DESC`、`SHOW CREATE TABLE` 以及 `information_schema` |
+| 数据查询 | 支持对外部表的查询，以及与内表、其他 Catalog 表的 Join、聚合、`ORDER BY`、`UNION` 和子查询 |
+| 列裁剪 | 支持，只向数据源请求查询实际需要的列 |
+| 谓词下推 | 支持将部分标量谓词下推为远端 `WHERE` 条件 |
+| `LIMIT` 下推 | 支持，在 `WHERE` 条件被完整下推后生效 |
+| `COUNT(*)` 优化 | 支持，不读取任何列数据 |
+| 并行读取 | 支持按驱动的结果分区拆分扫描，由多个 BE 并行读取 |
+| 类型映射 | 支持包括 `ARRAY`、`MAP`、`STRUCT`、`DECIMAL`、日期和带/不带时区时间戳在内的自动映射 |
+| 元数据缓存 | 支持，默认缓存 10 分钟，可通过 `REFRESH` 语句清除 |
+| `SELECT INTO OUTFILE` | 支持 |
+| 物化视图（MTMV） | 支持基于 ADBC 表构建和刷新 |
+| 写入数据源 | 暂不支持 `INSERT`、`CREATE TABLE`、`DROP TABLE` 等写操作 |
+| 统计信息 | 暂不支持 |
+| 聚合下推 | 暂不支持 |
+
+## 部署 ADBC 驱动
+
+Doris 不附带任何 ADBC 驱动，使用前需要先将驱动动态库部署到集群节点上。
+
+### 驱动放置要求
+
+:::caution
+FE 在 `CREATE CATALOG` 时会把 `driver_url` 解析为一个绝对路径，并将该路径原样下发给 BE，BE 直接按这个路径加载驱动库。因此：
+
+- 驱动文件必须以**相同的绝对路径**存在于 FE 和**每一个** BE 节点上。
+- FE 和所有 BE 必须加载**同一个构建产物**。ADBC 的分区信息使用驱动私有的格式描述，不同驱动实现之间没有互操作保证，混用不同版本的驱动可能不会报错，而是产生错误的读取结果。
+:::
+
+编译产物中会自动创建两个驱动放置目录：
+
+- FE：`<FE_HOME>/plugins/adbc_drivers`
+- BE：`<BE_HOME>/plugins/adbc_drivers`
+
+由于 FE 和 BE 的部署目录通常不同，这两个目录的绝对路径也不同。因此在多节点部署中，建议在所有 FE 和 BE 节点上使用一个统一的绝对路径存放驱动（例如 `/opt/doris/adbc_drivers`），并通过 FE 的 `adbc.conf` 将 `drivers_dir` 指向该目录。
+
+### adbc.conf
+
+FE 侧的 ADBC 连接器插件配置文件位于 `<DORIS_HOME>/plugins/connector/adbc/adbc.conf`。该文件需要在**每个 FE 节点**上都存在，它不会通过 Doris 元数据同步，修改后需要重启 FE 生效。
+
+| 配置项 | 默认值 | 说明 |
+| --- | --- | --- |
+| `drivers_dir` | `<DORIS_HOME>/plugins/adbc_drivers` | `driver_url` 中填写的纯文件名所解析的目录。 |
+| `driver_secure_path` | `*` | 允许加载驱动的目录白名单，多个目录用分号（`;`）分隔。`*` 或留空表示不限制。设置为具体路径后，驱动路径会按路径分量逐级匹配，路径穿越和前缀混淆（如 `/opt/drv` 与 `/opt/drv-evil`）都无法绕过。 |
+
+配置示例：
+
+```properties
+drivers_dir=/opt/doris/adbc_drivers
+driver_secure_path=/opt/doris/adbc_drivers
+```
+
+## 配置 Catalog
+
+### 语法
+
+```sql
+CREATE CATALOG [IF NOT EXISTS] catalog_name PROPERTIES (
+    'type' = 'adbc',
+    'driver_url' = '<driver_url>',
+    'uri' = '<connection_uri>',
+    {DriverProperties},
+    {ConnectionProperties},
+    {ReadProperties},
+    {DriverOptions},
+    {CommonProperties}
+);
+```
+
+* `<driver_url>`
+
+    必填。ADBC 驱动动态库。
+
+    **只支持本地引用**，可以填写以下三种形式：
+
+    * 纯文件名：在 `adbc.conf` 的 `drivers_dir` 目录下解析。文件名必须匹配 `[A-Za-z0-9._-]+.so`（允许带版本号后缀，如 `.so.1`），不能包含路径分隔符。
+
+    * `file://` URL：不能带有 authority、query 或 fragment。
+
+    * 绝对路径。
+
+    不支持 `http://` 等远程协议，因为逐节点下载无法保证各节点拿到同一个驱动构建。
+
+* `<connection_uri>`
+
+    必填。ADBC 连接串。
+
+    **必须指向一个确定的远端 Catalog**（例如 `postgresql://host:5432/mydb`），因为 Doris 需要把 ADBC 的三级命名空间映射到自身的两级命名空间。详情可参阅【命名空间映射】部分。
+
+* `{DriverProperties}`
+
+    DriverProperties 部分用于填写驱动加载相关的可选属性。
+
+    - `driver_checksum`
+
+        驱动库文件的 MD5 值，在 `CREATE CATALOG` 时校验。默认不校验。
+
+        用于避免放错驱动版本，或某个节点上是旧副本这类问题。这类问题通常可以正常加载驱动，但会在很久之后表现为一个看起来与驱动文件无关的查询失败。
+
+        注意：该校验只作用于 FE 上的驱动副本，不会校验 BE 上的副本。
+
+    - `driver_entrypoint`
+
+        驱动的入口函数符号名。默认为空，此时由驱动自行推断。
+
+* `{ConnectionProperties}`
+
+    ConnectionProperties 部分用于填写数据源的认证信息，以及生成下推 SQL 时使用的方言。
+
+    - `user`
+
+        用户名。会原样传递给驱动，是否必填取决于数据源。
+
+    - `password`
+
+        密码。会原样传递给驱动，是否必填取决于数据源。
+
+    - `sql_dialect`
+
+        生成下推 SQL 时使用的方言。默认自动探测：由驱动上报数据源的 Vendor 名称来选择方言，无法识别时使用 `ansi`。
+
+        当数据源上报的 Vendor 名称不可用，或其 SQL 与 Vendor 名称暗示的不一致时，可以显式指定。当前内置两种方言：
+
+        * `ansi`：标准 SQL。默认值，也是无法识别的数据源所使用的方言。
+
+        * `doris`：与 `ansi` 的唯一区别是标识符使用反引号（`` ` ``）引用。Doris 会把双引号解析为字符串字面量，因此 ANSI 的引用方式在 Doris 数据源上无法解析。Vendor 名称以 `doris` 开头（不区分大小写）的数据源会自动选中该方言。
+
+* `{ReadProperties}`
+
+    ReadProperties 部分用于控制并行读取行为。
+
+    - `partitioned_read`
+
+        并行读取模式，默认为 `auto`。取值非法时直接报错，不会回退到默认值。支持以下三种取值：
+
+        * `auto`：默认值。驱动支持分区时拆分扫描，不支持时回退为单条语句读取。
+
+        * `disabled`：从不请求分区。请求分区并非零开销：在 Arrow Flight SQL 数据源上，返回分区的调用**就是**查询的执行，因此会多一次远程交互，并且数据源会在 Doris 决定执行该查询之前就开始工作。当数据源为此付出的代价过高，或其分区 Doris 无法读取时，可以用该值回到单条语句读取的方式。
+
+        * `required`：必须拆分扫描，否则查询报错并说明原因。适用于不允许静默丢失并行度的场景：在 `auto` 下，驱动一旦停止分区，查询仍然会成功，只是悄悄走了回退路径。
+
+    - `max_partitions`
+
+        一次扫描最多可以规划的分区数，默认为 `1024`。
+
+        这是防止异常数据源的保护阈值，不是调优参数：每个分区都会占用一定的规划开销，分区过多会耗尽 FE 资源。
+
+        超过该值时查询直接失败，而不是回退为单条语句读取。因为此时数据源已经执行过该查询，回退会导致它再执行一次。
+
+* `{DriverOptions}`
+
+    DriverOptions 部分用于填写直接传给驱动的选项，需要使用 `adbc.` 前缀。
+
+    :::caution
+    **前缀是选项名的一部分，不会被去掉。** ADBC 自身的选项名就以 `adbc.` 开头（例如 `adbc.snowflake.sql.db`），因此在 `CREATE CATALOG` 中需要写成 `adbc.adbc.snowflake.sql.db`。
+    :::
+
+    ```sql
+    'adbc.adbc.snowflake.sql.db' = 'my_database'
+    ```
+
+* `{CommonProperties}`
+
+    CommonProperties 部分用于填写通用属性。请参阅[数据目录概述](../catalog-overview.md)中【通用属性】部分。
+
+    元数据缓存相关的属性请参阅【元数据缓存】部分。
+
+## 基础示例
+
+### 访问另一个 Doris 集群
+
+通过 Arrow Flight SQL 驱动访问另一个 Doris 集群，`uri` 指向目标集群 FE 的 Arrow Flight 端口：
+
+```sql
+CREATE CATALOG remote_doris PROPERTIES (
+    'type' = 'adbc',
+    'driver_url' = 'libadbc_driver_flightsql.so',
+    'uri' = 'grpc://remote-doris-fe:8070',
+    'user' = 'root',
+    'password' = '<password>'
+);
+
+SELECT id, name FROM remote_doris.some_db.some_table ORDER BY id LIMIT 10;
+```
+
+`driver_url` 填写的是纯文件名，会在 `adbc.conf` 的 `drivers_dir` 下解析。
+
+### 使用绝对路径并校验驱动版本
+
+```sql
+CREATE CATALOG remote_source PROPERTIES (
+    'type' = 'adbc',
+    'driver_url' = '/opt/doris/adbc_drivers/libadbc_driver_flightsql.so',
+    'driver_checksum' = 'd41d8cd98f00b204e9800998ecf8427e',
+    'uri' = 'grpc+tls://remote-host:8070',
+    'user' = 'analyst',
+    'password' = '<password>'
+);
+```
+
+### 显式指定方言并强制并行读取
+
+```sql
+CREATE CATALOG remote_doris_parallel PROPERTIES (
+    'type' = 'adbc',
+    'driver_url' = 'libadbc_driver_flightsql.so',
+    'uri' = 'grpc://remote-doris-fe:8070',
+    'user' = 'root',
+    'password' = '<password>',
+    'sql_dialect' = 'doris',
+    'partitioned_read' = 'required',
+    'max_partitions' = '256'
+);
+```
+
+### 关闭并行读取
+
+当数据源为查询开始前的分区请求付出的代价过高时，可以关闭并行读取：
+
+```sql
+CREATE CATALOG remote_source_single PROPERTIES (
+    'type' = 'adbc',
+    'driver_url' = 'libadbc_driver_flightsql.so',
+    'uri' = 'grpc://remote-host:8070',
+    'user' = 'root',
+    'password' = '<password>',
+    'partitioned_read' = 'disabled'
+);
+```
+
+## 命名空间映射
+
+ADBC 使用三级命名（catalog / db_schema / table），而 Doris 外部表只有两级（database / table）——最外层的名字已经被用户创建的 Catalog 占用。因此：
+
+- `uri` 必须指向一个确定的远端 Catalog。这样两个远端层级中最多只有一个是变化的，无需将两级名字拼接成一个数据库名。
+- 远端的 `db_schema` 非空时，Doris 数据库名使用 `db_schema`；否则使用远端 catalog 名。
+
+| 远端 (catalog, db_schema) | Doris 数据库名 |
+| --- | --- |
+| `mydb`, `public` | `public` |
+| `mydb`, 空 | `mydb` |
+
+如果数据源报告的对象既没有 catalog 名也没有 db_schema 名，Doris 无法为其确定数据库名，会直接报错。
+
+如果 `uri` 没有指向确定的远端 Catalog，Doris 会在 `CREATE CATALOG` 时报错，提示在 `uri` 中指定远端 Catalog 名（如 `postgresql://host:5432/mydb`），或通过驱动选项指定。部分驱动不实现相关的查询接口，此时 Doris 会接受该 `uri`，问题会在第一次 `SHOW DATABASES` 时暴露。
+
+## 列类型映射
+
+Doris 按数据源返回的 Arrow 类型进行映射。
+
+| Arrow 类型 | Doris 类型 | 说明 |
+| --- | --- | --- |
+| `bool` | `BOOLEAN` | |
+| `int8` | `TINYINT` | |
+| `int16` | `SMALLINT` | |
+| `int32` | `INT` | |
+| `int64` | `BIGINT` | |
+| `uint8` | `SMALLINT` | 无符号整数提升一级 |
+| `uint16` | `INT` | 无符号整数提升一级 |
+| `uint32` | `BIGINT` | 无符号整数提升一级 |
+| `uint64` | `LARGEINT` | 无符号整数提升一级 |
+| `float16`、`float32` | `FLOAT` | |
+| `float64` | `DOUBLE` | |
+| `decimal128(P,S)` | `DECIMAL(P,S)` | 精度上限为 38，超出则报错 |
+| `decimal256(P,S)` | `DECIMAL(P,S)` | 精度上限为 76，超出则报错 |
+| `date32(day)` | `DATE` | |
+| `date64(ms)` | `DATETIME(3)` | `date64` 带有时间部分，映射为 `DATE` 会丢失 |
+| 无时区 `timestamp(s)` | `DATETIME(0)` | |
+| 无时区 `timestamp(ms)` | `DATETIME(3)` | |
+| 无时区 `timestamp(us)`、`timestamp(ns)` | `DATETIME(6)` | 纳秒精度截断为微秒 |
+| 带时区 `timestamp` | `TIMESTAMPTZ(0-6)` | 精度规则同上。带时区的 Arrow 时间戳表示一个时间点，`DATETIME` 会丢弃时区信息 |
+| `utf8`、`large_utf8`、`utf8_view` | `STRING` | |
+| `binary`、`large_binary`、`binary_view`、`fixed_size_binary` | `STRING` | 外表路径上 Doris 没有通用的二进制列类型 |
+| `list`、`large_list`、`fixed_size_list`、`list_view`、`large_list_view` | `ARRAY` | 元素类型递归映射 |
+| `struct` | `STRUCT` | 子字段类型递归映射，**子字段名统一转为小写** |
+| `map` | `MAP` | Key 和 Value 类型递归映射 |
+| `dictionary` | 按字典值类型映射 | |
+| `run_end_encoded` | 按值类型映射 | |
+| 其他 | 不支持 | |
+
+> 注：
+>
+> Doris 没有无符号整数类型，因此无符号类型会提升一级映射。例如 `uint32` 映射为 `BIGINT` 而不是 `INT`，否则超过 2^31 的值会静默回绕为负数。
+>
+> 遇到无法映射的类型时，Doris 会在描述表结构时直接报错，并指出具体的列名和 Arrow 类型，而不是映射为一个有损的类型。可以在源端将该列 CAST 为可映射的类型，或在查询中排除该列。
+>
+> 从 Doris 数据源读取时，`IPV4` 列会以 `INT` 返回（两端都按 int32 编码），源端的 `DATETIME` 列会以 `TIMESTAMPTZ` 返回。
+
+## 查询操作
+
+### 基础查询
+
+配置好 Catalog 后，可以通过以下方式查询 Catalog 中的表数据：
+
+```sql
+-- 1. switch to catalog, use database and query
+SWITCH adbc_ctl;
+USE adbc_db;
+SELECT * FROM adbc_tbl LIMIT 10;
+
+-- 2. use adbc database directly
+USE adbc_ctl.adbc_db;
+SELECT * FROM adbc_tbl LIMIT 10;
+
+-- 3. use full qualified name to query
+SELECT * FROM adbc_ctl.adbc_db.adbc_tbl LIMIT 10;
+```
+
+### 元数据操作
+
+```sql
+SHOW DATABASES FROM adbc_ctl;
+
+SHOW TABLES FROM adbc_ctl.adbc_db;
+
+DESC adbc_ctl.adbc_db.adbc_tbl;
+
+SHOW CREATE TABLE adbc_ctl.adbc_db.adbc_tbl;
+```
+
+数据库列表和表列表始终实时读取，因此在数据源上新建的表无需执行任何 `REFRESH` 即可看到。表结构（Schema）会被缓存，详见【元数据缓存】。
+
+> 注：数据源上的视图不会作为表列出。
+
+### 数据集成
+
+可以将外部数据源的数据写入 Doris 内表：
+
+```sql
+INSERT INTO internal.demo.local_tbl
+SELECT * FROM adbc_ctl.adbc_db.adbc_tbl;
+```
+
+也支持与内表、其他 Catalog 的表进行联邦查询，以及 `SELECT ... INTO OUTFILE` 和基于 ADBC 表构建物化视图（MTMV）。
+
+### 列裁剪
+
+Doris 只向数据源请求查询实际需要的列，生成的远端 SQL 中不会包含未使用的列。
+
+### 谓词下推
+
+以下谓词会被转换为远端 SQL 的 `WHERE` 条件：
+
+| 类别 | 支持的形式 |
+| --- | --- |
+| 比较 | `=`、`!=`、`<`、`<=`、`>`、`>=` |
+| 空值判断 | `IS NULL`、`IS NOT NULL` |
+| 集合 | `IN`、`NOT IN` |
+| 逻辑运算 | 由上述谓词组成的 `AND`、`OR`、`NOT` |
+
+函数调用、算术表达式、`LIKE`、`BETWEEN` 等形式不会下推，仍由 Doris 计算。
+
+顶层的每个 `AND` 条件按「全部下推或全部不下推」处理。**Doris 无论如何都会重新计算所有谓词**，因此谓词下推只影响性能，不会改变查询结果。
+
+### LIMIT 下推
+
+只有在整个 `WHERE` 条件都被下推之后，`LIMIT` 才会下推，避免数据源在 Doris 仍需应用的过滤条件之前就截断结果。
+
+### COUNT(*) 优化
+
+`COUNT(*)` 不会从数据源读取任何列数据。
+
+### 查看生成的远端 SQL
+
+可以通过 `EXPLAIN` 查看实际发送给数据源的 SQL 语句：
+
+```sql
+EXPLAIN
+SELECT id, name
+FROM adbc_ctl.adbc_db.adbc_tbl
+WHERE id > 100 AND name IS NOT NULL
+LIMIT 10;
+```
+
+输出中的 `QUERY:` 行即为下推后的远端语句，其中的列与实际扫描请求的列一致。
+
+:::tip
+在 Arrow Flight SQL 数据源上，请求分区的调用本身就是查询的执行。因此对 ADBC 表执行 `EXPLAIN` 时，Doris 不会向数据源请求分区，也就不会触发数据源真正执行这条查询。
+:::
+
+### 并行读取
+
+`partitioned_read` 为 `auto`（默认）或 `required` 时，Doris 会请求驱动将一次扫描拆分为多个结果分区，每个分区由一个 BE 节点读取，多个 BE 节点并行工作。
+
+数据源无法分区时：
+
+- `auto`：回退为单条语句读取，由一个 BE 完成。
+- `required`：查询失败并说明原因。
+
+分区数超过 `max_partitions` 时查询直接失败。
+
+## 元数据缓存 {#meta-cache}
+
+为了提升访问外部数据源的性能，Doris 会缓存 ADBC Catalog 的部分元数据，包括数据库名解析、表名解析和表结构（Schema）。
+
+数据库列表和表列表**不做缓存**，始终实时读取，因此数据源上新建的表无需 `REFRESH` 即可访问。
+
+### 缓存属性配置 {#meta-cache-unified-model}
+
+ADBC Catalog 的元数据缓存使用统一键 `meta.cache.<engine>.<entry>.{enable,ttl-second,capacity}` 配置。
+
+| 属性 | 默认值 | 含义 |
+| --- | --- | --- |
+| `meta.cache.adbc.metadata.enable` | `true` | 是否启用元数据缓存。 |
+| `meta.cache.adbc.metadata.ttl-second` | `600` | `0` 表示关闭缓存（即刻生效，可用于查看最新元数据）；`-1` 表示永不过期；其他正整数表示按访问时间计算的 TTL（秒）。 |
+| `meta.cache.adbc.metadata.capacity` | `1000` | 最大缓存条目数。`0` 表示关闭。 |
+
+**生效逻辑说明：** 只有当 `enable=true` 且 `ttl-second != 0` 且 `capacity > 0` 时，缓存才会生效。
+
+:::tip
+默认 TTL 为 10 分钟，明显低于其他 Catalog 的默认值。ADBC 数据源是另一个在线数据库，其表结构随时可能被其他人的 DDL 修改，且不会通知 Doris。该值决定了忘记执行 `REFRESH` 的用户最长会看到多久的旧表结构。
+:::
+
+### 缓存模块 {#meta-cache-unified-modules}
+
+数据库解析、表名解析和表结构共用同一组配置：它们被一起读取、一起失效，描述的是同一件事——远端数据源的结构。
+
+| 模块 (`<entry>`) | 属性键前缀 | 缓存内容与影响 |
+| --- | --- | --- |
+| `metadata` | `meta.cache.adbc.metadata.` | 缓存数据库名解析、表名解析和表结构。影响：源端列新增、删除、类型变更在 Doris 中的可见性。 |
+
+### 手动刷新
+
+以下语句都会清除对应范围的缓存：
+
+```sql
+REFRESH CATALOG adbc_ctl;
+REFRESH DATABASE adbc_ctl.adbc_db;
+REFRESH TABLE adbc_ctl.adbc_db.adbc_tbl;
+```
+
+### 最佳实践 {#meta-cache-best-practices}
+
+* **实时查看最新元数据**：如果希望每次查询都读取数据源的最新表结构，可以将 `ttl-second` 设置为 `0`：
+
+  ```sql
+  ALTER CATALOG adbc_ctl SET PROPERTIES ("meta.cache.adbc.metadata.ttl-second" = "0");
+  ```
+
+* **表结构变更频繁的数据源**：适当调低 `ttl-second`，或在已知发生变更后执行 `REFRESH`。
+
+### 可观测性 {#meta-cache-unified-observability}
+
+可以通过 `information_schema.catalog_meta_cache_statistics` 系统表观测缓存指标：
+
+```sql
+SELECT catalog_name, engine_name, entry_name,
+       effective_enabled, ttl_second, capacity,
+       estimated_size, hit_rate, load_failure_count, last_error
+FROM information_schema.catalog_meta_cache_statistics
+WHERE catalog_name = 'adbc_ctl' AND engine_name = 'adbc'
+ORDER BY entry_name;
+```
+
+该系统表文档见：[catalog_meta_cache_statistics](../../admin-manual/system-tables/information_schema/catalog_meta_cache_statistics.md)。
+
+:::caution
+ADBC 连接使用 Catalog 中配置的固定身份访问数据源，与发起查询的 Doris 用户无关，因此缓存条目在所有用户之间共享。
+:::
+
+## 使用限制
+
+- **只读**：不支持 `INSERT`、`CREATE TABLE`、`DROP TABLE` 等针对数据源的写操作。
+- 不支持统计信息收集和聚合下推。
+- 数据源上的视图不会作为表列出。
+- `driver_checksum` 只校验 FE 上的驱动副本，不会校验 BE 上的副本，FE 与 BE 的驱动文件之间也不会相互比对。
+- `driver_url` 只接受本地引用，不支持从远程 URL 下载驱动。
+- 从 Doris 数据源读取时，`IPV4` 列会以 `INT` 返回，源端的 `DATETIME` 列会以 `TIMESTAMPTZ` 返回。
+
+## 附录
+
+### FAQ
+
+1. `Driver file not found`
+
+    FE 无法在解析出的路径上找到驱动文件。请检查：
+
+    - `driver_url` 填写的纯文件名是否位于 `adbc.conf` 的 `drivers_dir` 目录下；
+    - 使用绝对路径或 `file://` URL 时，该路径在 FE 节点上是否存在且可读。
+
+2. `Driver path does not match any path allowed by driver_secure_path`
+
+    驱动路径不在 `adbc.conf` 的 `driver_secure_path` 白名单内。将驱动移动到白名单目录下，或调整 `driver_secure_path` 配置后重启 FE。
+
+3. `scheme 'xxx' is not supported, only a local file is`
+
+    `driver_url` 使用了 `http://` 等远程协议。ADBC 驱动不支持逐节点下载，请将驱动文件放置到 FE 和所有 BE 上，并通过纯文件名、绝对路径或 `file://` URL 引用。
+
+4. `The ADBC source reports no current catalog, so 'uri' does not pin one`
+
+    `uri` 没有指向一个确定的远端 Catalog。请在 `uri` 中指定远端 Catalog 名（如 `postgresql://host:5432/mydb`），或通过 `adbc.` 前缀的驱动选项指定。
+
+5. 查询报错提示某列的 Arrow 类型没有对应的 Doris 类型
+
+    该列的类型当前不支持映射。可以在数据源侧将该列 CAST 为可映射的类型，或在查询中排除该列（不要使用 `SELECT *`）。
+
+6. 查询结果异常，但没有报错
+
+    请确认 FE 和所有 BE 上的驱动文件是同一个构建产物。ADBC 的分区信息使用驱动私有的格式描述，不同实现之间可能会错误解析而不报错。可以通过 `driver_checksum` 固定 FE 侧的驱动版本，并人工核对各 BE 上驱动文件的 MD5。
+
+7. 远端 SQL 报语法错误
+
+    数据源的 SQL 方言与当前使用的方言不匹配。可以通过 `sql_dialect` 显式指定方言，例如访问 Doris 数据源时指定 `'sql_dialect' = 'doris'`。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/data-integration/metabase.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/data-integration/metabase.md
@@ -12,8 +12,8 @@
 }
 ---
 
-{/* 知识类型: 操作步骤 */}
-{/* 适用场景: 在 Metabase 中连接 Apache Doris 并构建可视化仪表盘 */}
+<!-- 知识类型: 操作步骤 -->
+<!-- 适用场景: 在 Metabase 中连接 Apache Doris 并构建可视化仪表盘 -->
 
 Metabase 是一个开源商业智能工具，提供数据分析、数据可视化、交互式仪表盘、数据钻取、SQL 查询编辑和数据导出等能力。通过 Metabase Apache Doris Driver，Metabase 可以将 Apache Doris 数据库和表集成为数据源，用于查询 Doris 内部数据和外部数据，并构建可视化看板。
 
@@ -101,8 +101,8 @@ b23e82f19a7f9226343e42566e1e192b6df7a0dfc48a73d2101fc74bfec243f3
 
 ## 配置 Doris 数据源
 
-{/* 知识类型: 配置参数 */}
-{/* 适用场景: 在 Metabase 管理页面新增 Apache Doris 数据库连接 */}
+<!-- 知识类型: 配置参数 -->
+<!-- 适用场景: 在 Metabase 管理页面新增 Apache Doris 数据库连接 -->
 
 安装 Metabase 和 `metabase-doris-driver` 后，可以在 Metabase 中新增一个连接到 Doris `tpch` 数据库的数据源。
 
@@ -172,8 +172,8 @@ b23e82f19a7f9226343e42566e1e192b6df7a0dfc48a73d2101fc74bfec243f3
 
 ## 构建可视化仪表盘
 
-{/* 知识类型: 操作步骤 */}
-{/* 适用场景: 使用 Doris TPC-H 数据在 Metabase 中创建 Question 和 Dashboard */}
+<!-- 知识类型: 操作步骤 -->
+<!-- 适用场景: 使用 Doris TPC-H 数据在 Metabase 中创建 Question 和 Dashboard -->
 
 本示例使用 TPC-H 数据作为数据源。Doris TPC-H 数据源构建方式请参见 [Doris TPC-H 基准测试文档](../../lakehouse/best-practices/tpch.md)。
 
@@ -280,8 +280,8 @@ b23e82f19a7f9226343e42566e1e192b6df7a0dfc48a73d2101fc74bfec243f3
 
 ## 高级使用场景
 
-{/* 知识类型: 功能说明 */}
-{/* 适用场景: 访问外部数据源、创建交互式仪表盘和优化查询性能 */}
+<!-- 知识类型: 功能说明 -->
+<!-- 适用场景: 访问外部数据源、创建交互式仪表盘和优化查询性能 -->
 
 ### 使用 Catalog 访问外部数据
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -688,6 +688,7 @@ const sidebars: SidebarsConfig = {
                         'lakehouse/catalogs/kafka-catalog',
                         'lakehouse/catalogs/es-catalog',
                         'lakehouse/catalogs/doris-catalog',
+                        'lakehouse/catalogs/adbc-catalog',
                         'lakehouse/catalogs/jdbc-catalog-overview',
                         'lakehouse/catalogs/jdbc-mysql-catalog',
                         'lakehouse/catalogs/jdbc-pg-catalog',

--- a/versioned_docs/version-4.x/connection-integration/data-integration/metabase.md
+++ b/versioned_docs/version-4.x/connection-integration/data-integration/metabase.md
@@ -12,8 +12,8 @@
 }
 ---
 
-{/* Knowledge type: Procedure */}
-{/* Applicable scenario: Connect to Apache Doris in Metabase and build visualization dashboards */}
+<!-- Knowledge type: Procedure -->
+<!-- Applicable scenario: Connect to Apache Doris in Metabase and build visualization dashboards -->
 
 Metabase is an open source business intelligence tool that provides data analysis, data visualization, interactive dashboards, data drill-down, SQL query editing, and data export. With the Metabase Apache Doris Driver, Metabase can integrate Apache Doris databases and tables as data sources to query Doris internal data and external data, and to build visualization dashboards.
 
@@ -101,8 +101,8 @@ If you start Metabase with Docker, you are recommended to start it by mounting `
 
 ## Configure the Doris data source
 
-{/* Knowledge type: Configuration parameters */}
-{/* Applicable scenario: Add an Apache Doris database connection on the Metabase admin page */}
+<!-- Knowledge type: Configuration parameters -->
+<!-- Applicable scenario: Add an Apache Doris database connection on the Metabase admin page -->
 
 After installing Metabase and `metabase-doris-driver`, you can add a data source in Metabase that connects to the Doris `tpch` database.
 
@@ -172,8 +172,8 @@ After the data source configuration is complete, you can build visualizations in
 
 ## Build a visualization dashboard
 
-{/* Knowledge type: Procedure */}
-{/* Applicable scenario: Use Doris TPC-H data to create a Question and a Dashboard in Metabase */}
+<!-- Knowledge type: Procedure -->
+<!-- Applicable scenario: Use Doris TPC-H data to create a Question and a Dashboard in Metabase -->
 
 This example uses TPC-H data as the data source. For how to build the Doris TPC-H data source, see the [Doris TPC-H benchmark documentation](../../lakehouse/best-practices/tpch.md).
 
@@ -280,8 +280,8 @@ The following table summarizes the driver capabilities and current support bound
 
 ## Advanced scenarios
 
-{/* Knowledge type: Feature description */}
-{/* Applicable scenario: Access external data sources, create interactive dashboards, and optimize query performance */}
+<!-- Knowledge type: Feature description -->
+<!-- Applicable scenario: Access external data sources, create interactive dashboards, and optimize query performance -->
 
 ### Use Catalog to access external data
 


### PR DESCRIPTION
## Summary

Adds user documentation for the ADBC Catalog introduced in apache/doris#66331.

An ADBC Catalog reads an external data source through an [Arrow Database Connectivity](https://arrow.apache.org/adbc/) driver. Data is transferred in Arrow format instead of being converted value by value as in a JDBC catalog, and one scan is split by the driver's own result partitions so several BE nodes read it in parallel. Phase one targets Arrow Flight SQL sources, including another Doris cluster.

The feature is experimental and ships in 5.0.0.

## What the doc covers

- Overview, differences from a JDBC Catalog, applicable scenarios and a feature matrix
- Driver deployment. Doris ships no ADBC driver, and the FE resolves `driver_url` into an absolute path that it sends to the BEs unchanged, so the same driver build must sit at the same absolute path on the FE and on every BE. The `adbc.conf` settings (`drivers_dir`, `driver_secure_path`) are documented alongside.
- Catalog properties, organized as an unordered list in the same style as the Iceberg doc: `driver_url`, `uri`, `{DriverProperties}`, `{ConnectionProperties}`, `{ReadProperties}`, `{DriverOptions}`, `{CommonProperties}`
- Examples: querying another Doris cluster, pinning the driver build with `driver_checksum`, requiring parallel reads, disabling parallel reads
- Namespace mapping from ADBC's three naming levels onto the two a Doris external table has
- Column type mapping from Arrow types, including unsigned widening and the behavior for unmappable types
- Query operations: column pruning, predicate pushdown, `LIMIT` pushdown, `COUNT(*)`, inspecting the generated remote SQL, parallel reads
- Metadata cache (`meta.cache.adbc.metadata.*`), manual refresh and observability
- Limitations and FAQ

## Notes

- Both the English page and the Chinese translation are included, and only the `current` version is touched.
- `sidebars.ts` lists the new page after `doris-catalog`, since the ADBC catalog is the intended replacement for it.
- Content was verified against the source on the feature branch rather than the PR description alone. Two places where the two disagree follow the code: `user` and `password` are documented as optional, because only `driver_url` and `uri` are actually required; and `drivers_dir` / `driver_secure_path` are documented as `adbc.conf` settings rather than `fe.conf` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
