### PR TITLE
Add SeaweedFS to Iceberg catalog storage list and REST catalog examples

### DIFF
--- a/docs/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/docs/lakehouse/catalogs/iceberg-catalog.mdx
@@ -216,6 +216,7 @@ See the documentation for this system table: [catalog_meta_cache_statistics](../
 * [Tencent COS](../storages/tencent-cos.md)
 * [Huawei OBS](../storages/huawei-obs.md)
 * [MINIO](../storages/minio.md)
+* [SeaweedFS](../storages/seaweedfs.md)
 
 > Note: The service types and parameters supported by different Doris versions are slightly different. Please refer to the [Examples] section.
 

--- a/docs/lakehouse/metastores/iceberg-rest.md
+++ b/docs/lakehouse/metastores/iceberg-rest.md
@@ -198,3 +198,22 @@ mysql> REFRESH TABLE ice.`ns1.ns2`.tbl1;
         's3.region' = 'us-west-2'
     );
     ```
+
+- Connecting to SeaweedFS Rest Catalog
+
+    ```sql
+    CREATE CATALOG seaweedfs_iceberg PROPERTIES (
+        'type' = 'iceberg',
+        'iceberg.catalog.type' = 'rest',
+        'uri' = 'http://<seaweedfs_host>:8181',
+        'warehouse' = 's3://<table_bucket_name>',
+        'credential' = '<ak>:<sk>',
+        's3.access_key' = '<ak>',
+        's3.secret_key' = '<sk>',
+        's3.endpoint' = 'http://<seaweedfs_host>:8333',
+        's3.region' = 'us-west-2',
+        'use_path_style' = 'true'
+    );
+    ```
+
+    SeaweedFS table buckets serve the Iceberg REST catalog for table metadata and store the table data as Parquet files behind the same S3 gateway. See [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md) for a full walkthrough.

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
@@ -236,6 +236,7 @@ ORDER BY entry_name;
 * [华为云 OBS](../storages/huawei-obs.md)
 
 * [MINIO](../storages/minio.md)
+* [SeaweedFS](../storages/seaweedfs.md)
 
 > 注意：不同 Doris 版本所支持的服务类型和参数略有区别，请参阅【基础示例】章节。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/metastores/iceberg-rest.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/metastores/iceberg-rest.md
@@ -198,3 +198,22 @@ mysql> REFRESH TABLE ice.`ns1.ns2`.tbl1;
         's3.region' = 'us-west-2'
     );
     ```
+
+- 连接 SeaweedFS Rest Catalog
+
+    ```sql
+    CREATE CATALOG seaweedfs_iceberg PROPERTIES (
+        'type' = 'iceberg',
+        'iceberg.catalog.type' = 'rest',
+        'uri' = 'http://<seaweedfs_host>:8181',
+        'warehouse' = 's3://<table_bucket_name>',
+        'credential' = '<ak>:<sk>',
+        's3.access_key' = '<ak>',
+        's3.secret_key' = '<sk>',
+        's3.endpoint' = 'http://<seaweedfs_host>:8333',
+        's3.region' = 'us-west-2',
+        'use_path_style' = 'true'
+    );
+    ```
+
+    SeaweedFS 的 Table Bucket 同时提供两部分能力：内置的 Iceberg REST Catalog 提供表元数据，Table Bucket 本身以 Parquet 文件存储表数据，二者共用同一个 S3 网关。完整教程见[与 SeaweedFS 集成](../best-practices/doris-seaweedfs.md)。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/lakehouse/catalogs/iceberg-catalog.mdx
@@ -223,6 +223,7 @@ ORDER BY entry_name;
 * [华为云 OBS](../storages/huawei-obs.md)
 
 * [MINIO](../storages/minio.md)
+* [SeaweedFS](../storages/seaweedfs.md)
 
 > 注意：不同 Doris 版本所支持的服务类型和参数略有区别，请参阅【基础示例】章节。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/lakehouse/metastores/iceberg-rest.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/lakehouse/metastores/iceberg-rest.md
@@ -198,3 +198,22 @@ mysql> REFRESH TABLE ice.`ns1.ns2`.tbl1;
         's3.region' = 'us-west-2'
     );
     ```
+
+- 连接 SeaweedFS Rest Catalog
+
+    ```sql
+    CREATE CATALOG seaweedfs_iceberg PROPERTIES (
+        'type' = 'iceberg',
+        'iceberg.catalog.type' = 'rest',
+        'uri' = 'http://<seaweedfs_host>:8181',
+        'warehouse' = 's3://<table_bucket_name>',
+        'credential' = '<ak>:<sk>',
+        's3.access_key' = '<ak>',
+        's3.secret_key' = '<sk>',
+        's3.endpoint' = 'http://<seaweedfs_host>:8333',
+        's3.region' = 'us-west-2',
+        'use_path_style' = 'true'
+    );
+    ```
+
+    SeaweedFS 的 Table Bucket 同时提供两部分能力：内置的 Iceberg REST Catalog 提供表元数据，Table Bucket 本身以 Parquet 文件存储表数据，二者共用同一个 S3 网关。完整教程见[与 SeaweedFS 集成](../best-practices/doris-seaweedfs.md)。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/iceberg-catalog.mdx
@@ -236,6 +236,7 @@ ORDER BY entry_name;
 * [华为云 OBS](../storages/huawei-obs.md)
 
 * [MINIO](../storages/minio.md)
+* [SeaweedFS](../storages/seaweedfs.md)
 
 > 注意：不同 Doris 版本所支持的服务类型和参数略有区别，请参阅【基础示例】章节。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/metastores/iceberg-rest.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/metastores/iceberg-rest.md
@@ -198,3 +198,22 @@ mysql> REFRESH TABLE ice.`ns1.ns2`.tbl1;
         's3.region' = 'us-west-2'
     );
     ```
+
+- 连接 SeaweedFS Rest Catalog
+
+    ```sql
+    CREATE CATALOG seaweedfs_iceberg PROPERTIES (
+        'type' = 'iceberg',
+        'iceberg.catalog.type' = 'rest',
+        'uri' = 'http://<seaweedfs_host>:8181',
+        'warehouse' = 's3://<table_bucket_name>',
+        'credential' = '<ak>:<sk>',
+        's3.access_key' = '<ak>',
+        's3.secret_key' = '<sk>',
+        's3.endpoint' = 'http://<seaweedfs_host>:8333',
+        's3.region' = 'us-west-2',
+        'use_path_style' = 'true'
+    );
+    ```
+
+    SeaweedFS 的 Table Bucket 同时提供两部分能力：内置的 Iceberg REST Catalog 提供表元数据，Table Bucket 本身以 Parquet 文件存储表数据，二者共用同一个 S3 网关。完整教程见[与 SeaweedFS 集成](../best-practices/doris-seaweedfs.md)。

--- a/versioned_docs/version-3.x/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/versioned_docs/version-3.x/lakehouse/catalogs/iceberg-catalog.mdx
@@ -203,6 +203,7 @@ See the documentation for this system table: [catalog_meta_cache_statistics](../
 * [Tencent COS](../storages/tencent-cos.md)
 * [Huawei OBS](../storages/huawei-obs.md)
 * [MINIO](../storages/minio.md)
+* [SeaweedFS](../storages/seaweedfs.md)
 
 > Note: The service types and parameters supported by different Doris versions are slightly different. Please refer to the [Examples] section.
 

--- a/versioned_docs/version-3.x/lakehouse/metastores/iceberg-rest.md
+++ b/versioned_docs/version-3.x/lakehouse/metastores/iceberg-rest.md
@@ -198,3 +198,22 @@ mysql> REFRESH TABLE ice.`ns1.ns2`.tbl1;
         's3.region' = 'us-west-2'
     );
     ```
+
+- Connecting to SeaweedFS Rest Catalog
+
+    ```sql
+    CREATE CATALOG seaweedfs_iceberg PROPERTIES (
+        'type' = 'iceberg',
+        'iceberg.catalog.type' = 'rest',
+        'uri' = 'http://<seaweedfs_host>:8181',
+        'warehouse' = 's3://<table_bucket_name>',
+        'credential' = '<ak>:<sk>',
+        's3.access_key' = '<ak>',
+        's3.secret_key' = '<sk>',
+        's3.endpoint' = 'http://<seaweedfs_host>:8333',
+        's3.region' = 'us-west-2',
+        'use_path_style' = 'true'
+    );
+    ```
+
+    SeaweedFS table buckets serve the Iceberg REST catalog for table metadata and store the table data as Parquet files behind the same S3 gateway. See [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md) for a full walkthrough.

--- a/versioned_docs/version-4.x/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/versioned_docs/version-4.x/lakehouse/catalogs/iceberg-catalog.mdx
@@ -216,6 +216,7 @@ See the documentation for this system table: [catalog_meta_cache_statistics](../
 * [Tencent COS](../storages/tencent-cos.md)
 * [Huawei OBS](../storages/huawei-obs.md)
 * [MINIO](../storages/minio.md)
+* [SeaweedFS](../storages/seaweedfs.md)
 
 > Note: The service types and parameters supported by different Doris versions are slightly different. Please refer to the [Examples] section.
 

--- a/versioned_docs/version-4.x/lakehouse/metastores/iceberg-rest.md
+++ b/versioned_docs/version-4.x/lakehouse/metastores/iceberg-rest.md
@@ -198,3 +198,22 @@ mysql> REFRESH TABLE ice.`ns1.ns2`.tbl1;
         's3.region' = 'us-west-2'
     );
     ```
+
+- Connecting to SeaweedFS Rest Catalog
+
+    ```sql
+    CREATE CATALOG seaweedfs_iceberg PROPERTIES (
+        'type' = 'iceberg',
+        'iceberg.catalog.type' = 'rest',
+        'uri' = 'http://<seaweedfs_host>:8181',
+        'warehouse' = 's3://<table_bucket_name>',
+        'credential' = '<ak>:<sk>',
+        's3.access_key' = '<ak>',
+        's3.secret_key' = '<sk>',
+        's3.endpoint' = 'http://<seaweedfs_host>:8333',
+        's3.region' = 'us-west-2',
+        'use_path_style' = 'true'
+    );
+    ```
+
+    SeaweedFS table buckets serve the Iceberg REST catalog for table metadata and store the table data as Parquet files behind the same S3 gateway. See [Integration with SeaweedFS](../best-practices/doris-seaweedfs.md) for a full walkthrough.


### PR DESCRIPTION
Two cross-link gaps for the existing SeaweedFS pages:

- The Iceberg catalog page's Supported Storage Systems list now links to the SeaweedFS storage page alongside the other S3-compatible stores.
- The Iceberg REST metastore page's Example Configurations now include Connecting to SeaweedFS Rest Catalog, using the same CREATE CATALOG statement as the Integration with SeaweedFS best-practices page. SeaweedFS table buckets serve the Iceberg REST catalog for table metadata and store the table data as Parquet files behind the same S3 gateway.

Applied to en and zh-CN for current, 3.x, and 4.x. The configuration is the one exercised by the TestDorisIcebergCatalog suite in the SeaweedFS repository: https://github.com/seaweedfs/seaweedfs/tree/master/test/s3tables/catalog_doris