### PR TITLE
[doc](lakehouse) Add Alibaba Cloud OSS Tables integration guide

### DIFF
--- a/docs/lakehouse/best-practices/doris-aliyun-oss-tables.md
+++ b/docs/lakehouse/best-practices/doris-aliyun-oss-tables.md
@@ -2,9 +2,25 @@
 {
     "title": "Integration with Alibaba Cloud OSS Tables",
     "language": "en",
-    "description": "Connect Apache Doris to Alibaba Cloud OSS Tables through Iceberg REST Catalog and use S3FileIO to query and write managed Iceberg tables."
+    "description": "Connect Doris to Alibaba Cloud OSS Tables with Iceberg REST Catalog and S3FileIO for managed Iceberg reads and writes.",
+    "keywords": [
+        "Alibaba Cloud OSS Tables",
+        "Apache Doris OSS Tables",
+        "Iceberg REST Catalog",
+        "S3FileIO",
+        "OSS Table Bucket",
+        "OSS Tables Catalog",
+        "managed Iceberg tables",
+        "SigV4 osstables",
+        "OSS Tables 403 Forbidden",
+        "OSS STS credentials",
+        "Doris lakehouse"
+    ]
 }
 ---
+
+<!-- Knowledge Type: Capability Definition + Integration Guide -->
+<!-- Applicable Scenarios: Alibaba Cloud OSS Tables integration / Managed Iceberg table queries and writes -->
 
 [Alibaba Cloud OSS Tables](https://help.aliyun.com/zh/oss/user-guide/spark-access-oss-tables) is a managed storage service for Apache Iceberg tables. OSS Tables uses Table Buckets as storage units, exposes a metadata interface compatible with Apache Iceberg REST Catalog, and provides access to table data through the OSS S3-compatible interface.
 
@@ -20,6 +36,9 @@ Apache Doris connects to OSS Tables through Iceberg REST Catalog: REST Catalog m
 This feature is experimental and will be released in Doris 5.0.0.
 :::
 
+<!-- Knowledge Type: Operational Steps -->
+<!-- Applicable Scenarios: Creating an OSS Tables Catalog / Querying and writing Iceberg tables -->
+
 ## Usage Guide
 
 ### 01 Create an OSS Table Bucket
@@ -33,6 +52,9 @@ acs:osstables:<region>:<account_id>:bucket/<table_bucket_name>
 Create a RAM user AccessKey that has access to the target Table Bucket, or obtain temporary STS credentials. Ensure that FE nodes can access the OSS Tables REST Catalog endpoint, and that FE and BE nodes can access the OSS data access endpoint.
 
 For the permissions required by each OSS Tables operation, see [Alibaba Cloud OSS Tables permissions and access control](https://help.aliyun.com/zh/oss/user-guide/oss-tables-access-control).
+
+<!-- Knowledge Type: Configuration Parameters -->
+<!-- Applicable Scenarios: Configuring REST Catalog authentication and S3FileIO data access -->
 
 ### 02 Create an Iceberg Catalog
 
@@ -108,6 +130,9 @@ SHOW TABLES;
 SELECT * FROM <table_name> LIMIT 10;
 ```
 
+<!-- Knowledge Type: Operational Example -->
+<!-- Applicable Scenarios: Creating an Iceberg table and writing data to OSS Tables -->
+
 ### 04 Create an OSS Tables Table and Write Data
 
 ```sql
@@ -146,11 +171,16 @@ FROM `orders$files`
 ORDER BY file_path;
 ```
 
+<!-- Knowledge Type: Limitations + Usage Guidance -->
+
 ## Usage Notes
 
 - OSS Tables supports only the Iceberg table format.
 - `iceberg.rest.signing-name` must be set to the lowercase value `osstables`. You must also set the correct `iceberg.rest.signing-region` and set `iceberg.rest.sigv4-enabled` to `true`.
 - When using temporary STS credentials, update the AK, SK, and token in the Catalog before the credentials expire.
+
+<!-- Knowledge Type: Troubleshooting -->
+<!-- Applicable Scenarios: 403 authentication errors / Metadata access succeeds but data queries fail -->
 
 ## FAQ
 

--- a/docs/lakehouse/best-practices/doris-aliyun-oss-tables.md
+++ b/docs/lakehouse/best-practices/doris-aliyun-oss-tables.md
@@ -22,7 +22,7 @@
 <!-- Knowledge Type: Capability Definition + Integration Guide -->
 <!-- Applicable Scenarios: Alibaba Cloud OSS Tables integration / Managed Iceberg table queries and writes -->
 
-[Alibaba Cloud OSS Tables](https://help.aliyun.com/zh/oss/user-guide/spark-access-oss-tables) is a managed storage service for Apache Iceberg tables. OSS Tables uses Table Buckets as storage units, exposes a metadata interface compatible with Apache Iceberg REST Catalog, and provides access to table data through the OSS S3-compatible interface.
+[Alibaba Cloud OSS Tables](https://www.alibabacloud.com/help/en/oss/user-guide/spark-access-oss-tables) is a managed storage service for Apache Iceberg tables. OSS Tables uses Table Buckets as storage units, exposes a metadata interface compatible with Apache Iceberg REST Catalog, and provides access to table data through the OSS S3-compatible interface.
 
 Compared with managing Iceberg tables in a regular OSS Bucket, OSS Tables provides the following capabilities:
 
@@ -51,7 +51,7 @@ acs:osstables:<region>:<account_id>:bucket/<table_bucket_name>
 
 Create a RAM user AccessKey that has access to the target Table Bucket, or obtain temporary STS credentials. Ensure that FE nodes can access the OSS Tables REST Catalog endpoint, and that FE and BE nodes can access the OSS data access endpoint.
 
-For the permissions required by each OSS Tables operation, see [Alibaba Cloud OSS Tables permissions and access control](https://help.aliyun.com/zh/oss/user-guide/oss-tables-access-control).
+For the permissions required by each OSS Tables operation, see [Alibaba Cloud OSS Tables permissions and access control](https://www.alibabacloud.com/help/en/oss/user-guide/oss-tables-access-control).
 
 <!-- Knowledge Type: Configuration Parameters -->
 <!-- Applicable Scenarios: Configuring REST Catalog authentication and S3FileIO data access -->
@@ -197,4 +197,4 @@ Check the following configurations:
 
 Verify that FE and all BE nodes can access `oss.endpoint`, and that the RAM user or STS identity has the `oss:GetTableMetadataLocation` and `oss:GetTableData` permissions.
 
-For the complete list of permissions required by OSS Tables operations, see [Alibaba Cloud OSS Tables permissions and access control](https://help.aliyun.com/zh/oss/user-guide/oss-tables-access-control).
+For the complete list of permissions required by OSS Tables operations, see [Alibaba Cloud OSS Tables permissions and access control](https://www.alibabacloud.com/help/en/oss/user-guide/oss-tables-access-control).

--- a/docs/lakehouse/best-practices/doris-aliyun-oss-tables.md
+++ b/docs/lakehouse/best-practices/doris-aliyun-oss-tables.md
@@ -1,0 +1,170 @@
+---
+{
+    "title": "Integration with Alibaba Cloud OSS Tables",
+    "language": "en",
+    "description": "Connect Apache Doris to Alibaba Cloud OSS Tables through Iceberg REST Catalog and use S3FileIO to query and write managed Iceberg tables."
+}
+---
+
+[Alibaba Cloud OSS Tables](https://help.aliyun.com/zh/oss/user-guide/spark-access-oss-tables) is a managed storage service for Apache Iceberg tables. OSS Tables uses Table Buckets as storage units, exposes a metadata interface compatible with Apache Iceberg REST Catalog, and provides access to table data through the OSS S3-compatible interface.
+
+Compared with managing Iceberg tables in a regular OSS Bucket, OSS Tables provides the following capabilities:
+
+- A built-in Iceberg REST Catalog, eliminating the need to deploy an external metadata service such as Hive Metastore.
+- Automatic small-file compaction, snapshot expiration, and orphan-file cleanup.
+- Standard Iceberg interfaces that allow multiple compute engines to access the same table data.
+
+Apache Doris connects to OSS Tables through Iceberg REST Catalog: REST Catalog manages namespaces and table metadata, while `S3FileIO` reads and writes data files. This guide explains how to create an OSS Tables Catalog in Doris and query and write Iceberg tables.
+
+:::caution
+This feature is experimental and will be released in Doris 5.0.0.
+:::
+
+## Usage Guide
+
+### 01 Create an OSS Table Bucket
+
+Create a Table Bucket in the Alibaba Cloud OSS console. After it is created, record the Table Bucket ARN, region, and name. The ARN has the following format:
+
+```text
+acs:osstables:<region>:<account_id>:bucket/<table_bucket_name>
+```
+
+Create a RAM user AccessKey that has access to the target Table Bucket, or obtain temporary STS credentials. Ensure that FE nodes can access the OSS Tables REST Catalog endpoint, and that FE and BE nodes can access the OSS data access endpoint.
+
+For the permissions required by each OSS Tables operation, see [Alibaba Cloud OSS Tables permissions and access control](https://help.aliyun.com/zh/oss/user-guide/oss-tables-access-control).
+
+### 02 Create an Iceberg Catalog
+
+Replace the region, account ID, Table Bucket name, and access credentials with actual values:
+
+```sql
+CREATE CATALOG oss_tables PROPERTIES (
+    'type' = 'iceberg',
+    'iceberg.catalog.type' = 'rest',
+    'iceberg.rest.uri' = 'https://<region>.oss-tables.aliyuncs.com/iceberg',
+    'warehouse' = 'acs:osstables:<region>:<account_id>:bucket/<table_bucket_name>',
+
+    'iceberg.rest.sigv4-enabled' = 'true',
+    'iceberg.rest.signing-name' = 'osstables',
+    'iceberg.rest.signing-region' = '<region>',
+    'iceberg.rest.view-enabled' = 'false',
+
+    'io-impl' = 'org.apache.iceberg.aws.s3.S3FileIO',
+    'oss.endpoint' = 'https://oss-<region>.aliyuncs.com',
+    'oss.region' = '<region>',
+    'oss.access_key' = '<access_key_id>',
+    'oss.secret_key' = '<access_key_secret>',
+    'oss.use_path_style' = 'false',
+
+    'test_connection' = 'true'
+);
+```
+
+To access Alibaba Cloud over its internal network, replace `iceberg.rest.uri` and `oss.endpoint` with `https://<region>-internal.oss-tables.aliyuncs.com/iceberg` and `https://oss-<region>-internal.aliyuncs.com`, respectively.
+
+When using temporary STS credentials, add `oss.session_token` after `oss.secret_key`:
+
+```sql
+'oss.session_token' = '<sts_token>',
+```
+
+Doris uses `oss.access_key`, `oss.secret_key`, and the optional `oss.session_token` for both REST Catalog SigV4 signing and `S3FileIO` data access. You do not need to configure `iceberg.rest.access-key-id` and `iceberg.rest.secret-access-key` separately.
+
+#### Parameters
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `type` | Yes | Must be `iceberg`. |
+| `iceberg.catalog.type` | Yes | Must be `rest` to access OSS Tables through Iceberg REST Catalog. |
+| `iceberg.rest.uri` | Yes | OSS Tables REST Catalog endpoint. |
+| `warehouse` | Yes | Table Bucket ARN. |
+| `iceberg.rest.sigv4-enabled` | Yes | Must be `true`. |
+| `iceberg.rest.signing-name` | Yes | Must be the lowercase value `osstables`. This value is case-sensitive. |
+| `iceberg.rest.signing-region` | Yes | SigV4 signing region. It must match the Table Bucket region. |
+| `iceberg.rest.view-enabled` | Yes | Set to `false`. OSS Tables currently does not support the Iceberg View interface. |
+| `io-impl` | Yes | Must be `org.apache.iceberg.aws.s3.S3FileIO`. Do not use `HadoopFileIO`. |
+| `oss.endpoint` | Yes | Endpoint used by `S3FileIO` to access OSS data files. |
+| `oss.region` | Yes | OSS data access region. It must match the Table Bucket region. |
+| `oss.access_key` | Yes | Alibaba Cloud AccessKey ID. |
+| `oss.secret_key` | Yes | Alibaba Cloud AccessKey Secret. |
+| `oss.session_token` | No | Set this parameter when using temporary STS credentials. |
+| `oss.use_path_style` | No | Whether to use path-style access. The default is `false`. |
+| `test_connection` | No | When set to `true`, Doris checks the REST Catalog connection and authentication while creating the Catalog. |
+
+`test_connection=true` does not replace data access verification. After the Catalog is created, run an actual query or write operation to verify network connectivity and permissions from FE and BE nodes to the OSS data access endpoint.
+
+### 03 Access OSS Tables
+
+```sql
+SWITCH oss_tables;
+
+SHOW DATABASES;
+
+USE <namespace_name>;
+
+SHOW TABLES;
+
+SELECT * FROM <table_name> LIMIT 10;
+```
+
+### 04 Create an OSS Tables Table and Write Data
+
+```sql
+SWITCH oss_tables;
+
+CREATE DATABASE IF NOT EXISTS doris_demo;
+USE doris_demo;
+
+CREATE TABLE orders (
+    order_id BIGINT,
+    customer STRING,
+    amount DECIMAL(10, 2),
+    created_at DATETIME
+)
+PROPERTIES (
+    'format-version' = '2',
+    'write-format' = 'parquet',
+    'write.format.default' = 'parquet',
+    'write.parquet.compression-codec' = 'zstd'
+);
+
+INSERT INTO orders VALUES
+    (1, 'Alice', 99.50, '2026-08-11 10:00:00'),
+    (2, 'Bob', 120.00, '2026-08-11 10:01:00');
+
+SELECT order_id, customer, amount, created_at
+FROM orders
+ORDER BY order_id;
+```
+
+You can query the Iceberg `$files` metadata table to verify that data files have been written to OSS Tables:
+
+```sql
+SELECT file_path, file_format, record_count
+FROM `orders$files`
+ORDER BY file_path;
+```
+
+## Usage Notes
+
+- OSS Tables supports only the Iceberg table format.
+- `iceberg.rest.signing-name` must be set to the lowercase value `osstables`. You must also set the correct `iceberg.rest.signing-region` and set `iceberg.rest.sigv4-enabled` to `true`.
+- When using temporary STS credentials, update the AK, SK, and token in the Catalog before the credentials expire.
+
+## FAQ
+
+### Creating the Catalog Returns 403 Forbidden
+
+Check the following configurations:
+
+- Verify that `oss.access_key` and `oss.secret_key` are valid. When using temporary STS credentials, also verify that `oss.session_token` is correct and has not expired.
+- Verify that the RAM user or STS identity has the `oss:GetTableBucket` and `oss:ListNamespaces` permissions on the target Table Bucket.
+- Verify that the account ID, region, and Table Bucket name in `warehouse` are correct.
+- Verify that `iceberg.rest.signing-name` is `osstables` and that `iceberg.rest.signing-region` is the region of the Table Bucket.
+
+### Namespaces and Tables Are Visible, but Data Queries Fail
+
+Verify that FE and all BE nodes can access `oss.endpoint`, and that the RAM user or STS identity has the `oss:GetTableMetadataLocation` and `oss:GetTableData` permissions.
+
+For the complete list of permissions required by OSS Tables operations, see [Alibaba Cloud OSS Tables permissions and access control](https://help.aliyun.com/zh/oss/user-guide/oss-tables-access-control).

--- a/docs/lakehouse/best-practices/doris-aliyun-oss-tables.md
+++ b/docs/lakehouse/best-practices/doris-aliyun-oss-tables.md
@@ -22,7 +22,7 @@
 <!-- Knowledge Type: Capability Definition + Integration Guide -->
 <!-- Applicable Scenarios: Alibaba Cloud OSS Tables integration / Managed Iceberg table queries and writes -->
 
-[Alibaba Cloud OSS Tables](https://www.alibabacloud.com/help/en/oss/user-guide/spark-access-oss-tables) is a managed storage service for Apache Iceberg tables. OSS Tables uses Table Buckets as storage units, exposes a metadata interface compatible with Apache Iceberg REST Catalog, and provides access to table data through the OSS S3-compatible interface.
+[Alibaba Cloud OSS Tables](https://www.alibabacloud.com/help/en/oss/user-guide/oss-tables/) is a managed storage service for Apache Iceberg tables. OSS Tables uses Table Buckets as storage units, exposes a metadata interface compatible with Apache Iceberg REST Catalog, and provides access to table data through the OSS S3-compatible interface.
 
 Compared with managing Iceberg tables in a regular OSS Bucket, OSS Tables provides the following capabilities:
 

--- a/docs/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/docs/lakehouse/catalogs/iceberg-catalog.mdx
@@ -1426,10 +1426,6 @@ This is an experimental feature, supported since version 4.1.0.
 
 ### Alibaba Cloud OSS Tables
 
-:::caution
-This integration is experimental and will be released in Doris 5.0.0.
-:::
-
 <details>
     <summary>5.0+ Version</summary>
     <Tabs>

--- a/docs/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/docs/lakehouse/catalogs/iceberg-catalog.mdx
@@ -1424,6 +1424,40 @@ This is an experimental feature, supported since version 4.1.0.
     </Tabs>
 </details>
 
+### Alibaba Cloud OSS Tables
+
+:::caution
+This integration is experimental and will be released in Doris 5.0.0.
+:::
+
+<details>
+    <summary>5.0+ Version</summary>
+    <Tabs>
+        <TabItem value='OSS Tables REST Catalog' label='OSS Tables REST Catalog' default>
+            For complete configuration and usage instructions, see [Alibaba Cloud OSS Tables Integration](../best-practices/doris-aliyun-oss-tables).
+            ```sql
+            CREATE CATALOG oss_tables PROPERTIES (
+                'type' = 'iceberg',
+                'iceberg.catalog.type' = 'rest',
+                'iceberg.rest.uri' = 'https://<region>.oss-tables.aliyuncs.com/iceberg',
+                'warehouse' = 'acs:osstables:<region>:<account_id>:bucket/<table_bucket_name>',
+                'iceberg.rest.sigv4-enabled' = 'true',
+                'iceberg.rest.signing-name' = 'osstables',
+                'iceberg.rest.signing-region' = '<region>',
+                'iceberg.rest.view-enabled' = 'false',
+                'io-impl' = 'org.apache.iceberg.aws.s3.S3FileIO',
+                'oss.endpoint' = 'https://oss-<region>.aliyuncs.com',
+                'oss.region' = '<region>',
+                'oss.access_key' = '<access_key_id>',
+                'oss.secret_key' = '<access_key_secret>',
+                'oss.use_path_style' = 'false',
+                'test_connection' = 'true'
+            );
+            ```
+        </TabItem>
+    </Tabs>
+</details>
+
 ## Query Operations
 
 ### Basic Query

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-aliyun-oss-tables.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-aliyun-oss-tables.md
@@ -23,7 +23,7 @@
 <!-- 知识类型: 能力定义 + 集成指南 -->
 <!-- 适用场景: 阿里云 OSS Tables 接入 / 托管 Iceberg 表查询与写入 -->
 
-[阿里云 OSS Tables](https://help.aliyun.com/zh/oss/user-guide/spark-access-oss-tables) 是面向 Apache Iceberg 表的托管存储服务。OSS Tables 以 Table Bucket 作为存储单元，对外提供兼容 Apache Iceberg REST Catalog 的元数据接口，并通过 OSS 的 S3 兼容接口访问表数据。
+[阿里云 OSS Tables](https://help.aliyun.com/zh/oss/user-guide/oss-tables/) 是面向 Apache Iceberg 表的托管存储服务。OSS Tables 以 Table Bucket 作为存储单元，对外提供兼容 Apache Iceberg REST Catalog 的元数据接口，并通过 OSS 的 S3 兼容接口访问表数据。
 
 相比在普通 OSS Bucket 中自行管理 Iceberg 表，OSS Tables 提供以下能力：
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-aliyun-oss-tables.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-aliyun-oss-tables.md
@@ -2,9 +2,26 @@
 {
     "title": "集成阿里云 OSS Tables",
     "language": "zh-CN",
-    "description": "阿里云 OSS Tables 是面向 Apache Iceberg 表的托管存储服务。本文介绍如何使用 Apache Doris 接入 OSS Tables，并完成 Iceberg 表的查询与写入。"
+    "description": "使用 Iceberg REST Catalog 和 S3FileIO 将 Doris 接入阿里云 OSS Tables，实现托管 Iceberg 表的查询与写入。",
+    "keywords": [
+        "阿里云 OSS Tables",
+        "Doris OSS Tables",
+        "阿里云 OSS Tables 接入",
+        "Iceberg REST Catalog",
+        "S3FileIO",
+        "OSS Table Bucket",
+        "OSS Tables Catalog",
+        "托管 Iceberg 表",
+        "SigV4 osstables",
+        "OSS Tables 403 Forbidden",
+        "OSS STS 临时凭证",
+        "Doris 湖仓"
+    ]
 }
 ---
+
+<!-- 知识类型: 能力定义 + 集成指南 -->
+<!-- 适用场景: 阿里云 OSS Tables 接入 / 托管 Iceberg 表查询与写入 -->
 
 [阿里云 OSS Tables](https://help.aliyun.com/zh/oss/user-guide/spark-access-oss-tables) 是面向 Apache Iceberg 表的托管存储服务。OSS Tables 以 Table Bucket 作为存储单元，对外提供兼容 Apache Iceberg REST Catalog 的元数据接口，并通过 OSS 的 S3 兼容接口访问表数据。
 
@@ -20,6 +37,9 @@ Apache Doris 可以通过 Iceberg REST Catalog 接入 OSS Tables：使用 REST C
 该功能目前为实验功能，将在 Doris 5.0.0 版本中发布。
 :::
 
+<!-- 知识类型: 操作步骤 -->
+<!-- 适用场景: 创建 OSS Tables Catalog / 查询与写入 Iceberg 表 -->
+
 ## 使用指南
 
 ### 01 创建 OSS Table Bucket
@@ -33,6 +53,9 @@ acs:osstables:<region>:<account_id>:bucket/<table_bucket_name>
 创建具有目标 Table Bucket 访问权限的 RAM 用户 AccessKey，或获取 STS 临时凭证。确保 FE 节点可以访问 OSS Tables REST Catalog Endpoint，FE 和 BE 节点可以访问 OSS 数据访问 Endpoint。
 
 OSS Tables 操作与 RAM 权限的对应关系，请参阅[阿里云 OSS Tables 权限与访问控制](https://help.aliyun.com/zh/oss/user-guide/oss-tables-access-control)。
+
+<!-- 知识类型: 配置参数 -->
+<!-- 适用场景: 配置 REST Catalog 鉴权和 S3FileIO 数据访问 -->
 
 ### 02 创建 Iceberg Catalog
 
@@ -108,6 +131,9 @@ SHOW TABLES;
 SELECT * FROM <table_name> LIMIT 10;
 ```
 
+<!-- 知识类型: 操作示例 -->
+<!-- 适用场景: 创建 Iceberg 表并向 OSS Tables 写入数据 -->
+
 ### 04 创建 OSS Tables 表并写入数据
 
 ```sql
@@ -146,11 +172,16 @@ FROM `orders$files`
 ORDER BY file_path;
 ```
 
+<!-- 知识类型: 使用限制 + 使用建议 -->
+
 ## 注意事项
 
 - OSS Tables 仅支持 Iceberg 表格式。
 - `iceberg.rest.signing-name` 必须设置为小写的 `osstables`，并同时设置正确的 `iceberg.rest.signing-region` 和 `iceberg.rest.sigv4-enabled=true`。
 - 使用 STS 临时凭证时，需要在凭证过期前更新 Catalog 中的 AK、SK 和 Token。
+
+<!-- 知识类型: 故障排查 -->
+<!-- 适用场景: 403 鉴权失败 / 元数据访问成功但数据查询失败 -->
 
 ## 常见问题
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-aliyun-oss-tables.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-aliyun-oss-tables.md
@@ -1,0 +1,170 @@
+---
+{
+    "title": "集成阿里云 OSS Tables",
+    "language": "zh-CN",
+    "description": "阿里云 OSS Tables 是面向 Apache Iceberg 表的托管存储服务。本文介绍如何使用 Apache Doris 接入 OSS Tables，并完成 Iceberg 表的查询与写入。"
+}
+---
+
+[阿里云 OSS Tables](https://help.aliyun.com/zh/oss/user-guide/spark-access-oss-tables) 是面向 Apache Iceberg 表的托管存储服务。OSS Tables 以 Table Bucket 作为存储单元，对外提供兼容 Apache Iceberg REST Catalog 的元数据接口，并通过 OSS 的 S3 兼容接口访问表数据。
+
+相比在普通 OSS Bucket 中自行管理 Iceberg 表，OSS Tables 提供以下能力：
+
+- 内置 Iceberg REST Catalog，无需部署 Hive Metastore 等外部元数据服务；
+- 自动执行小文件合并、快照清理和未引用文件清理；
+- 使用标准 Iceberg 接口，支持多个计算引擎访问同一份表数据。
+
+Apache Doris 可以通过 Iceberg REST Catalog 接入 OSS Tables：使用 REST Catalog 管理 Namespace 和表元数据，使用 `S3FileIO` 读写数据文件。本文介绍如何在 Doris 中创建 OSS Tables Catalog，并查询和写入 Iceberg 表。
+
+:::caution
+该功能目前为实验功能，将在 Doris 5.0.0 版本中发布。
+:::
+
+## 使用指南
+
+### 01 创建 OSS Table Bucket
+
+在阿里云 OSS 控制台创建 Table Bucket。创建后，记录 Table Bucket ARN、地域和名称。ARN 格式如下：
+
+```text
+acs:osstables:<region>:<account_id>:bucket/<table_bucket_name>
+```
+
+创建具有目标 Table Bucket 访问权限的 RAM 用户 AccessKey，或获取 STS 临时凭证。确保 FE 节点可以访问 OSS Tables REST Catalog Endpoint，FE 和 BE 节点可以访问 OSS 数据访问 Endpoint。
+
+OSS Tables 操作与 RAM 权限的对应关系，请参阅[阿里云 OSS Tables 权限与访问控制](https://help.aliyun.com/zh/oss/user-guide/oss-tables-access-control)。
+
+### 02 创建 Iceberg Catalog
+
+将地域、账号 ID、Table Bucket 名称和访问凭证替换为实际值：
+
+```sql
+CREATE CATALOG oss_tables PROPERTIES (
+    'type' = 'iceberg',
+    'iceberg.catalog.type' = 'rest',
+    'iceberg.rest.uri' = 'https://<region>.oss-tables.aliyuncs.com/iceberg',
+    'warehouse' = 'acs:osstables:<region>:<account_id>:bucket/<table_bucket_name>',
+
+    'iceberg.rest.sigv4-enabled' = 'true',
+    'iceberg.rest.signing-name' = 'osstables',
+    'iceberg.rest.signing-region' = '<region>',
+    'iceberg.rest.view-enabled' = 'false',
+
+    'io-impl' = 'org.apache.iceberg.aws.s3.S3FileIO',
+    'oss.endpoint' = 'https://oss-<region>.aliyuncs.com',
+    'oss.region' = '<region>',
+    'oss.access_key' = '<access_key_id>',
+    'oss.secret_key' = '<access_key_secret>',
+    'oss.use_path_style' = 'false',
+
+    'test_connection' = 'true'
+);
+```
+
+如需通过阿里云内网访问，将 `iceberg.rest.uri` 和 `oss.endpoint` 分别替换为 `https://<region>-internal.oss-tables.aliyuncs.com/iceberg` 和 `https://oss-<region>-internal.aliyuncs.com`。
+
+使用 STS 临时凭证时，在 `oss.secret_key` 后增加 `oss.session_token`：
+
+```sql
+'oss.session_token' = '<sts_token>',
+```
+
+Doris 会将 `oss.access_key`、`oss.secret_key` 和可选的 `oss.session_token` 同时用于 REST Catalog 的 SigV4 签名和 `S3FileIO` 数据访问，无需重复配置 `iceberg.rest.access-key-id` 和 `iceberg.rest.secret-access-key`。
+
+#### 参数说明
+
+| 参数 | 是否必须 | 说明 |
+| --- | --- | --- |
+| `type` | 是 | 固定为 `iceberg`。 |
+| `iceberg.catalog.type` | 是 | 固定为 `rest`，通过 Iceberg REST Catalog 访问 OSS Tables。 |
+| `iceberg.rest.uri` | 是 | OSS Tables REST Catalog Endpoint。 |
+| `warehouse` | 是 | Table Bucket ARN。 |
+| `iceberg.rest.sigv4-enabled` | 是 | 固定为 `true`。 |
+| `iceberg.rest.signing-name` | 是 | 固定为小写的 `osstables`。该值区分大小写。 |
+| `iceberg.rest.signing-region` | 是 | SigV4 签名地域，必须与 Table Bucket 地域一致。 |
+| `iceberg.rest.view-enabled` | 是 | 设置为 `false`。OSS Tables 当前不支持 Iceberg View 接口。 |
+| `io-impl` | 是 | 固定为 `org.apache.iceberg.aws.s3.S3FileIO`。不要使用 `HadoopFileIO`。 |
+| `oss.endpoint` | 是 | `S3FileIO` 访问 OSS 数据文件的 Endpoint。 |
+| `oss.region` | 是 | OSS 数据访问地域，必须与 Table Bucket 地域一致。 |
+| `oss.access_key` | 是 | 阿里云 AccessKey ID。 |
+| `oss.secret_key` | 是 | 阿里云 AccessKey Secret。 |
+| `oss.session_token` | 否 | 使用 STS 临时凭证时设置。 |
+| `oss.use_path_style` | 否 | 是否使用 Path Style，默认值为 `false`。 |
+| `test_connection` | 否 | 设置为 `true` 时，Doris 在创建 Catalog 时检查 REST Catalog 连接和鉴权。 |
+
+`test_connection=true` 不会替代数据访问验证。Catalog 创建成功后，仍需执行一次实际查询或写入，确认 FE、BE 到 OSS 数据访问 Endpoint 的网络和权限均正常。
+
+### 03 访问 OSS Tables
+
+```sql
+SWITCH oss_tables;
+
+SHOW DATABASES;
+
+USE <namespace_name>;
+
+SHOW TABLES;
+
+SELECT * FROM <table_name> LIMIT 10;
+```
+
+### 04 创建 OSS Tables 表并写入数据
+
+```sql
+SWITCH oss_tables;
+
+CREATE DATABASE IF NOT EXISTS doris_demo;
+USE doris_demo;
+
+CREATE TABLE orders (
+    order_id BIGINT,
+    customer STRING,
+    amount DECIMAL(10, 2),
+    created_at DATETIME
+)
+PROPERTIES (
+    'format-version' = '2',
+    'write-format' = 'parquet',
+    'write.format.default' = 'parquet',
+    'write.parquet.compression-codec' = 'zstd'
+);
+
+INSERT INTO orders VALUES
+    (1, 'Alice', 99.50, '2026-08-11 10:00:00'),
+    (2, 'Bob', 120.00, '2026-08-11 10:01:00');
+
+SELECT order_id, customer, amount, created_at
+FROM orders
+ORDER BY order_id;
+```
+
+可以通过 Iceberg `$files` 元数据表确认数据文件已经写入 OSS Tables：
+
+```sql
+SELECT file_path, file_format, record_count
+FROM `orders$files`
+ORDER BY file_path;
+```
+
+## 注意事项
+
+- OSS Tables 仅支持 Iceberg 表格式。
+- `iceberg.rest.signing-name` 必须设置为小写的 `osstables`，并同时设置正确的 `iceberg.rest.signing-region` 和 `iceberg.rest.sigv4-enabled=true`。
+- 使用 STS 临时凭证时，需要在凭证过期前更新 Catalog 中的 AK、SK 和 Token。
+
+## 常见问题
+
+### 创建 Catalog 返回 403 Forbidden
+
+检查以下配置：
+
+- `oss.access_key` 和 `oss.secret_key` 是否有效；使用 STS 临时凭证时，同时检查 `oss.session_token` 是否正确且未过期；
+- RAM 用户或 STS 身份是否具有目标 Table Bucket 的 `oss:GetTableBucket` 和 `oss:ListNamespaces` 权限；
+- `warehouse` 中的账号 ID、地域和 Table Bucket 名称是否正确；
+- `iceberg.rest.signing-name` 是否为 `osstables`，`iceberg.rest.signing-region` 是否为 Table Bucket 所在地域。
+
+### 可以查看 Namespace 和表，但查询数据失败
+
+检查 FE 和所有 BE 节点是否能够访问 `oss.endpoint`，以及 RAM 用户或 STS 身份是否具有 `oss:GetTableMetadataLocation` 和 `oss:GetTableData` 权限。
+
+OSS Tables 操作所需的完整权限，请参阅[阿里云 OSS Tables 权限与访问控制](https://help.aliyun.com/zh/oss/user-guide/oss-tables-access-control)。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
@@ -1448,10 +1448,6 @@ Iceberg 的元数据层级关系是 Catalog -> Namespace -> Table。其中 Names
 
 ### 阿里云 OSS Tables
 
-:::caution
-该功能目前为实验功能，将在 Doris 5.0.0 版本中发布。
-:::
-
 <details>
     <summary>5.0+ 版本</summary>
     <Tabs>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
@@ -1446,6 +1446,40 @@ Iceberg 的元数据层级关系是 Catalog -> Namespace -> Table。其中 Names
     </Tabs>
 </details>
 
+### 阿里云 OSS Tables
+
+:::caution
+该功能目前为实验功能，将在 Doris 5.0.0 版本中发布。
+:::
+
+<details>
+    <summary>5.0+ 版本</summary>
+    <Tabs>
+        <TabItem value='OSS Tables REST Catalog' label='OSS Tables REST Catalog' default>
+            完整配置和使用说明请参阅[集成阿里云 OSS Tables](../best-practices/doris-aliyun-oss-tables)。
+            ```sql
+            CREATE CATALOG oss_tables PROPERTIES (
+                'type' = 'iceberg',
+                'iceberg.catalog.type' = 'rest',
+                'iceberg.rest.uri' = 'https://<region>.oss-tables.aliyuncs.com/iceberg',
+                'warehouse' = 'acs:osstables:<region>:<account_id>:bucket/<table_bucket_name>',
+                'iceberg.rest.sigv4-enabled' = 'true',
+                'iceberg.rest.signing-name' = 'osstables',
+                'iceberg.rest.signing-region' = '<region>',
+                'iceberg.rest.view-enabled' = 'false',
+                'io-impl' = 'org.apache.iceberg.aws.s3.S3FileIO',
+                'oss.endpoint' = 'https://oss-<region>.aliyuncs.com',
+                'oss.region' = '<region>',
+                'oss.access_key' = '<access_key_id>',
+                'oss.secret_key' = '<access_key_secret>',
+                'oss.use_path_style' = 'false',
+                'test_connection' = 'true'
+            );
+            ```
+        </TabItem>
+    </Tabs>
+</details>
+
 ## 查询操作
 
 ### 基础查询
@@ -2779,7 +2813,7 @@ EXECUTE rewrite_data_files (
 1. `rewrite_data_files` 操作会读取数据文件并重新写入，会产生额外的 I/O 和计算开销，请合理分配集群资源。
 2. 执行前可以通过[查看数据文件分布](#查看数据文件分布)章节中的 SQL 来评估是否需要执行重写操作。
 3. WHERE 条件可用于限制重写的分区或数据范围，这个条件会过滤掉那些不包含符合 WHERE 条件的数据的文件，从而减少重写的文件数量和数据量。
-4. 执行前可以通过[重写文件选择逻辑](#重写文件选择逻辑)章节中的 SQL 来计算哪些文件会被重写。
+4. 执行前可以通过[重写文件选择逻辑](#rewrite_data_files-文件选择策略)章节中的 SQL 来计算哪些文件会被重写。
 
 ### rewrite_manifests
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -649,6 +649,7 @@ const sidebars: SidebarsConfig = {
                             items: [
                                 'lakehouse/best-practices/doris-iceberg',
                                 'lakehouse/best-practices/doris-aws-s3tables',
+                                'lakehouse/best-practices/doris-aliyun-oss-tables',
                                 'lakehouse/best-practices/doris-polaris',
                                 'lakehouse/best-practices/doris-gravitino',
                                 'lakehouse/best-practices/doris-onelake',


### PR DESCRIPTION
## What changed

- Add an English dev guide for integrating Doris with Alibaba Cloud OSS Tables.
- Add the corresponding Chinese dev documentation.
- Add the guide to the dev Iceberg Catalog navigation.
- Add a 5.0+ Alibaba Cloud OSS Tables example to the English and Chinese Iceberg Catalog reference pages.
- Mark the integration as experimental and planned for Doris 5.0.0.
- Optimize English and Chinese descriptions and keywords for SEO.
- Add GEO knowledge-type and applicable-scenario annotations without changing the document structure.

## Why

Alibaba Cloud OSS Tables exposes an Iceberg REST Catalog for metadata operations and an OSS S3-compatible endpoint for table data. This guide documents the complete Doris Catalog configuration, credential mapping, query and write examples, required permissions, and common failure modes.

Only the dev documentation is updated because this experimental integration is planned for Doris 5.0.0 and is not available in the currently released 4.x or earlier versions.

## Validation

- `git diff --check`
- Front matter JSON parsing and Markdown code-fence balance checks
- Verified that all headings and code blocks remain unchanged after SEO/GEO optimization
- Verified both Alibaba Cloud documentation URLs return HTTP 200
- Verified the rendered Chinese page emits the expected description and keywords meta tags
- Verified the rendered Iceberg Catalog page shows the OSS Tables entry, 5.0+ version panel, configuration tab, and SQL example
- `yarn docs:links:changed`
  - Completed without errors.
- `yarn docs:lint:changed`
  - Completed successfully with report-only notices.
  - The missing 4.x counterpart is intentional because this feature is planned for Doris 5.0.0 and this PR updates dev only.
  - Alibaba Cloud external links are report-only and were not fetched by the checker.
