### PR TITLE
[skill] fix add-release validator false failure and correct stale guidance

### DIFF
--- a/doc-tools/skills/add-release/SKILL.md
+++ b/doc-tools/skills/add-release/SKILL.md
@@ -36,6 +36,21 @@ Also run git status --short before editing. Existing unrelated modifications and
 
 Collect all missing release decisions in one concise confirmation instead of asking one field at a time. Do not ask again for values the user has already supplied.
 
+Look for the values yourself before asking. Most are discoverable, and proposing a confirmed default is faster than asking cold:
+
+- Release-note source: releases are announced in a tracking issue on the component's repository, titled with the version. Search the repository rather than guessing an issue number:
+
+        gh api "search/issues?q=repo:apache/doris+<version>+in:title&sort=created&order=desc"
+        gh api "repos/apache/doris-operator/issues?state=all&sort=created&direction=desc"
+
+- Release date: prefer the GitHub release for the tag. A tag often has no published release yet, in which case use the upload time of the source tarball on dist.apache.org:
+
+        curl -sSI <source-dir>/apache-doris-<source-version>-src.tar.gz | grep -i last-modified
+
+- Source filename version: read it from the release directory listing rather than deriving it from the public version. It may or may not carry an RC suffix, and this differs between releases in the same series.
+
+Ask only about what is left, and about anything where the discovered answer is ambiguous or would be unsafe to assume.
+
 Use this template:
 
     Please confirm:
@@ -58,7 +73,7 @@ Canonical component IDs:
 | doris-spark-connector | Spark ecosystem page and TOOL_VERSIONS when present | https://downloads.apache.org/doris/spark-connector/<version>/ |
 | doris-kafka-connector | Kafka ecosystem page and TOOL_VERSIONS when present | https://downloads.apache.org/doris/kafka-connector/<version>/ |
 | doris-streamloader | Streamloader ecosystem page and download data when present | Verify from the release directory |
-| doris-operator | Operator ecosystem page, images, and charts when applicable | Verify from the release announcement |
+| doris-operator | Operator ecosystem page, operator download data, images, and charts when applicable | https://downloads.apache.org/doris/doris-operator/&lt;version&gt;/ |
 | doris-mcp-server | MCP Server ecosystem page | Verify package locations |
 | doris-skills | Doris Skills ecosystem page | Verify package locations |
 | doris-cli | Doris CLI ecosystem page | Verify package locations |
@@ -85,9 +100,13 @@ The version field inside each architecture row in download.data.ts controls the 
 
 ### Discover and Verify Artifacts
 
-Inspect the official release directory before editing. Prefer the stable dist.apache.org release repository when downloads.apache.org has not synchronized yet:
+Source artifacts and binaries live in two different places. Check both.
+
+Source artifacts are published to the Apache mirrors. Prefer the stable dist.apache.org release repository when downloads.apache.org has not synchronized yet:
 
     https://dist.apache.org/repos/dist/release/doris/<series>/<public-version>/
+
+Convenience binaries are not on the Apache mirrors at all. They come from the CDN named by the ORIGIN constant in src/constant/download.data.ts. Read that constant instead of assuming a host; it has moved before, and any host written down elsewhere goes stale silently. The validator resolves the same way, so a host change needs no flag.
 
 Record the exact source tarball filename and derive the source filename version from it. Verify this complete matrix:
 
@@ -101,6 +120,14 @@ Record the exact source tarball filename and derive the source filename version 
 This is twelve URLs: three source artifacts and nine binary artifacts. A directory listing alone is insufficient. Check every URL and follow redirects. A small ranged GET may be used when a server rejects HEAD.
 
 If the canonical downloads mirror is delayed but dist.apache.org already serves the official release, use the working dist.apache.org directory in download.data.ts and record that choice in the handoff.
+
+### When Binaries Lag the Source Release
+
+The source tarball is voted on and published before the convenience binaries are uploaded, so it is normal to find the three source artifacts live while all nine binaries still return 404. This is a timing state, not an error in the release data.
+
+Do not silently invent, rename, or drop the binary rows. Confirm the gap is timing rather than a filename mistake by checking a previous release with the same URL shape on the same host; if that one resolves, the pattern is right and the files are simply not uploaded yet.
+
+Then ask the release manager whether to publish now or wait, and state the tradeoff: publishing now means the download page serves broken links until the upload completes. Record the decision and the exact missing artifacts in the handoff, and re-run the validator without --skip-links once the binaries land. Binaries can appear at any time, including mid-task, so re-check before reporting rather than trusting an earlier probe.
 
 ### Files to Update
 
@@ -131,9 +158,20 @@ Add the public version to both structures:
 - DORIS_VERSIONS drives the quick-download selector.
 - ALL_VERSIONS drives the all-releases form.
 
-In both structures, add x64, x64-noavx2, and arm64 rows. Each row must contain the binary gz, asc, sha512, source directory, and exact source filename version.
+In both structures, add x64, x64-noavx2, and arm64 rows. Each row must contain the binary gz, asc, sha512, source directory, and exact source filename version. Build the binary URLs from the ORIGIN constant rather than writing the host inline.
 
-Keep patch releases newest-first within their series. Audit the entire target series in both arrays, not only the new entry. Every target-series version in DORIS_VERSIONS must exist in ALL_VERSIONS and vice versa. Fix a discovered omission when it is clearly a data drift in the requested release scope; mention it explicitly in the handoff.
+Keep patch releases newest-first within their series. Add the new version to both arrays, and audit the target series in both.
+
+The two arrays are not mirrors, and treating them as such produces false alarms:
+
+- ALL_VERSIONS is the exhaustive archive. Every version the site offers anywhere must appear here, so a version present in DORIS_VERSIONS but absent from ALL_VERSIONS is a real defect.
+- DORIS_VERSIONS is a curated shortlist. It carries every patch of the current series but only the newest release of older ones, and a superseded version is sometimes dropped deliberately. A version present only in ALL_VERSIONS is therefore expected, not drift.
+
+The validator reports the second case as a warning rather than a failure. Before "fixing" one, check git history for that version, because the omission is often intentional:
+
+    git log -S"label: '<version>'" -- src/constant/download.data.ts
+
+Restoring a deliberately retired version would put a superseded release back into the quick-download selector. Leave it alone and mention it in the handoff instead.
 
 Do not broadly reformat download.data.ts.
 
@@ -206,10 +244,12 @@ Component profiles:
 | Spark Connector | ecosystem/doris-spark-connector.md | ToolsEnum.Spark | Spark and Scala compatibility; Maven coordinates |
 | Kafka Connector | ecosystem/doris-kafka-connector.md | ToolsEnum.Kafka | Kafka Connect compatibility; plugin package layout |
 | Streamloader | ecosystem/doris-streamloader.md | ToolsEnum.StreamLoader when present | Platform binaries, checksums, usage examples |
-| Doris Operator | ecosystem/doris-operator.md | Usually none | Controller image, Helm chart, CRD compatibility |
+| Doris Operator | ecosystem/doris-operator.md | DORIS_OPERATOR_SOURCE_VERSIONS and DORIS_OPERATOR_BINARY_VERSIONS | Controller image, Helm chart, CRD compatibility |
 | MCP Server | ecosystem/doris-mcp-server.md | Usually none | Package installation and supported Doris versions |
 | Doris Skills | ecosystem/doris-skills.md | Usually none | Installation source and supported environments |
 | Doris CLI | ecosystem/doris-cli.md | Usually none | Platform packages and install commands |
+
+Doris Operator releases add a version to both DORIS_OPERATOR_SOURCE_VERSIONS and DORIS_OPERATOR_BINARY_VERSIONS in download.data.ts. The source list drives the download links; the binary list gates whether a `docker pull` command is shown. Add to both unless the release genuinely ships no image, and confirm the image tag exists before listing it.
 
 For an existing page:
 
@@ -217,6 +257,8 @@ For an existing page:
 - Preserve the page frontmatter and anchors.
 - Update English and zh-CN with matching facts, links, compatibility data, and issue references.
 - Verify every official artifact or package link directly.
+
+Upstream release notes are written for GitHub, so their structure rarely matches the page. Normalize to the page, not to the source: map the source headings onto the heading names the page already uses, and convert bare issue references such as `#507` into the page's linked form. Keep the facts, ordering, and issue numbers exactly as the source has them.
 
 For a new page:
 
@@ -244,6 +286,8 @@ For Doris Core, run the bundled validator with the confirmed values:
 
     node doc-tools/skills/add-release/scripts/validate-release.mjs --component doris-core --version <public-version> --series <series> --source-version <source-version> --release-date <YYYY-MM-DD> --position <latest|prev|earlier|historical> --source-dir <official-source-directory>
 
+The validator resolves the binary host from the ORIGIN constant in download.data.ts, so a host migration needs no flag. Pass --binary-origin only to assert an expected host, which is useful when auditing such a migration; it turns a mismatch with the repository into a failure.
+
 The validator checks:
 
 - Both release-note files, JSON frontmatter, and trailing whitespace
@@ -252,9 +296,11 @@ The validator checks:
 - That both all-release.md project indexes still route to core.md and remain untouched
 - sidebarsReleases.json parseability and newest-first placement
 - VersionEnum positioning
-- Target-series ordering and drift between DORIS_VERSIONS and ALL_VERSIONS
+- Target-series ordering, and that every DORIS_VERSIONS entry is archived in ALL_VERSIONS
 - All six architecture rows, source filename version, source directory, and binary filenames
 - The full twelve-artifact URL matrix
+
+Output is PASS, WARN, and failure lines. WARN reports pre-existing repository state that must not block a correct release, such as an archived version deliberately absent from the curated DORIS_VERSIONS list. Read warnings and account for them in the handoff, but do not treat them as work items by default. Only failures set a nonzero exit code.
 
 Use --skip-links only when external link verification is explicitly out of scope, and disclose the skipped check. --skip-git-routing is intended for isolated test fixtures, not routine release work.
 
@@ -282,6 +328,16 @@ When compilation checks are allowed and download data or TypeScript changed, run
 
     yarn typecheck
 
+This currently exhausts memory on this repository and dies before reporting anything, even with a raised heap. tsconfig.json declares no include or exclude, so tsc walks the entire docs tree; its own comment notes the file is not used for compilation. The failure is environmental and reproduces on an unmodified checkout.
+
+Confirm that before blaming the release: revert the touched TypeScript file, re-run, and observe the same crash. Then typecheck the changed file on its own, which is fast and gives real signal:
+
+    npx tsc --noEmit --strict false --skipLibCheck --jsx react --esModuleInterop \
+        --resolveJsonModule --target es2020 --module esnext --moduleResolution bundler \
+        src/constant/download.data.ts
+
+Report the isolated result and say plainly that the repository-wide check could not run. Do not report Tier 1 as passed on the strength of the isolated check alone.
+
 ### Tier 2: Full Site Build
 
 When the release manager requests full validation, or routing and rendering risk warrants it, run:
@@ -298,8 +354,8 @@ Before reporting completion:
 
 - Re-read the request and compare it with the exact changed-file set.
 - Confirm the public version, source filename version, release date, scope, locales, and positioning.
-- Confirm all artifact checks and note any mirror choice.
-- Confirm DORIS_VERSIONS and ALL_VERSIONS are aligned for the target series.
+- Confirm all artifact checks and note any mirror choice. Re-check any artifact that was missing earlier, because binaries can land mid-task.
+- Confirm the new version is in both DORIS_VERSIONS and ALL_VERSIONS, and that any validator warning about the target series was investigated rather than acted on blindly.
 - Confirm Core history is in core.md, not all-release.md.
 - Confirm no unrelated files were modified.
 
@@ -311,8 +367,10 @@ Report:
 - Public version versus source filename version
 - Release date, position, website scope, and locales
 - Artifact validation result
-- Tier 0, Tier 1, and Tier 2 results or explicit skips
+- Tier 0, Tier 1, and Tier 2 results or explicit skips, including any tier that could not run and why
 - Any repaired pre-existing data drift, such as a missing ALL_VERSIONS entry
+- Any validator warning left in place, and why it is not drift
+- Any pre-existing defect found but deliberately not changed, so the release manager can decide separately
 - Any remaining limitation or manual follow-up
 
 Do not commit, push, publish externally, or open a pull request unless the release manager asks.

--- a/doc-tools/skills/add-release/scripts/validate-release.mjs
+++ b/doc-tools/skills/add-release/scripts/validate-release.mjs
@@ -9,19 +9,23 @@ const ARCHITECTURES = ['x64', 'x64-noavx2', 'arm64'];
 const SIDECAR_SUFFIXES = ['', '.asc', '.sha512'];
 
 class ReleaseValidationError extends Error {
-    constructor(failures, checks) {
+    constructor(failures, checks, warnings) {
         super('Release validation failed:\n- ' + failures.join('\n- '));
         this.name = 'ReleaseValidationError';
         this.failures = failures;
         this.checks = checks;
+        this.warnings = warnings || [];
     }
 }
 
-function addResult(condition, label, failure, checks, failures) {
+// Pass `failures` as the sink for conditions that must block the release, or
+// `warnings` for pre-existing repository state the release manager should see
+// but that must not fail an otherwise correct release.
+function addResult(condition, label, failure, checks, sink) {
     if (condition) {
         checks.push(label);
     } else {
-        failures.push(failure || label);
+        sink.push(failure || label);
     }
 }
 
@@ -412,11 +416,18 @@ export async function validateCoreRelease(options) {
     const sourceDir =
         options.sourceDir ||
         'https://dist.apache.org/repos/dist/release/doris/' + series + '/' + version + '/';
-    const binaryOrigin = options.binaryOrigin || 'https://download.selectdb.com/';
+    // Binaries are not served from the Apache mirrors: they come from the CDN
+    // named by the ORIGIN constant in download.data.ts. Do not hardcode that
+    // host here -- a copy in this script silently rots the moment the host
+    // moves. Default to whatever the repository declares, and treat an explicit
+    // --binary-origin as an assertion about the expected host instead.
+    const expectedBinaryOrigin = options.binaryOrigin || '';
+    let binaryOrigin = expectedBinaryOrigin;
     const checkLinks = options.checkLinks !== false;
     const checkGitRouting = options.checkGitRouting !== false;
     const checks = [];
     const failures = [];
+    const warnings = [];
 
     if (!/^\d+\.\d+\.\d+$/.test(version || '')) {
         throw new Error('version must use x.y.z format');
@@ -594,6 +605,9 @@ export async function validateCoreRelease(options) {
                 failures,
             );
 
+            // ALL_VERSIONS is the exhaustive archive, so anything offered by the
+            // quick-download selector must also appear there. A gap here is a
+            // genuine defect regardless of which release introduced it.
             for (const listedVersion of dorisVersions) {
                 addResult(
                     allVersions.includes(listedVersion),
@@ -603,13 +617,21 @@ export async function validateCoreRelease(options) {
                     failures,
                 );
             }
+            // The reverse does not hold. DORIS_VERSIONS is a curated shortlist:
+            // it carries every patch of the current series but only the newest
+            // release of older ones, and a superseded version is sometimes
+            // dropped on purpose. Report the asymmetry so the release manager
+            // can judge it, but never fail a correct release over pre-existing
+            // curation. The version being released is checked separately above.
             for (const listedVersion of allVersions) {
                 addResult(
                     dorisVersions.includes(listedVersion),
                     listedVersion + ' is mirrored in DORIS_VERSIONS',
-                    listedVersion + ' is missing from DORIS_VERSIONS',
+                    listedVersion +
+                        ' is in ALL_VERSIONS but not DORIS_VERSIONS' +
+                        ' (intentional curation or drift? check git history before changing)',
                     checks,
-                    failures,
+                    warnings,
                 );
             }
 
@@ -688,21 +710,42 @@ export async function validateCoreRelease(options) {
         const originMatch = downloadSource.match(
             /\bORIGIN\s*=\s*['"]([^'"]+)['"]/,
         );
-        addResult(
-            Boolean(originMatch) &&
-                originMatch[1].replace(/\/?$/, '/') === binaryOrigin.replace(/\/?$/, '/'),
-            'Binary ORIGIN matches ' + binaryOrigin,
-            'Binary ORIGIN must match ' + binaryOrigin,
-            checks,
-            failures,
-        );
+        const repoOrigin = originMatch ? originMatch[1].replace(/\/?$/, '/') : '';
+        if (expectedBinaryOrigin) {
+            addResult(
+                repoOrigin === expectedBinaryOrigin.replace(/\/?$/, '/'),
+                'Binary ORIGIN matches ' + expectedBinaryOrigin,
+                'Binary ORIGIN must match ' +
+                    expectedBinaryOrigin +
+                    ' (' +
+                    downloadPath +
+                    ' declares ' +
+                    (repoOrigin || 'no parseable ORIGIN') +
+                    ')',
+                checks,
+                failures,
+            );
+        } else {
+            addResult(
+                Boolean(repoOrigin),
+                'Binary ORIGIN read from ' + downloadPath + ': ' + repoOrigin,
+                downloadPath + ' has no parseable ORIGIN constant to resolve binary URLs from',
+                checks,
+                failures,
+            );
+            if (repoOrigin) {
+                binaryOrigin = repoOrigin;
+            }
+        }
     }
 
     if (checkLinks) {
         const normalizedSourceDir = sourceDir.endsWith('/') ? sourceDir : sourceDir + '/';
-        const normalizedBinaryOrigin = binaryOrigin.endsWith('/')
-            ? binaryOrigin
-            : binaryOrigin + '/';
+        const normalizedBinaryOrigin = binaryOrigin
+            ? binaryOrigin.endsWith('/')
+                ? binaryOrigin
+                : binaryOrigin + '/'
+            : '';
         const urls = [
             ...SIDECAR_SUFFIXES.map(
                 suffix =>
@@ -712,27 +755,31 @@ export async function validateCoreRelease(options) {
                     '-src.tar.gz' +
                     suffix,
             ),
-            ...ARCHITECTURES.flatMap(architecture =>
-                SIDECAR_SUFFIXES.map(
-                    suffix =>
-                        normalizedBinaryOrigin +
-                        'apache-doris-' +
-                        version +
-                        '-bin-' +
-                        architecture +
-                        '.tar.gz' +
-                        suffix,
-                ),
-            ),
+            // Skipped only when ORIGIN could not be resolved, which is already
+            // recorded as a failure above.
+            ...(normalizedBinaryOrigin
+                ? ARCHITECTURES.flatMap(architecture =>
+                      SIDECAR_SUFFIXES.map(
+                          suffix =>
+                              normalizedBinaryOrigin +
+                              'apache-doris-' +
+                              version +
+                              '-bin-' +
+                              architecture +
+                              '.tar.gz' +
+                              suffix,
+                      ),
+                  )
+                : []),
         ];
         await validateLinks(urls, checks, failures);
     }
 
     if (failures.length > 0) {
-        throw new ReleaseValidationError(failures, checks);
+        throw new ReleaseValidationError(failures, checks, warnings);
     }
 
-    return { checks };
+    return { checks, warnings };
 }
 
 function usage() {
@@ -819,11 +866,28 @@ async function main() {
         for (const check of result.checks) {
             console.log('PASS ' + check);
         }
-        console.log('Validated Doris Core ' + args.version + ': ' + result.checks.length + ' checks passed.');
+        for (const warning of result.warnings || []) {
+            console.log('WARN ' + warning);
+        }
+        console.log(
+            'Validated Doris Core ' +
+                args.version +
+                ': ' +
+                result.checks.length +
+                ' checks passed' +
+                ((result.warnings || []).length > 0
+                    ? ', ' + result.warnings.length + ' warning(s) to review.'
+                    : '.'),
+        );
     } catch (error) {
         if (Array.isArray(error.checks)) {
             for (const check of error.checks) {
                 console.log('PASS ' + check);
+            }
+        }
+        if (Array.isArray(error.warnings)) {
+            for (const warning of error.warnings) {
+                console.log('WARN ' + warning);
             }
         }
         console.error(error.message);

--- a/doc-tools/skills/add-release/scripts/validate-release.test.mjs
+++ b/doc-tools/skills/add-release/scripts/validate-release.test.mjs
@@ -18,9 +18,9 @@ function packageRows(version, sourceVersion) {
     return ['x64', 'x64-noavx2', 'arm64']
         .map(
             arch => `{
-                gz: 'https://download.selectdb.com/apache-doris-${version}-bin-${arch}.tar.gz',
-                asc: 'https://download.selectdb.com/apache-doris-${version}-bin-${arch}.tar.gz.asc',
-                sha512: 'https://download.selectdb.com/apache-doris-${version}-bin-${arch}.tar.gz.sha512',
+                gz: 'https://download.velodb.io/apache-doris-${version}-bin-${arch}.tar.gz',
+                asc: 'https://download.velodb.io/apache-doris-${version}-bin-${arch}.tar.gz.asc',
+                sha512: 'https://download.velodb.io/apache-doris-${version}-bin-${arch}.tar.gz.sha512',
                 source: 'https://dist.apache.org/repos/dist/release/doris/4.1/${version}/',
                 version: '${sourceVersion}',
             }`,
@@ -61,11 +61,15 @@ function releaseNote(language, issueRef) {
 `;
 }
 
-function createFixture({ omit412FromAll = false, zhIssueRef = '#10001' } = {}) {
+function createFixture({
+    omit412FromAll = false,
+    omit412FromDoris = false,
+    zhIssueRef = '#10001',
+} = {}) {
     const root = mkdtempSync(path.join(tmpdir(), 'add-release-validator-'));
     const dorisVersions = [
         versionEntry('4.1.3', '4.1.3-rc02'),
-        versionEntry('4.1.2', '4.1.2'),
+        ...(omit412FromDoris ? [] : [versionEntry('4.1.2', '4.1.2')]),
     ].join(',\n');
     const allVersions = [
         versionEntry('4.1.3', '4.1.3-rc02'),
@@ -75,7 +79,7 @@ function createFixture({ omit412FromAll = false, zhIssueRef = '#10001' } = {}) {
     write(
         root,
         'src/constant/download.data.ts',
-        `export const ORIGIN = 'https://download.selectdb.com/';
+        `export const ORIGIN = 'https://download.velodb.io/';
 export enum VersionEnum {
     Latest = '4.1.3',
     Prev = '4.0.7',
@@ -202,6 +206,84 @@ test('validator catches versions missing from ALL_VERSIONS', async () => {
                 checkGitRouting: false,
             }),
             /4\.1\.2.*missing from ALL_VERSIONS/,
+        );
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('validator warns, but does not fail, when DORIS_VERSIONS omits an archived version', async () => {
+    // DORIS_VERSIONS is a curated shortlist, so a version present only in
+    // ALL_VERSIONS is normal and must not block an otherwise correct release.
+    const root = createFixture({ omit412FromDoris: true });
+
+    try {
+        const { validateCoreRelease } = await import('./validate-release.mjs');
+        const result = await validateCoreRelease({
+            repoRoot: root,
+            version: '4.1.3',
+            series: '4.1',
+            sourceVersion: '4.1.3-rc02',
+            releaseDate: '2026-07-13',
+            position: 'latest',
+            checkLinks: false,
+            checkGitRouting: false,
+        });
+
+        assert.ok(
+            result.warnings.some(warning => /4\.1\.2.*not DORIS_VERSIONS/.test(warning)),
+            'expected a warning about 4.1.2 being absent from DORIS_VERSIONS',
+        );
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('validator resolves the binary origin from download.data.ts', async () => {
+    const root = createFixture();
+
+    try {
+        const { validateCoreRelease } = await import('./validate-release.mjs');
+        const result = await validateCoreRelease({
+            repoRoot: root,
+            version: '4.1.3',
+            series: '4.1',
+            sourceVersion: '4.1.3-rc02',
+            releaseDate: '2026-07-13',
+            position: 'latest',
+            checkLinks: false,
+            checkGitRouting: false,
+        });
+
+        assert.ok(
+            result.checks.some(check =>
+                /Binary ORIGIN read from .*https:\/\/download\.velodb\.io\//.test(check),
+            ),
+            'expected the binary origin to be read from download.data.ts',
+        );
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('validator treats an explicit --binary-origin as an assertion', async () => {
+    const root = createFixture();
+
+    try {
+        const { validateCoreRelease } = await import('./validate-release.mjs');
+        await assert.rejects(
+            validateCoreRelease({
+                repoRoot: root,
+                version: '4.1.3',
+                series: '4.1',
+                sourceVersion: '4.1.3-rc02',
+                releaseDate: '2026-07-13',
+                position: 'latest',
+                binaryOrigin: 'https://downloads.example.invalid/',
+                checkLinks: false,
+                checkGitRouting: false,
+            }),
+            /Binary ORIGIN must match https:\/\/downloads\.example\.invalid\//,
         );
     } finally {
         rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
Follow-up to #4062. Applying the `add-release` skill to a real release (Doris 4.0.8 and Doris Operator 26.0.1) surfaced defects in the skill itself: one made the bundled validator impossible to pass, and several sent the release manager down avoidable dead ends. This fixes them.

Scope is limited to `doc-tools/skills/add-release/`. No site content changes.

## Versions

- [ ] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

Not applicable — this changes release tooling, not documentation.

## Languages

- [ ] Chinese
- [ ] English
- [ ] Japanese candidate translation needed

Not applicable — same reason.

## Docs Checklist

- [x] Checked by AI
- [x] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

## The validator could not pass

`DORIS_VERSIONS` was asserted to mirror `ALL_VERSIONS` in **both** directions. That is not the design:

- `ALL_VERSIONS` is the exhaustive archive, so anything `DORIS_VERSIONS` offers must appear there — a real defect if missing.
- `DORIS_VERSIONS` is a curated shortlist. It carries every patch of the current series but only the newest release of older series, and a superseded version is sometimes retired deliberately — `4.0.0` was removed in 262c757f46 when 4.0.1 replaced it.

So every run failed on `4.0.0 is missing from DORIS_VERSIONS`, a failure nobody should ever fix; restoring it would put a superseded release back into the quick-download selector. The reverse direction is now a warning. The version actually being released is still checked against both arrays as a hard failure, so the useful check is unchanged.

This adds a `WARN` channel for pre-existing repository state that must not block a correct release. Only failures set a nonzero exit code.

## The binary host was hardcoded, and had already gone stale

Binaries do not come from the Apache mirrors — they come from the CDN named by the `ORIGIN` constant in `download.data.ts`. The validator kept its own copy of that host, which silently rotted when the host moved (#4062). A second copy of a value that already exists in the repository is the bug, not the particular value it held.

The host is now read from `ORIGIN`. `--binary-origin` becomes an assertion about the expected host — useful when auditing a migration — and its failure message now reports what the repository actually declares:

```
Binary ORIGIN must match https://download.velodb.io/ (src/constant/download.data.ts declares https://download.selectdb.com/)
```

## SKILL.md corrections

- **Doris Operator download data.** The component table said "Usually none". Operator releases update `DORIS_OPERATOR_SOURCE_VERSIONS` and `DORIS_OPERATOR_BINARY_VERSIONS`; following the old text would have shipped an incomplete release.
- **Where binaries live.** Previously undocumented, so the separate CDN and the `ORIGIN` constant had to be rediscovered.
- **Binaries lagging the source release.** The source tarball is voted and published before binaries are uploaded, so finding three source artifacts live and nine binaries returning 404 is a normal timing state with no guidance. Adds how to tell timing from a filename mistake, what to confirm with the release manager, and a reminder to re-check before reporting — during the 4.0.8 work the binaries went live mid-task.
- **`yarn typecheck` cannot run here.** It exhausts memory even at a 12 GB heap and reproduces on an unmodified checkout: `tsconfig.json` declares no `include`/`exclude` and its own comment says it is not used for compilation. Tier 1 stated it flatly. Now records how to confirm the failure is environmental and how to get real signal from an isolated typecheck, while forbidding a claim that Tier 1 passed.
- **Discovery recipes** for the release-note issue and the release date, so the confirmation gate asks only about what is genuinely unknown.
- **Ecosystem heading normalization.** Upstream notes are written for GitHub; their headings and bare `#507`-style references have to be mapped onto the page's conventions while keeping the facts intact.

## Verification

The validator now reaches a green run against this repository for the first time — previously impossible:

```
$ node doc-tools/skills/add-release/scripts/validate-release.mjs --component doris-core \
    --version 4.0.7 --series 4.0 --source-version 4.0.7 --release-date 2026-07-12 \
    --position prev --source-dir https://dist.apache.org/repos/dist/release/doris/4.0/4.0.7/
...
WARN 4.0.0 is in ALL_VERSIONS but not DORIS_VERSIONS (intentional curation or drift? check git history before changing)
Validated Doris Core 4.0.7: 76 checks passed, 1 warning(s) to review.
$ echo $?
0
```

Test suite grows from 4 to 7, covering the warning path, origin resolution from `download.data.ts`, and `--binary-origin` as an assertion. All 7 pass.

## Note on overlap with #4062

#4062 swapped the validator's hardcoded host to `download.velodb.io`. This PR removes the hardcoded host entirely, so the two touch the same line and whichever merges second needs a one-line conflict resolution — keep this PR's version, which reads the host from the repository. Happy to drop that hunk from #4062 instead if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
