### PR TITLE
[chore](download) switch download host to velodb.io in the 1.2 / 2.0 / 2.1 / 3.x docs

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/ecosystem/beats.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/ecosystem/beats.md
@@ -23,7 +23,7 @@ Beats Doris output plugin 调用 [Doris Stream Load](../data-operate/import/impo
 
 ### 从官网下载
 
-https://download.selectdb.com/extension/filebeat-doris-2.1.1
+https://download.velodb.io/extension/filebeat-doris-2.1.1
 
 
 ### 从源码编译

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/ecosystem/fluentbit.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/ecosystem/fluentbit.md
@@ -18,7 +18,7 @@ Fluent Bit Doris Output Plugin 调用 [Doris Stream Load](../data-operate/import
 
 ### 从官网下载
 
-https://download.selectdb.com/integrations/fluent-bit-doris-3.1.9
+https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
 
 ### 从源码编译
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/gettingStarted/quick-start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/gettingStarted/quick-start.md
@@ -22,7 +22,7 @@
 
 ```shell
 # 下载 Apache Doris 二进制安装包
-server1:~ doris$ wget https://download.selectdb.com/apache-doris-2.0.12-bin-x64.tar.gz
+server1:~ doris$ wget https://download.velodb.io/apache-doris-2.0.12-bin-x64.tar.gz
 
 # 解压安装包
 server1:~ doris$ tar zxf apache-doris-2.0.12-bin-x64.tar.gz

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/gettingStarted/quick-start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2/gettingStarted/quick-start.md
@@ -93,7 +93,7 @@ mysql -uroot -P9030 -h127.0.0.1
 
 :::caution 注意
 
--   这里使用的 Root 用户是 Apache Doris 内置的超级管理员用户，具体的用户权限查看 [认证和鉴权](../admin-manual/auth/authentication-and-authorization.md)
+-   这里使用的 Root 用户是 Apache Doris 内置的超级管理员用户，具体的用户权限查看 [认证和鉴权](../admin-manual/privilege-ldap/user-privilege.md)
 -   -P：这里是我们连接 Apache Doris 的查询端口，默认端口是 9030，对应的是 fe.conf 里的 `query_port`
 -   -h：这里是我们连接的 FE IP 地址，如果你的客户端和 FE 安装在同一个节点可以使用 127.0.0.1。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/ecosystem/beats.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/ecosystem/beats.md
@@ -23,7 +23,7 @@ Beats Doris output plugin 调用 [Doris Stream Load](../data-operate/import/stre
 
 ### 从官网下载
 
-https://download.selectdb.com/extension/filebeat-doris-2.1.1
+https://download.velodb.io/extension/filebeat-doris-2.1.1
 
 
 ### 从源码编译

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/ecosystem/fluentbit.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/ecosystem/fluentbit.md
@@ -18,7 +18,7 @@ Fluent Bit Doris Output Plugin 调用 [Doris Stream Load](../data-operate/import
 
 ### 从官网下载
 
-https://download.selectdb.com/integrations/fluent-bit-doris-3.1.9
+https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
 
 ### 从源码编译
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/gettingStarted/quick-start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/gettingStarted/quick-start.md
@@ -22,7 +22,7 @@
 
 ```shell
 # 下载 Apache Doris 二进制安装包
-server1:~ doris$ wget https://download.selectdb.com/apache-doris-2.0.12-bin-x64.tar.gz
+server1:~ doris$ wget https://download.velodb.io/apache-doris-2.0.12-bin-x64.tar.gz
 
 # 解压安装包
 server1:~ doris$ tar zxf apache-doris-2.0.12-bin-x64.tar.gz

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/gettingStarted/quick-start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/gettingStarted/quick-start.md
@@ -93,7 +93,7 @@ mysql -uroot -P9030 -h127.0.0.1
 
 :::caution 注意
 
--   这里使用的 Root 用户是 Apache Doris 内置的超级管理员用户，具体的用户权限查看 [认证和鉴权](../admin-manual/auth/authentication-and-authorization.md)
+-   这里使用的 Root 用户是 Apache Doris 内置的超级管理员用户，具体的用户权限查看 [认证和鉴权](../admin-manual/privilege-ldap/user-privilege.md)
 -   -P：这里是我们连接 Apache Doris 的查询端口，默认端口是 9030，对应的是 fe.conf 里的 `query_port`
 -   -h：这里是我们连接的 FE IP 地址，如果你的客户端和 FE 安装在同一个节点可以使用 127.0.0.1。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/log-storage-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/log-storage-analysis.md
@@ -285,7 +285,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -353,7 +353,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.selectdb.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr/overview.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr/overview.md
@@ -82,9 +82,9 @@ CCR 支持四种同步方式：
 
 | 版本 | 架构  | 包地址                                                                                                                                         | SHA256                                                           |
 |------|-------|------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| 2.1     | ARM64 | [ccr-syncer-2.1.10-rc08-arm64.tar.xz](https://download.selectdb.com/ccr-release/ccr-syncer-2.1.10-rc08-arm64.tar.xz) | 060093e90150ee24f8a784066436a0a4a1116876ebd6f33d5a844e2dc67f10b0 |
-| 2.1     | X64   | [ccr-syncer-2.1.10-rc08-x64.tar.xz](https://download.selectdb.com/ccr-release/ccr-syncer-2.1.10-rc08-x64.tar.xz)     | 656c0a46e3f0e12b9ff2fb76116ad8362e344a8d1ac31f1b26834aaaa1987a7b |
-| 3.0     | ARM64 | [ccr-syncer-3.0.6-rc07-arm64.tar.xz](https://download.selectdb.com/ccr-release/ccr-syncer-3.0.6-rc07-arm64.tar.xz) | bb136f5c9db60f18c174d32304557065e1581e96ce14009f8e8f9aa4d58628f1 |
-| 3.0     | X64   | [ccr-syncer-3.0.6-rc07-x64.tar.xz](https://download.selectdb.com/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz)   | 31e514b4d55fb4f11204cd023369ef5988ffda3cb3728e974899623ea81dc1ad |
+| 2.1     | ARM64 | [ccr-syncer-2.1.10-rc08-arm64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-2.1.10-rc08-arm64.tar.xz) | 060093e90150ee24f8a784066436a0a4a1116876ebd6f33d5a844e2dc67f10b0 |
+| 2.1     | X64   | [ccr-syncer-2.1.10-rc08-x64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-2.1.10-rc08-x64.tar.xz)     | 656c0a46e3f0e12b9ff2fb76116ad8362e344a8d1ac31f1b26834aaaa1987a7b |
+| 3.0     | ARM64 | [ccr-syncer-3.0.6-rc07-arm64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc07-arm64.tar.xz) | bb136f5c9db60f18c174d32304557065e1581e96ce14009f8e8f9aa4d58628f1 |
+| 3.0     | X64   | [ccr-syncer-3.0.6-rc07-x64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz)   | 31e514b4d55fb4f11204cd023369ef5988ffda3cb3728e974899623ea81dc1ad |
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr/quickstart.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr/quickstart.md
@@ -18,7 +18,7 @@ enable_feature_binlog=true
 
 2.1. 从如下链接下载最新的包
 
-`https://download.selectdb.com/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz`
+`https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz`
 
 2.2. 启动和停止 Syncer
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
@@ -207,7 +207,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -275,7 +275,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.selectdb.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
@@ -55,7 +55,7 @@
 
 ### 第 2 步：部署集群
 
-完成资源评估后，可以开始部署 Apache Doris 集群，推荐在物理机及虚拟机环境中进行部署。手动部署集群，可参考 [手动部署](./install/deploy-manually/integrated-storage-compute-deploy-manually)。
+完成资源评估后，可以开始部署 Apache Doris 集群，推荐在物理机及虚拟机环境中进行部署。手动部署集群，可参考 [手动部署](../../../install/deploy-manually/integrated-storage-compute-deploy-manually)。
 
 ### 第 3 步：优化 FE 和 BE 配置
 
@@ -74,7 +74,7 @@
 | `autobucket_min_buckets = 10`                                | 将自动分桶的最小分桶数从 1 调大到 10，避免日志量增加时分桶不够。 |
 | `max_backend_heartbeat_failure_tolerance_count = 10`         | 日志场景下 BE 服务器压力较大，可能短时间心跳超时，因此将容忍次数从 1 调大到 10。 |
 
-更多关于 FE 配置项的信息，可参考 [FE 配置项](./admin-manual/config/fe-config)。
+更多关于 FE 配置项的信息，可参考 [FE 配置项](../../../admin-manual/config/fe-config)。
 
 **优化 BE 配置**
 
@@ -102,7 +102,7 @@
 | 其他       | `string_type_length_soft_limit_bytes = 10485760`             | 将 String 类型数据的长度限制调高至 10 MB。                   |
 | -          | `trash_file_expire_time_sec = 300` `path_gc_check_interval_second  = 900` `path_scan_interval_second = 900` | 调快垃圾文件的回收时间。                                     |
 
-更多关于 BE 配置项的信息，可参考 [BE 配置项](./admin-manual/config/be-config)。
+更多关于 BE 配置项的信息，可参考 [BE 配置项](../../../admin-manual/config/be-config)。
 
 ### 第 4 步：建表
 
@@ -111,14 +111,14 @@
 **配置分区分桶参数**
 
 分区时，按照以下说明配置：
-- 使用时间字段上的 [Range 分区](./table-design/data-partitioning/manual-partitioning.md#range-分区) (`PARTITION BY RANGE(`ts`)`)，并开启 [动态分区](./table-design/data-partitioning/dynamic-partitioning) (`"dynamic_partition.enable" = "true"`)，按天自动管理分区。
+- 使用时间字段上的 [Range 分区](../../../table-design/data-partitioning/manual-partitioning.md#range-分区) (`PARTITION BY RANGE(`ts`)`)，并开启 [动态分区](../../../table-design/data-partitioning/dynamic-partitioning) (`"dynamic_partition.enable" = "true"`)，按天自动管理分区。
 - 使用 Datetime 类型的时间字段作为 Key (`DUPLICATE KEY(ts)`)，在查询最新 N 条日志时有数倍加速。
 
 分桶时，按照以下说明配置：
 - 分桶数量大致为集群磁盘总数的 3 倍，每个桶的数据量压缩后 5GB 左右。
 - 使用 Random 策略 (`DISTRIBUTED BY RANDOM BUCKETS 60`)，配合写入时的 Single Tablet 导入，可以提升批量（Batch）写入的效率。
 
-更多关于分区分桶的信息，可参考 [数据划分](./table-design/data-partitioning/data-distribution)。
+更多关于分区分桶的信息，可参考 [数据划分](../../../table-design/data-partitioning/data-distribution)。
 
 **配置压缩参数**
 - 使用 zstd 压缩算法 (`"compression" = "zstd"`), 提高数据压缩率。
@@ -269,7 +269,7 @@ output {
 ./bin/logstash -f logstash_demo.conf
 ```
 
-更多关于 Logstash 配置和使用的说明，可参考 [Logstash Doris Output Plugin](./ecosystem/observability/logstash)。
+更多关于 Logstash 配置和使用的说明，可参考 [Logstash Doris Output Plugin](../../../ecosystem/observability/logstash)。
 
 **对接 Filebeat**
 
@@ -345,7 +345,7 @@ chmod +x filebeat-doris-2.1.1
 ./filebeat-doris-2.1.1 -c filebeat_demo.yml
 ```
 
-更多关于 Filebeat 配置和使用的说明，可参考 [Beats Doris Output Plugin](./ecosystem/observability/beats)。
+更多关于 Filebeat 配置和使用的说明，可参考 [Beats Doris Output Plugin](../../../ecosystem/observability/beats)。
 
 **对接 Kafka**
 
@@ -379,7 +379,7 @@ FROM KAFKA (
 SHOW ROUTINE LOAD;
 ```
 
-更多关于 Kafka 配置和使用的说明，可参考 [Routine Load](./data-operate/import/import-way/routine-load-manual.md)。
+更多关于 Kafka 配置和使用的说明，可参考 [Routine Load](./routine-load-manual.md)。
 
 **使用自定义程序采集日志**
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/ecosystem/observability/beats.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/ecosystem/observability/beats.md
@@ -24,7 +24,7 @@ Beats Doris output plugin 调用 [Doris Stream Load](../../data-operate/import/i
 
 ### 从官网下载
 
-https://download.selectdb.com/extension/filebeat-doris-2.1.1
+https://download.velodb.io/extension/filebeat-doris-2.1.1
 
 
 ### 从源码编译

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/ecosystem/observability/fluentbit.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/ecosystem/observability/fluentbit.md
@@ -19,7 +19,7 @@ Fluent Bit Doris Output Plugin 调用 [Doris Stream Load](../../data-operate/imp
 
 ### 从官网下载
 
-https://download.selectdb.com/integrations/fluent-bit-doris-3.1.9
+https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
 
 ### 从源码编译
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/observability/log-storage-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/observability/log-storage-analysis.md
@@ -207,7 +207,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -275,7 +275,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.selectdb.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/observability/log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/observability/log.md
@@ -215,7 +215,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -283,7 +283,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.selectdb.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
@@ -207,7 +207,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -275,7 +275,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.selectdb.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
@@ -55,7 +55,7 @@
 
 ### 第 2 步：部署集群
 
-完成资源评估后，可以开始部署 Apache Doris 集群，推荐在物理机及虚拟机环境中进行部署。手动部署集群，可参考 [手动部署](./install/deploy-manually/integrated-storage-compute-deploy-manually)。
+完成资源评估后，可以开始部署 Apache Doris 集群，推荐在物理机及虚拟机环境中进行部署。手动部署集群，可参考 [手动部署](../../../install/deploy-manually/integrated-storage-compute-deploy-manually)。
 
 ### 第 3 步：优化 FE 和 BE 配置
 
@@ -74,7 +74,7 @@
 | `autobucket_min_buckets = 10`                                | 将自动分桶的最小分桶数从 1 调大到 10，避免日志量增加时分桶不够。 |
 | `max_backend_heartbeat_failure_tolerance_count = 10`         | 日志场景下 BE 服务器压力较大，可能短时间心跳超时，因此将容忍次数从 1 调大到 10。 |
 
-更多关于 FE 配置项的信息，可参考 [FE 配置项](./admin-manual/config/fe-config)。
+更多关于 FE 配置项的信息，可参考 [FE 配置项](../../../admin-manual/config/fe-config)。
 
 **优化 BE 配置**
 
@@ -102,7 +102,7 @@
 | 其他       | `string_type_length_soft_limit_bytes = 10485760`             | 将 String 类型数据的长度限制调高至 10 MB。                   |
 | -          | `trash_file_expire_time_sec = 300` `path_gc_check_interval_second  = 900` `path_scan_interval_second = 900` | 调快垃圾文件的回收时间。                                     |
 
-更多关于 BE 配置项的信息，可参考 [BE 配置项](./admin-manual/config/be-config)。
+更多关于 BE 配置项的信息，可参考 [BE 配置项](../../../admin-manual/config/be-config)。
 
 ### 第 4 步：建表
 
@@ -111,14 +111,14 @@
 **配置分区分桶参数**
 
 分区时，按照以下说明配置：
-- 使用时间字段上的 [Range 分区](./table-design/data-partitioning/manual-partitioning.md#range-分区) (`PARTITION BY RANGE(`ts`)`)，并开启 [动态分区](./table-design/data-partitioning/dynamic-partitioning) (`"dynamic_partition.enable" = "true"`)，按天自动管理分区。
+- 使用时间字段上的 [Range 分区](../../../table-design/data-partitioning/manual-partitioning.md#range-分区) (`PARTITION BY RANGE(`ts`)`)，并开启 [动态分区](../../../table-design/data-partitioning/dynamic-partitioning) (`"dynamic_partition.enable" = "true"`)，按天自动管理分区。
 - 使用 Datetime 类型的时间字段作为 Key (`DUPLICATE KEY(ts)`)，在查询最新 N 条日志时有数倍加速。
 
 分桶时，按照以下说明配置：
 - 分桶数量大致为集群磁盘总数的 3 倍，每个桶的数据量压缩后 5GB 左右。
 - 使用 Random 策略 (`DISTRIBUTED BY RANDOM BUCKETS 60`)，配合写入时的 Single Tablet 导入，可以提升批量（Batch）写入的效率。
 
-更多关于分区分桶的信息，可参考 [数据划分](./table-design/data-partitioning/data-distribution)。
+更多关于分区分桶的信息，可参考 [数据划分](../../../table-design/data-partitioning/data-distribution)。
 
 **配置压缩参数**
 - 使用 zstd 压缩算法 (`"compression" = "zstd"`), 提高数据压缩率。
@@ -269,7 +269,7 @@ output {
 ./bin/logstash -f logstash_demo.conf
 ```
 
-更多关于 Logstash 配置和使用的说明，可参考 [Logstash Doris Output Plugin](./ecosystem/observability/logstash)。
+更多关于 Logstash 配置和使用的说明，可参考 [Logstash Doris Output Plugin](../../../ecosystem/observability/logstash)。
 
 **对接 Filebeat**
 
@@ -345,7 +345,7 @@ chmod +x filebeat-doris-2.1.1
 ./filebeat-doris-2.1.1 -c filebeat_demo.yml
 ```
 
-更多关于 Filebeat 配置和使用的说明，可参考 [Beats Doris Output Plugin](./ecosystem/observability/beats)。
+更多关于 Filebeat 配置和使用的说明，可参考 [Beats Doris Output Plugin](../../../ecosystem/observability/beats)。
 
 **对接 Kafka**
 
@@ -379,7 +379,7 @@ FROM KAFKA (
 SHOW ROUTINE LOAD;
 ```
 
-更多关于 Kafka 配置和使用的说明，可参考 [Routine Load](./data-operate/import/import-way/routine-load-manual.md)。
+更多关于 Kafka 配置和使用的说明，可参考 [Routine Load](./routine-load-manual.md)。
 
 **使用自定义程序采集日志**
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/ecosystem/observability/beats.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/ecosystem/observability/beats.md
@@ -24,7 +24,7 @@ Beats Doris output plugin 调用 [Doris Stream Load](../../data-operate/import/i
 
 ### 从官网下载
 
-https://download.selectdb.com/extension/filebeat-doris-2.1.1
+https://download.velodb.io/extension/filebeat-doris-2.1.1
 
 
 ### 从源码编译

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/ecosystem/observability/fluentbit.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/ecosystem/observability/fluentbit.md
@@ -19,7 +19,7 @@ Fluent Bit Doris Output Plugin 调用 [Doris Stream Load](../../data-operate/imp
 
 ### 从官网下载
 
-https://download.selectdb.com/integrations/fluent-bit-doris-3.1.9
+https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
 
 ### 从源码编译
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/observability/log-storage-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/observability/log-storage-analysis.md
@@ -207,7 +207,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -275,7 +275,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.selectdb.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/observability/log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/observability/log.md
@@ -215,7 +215,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -283,7 +283,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.selectdb.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/versioned_docs/version-1.2/ecosystem/beats.md
+++ b/versioned_docs/version-1.2/ecosystem/beats.md
@@ -22,7 +22,7 @@ To use the Beats Doris output plugin, there are three main steps:
 
 ### Download from the Official Website
 
-[https://download.selectdb.com/extension/filebeat-doris-2.1.1](https://download.selectdb.com/extension/filebeat-doris-2.1.1)
+[https://download.velodb.io/extension/filebeat-doris-2.1.1](https://download.velodb.io/extension/filebeat-doris-2.1.1)
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-1.2/ecosystem/fluentbit.md
+++ b/versioned_docs/version-1.2/ecosystem/fluentbit.md
@@ -18,7 +18,7 @@ To use the Fluent Bit Doris output plugin, there are three main steps:
 
 ### Download from the Official Website
 
-https://download.selectdb.com/integrations/fluent-bit-doris-3.1.9
+https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-1.2/gettingStarted/quick-start.md
+++ b/versioned_docs/version-1.2/gettingStarted/quick-start.md
@@ -21,7 +21,7 @@ Download the Apache Doris installation package from doris.apache.org and proceed
 
 ```shell
 # Download the binary installation package of Apache Doris
-server1:~ doris$ wget https://download.selectdb.com/apache-doris-2.0.3-bin-x64.tar.gz
+server1:~ doris$ wget https://download.velodb.io/apache-doris-2.0.3-bin-x64.tar.gz
 
 # Extract the installation package
 server1:~ doris$ tar zxf apache-doris-2.0.3-bin-x64.tar.gz

--- a/versioned_docs/version-1.2/gettingStarted/quick-start.md
+++ b/versioned_docs/version-1.2/gettingStarted/quick-start.md
@@ -92,7 +92,7 @@ mysql -uroot -P9030 -h127.0.0.1
 
 Note:
 
-- The root user here is the built-in super admin user of Apache Doris. See [Authentication and Authorization](../admin-manual/auth/authentication-and-authorization.md) for more information.
+- The root user here is the built-in super admin user of Apache Doris. See [Authentication and Authorization](../admin-manual/privilege-ldap/user-privilege.md) for more information.
 - -P: This specifies the query port that is connected to. The default port is 9030. It corresponds to the `query_port`setting in fe.conf.
 - -h: This specifies the IP address of the FE that is connected to. If your client and FE are installed on the same node, you can use 127.0.0.1.
 

--- a/versioned_docs/version-2.0/ecosystem/beats.md
+++ b/versioned_docs/version-2.0/ecosystem/beats.md
@@ -22,7 +22,7 @@ To use the Beats Doris output plugin, there are three main steps:
 
 ### Download from the Official Website
 
-[https://download.selectdb.com/extension/filebeat-doris-2.1.1](https://download.selectdb.com/extension/filebeat-doris-2.1.1)
+[https://download.velodb.io/extension/filebeat-doris-2.1.1](https://download.velodb.io/extension/filebeat-doris-2.1.1)
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-2.0/ecosystem/fluentbit.md
+++ b/versioned_docs/version-2.0/ecosystem/fluentbit.md
@@ -18,7 +18,7 @@ To use the Fluent Bit Doris output plugin, there are three main steps:
 
 ### Download from the Official Website
 
-https://download.selectdb.com/integrations/fluent-bit-doris-3.1.9
+https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-2.0/gettingStarted/quick-start.md
+++ b/versioned_docs/version-2.0/gettingStarted/quick-start.md
@@ -21,7 +21,7 @@ Download the Apache Doris installation package from doris.apache.org and proceed
 
 ```shell
 # Download the binary installation package of Apache Doris
-server1:~ doris$ wget https://download.selectdb.com/apache-doris-2.0.3-bin-x64.tar.gz
+server1:~ doris$ wget https://download.velodb.io/apache-doris-2.0.3-bin-x64.tar.gz
 
 # Extract the installation package
 server1:~ doris$ tar zxf apache-doris-2.0.3-bin-x64.tar.gz

--- a/versioned_docs/version-2.0/gettingStarted/quick-start.md
+++ b/versioned_docs/version-2.0/gettingStarted/quick-start.md
@@ -92,7 +92,7 @@ mysql -uroot -P9030 -h127.0.0.1
 
 Note:
 
-- The root user here is the built-in super admin user of Apache Doris. See [Authentication and Authorization](../admin-manual/auth/authentication-and-authorization.md) for more information.
+- The root user here is the built-in super admin user of Apache Doris. See [Authentication and Authorization](../admin-manual/privilege-ldap/user-privilege.md) for more information.
 - -P: This specifies the query port that is connected to. The default port is 9030. It corresponds to the `query_port`setting in fe.conf.
 - -h: This specifies the IP address of the FE that is connected to. If your client and FE are installed on the same node, you can use 127.0.0.1.
 

--- a/versioned_docs/version-2.0/practical-guide/log-storage-analysis.md
+++ b/versioned_docs/version-2.0/practical-guide/log-storage-analysis.md
@@ -306,7 +306,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. You can choose one of the following two methods:
 
-   - [Click to download](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem) and install.
+   - [Click to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem) and install.
 
    - Compile from the source code and run the following command to install:
 
@@ -373,7 +373,7 @@ For more information about the Logstash Doris Output plugin, see [Logstash Doris
 
 Follow these steps:
 
-1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.selectdb.com/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
+1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
 
 2. Configure Filebeat. Specify the filebeat_demo.yml field that is used to configure the specific input path of the collected logs and the settings for output to Apache Doris.
 

--- a/versioned_docs/version-2.1/admin-manual/data-admin/ccr/overview.md
+++ b/versioned_docs/version-2.1/admin-manual/data-admin/ccr/overview.md
@@ -85,9 +85,9 @@ requirement: glibc >= 2.28
 
 | Version | Arch  | Tarball                                                                                                                                        | SHA256                                                           |
 |---------|-------|------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| 2.1     | ARM64 | [ccr-syncer-2.1.10-rc08-arm64.tar.xz](https://download.selectdb.com/ccr-release/ccr-syncer-2.1.10-rc08-arm64.tar.xz) | 060093e90150ee24f8a784066436a0a4a1116876ebd6f33d5a844e2dc67f10b0 |
-| 2.1     | X64   | [ccr-syncer-2.1.10-rc08-x64.tar.xz](https://download.selectdb.com/ccr-release/ccr-syncer-2.1.10-rc08-x64.tar.xz)     | 656c0a46e3f0e12b9ff2fb76116ad8362e344a8d1ac31f1b26834aaaa1987a7b |
-| 3.0     | ARM64 | [ccr-syncer-3.0.6-rc07-arm64.tar.xz](https://download.selectdb.com/ccr-release/ccr-syncer-3.0.6-rc07-arm64.tar.xz) | dd5f154c68007732c3c3a9f808f16a7f287fd742bd35d0272ef596779f0eb8e6 |
-| 3.0     | X64   | [ccr-syncer-3.0.6-rc07-x64.tar.xz](https://download.selectdb.com/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz)   | 31e514b4d55fb4f11204cd023369ef5988ffda3cb3728e974899623ea81dc1ad |
+| 2.1     | ARM64 | [ccr-syncer-2.1.10-rc08-arm64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-2.1.10-rc08-arm64.tar.xz) | 060093e90150ee24f8a784066436a0a4a1116876ebd6f33d5a844e2dc67f10b0 |
+| 2.1     | X64   | [ccr-syncer-2.1.10-rc08-x64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-2.1.10-rc08-x64.tar.xz)     | 656c0a46e3f0e12b9ff2fb76116ad8362e344a8d1ac31f1b26834aaaa1987a7b |
+| 3.0     | ARM64 | [ccr-syncer-3.0.6-rc07-arm64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc07-arm64.tar.xz) | dd5f154c68007732c3c3a9f808f16a7f287fd742bd35d0272ef596779f0eb8e6 |
+| 3.0     | X64   | [ccr-syncer-3.0.6-rc07-x64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz)   | 31e514b4d55fb4f11204cd023369ef5988ffda3cb3728e974899623ea81dc1ad |
 
 

--- a/versioned_docs/version-2.1/admin-manual/data-admin/ccr/quickstart.md
+++ b/versioned_docs/version-2.1/admin-manual/data-admin/ccr/quickstart.md
@@ -19,7 +19,7 @@ enable_feature_binlog=true
 
 2.1. Download the latest package from the following link:
 
-`https://download.selectdb.com/ccr-release/ccr-syncer-3.0.6-rc05-x64.tar.xz`
+`https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc05-x64.tar.xz`
 
 2.2. Start and stop Syncer
 

--- a/versioned_docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
+++ b/versioned_docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
@@ -158,7 +158,7 @@ Refer to the following table to learn about the values of indicators in the exam
 
 ### Step 2: Deploy the cluster
 
-After estimating the resources, you need to deploy the cluster. It is recommended to deploy in both physical and virtual environments manually. For manual deployment, refer to [Manual Deployment](./install/deploy-manually/integrated-storage-compute-deploy-manually).
+After estimating the resources, you need to deploy the cluster. It is recommended to deploy in both physical and virtual environments manually. For manual deployment, refer to [Manual Deployment](../../../install/deploy-manually/integrated-storage-compute-deploy-manually).
 
 ### Step 3: Optimize FE and BE configurations
 
@@ -177,7 +177,7 @@ You can find FE configuration fields in `fe/conf/fe.conf`. Refer to the followin
 | `autobucket_min_buckets = 10`                                | Increase the minimum number of automatically bucketed buckets from 1 to 10 to avoid insufficient buckets when the log volume increases. |
 | `max_backend_heartbeat_failure_tolerance_count = 10`         | In log scenarios, the BE server may experience high pressure, leading to short-term timeouts, so increase the tolerance count from 1 to 10. |
 
-For more information, refer to [FE Configuration](./admin-manual/config/fe-config.md).
+For more information, refer to [FE Configuration](../../../admin-manual/config/fe-config.md).
 
 **Optimize BE configurations**
 
@@ -206,7 +206,7 @@ You can find BE configuration fields in `be/conf/be.conf`. Refer to the followin
 | -          | `trash_file_expire_time_sec = 300` `path_gc_check_interval_second  = 900` `path_scan_interval_second = 900` | Accelerate the recycling of trash files.                     |
 
 
-For more information, refer to [BE Configuration](./admin-manual/config/be-config).
+For more information, refer to [BE Configuration](../../../admin-manual/config/be-config).
 
 ### Step 4: Create tables
 
@@ -216,7 +216,7 @@ Due to the distinct characteristics of both writing and querying log data, it is
 
 - For data partitioning:
 
-    - Enable [range partitioning](./table-design/data-partitioning/manual-partitioning.md#range-partitioning) (`PARTITION BY RANGE(`ts`)`) with [dynamic partitions](./table-design/data-partitioning/dynamic-partitioning)   (`"dynamic_partition.enable" = "true"`) managed automatically by day.
+    - Enable [range partitioning](../../../table-design/data-partitioning/manual-partitioning.md#range-partitioning) (`PARTITION BY RANGE(`ts`)`) with [dynamic partitions](../../../table-design/data-partitioning/dynamic-partitioning)   (`"dynamic_partition.enable" = "true"`) managed automatically by day.
 
     - Use a field in the DATETIME type as the key (`DUPLICATE KEY(ts)`) for accelerated retrieval of the latest N log entries.
 
@@ -226,7 +226,7 @@ Due to the distinct characteristics of both writing and querying log data, it is
 
     - Use the Random strategy (`DISTRIBUTED BY RANDOM BUCKETS 60`) to optimize batch writing efficiency when paired with single tablet imports.
 
-For more information, refer to [Data Partitioning](./table-design/data-partitioning/auto-partitioning).
+For more information, refer to [Data Partitioning](../../../table-design/data-partitioning/auto-partitioning).
 
 **Configure compression parameters**
 
@@ -379,7 +379,7 @@ output {
 ./bin/logstash -f logstash_demo.conf
 ```
 
-For more information about the Logstash Doris Output plugin, see [Logstash Doris Output Plugin](./ecosystem/observability/logstash).
+For more information about the Logstash Doris Output plugin, see [Logstash Doris Output Plugin](../../../ecosystem/observability/logstash).
 
 **Integrating Filebeat**
 
@@ -447,7 +447,7 @@ headers:
     ./filebeat-doris-2.1.1 -c filebeat_demo.yml
     ```
 
-For more information about Filebeat, refer to [Beats Doris Output Plugin](./ecosystem/observability/beats).
+For more information about Filebeat, refer to [Beats Doris Output Plugin](../../../ecosystem/observability/beats).
 
 **Integrating Kafka**
 
@@ -478,7 +478,7 @@ FROM KAFKA (
 <br />SHOW ROUTINE LOAD;
 ```
 
-For more information about Kafka, see [Routine Load](./data-operate/import/import-way/routine-load-manual.md).
+For more information about Kafka, see [Routine Load](./routine-load-manual.md).
 
 **Using customized programs to collect logs**
 

--- a/versioned_docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
+++ b/versioned_docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
@@ -318,7 +318,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. You can choose one of the following two methods:
 
-   - [Click to download](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem) and install.
+   - [Click to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem) and install.
 
    - Compile from the source code and run the following command to install:
 
@@ -385,7 +385,7 @@ For more information about the Logstash Doris Output plugin, see [Logstash Doris
 
 Follow these steps:
 
-1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.selectdb.com/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
+1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
 
 2. Configure Filebeat. Specify the filebeat_demo.yml field that is used to configure the specific input path of the collected logs and the settings for output to Apache Doris.
 

--- a/versioned_docs/version-2.1/ecosystem/observability/beats.md
+++ b/versioned_docs/version-2.1/ecosystem/observability/beats.md
@@ -23,7 +23,7 @@ To use the Beats Doris output plugin, there are three main steps:
 
 ### Download from the Official Website
 
-[https://download.selectdb.com/extension/filebeat-doris-2.1.1](https://download.selectdb.com/extension/filebeat-doris-2.1.1)
+[https://download.velodb.io/extension/filebeat-doris-2.1.1](https://download.velodb.io/extension/filebeat-doris-2.1.1)
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-2.1/ecosystem/observability/fluentbit.md
+++ b/versioned_docs/version-2.1/ecosystem/observability/fluentbit.md
@@ -19,7 +19,7 @@ To use the Fluent Bit Doris output plugin, there are three main steps:
 
 ### Download
 
-https://download.selectdb.com/integrations/fluent-bit-doris-3.1.9
+https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-2.1/observability/log.md
+++ b/versioned_docs/version-2.1/observability/log.md
@@ -234,7 +234,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. You can choose one of the following two methods:
 
-   - [Click to download](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem) and install.
+   - [Click to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem) and install.
 
    - Compile from the source code and run the following command to install:
 
@@ -301,7 +301,7 @@ For more information about the Logstash Doris Output plugin, see [Logstash Doris
 
 Follow these steps:
 
-1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.selectdb.com/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
+1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
 
 2. Configure Filebeat. Specify the filebeat_demo.yml field that is used to configure the specific input path of the collected logs and the settings for output to Apache Doris.
 

--- a/versioned_docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
+++ b/versioned_docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
@@ -318,7 +318,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. You can choose one of the following two methods:
 
-   - [Click to download](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem) and install.
+   - [Click to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem) and install.
 
    - Compile from the source code and run the following command to install:
 
@@ -385,7 +385,7 @@ For more information about the Logstash Doris Output plugin, see [Logstash Doris
 
 Follow these steps:
 
-1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.selectdb.com/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
+1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
 
 2. Configure Filebeat. Specify the filebeat_demo.yml field that is used to configure the specific input path of the collected logs and the settings for output to Apache Doris.
 

--- a/versioned_docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
+++ b/versioned_docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
@@ -158,7 +158,7 @@ Refer to the following table to learn about the values of indicators in the exam
 
 ### Step 2: Deploy the cluster
 
-After estimating the resources, you need to deploy the cluster. It is recommended to deploy in both physical and virtual environments manually. For manual deployment, refer to [Manual Deployment](../../docs/install/deploy-manually/integrated-storage-compute-deploy-manually).
+After estimating the resources, you need to deploy the cluster. It is recommended to deploy in both physical and virtual environments manually. For manual deployment, refer to [Manual Deployment](../../../install/deploy-manually/integrated-storage-compute-deploy-manually).
 
 ### Step 3: Optimize FE and BE configurations
 
@@ -177,7 +177,7 @@ You can find FE configuration fields in `fe/conf/fe.conf`. Refer to the followin
 | `autobucket_min_buckets = 10`                                | Increase the minimum number of automatically bucketed buckets from 1 to 10 to avoid insufficient buckets when the log volume increases. |
 | `max_backend_heartbeat_failure_tolerance_count = 10`         | In log scenarios, the BE server may experience high pressure, leading to short-term timeouts, so increase the tolerance count from 1 to 10. |
 
-For more information, refer to [FE Configuration](./admin-manual/config/fe-config).
+For more information, refer to [FE Configuration](../../../admin-manual/config/fe-config).
 
 **Optimize BE configurations**
 
@@ -206,7 +206,7 @@ You can find BE configuration fields in `be/conf/be.conf`. Refer to the followin
 | -          | `trash_file_expire_time_sec = 300` `path_gc_check_interval_second  = 900` `path_scan_interval_second = 900` | Accelerate the recycling of trash files.                     |
 
 
-For more information, refer to [BE Configuration](./admin-manual/config/be-config).
+For more information, refer to [BE Configuration](../../../admin-manual/config/be-config).
 
 ### Step 4: Create tables
 
@@ -216,7 +216,7 @@ Due to the distinct characteristics of both writing and querying log data, it is
 
 - For data partitioning:
 
-    - Enable [range partitioning](./table-design/data-partitioning/manual-partitioning.md#range-partitioning) (`PARTITION BY RANGE(`ts`)`) with [dynamic partitions](./table-design/data-partitioning/dynamic-partitioning)   (`"dynamic_partition.enable" = "true"`) managed automatically by day.
+    - Enable [range partitioning](../../../table-design/data-partitioning/manual-partitioning.md#range-partitioning) (`PARTITION BY RANGE(`ts`)`) with [dynamic partitions](../../../table-design/data-partitioning/dynamic-partitioning)   (`"dynamic_partition.enable" = "true"`) managed automatically by day.
 
     - Use a field in the DATETIME type as the key (`DUPLICATE KEY(ts)`) for accelerated retrieval of the latest N log entries.
 
@@ -226,7 +226,7 @@ Due to the distinct characteristics of both writing and querying log data, it is
 
     - Use the Random strategy (`DISTRIBUTED BY RANDOM BUCKETS 60`) to optimize batch writing efficiency when paired with single tablet imports.
 
-For more information, refer to [Data Partitioning](./table-design/data-partitioning/auto-partitioning).
+For more information, refer to [Data Partitioning](../../../table-design/data-partitioning/auto-partitioning).
 
 **Configure compression parameters**
 
@@ -379,7 +379,7 @@ output {
 ./bin/logstash -f logstash_demo.conf
 ```
 
-For more information about the Logstash Doris Output plugin, see [Logstash Doris Output Plugin](./ecosystem/observability/logstash).
+For more information about the Logstash Doris Output plugin, see [Logstash Doris Output Plugin](../../../ecosystem/observability/logstash).
 
 **Integrating Filebeat**
 
@@ -447,7 +447,7 @@ headers:
     ./filebeat-doris-2.1.1 -c filebeat_demo.yml
     ```
 
-For more information about Filebeat, refer to [Beats Doris Output Plugin](./ecosystem/observability/beats).
+For more information about Filebeat, refer to [Beats Doris Output Plugin](../../../ecosystem/observability/beats).
 
 **Integrating Kafka**
 
@@ -478,7 +478,7 @@ FROM KAFKA (
 <br />SHOW ROUTINE LOAD;
 ```
 
-For more information about Kafka, see [Routine Load](./data-operate/import/import-way/routine-load-manual.md).
+For more information about Kafka, see [Routine Load](./routine-load-manual.md).
 
 **Using customized programs to collect logs**
 

--- a/versioned_docs/version-3.x/ecosystem/observability/beats.md
+++ b/versioned_docs/version-3.x/ecosystem/observability/beats.md
@@ -23,7 +23,7 @@ To use the Beats Doris output plugin, there are three main steps:
 
 ### Download from the Official Website
 
-[https://download.selectdb.com/extension/filebeat-doris-2.1.1](https://download.selectdb.com/extension/filebeat-doris-2.1.1)
+[https://download.velodb.io/extension/filebeat-doris-2.1.1](https://download.velodb.io/extension/filebeat-doris-2.1.1)
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-3.x/ecosystem/observability/fluentbit.md
+++ b/versioned_docs/version-3.x/ecosystem/observability/fluentbit.md
@@ -19,7 +19,7 @@ To use the Fluent Bit Doris output plugin, there are three main steps:
 
 ### Download
 
-https://download.selectdb.com/integrations/fluent-bit-doris-3.1.9
+https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-3.x/observability/log.md
+++ b/versioned_docs/version-3.x/observability/log.md
@@ -234,7 +234,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. You can choose one of the following two methods:
 
-   - [Click to download](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem) and install.
+   - [Click to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem) and install.
 
    - Compile from the source code and run the following command to install:
 
@@ -301,7 +301,7 @@ For more information about the Logstash Doris Output plugin, see [Logstash Doris
 
 Follow these steps:
 
-1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.selectdb.com/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
+1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
 
 2. Configure Filebeat. Specify the filebeat_demo.yml field that is used to configure the specific input path of the collected logs and the settings for output to Apache Doris.
 

--- a/versioned_docs/version-3.x/practical-guide/log-storage-analysis.md
+++ b/versioned_docs/version-3.x/practical-guide/log-storage-analysis.md
@@ -318,7 +318,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. You can choose one of the following two methods:
 
-   - [Click to download](https://download.selectdb.com/extension/logstash-output-doris-1.2.0.gem) and install.
+   - [Click to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem) and install.
 
    - Compile from the source code and run the following command to install:
 
@@ -385,7 +385,7 @@ For more information about the Logstash Doris Output plugin, see [Logstash Doris
 
 Follow these steps:
 
-1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.selectdb.com/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
+1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
 
 2. Configure Filebeat. Specify the filebeat_demo.yml field that is used to configure the specific input path of the collected logs and the settings for output to Apache Doris.
 


### PR DESCRIPTION
Switches the download host from `download.selectdb.com` to `download.velodb.io` in the 1.2 / 2.0 / 2.1 / 3.x doc trees, and repairs the latent broken links that swap exposes.

Split out of #4062 to keep the release PR reviewable. #4062 now carries the release itself plus the `current` / 4.x trees, the download page and the release tooling; this PR carries only the older versions. The two are disjoint and can land in either order.

## Versions

- [ ] dev
- [ ] 4.x
- [x] 3.x
- [x] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [ ] Japanese candidate translation needed

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

## 1. Download host swap (37 files)

Hostname-only across `versioned_docs/` and `i18n/zh-CN/` for 1.2, 2.0, 2.1 and 3.x — filebeat, logstash, fluent-bit, ccr-syncer and quick-start binary links. No path, filename or surrounding text changed; every changed line pairs exactly with its original.

Before the swap, every distinct affected URL was requested on both hosts and returned the same result, so the new host is a complete mirror and no link changes behavior.

`ja-source/` and `deprecated-docs/` are deliberately left on the old host and can be migrated separately.

## 2. Broken link repairs (8 files, second commit)

`scripts/check_move.js` validates **every** local link in a file the head commit touches, not just the changed lines. The hostname swap therefore turned 40 pre-existing broken links into a Build Check failure (see the failing run on #4062). None were introduced by the swap; they are fixed here so it can land.

**`data-operate/import/import-way/log-storage-analysis.md`** (2.1 and 3.x, en + zh) — the page was copied from `practical-guide/` (depth 1) to depth 3 without re-basing its links, so every `./<section>/...` resolved inside `import-way/`. The `practical-guide/` sibling still on `../` confirms which copy was missed. Re-based to `../../../<section>/...`; the self-referential `./data-operate/import/import-way/routine-load-manual.md` collapses to `./routine-load-manual.md`; version-3.x en additionally carried a stray `../../docs/install/...` prefix.

**`gettingStarted/quick-start.md`** (1.2 and 2.0, en + zh) — `admin-manual/auth/` does not exist in those two versions (it appears in 2.1). Pointed at the version-appropriate `admin-manual/privilege-ldap/user-privilege.md`, which both `version-1.2-sidebars.json` and `version-2.0-sidebars.json` list.

Every new target was verified to exist in its own version tree, and the two `#range-partitioning` / `#range-分区` anchors against the headings in `manual-partitioning.md`. `node scripts/check_move.js HEAD` is clean on this branch.

The link fixes are kept as the second commit deliberately: the checker only inspects the head commit, so this ordering is what makes the branch pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
