### PR TITLE
Remove Merge-on-Write decoupled mode limitation note (now supported in current/4.x)

### DIFF
--- a/docs/data-operate/transaction.md
+++ b/docs/data-operate/transaction.md
@@ -381,9 +381,6 @@ mysql> SELECT * FROM dt3;
 
 * When using JDBC to connect to Doris for transactional operations, add `useLocalSessionState=true` in the JDBC URL; otherwise the error `This is in a transaction, only insert, update, delete, commit, rollback is acceptable.` may be raised.
 
-* In compute-storage decoupled mode, transactional writes do not support Merge-on-Write tables. Otherwise the error `Transaction load is not supported for merge on write unique keys table in cloud mode` will be raised.
-
-
 ## Stream Load 2PC
 
 **1. Set `two_phase_commit:true` in the HTTP Header to enable two-phase commit.**

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/transaction.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data-operate/transaction.md
@@ -381,9 +381,6 @@ mysql> SELECT * FROM dt3;
 
 * 当使用 JDBC 连接 Doris 进行事务操作时，请在 JDBC URL 中添加 `useLocalSessionState=true`，否则可能会遇到错误 `This is in a transaction, only insert, update, delete, commit, rollback is acceptable.`
 
-* 存算分离模式下，事务写不支持 Merge-on-Write 表，否则会遇到报错 `Transaction load is not supported for merge on write unique keys table in cloud mode`
-
-
 ## Stream Load 2PC
 
 **1. 在 HTTP Header 中设置 `two_phase_commit:true` 启用两阶段提交。**

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/transaction.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/data-operate/transaction.md
@@ -381,9 +381,6 @@ mysql> SELECT * FROM dt3;
 
 * 当使用 JDBC 连接 Doris 进行事务操作时，请在 JDBC URL 中添加 `useLocalSessionState=true`，否则可能会遇到错误 `This is in a transaction, only insert, update, delete, commit, rollback is acceptable.`
 
-* 存算分离模式下，事务写不支持 Merge-on-Write 表，否则会遇到报错 `Transaction load is not supported for merge on write unique keys table in cloud mode`
-
-
 ## Stream Load 2PC
 
 **1. 在 HTTP Header 中设置 `two_phase_commit:true` 启用两阶段提交。**

--- a/ja-source/docusaurus-plugin-content-docs/current/data-operate/transaction.md
+++ b/ja-source/docusaurus-plugin-content-docs/current/data-operate/transaction.md
@@ -369,8 +369,6 @@ mysql> SELECT * FROM dt3;
 
 * JDBCを使用してDorisに接続してトランザクション操作を行う場合は、JDBC URLに`useLocalSessionState=true`を追加してください。そうでない場合、`This is in a transaction, only insert, update, delete, commit, rollback is acceptable`エラーが発生する可能性があります。
 
-* cloudモードでは、トランザクションロードは`merge on write` uniqueテーブルをサポートしません。そうでない場合、`Transaction load is not supported for merge on write unique keys table in cloud mode`エラーが発生します。
-
 ## stream Load 2PC
 
 **1. HTTPヘッダーで`two_phase_commit:true`を設定することにより、2フェーズコミットを有効にします。**

--- a/ja-source/docusaurus-plugin-content-docs/version-4.x/data-operate/transaction.md
+++ b/ja-source/docusaurus-plugin-content-docs/version-4.x/data-operate/transaction.md
@@ -369,8 +369,6 @@ mysql> SELECT * FROM dt3;
 
 * JDBCを使用してDorisに接続してトランザクション操作を行う場合、JDBC URLに`useLocalSessionState=true`を追加してください。そうでない場合、`This is in a transaction, only insert, update, delete, commit, rollback is acceptable`エラーが発生する可能性があります。
 
-* クラウドモードでは、トランザクションロードは`merge on write`のuniqueTableをサポートしません。そうでない場合、`Transaction load is not supported for merge on write unique keys table in cloud mode`エラーが発生します。
-
 ## Stream Load 2PC
 
 **1. HTTPヘッダーで`two_phase_commit:true`を設定して2フェーズコミットを有効にします。**

--- a/versioned_docs/version-4.x/data-operate/transaction.md
+++ b/versioned_docs/version-4.x/data-operate/transaction.md
@@ -381,9 +381,6 @@ mysql> SELECT * FROM dt3;
 
 * When using JDBC to connect to Doris for transactional operations, add `useLocalSessionState=true` in the JDBC URL; otherwise the error `This is in a transaction, only insert, update, delete, commit, rollback is acceptable.` may be raised.
 
-* In compute-storage decoupled mode, transactional writes do not support Merge-on-Write tables. Otherwise the error `Transaction load is not supported for merge on write unique keys table in cloud mode` will be raised.
-
-
 ## Stream Load 2PC
 
 **1. Set `two_phase_commit:true` in the HTTP Header to enable two-phase commit.**


### PR DESCRIPTION
## Versions 

- [x] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [x] Japanese candidate translation needed

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
- [ ] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync
