### PR TITLE
[chore](download) switch the download host to Aliyun OSS on the download page and in the current / 4.x docs

### DIFF
--- a/doc-tools/skills/add-release/scripts/validate-release.mjs
+++ b/doc-tools/skills/add-release/scripts/validate-release.mjs
@@ -412,7 +412,7 @@ export async function validateCoreRelease(options) {
     const sourceDir =
         options.sourceDir ||
         'https://dist.apache.org/repos/dist/release/doris/' + series + '/' + version + '/';
-    const binaryOrigin = options.binaryOrigin || 'https://download.velodb.io/';
+    const binaryOrigin = options.binaryOrigin || 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/';
     const checkLinks = options.checkLinks !== false;
     const checkGitRouting = options.checkGitRouting !== false;
     const checks = [];

--- a/doc-tools/skills/add-release/scripts/validate-release.test.mjs
+++ b/doc-tools/skills/add-release/scripts/validate-release.test.mjs
@@ -18,9 +18,9 @@ function packageRows(version, sourceVersion) {
     return ['x64', 'x64-noavx2', 'arm64']
         .map(
             arch => `{
-                gz: 'https://download.velodb.io/apache-doris-${version}-bin-${arch}.tar.gz',
-                asc: 'https://download.velodb.io/apache-doris-${version}-bin-${arch}.tar.gz.asc',
-                sha512: 'https://download.velodb.io/apache-doris-${version}-bin-${arch}.tar.gz.sha512',
+                gz: 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-${version}-bin-${arch}.tar.gz',
+                asc: 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-${version}-bin-${arch}.tar.gz.asc',
+                sha512: 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-${version}-bin-${arch}.tar.gz.sha512',
                 source: 'https://dist.apache.org/repos/dist/release/doris/4.1/${version}/',
                 version: '${sourceVersion}',
             }`,
@@ -75,7 +75,7 @@ function createFixture({ omit412FromAll = false, zhIssueRef = '#10001' } = {}) {
     write(
         root,
         'src/constant/download.data.ts',
-        `export const ORIGIN = 'https://download.velodb.io/';
+        `export const ORIGIN = 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/';
 export enum VersionEnum {
     Latest = '4.1.3',
     Prev = '4.0.7',

--- a/docs/connection-integration/data-integration/beats.md
+++ b/docs/connection-integration/data-integration/beats.md
@@ -33,7 +33,7 @@ You can either download a Beats binary that already includes the Doris output pl
 
 ### Download from the official site
 
-Download [filebeat-doris-2.1.1](https://download.velodb.io/extension/filebeat-doris-2.1.1).
+Download [filebeat-doris-2.1.1](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1).
 
 ### Compile from source
 

--- a/docs/connection-integration/data-integration/fluentbit.md
+++ b/docs/connection-integration/data-integration/fluentbit.md
@@ -52,7 +52,7 @@ You can either download a precompiled binary directly or build from source.
 
 ### Download from the official site
 
-Download [fluent-bit-doris-3.1.9](https://download.velodb.io/integrations/fluent-bit-doris-3.1.9).
+Download [fluent-bit-doris-3.1.9](https://apache-doris-releases.oss-accelerate.aliyuncs.com/integrations/fluent-bit-doris-3.1.9).
 
 ### Build from source
 

--- a/docs/observability/log.md
+++ b/docs/observability/log.md
@@ -360,7 +360,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. Choose one of the following methods:
 
-    - Direct download: [click here to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem).
+    - Direct download: [click here to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem).
     - Build from source, then install with the following command:
 
         ```shell
@@ -426,7 +426,7 @@ For more configuration details, refer to [Logstash Doris Output Plugin](../conne
 
 Follow these steps:
 
-1. Get a Filebeat binary that supports output to Apache Doris. You can [click here to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) it or build it from the Apache Doris source.
+1. Get a Filebeat binary that supports output to Apache Doris. You can [click here to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) it or build it from the Apache Doris source.
 
 2. Configure Filebeat. The main file is `filebeat_demo.yml`, which configures the input path of the collected logs and the settings for output to Apache Doris:
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/data-integration/beats.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/data-integration/beats.md
@@ -33,7 +33,7 @@ Beats Doris output plugin 支持以下 Beats 组件：
 
 ### 从官网下载
 
-下载 [filebeat-doris-2.1.1](https://download.velodb.io/extension/filebeat-doris-2.1.1)。
+下载 [filebeat-doris-2.1.1](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1)。
 
 ### 从源码编译
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/data-integration/fluentbit.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/connection-integration/data-integration/fluentbit.md
@@ -52,7 +52,7 @@
 
 ### 从官网下载
 
-下载 [fluent-bit-doris-3.1.9](https://download.velodb.io/integrations/fluent-bit-doris-3.1.9)。
+下载 [fluent-bit-doris-3.1.9](https://apache-doris-releases.oss-accelerate.aliyuncs.com/integrations/fluent-bit-doris-3.1.9)。
 
 ### 从源码编译
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/observability/log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/observability/log.md
@@ -360,7 +360,7 @@ PROPERTIES (
 
 1. 下载并安装 Logstash Doris Output 插件，可任选一种方式：
 
-    - 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
+    - 直接下载：[点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem)。
     - 从源码编译，并运行下方命令安装：
 
         ```shell
@@ -426,7 +426,7 @@ PROPERTIES (
 
 按以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) 或从 Apache Doris 源码编译。
 
 2. 配置 Filebeat，主要文件 `filebeat_demo.yml`，配置所采集日志的输入路径与输出到 Apache Doris 的设置：
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/data-integration/beats.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/data-integration/beats.md
@@ -33,7 +33,7 @@ Beats Doris output plugin 支持以下 Beats 组件：
 
 ### 从官网下载
 
-下载 [filebeat-doris-2.1.1](https://download.velodb.io/extension/filebeat-doris-2.1.1)。
+下载 [filebeat-doris-2.1.1](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1)。
 
 ### 从源码编译
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/data-integration/fluentbit.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/connection-integration/data-integration/fluentbit.md
@@ -52,7 +52,7 @@
 
 ### 从官网下载
 
-下载 [fluent-bit-doris-3.1.9](https://download.velodb.io/integrations/fluent-bit-doris-3.1.9)。
+下载 [fluent-bit-doris-3.1.9](https://apache-doris-releases.oss-accelerate.aliyuncs.com/integrations/fluent-bit-doris-3.1.9)。
 
 ### 从源码编译
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/observability/log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/observability/log.md
@@ -360,7 +360,7 @@ PROPERTIES (
 
 1. 下载并安装 Logstash Doris Output 插件，可任选一种方式：
 
-    - 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
+    - 直接下载：[点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem)。
     - 从源码编译，并运行下方命令安装：
 
         ```shell
@@ -426,7 +426,7 @@ PROPERTIES (
 
 按以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) 或从 Apache Doris 源码编译。
 
 2. 配置 Filebeat，主要文件 `filebeat_demo.yml`，配置所采集日志的输入路径与输出到 Apache Doris 的设置：
 

--- a/src/constant/download.data.ts
+++ b/src/constant/download.data.ts
@@ -39,7 +39,7 @@ export const TOOL_RELEASE_NOTES: Record<ToolsEnum, string> = {
     [ToolsEnum.Operator]: '/releases/ecosystem/doris-operator',
 };
 
-export const ORIGIN = 'https://download.velodb.io/';
+export const ORIGIN = 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/';
 export enum VersionEnum {
     Latest = '4.1.3',
     Prev = '4.0.8',
@@ -2335,40 +2335,6 @@ export const ALL_VERSIONS: AllVersionOption[] = [
                 ],
             },
             {
-                label: '2.0.3',
-                value: '2.0.3',
-                majorVersion: '2.0',
-                items: [
-                    {
-                        label: CPUEnum.X64,
-                        value: CPUEnum.X64,
-                        gz: `${ORIGIN}apache-doris-2.0.3-bin-x64.tar.gz`,
-                        asc: `${ORIGIN}apache-doris-2.0.3-bin-x64.tar.gz.asc`,
-                        sha512: `${ORIGIN}apache-doris-2.0.3-bin-x64.tar.gz.sha512`,
-                        source: 'https://archive.apache.org/dist/doris/2.0/2.0.3/',
-                        version: '2.0.3',
-                    },
-                    {
-                        label: CPUEnum.X64NoAvx2,
-                        value: CPUEnum.X64NoAvx2,
-                        gz: `${ORIGIN}apache-doris-2.0.3-bin-x64-noavx2.tar.gz`,
-                        asc: `${ORIGIN}apache-doris-2.0.3-bin-x64-noavx2.tar.gz.asc`,
-                        sha512: `${ORIGIN}apache-doris-2.0.3-bin-x64-noavx2.tar.gz.sha512`,
-                        source: 'https://archive.apache.org/dist/doris/2.0/2.0.3/',
-                        version: '2.0.3',
-                    },
-                    {
-                        label: CPUEnum.ARM64,
-                        value: CPUEnum.ARM64,
-                        gz: `${ORIGIN}apache-doris-2.0.3-bin-arm64.tar.gz`,
-                        asc: `${ORIGIN}apache-doris-2.0.3-bin-arm64.tar.gz.asc`,
-                        sha512: `${ORIGIN}apache-doris-2.0.3-bin-arm64.tar.gz.sha512`,
-                        source: 'https://archive.apache.org/dist/doris/2.0/2.0.3/',
-                        version: '2.0.3',
-                    },
-                ],
-            },
-            {
                 label: '2.0.2',
                 value: '2.0.2',
                 majorVersion: '2.0',
@@ -3600,14 +3566,14 @@ export const TOOL_VERSIONS = [
                     {
                         label: CPUEnum.X64,
                         value: CPUEnum.X64,
-                        gz: 'https://download.velodb.io/apache-doris-streamloader-1.0.3-bin-x64.tar.gz',
-                        Binary: 'https://download.velodb.io/apache-doris-streamloader-1.0.3-bin-x64.tar.gz',
+                        gz: `${ORIGIN}apache-doris-streamloader-1.0.3-bin-x64.tar.gz`,
+                        Binary: `${ORIGIN}apache-doris-streamloader-1.0.3-bin-x64.tar.gz`,
                     },
                     {
                         label: CPUEnum.ARM64,
                         value: CPUEnum.ARM64,
-                        gz: 'https://download.velodb.io/apache-doris-streamloader-1.0.3-bin-arm64.tar.gz',
-                        Binary: 'https://download.velodb.io/apache-doris-streamloader-1.0.3-bin-arm64.tar.gz',
+                        gz: `${ORIGIN}apache-doris-streamloader-1.0.3-bin-arm64.tar.gz`,
+                        Binary: `${ORIGIN}apache-doris-streamloader-1.0.3-bin-arm64.tar.gz`,
                     },
                 ],
                 source: 'https://downloads.apache.org/doris/doris-streamloader/1.0.3/apache-doris-streamloader-1.0.3-src.tar.gz',
@@ -3619,14 +3585,14 @@ export const TOOL_VERSIONS = [
                     {
                         label: CPUEnum.X64,
                         value: CPUEnum.X64,
-                        gz: 'https://download.velodb.io/apache-doris-streamloader-1.0.2-bin-x64.tar.gz',
-                        Binary: 'https://download.velodb.io/apache-doris-streamloader-1.0.2-bin-x64.tar.gz',
+                        gz: `${ORIGIN}apache-doris-streamloader-1.0.2-bin-x64.tar.gz`,
+                        Binary: `${ORIGIN}apache-doris-streamloader-1.0.2-bin-x64.tar.gz`,
                     },
                     {
                         label: CPUEnum.ARM64,
                         value: CPUEnum.ARM64,
-                        gz: 'https://download.velodb.io/apache-doris-streamloader-1.0.2-bin-arm64.tar.gz',
-                        Binary: 'https://download.velodb.io/apache-doris-streamloader-1.0.2-bin-arm64.tar.gz',
+                        gz: `${ORIGIN}apache-doris-streamloader-1.0.2-bin-arm64.tar.gz`,
+                        Binary: `${ORIGIN}apache-doris-streamloader-1.0.2-bin-arm64.tar.gz`,
                     },
                 ],
                 source: 'https://downloads.apache.org/doris/doris-streamloader/1.0.2/apache-doris-streamloader-1.0.2-src.tar.gz',
@@ -3638,14 +3604,14 @@ export const TOOL_VERSIONS = [
                     {
                         label: CPUEnum.X64,
                         value: CPUEnum.X64,
-                        gz: 'https://download.velodb.io/apache-doris-streamloader-1.0.1-bin-x64.tar.xz',
-                        Binary: 'https://download.velodb.io/apache-doris-streamloader-1.0.1-bin-x64.tar.xz',
+                        gz: `${ORIGIN}apache-doris-streamloader-1.0.1-bin-x64.tar.xz`,
+                        Binary: `${ORIGIN}apache-doris-streamloader-1.0.1-bin-x64.tar.xz`,
                     },
                     {
                         label: CPUEnum.ARM64,
                         value: CPUEnum.ARM64,
-                        gz: 'https://download.velodb.io/apache-doris-streamloader-1.0.1-bin-arm64.tar.xz',
-                        Binary: 'https://download.velodb.io/apache-doris-streamloader-1.0.1-bin-arm64.tar.xz',
+                        gz: `${ORIGIN}apache-doris-streamloader-1.0.1-bin-arm64.tar.xz`,
+                        Binary: `${ORIGIN}apache-doris-streamloader-1.0.1-bin-arm64.tar.xz`,
                     },
                 ],
                 source: 'https://downloads.apache.org/doris/doris-streamloader/1.0.1/apache-doris-streamloader-1.0.1-src.tar.gz',

--- a/versioned_docs/version-4.x/connection-integration/data-integration/beats.md
+++ b/versioned_docs/version-4.x/connection-integration/data-integration/beats.md
@@ -33,7 +33,7 @@ You can either download a Beats binary that already includes the Doris output pl
 
 ### Download from the official site
 
-Download [filebeat-doris-2.1.1](https://download.velodb.io/extension/filebeat-doris-2.1.1).
+Download [filebeat-doris-2.1.1](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1).
 
 ### Compile from source
 

--- a/versioned_docs/version-4.x/connection-integration/data-integration/fluentbit.md
+++ b/versioned_docs/version-4.x/connection-integration/data-integration/fluentbit.md
@@ -52,7 +52,7 @@ You can either download a precompiled binary directly or build from source.
 
 ### Download from the official site
 
-Download [fluent-bit-doris-3.1.9](https://download.velodb.io/integrations/fluent-bit-doris-3.1.9).
+Download [fluent-bit-doris-3.1.9](https://apache-doris-releases.oss-accelerate.aliyuncs.com/integrations/fluent-bit-doris-3.1.9).
 
 ### Build from source
 

--- a/versioned_docs/version-4.x/observability/log.md
+++ b/versioned_docs/version-4.x/observability/log.md
@@ -360,7 +360,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. Choose one of the following methods:
 
-    - Direct download: [click here to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem).
+    - Direct download: [click here to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem).
     - Build from source, then install with the following command:
 
         ```shell
@@ -426,7 +426,7 @@ For more configuration details, refer to [Logstash Doris Output Plugin](../conne
 
 Follow these steps:
 
-1. Get a Filebeat binary that supports output to Apache Doris. You can [click here to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) it or build it from the Apache Doris source.
+1. Get a Filebeat binary that supports output to Apache Doris. You can [click here to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) it or build it from the Apache Doris source.
 
 2. Configure Filebeat. The main file is `filebeat_demo.yml`, which configures the input path of the collected logs and the settings for output to Apache Doris:
 


### PR DESCRIPTION
Move every Apache Doris download link off `download.velodb.io` and onto
`https://apache-doris-releases.oss-accelerate.aliyuncs.com/` — first on the
download page itself, then in the `current` and 4.x doc trees.

## Versions

- [x] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [ ] Japanese candidate translation needed

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

## Download page

`src/constant/download.data.ts`

- `ORIGIN` now points at the OSS bucket, which covers all 670 `${ORIGIN}...`
  links — tarballs, `.asc` and `.sha512` alike.
- The twelve Doris Streamloader links were hardcoded to the old host. They now
  use `${ORIGIN}` like everything else in the file, so the next host change is
  a one-line edit.
- The whole 2.0.3 entry is dropped from `ALL_VERSIONS`. Its no-avx2 artifacts
  have been 404 on every host this page has used — aliyuncs, velodb and
  selectdb — and Apache only archives source for that release, so there is
  nothing to point the row at.

Source packages (`dist`/`archive.apache.org`), the Kafka / Flink / Spark
connectors (`downloads` and `repository.apache.org`, Maven Central) and Doris
Operator are untouched — they never used this host.

`doc-tools/skills/add-release/scripts/validate-release.{mjs,test.mjs}` — the
release validator asserts that `ORIGIN` matches its `binaryOrigin`, so its
default and fixtures move with it. Without this the next release would fail
validation.

## Docs

Twelve files, sixteen occurrences, three distinct artifacts — the Filebeat and
Fluent Bit builds and the Logstash output plugin gem — on the Beats, Fluent Bit
and log-analysis pages, in English and Chinese, for both `current` and 4.x.
These live under `extension/` and `integrations/` rather than the bucket root,
so the paths were confirmed on the new host before the swap.

## Verification

Every link was checked, not sampled.

**Download page** — the edited module was transpiled and evaluated, and every
URL it renders was probed:

| | before | after |
|---|---|---|
| file links | 535 | 526 |
| HTTP 200 | 532 | **526** |
| 404 | 3 (the 2.0.3 no-avx2 trio) | **0** |

Cross-checked against the old host as well: all 532 live artifacts matched on
both status and `Content-Length`, and the 350 `.asc` / `.sha512` files were
byte-identical across the two hosts.

**Docs** — all three artifacts resolve with a `Content-Length` identical to the
old host:

```
200  101723712  extension/filebeat-doris-2.1.1
200   45834456  integrations/fluent-bit-doris-3.1.9
200      10752  extension/logstash-output-doris-1.2.0.gem
```

`docs:links:changed` reports `errors=false`, and `docs:i18n-sync:changed`
reports info-level findings only.

## Left for a separate change

- The 3.x, 2.1, 2.0 and 1.2 doc trees still point at `download.velodb.io`
  (62 occurrences), as do three files under `community/`.
- The Japanese tree was never migrated off `download.selectdb.com`, so it does
  not match this PR's search and is untouched. Its links still resolve. Since
  this PR only rewrites URLs and adds no prose, no Japanese translation
  candidate is needed — the Japanese pages need their own host swap instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
