### PR TITLE
[chore](download) switch download host to Aliyun OSS in the 2.1 / 3.x docs

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr/overview.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr/overview.md
@@ -82,9 +82,9 @@ CCR 支持四种同步方式：
 
 | 版本 | 架构  | 包地址                                                                                                                                         | SHA256                                                           |
 |------|-------|------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| 2.1     | ARM64 | [ccr-syncer-2.1.10-rc08-arm64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-2.1.10-rc08-arm64.tar.xz) | 060093e90150ee24f8a784066436a0a4a1116876ebd6f33d5a844e2dc67f10b0 |
-| 2.1     | X64   | [ccr-syncer-2.1.10-rc08-x64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-2.1.10-rc08-x64.tar.xz)     | 656c0a46e3f0e12b9ff2fb76116ad8362e344a8d1ac31f1b26834aaaa1987a7b |
-| 3.0     | ARM64 | [ccr-syncer-3.0.6-rc07-arm64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc07-arm64.tar.xz) | bb136f5c9db60f18c174d32304557065e1581e96ce14009f8e8f9aa4d58628f1 |
-| 3.0     | X64   | [ccr-syncer-3.0.6-rc07-x64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz)   | 31e514b4d55fb4f11204cd023369ef5988ffda3cb3728e974899623ea81dc1ad |
+| 2.1     | ARM64 | [ccr-syncer-2.1.10-rc08-arm64.tar.xz](https://apache-doris-releases.oss-accelerate.aliyuncs.com/ccr-release/ccr-syncer-2.1.10-rc08-arm64.tar.xz) | 060093e90150ee24f8a784066436a0a4a1116876ebd6f33d5a844e2dc67f10b0 |
+| 2.1     | X64   | [ccr-syncer-2.1.10-rc08-x64.tar.xz](https://apache-doris-releases.oss-accelerate.aliyuncs.com/ccr-release/ccr-syncer-2.1.10-rc08-x64.tar.xz)     | 656c0a46e3f0e12b9ff2fb76116ad8362e344a8d1ac31f1b26834aaaa1987a7b |
+| 3.0     | ARM64 | [ccr-syncer-3.0.6-rc07-arm64.tar.xz](https://apache-doris-releases.oss-accelerate.aliyuncs.com/ccr-release/ccr-syncer-3.0.6-rc07-arm64.tar.xz) | bb136f5c9db60f18c174d32304557065e1581e96ce14009f8e8f9aa4d58628f1 |
+| 3.0     | X64   | [ccr-syncer-3.0.6-rc07-x64.tar.xz](https://apache-doris-releases.oss-accelerate.aliyuncs.com/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz)   | 31e514b4d55fb4f11204cd023369ef5988ffda3cb3728e974899623ea81dc1ad |
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr/quickstart.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/data-admin/ccr/quickstart.md
@@ -18,7 +18,7 @@ enable_feature_binlog=true
 
 2.1. 从如下链接下载最新的包
 
-`https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz`
+`https://apache-doris-releases.oss-accelerate.aliyuncs.com/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz`
 
 2.2. 启动和停止 Syncer
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
@@ -207,7 +207,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -275,7 +275,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/ecosystem/observability/beats.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/ecosystem/observability/beats.md
@@ -24,7 +24,7 @@ Beats Doris output plugin 调用 [Doris Stream Load](../../data-operate/import/i
 
 ### 从官网下载
 
-https://download.velodb.io/extension/filebeat-doris-2.1.1
+https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1
 
 
 ### 从源码编译

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/ecosystem/observability/fluentbit.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/ecosystem/observability/fluentbit.md
@@ -19,7 +19,7 @@ Fluent Bit Doris Output Plugin 调用 [Doris Stream Load](../../data-operate/imp
 
 ### 从官网下载
 
-https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
+https://apache-doris-releases.oss-accelerate.aliyuncs.com/integrations/fluent-bit-doris-3.1.9
 
 ### 从源码编译
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/observability/log-storage-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/observability/log-storage-analysis.md
@@ -207,7 +207,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -275,7 +275,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/observability/log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/observability/log.md
@@ -215,7 +215,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -283,7 +283,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
@@ -207,7 +207,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -275,7 +275,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/ecosystem/observability/beats.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/ecosystem/observability/beats.md
@@ -24,7 +24,7 @@ Beats Doris output plugin 调用 [Doris Stream Load](../../data-operate/import/i
 
 ### 从官网下载
 
-https://download.velodb.io/extension/filebeat-doris-2.1.1
+https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1
 
 
 ### 从源码编译

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/ecosystem/observability/fluentbit.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/ecosystem/observability/fluentbit.md
@@ -19,7 +19,7 @@ Fluent Bit Doris Output Plugin 调用 [Doris Stream Load](../../data-operate/imp
 
 ### 从官网下载
 
-https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
+https://apache-doris-releases.oss-accelerate.aliyuncs.com/integrations/fluent-bit-doris-3.1.9
 
 ### 从源码编译
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/observability/log-storage-analysis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/observability/log-storage-analysis.md
@@ -207,7 +207,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -275,7 +275,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/observability/log.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/observability/log.md
@@ -215,7 +215,7 @@ Apache Doris 提供开放、通用的 Stream HTTP APIs，通过这些 APIs，你
 
 1. 下载并安装 Logstash Doris Output 插件。你可选择以下两种方式之一：
 
-- 直接下载：[点此下载](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem)。
+- 直接下载：[点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem)。
   
 - 从源码编译，并运行下方命令安装：
 
@@ -283,7 +283,7 @@ output {
 
 按照以下步骤操作：
 
-1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://download.velodb.io/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
+1. 获取支持输出至 Apache Doris 的 Filebeat 二进制文件。可 [点此下载](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) 或者从 Apache Doris 源码编译。
 2. 配置 Filebeat。需配置以下参数：
 
 - `filebeat_demo.yml`：配置所采集日志的具体输入路径和输出到 Apache Doris 的设置。

--- a/versioned_docs/version-2.1/admin-manual/data-admin/ccr/overview.md
+++ b/versioned_docs/version-2.1/admin-manual/data-admin/ccr/overview.md
@@ -85,9 +85,9 @@ requirement: glibc >= 2.28
 
 | Version | Arch  | Tarball                                                                                                                                        | SHA256                                                           |
 |---------|-------|------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| 2.1     | ARM64 | [ccr-syncer-2.1.10-rc08-arm64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-2.1.10-rc08-arm64.tar.xz) | 060093e90150ee24f8a784066436a0a4a1116876ebd6f33d5a844e2dc67f10b0 |
-| 2.1     | X64   | [ccr-syncer-2.1.10-rc08-x64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-2.1.10-rc08-x64.tar.xz)     | 656c0a46e3f0e12b9ff2fb76116ad8362e344a8d1ac31f1b26834aaaa1987a7b |
-| 3.0     | ARM64 | [ccr-syncer-3.0.6-rc07-arm64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc07-arm64.tar.xz) | dd5f154c68007732c3c3a9f808f16a7f287fd742bd35d0272ef596779f0eb8e6 |
-| 3.0     | X64   | [ccr-syncer-3.0.6-rc07-x64.tar.xz](https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz)   | 31e514b4d55fb4f11204cd023369ef5988ffda3cb3728e974899623ea81dc1ad |
+| 2.1     | ARM64 | [ccr-syncer-2.1.10-rc08-arm64.tar.xz](https://apache-doris-releases.oss-accelerate.aliyuncs.com/ccr-release/ccr-syncer-2.1.10-rc08-arm64.tar.xz) | 060093e90150ee24f8a784066436a0a4a1116876ebd6f33d5a844e2dc67f10b0 |
+| 2.1     | X64   | [ccr-syncer-2.1.10-rc08-x64.tar.xz](https://apache-doris-releases.oss-accelerate.aliyuncs.com/ccr-release/ccr-syncer-2.1.10-rc08-x64.tar.xz)     | 656c0a46e3f0e12b9ff2fb76116ad8362e344a8d1ac31f1b26834aaaa1987a7b |
+| 3.0     | ARM64 | [ccr-syncer-3.0.6-rc07-arm64.tar.xz](https://apache-doris-releases.oss-accelerate.aliyuncs.com/ccr-release/ccr-syncer-3.0.6-rc07-arm64.tar.xz) | dd5f154c68007732c3c3a9f808f16a7f287fd742bd35d0272ef596779f0eb8e6 |
+| 3.0     | X64   | [ccr-syncer-3.0.6-rc07-x64.tar.xz](https://apache-doris-releases.oss-accelerate.aliyuncs.com/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz)   | 31e514b4d55fb4f11204cd023369ef5988ffda3cb3728e974899623ea81dc1ad |
 
 

--- a/versioned_docs/version-2.1/admin-manual/data-admin/ccr/quickstart.md
+++ b/versioned_docs/version-2.1/admin-manual/data-admin/ccr/quickstart.md
@@ -19,7 +19,7 @@ enable_feature_binlog=true
 
 2.1. Download the latest package from the following link:
 
-`https://download.velodb.io/ccr-release/ccr-syncer-3.0.6-rc05-x64.tar.xz`
+`https://apache-doris-releases.oss-accelerate.aliyuncs.com/ccr-release/ccr-syncer-3.0.6-rc05-x64.tar.xz`
 
 2.2. Start and stop Syncer
 

--- a/versioned_docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
+++ b/versioned_docs/version-2.1/data-operate/import/import-way/log-storage-analysis.md
@@ -318,7 +318,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. You can choose one of the following two methods:
 
-   - [Click to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem) and install.
+   - [Click to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem) and install.
 
    - Compile from the source code and run the following command to install:
 
@@ -385,7 +385,7 @@ For more information about the Logstash Doris Output plugin, see [Logstash Doris
 
 Follow these steps:
 
-1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
+1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
 
 2. Configure Filebeat. Specify the filebeat_demo.yml field that is used to configure the specific input path of the collected logs and the settings for output to Apache Doris.
 

--- a/versioned_docs/version-2.1/ecosystem/observability/beats.md
+++ b/versioned_docs/version-2.1/ecosystem/observability/beats.md
@@ -23,7 +23,7 @@ To use the Beats Doris output plugin, there are three main steps:
 
 ### Download from the Official Website
 
-[https://download.velodb.io/extension/filebeat-doris-2.1.1](https://download.velodb.io/extension/filebeat-doris-2.1.1)
+[https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1)
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-2.1/ecosystem/observability/fluentbit.md
+++ b/versioned_docs/version-2.1/ecosystem/observability/fluentbit.md
@@ -19,7 +19,7 @@ To use the Fluent Bit Doris output plugin, there are three main steps:
 
 ### Download
 
-https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
+https://apache-doris-releases.oss-accelerate.aliyuncs.com/integrations/fluent-bit-doris-3.1.9
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-2.1/observability/log.md
+++ b/versioned_docs/version-2.1/observability/log.md
@@ -234,7 +234,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. You can choose one of the following two methods:
 
-   - [Click to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem) and install.
+   - [Click to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem) and install.
 
    - Compile from the source code and run the following command to install:
 
@@ -301,7 +301,7 @@ For more information about the Logstash Doris Output plugin, see [Logstash Doris
 
 Follow these steps:
 
-1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
+1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
 
 2. Configure Filebeat. Specify the filebeat_demo.yml field that is used to configure the specific input path of the collected logs and the settings for output to Apache Doris.
 

--- a/versioned_docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
+++ b/versioned_docs/version-3.x/data-operate/import/import-way/log-storage-analysis.md
@@ -318,7 +318,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. You can choose one of the following two methods:
 
-   - [Click to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem) and install.
+   - [Click to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem) and install.
 
    - Compile from the source code and run the following command to install:
 
@@ -385,7 +385,7 @@ For more information about the Logstash Doris Output plugin, see [Logstash Doris
 
 Follow these steps:
 
-1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
+1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
 
 2. Configure Filebeat. Specify the filebeat_demo.yml field that is used to configure the specific input path of the collected logs and the settings for output to Apache Doris.
 

--- a/versioned_docs/version-3.x/ecosystem/observability/beats.md
+++ b/versioned_docs/version-3.x/ecosystem/observability/beats.md
@@ -23,7 +23,7 @@ To use the Beats Doris output plugin, there are three main steps:
 
 ### Download from the Official Website
 
-[https://download.velodb.io/extension/filebeat-doris-2.1.1](https://download.velodb.io/extension/filebeat-doris-2.1.1)
+[https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1)
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-3.x/ecosystem/observability/fluentbit.md
+++ b/versioned_docs/version-3.x/ecosystem/observability/fluentbit.md
@@ -19,7 +19,7 @@ To use the Fluent Bit Doris output plugin, there are three main steps:
 
 ### Download
 
-https://download.velodb.io/integrations/fluent-bit-doris-3.1.9
+https://apache-doris-releases.oss-accelerate.aliyuncs.com/integrations/fluent-bit-doris-3.1.9
 
 ### Compile from Source Code
 

--- a/versioned_docs/version-3.x/observability/log.md
+++ b/versioned_docs/version-3.x/observability/log.md
@@ -234,7 +234,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. You can choose one of the following two methods:
 
-   - [Click to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem) and install.
+   - [Click to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem) and install.
 
    - Compile from the source code and run the following command to install:
 
@@ -301,7 +301,7 @@ For more information about the Logstash Doris Output plugin, see [Logstash Doris
 
 Follow these steps:
 
-1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
+1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
 
 2. Configure Filebeat. Specify the filebeat_demo.yml field that is used to configure the specific input path of the collected logs and the settings for output to Apache Doris.
 

--- a/versioned_docs/version-3.x/practical-guide/log-storage-analysis.md
+++ b/versioned_docs/version-3.x/practical-guide/log-storage-analysis.md
@@ -318,7 +318,7 @@ Follow these steps:
 
 1. Download and install the Logstash Doris Output plugin. You can choose one of the following two methods:
 
-   - [Click to download](https://download.velodb.io/extension/logstash-output-doris-1.2.0.gem) and install.
+   - [Click to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/logstash-output-doris-1.2.0.gem) and install.
 
    - Compile from the source code and run the following command to install:
 
@@ -385,7 +385,7 @@ For more information about the Logstash Doris Output plugin, see [Logstash Doris
 
 Follow these steps:
 
-1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://download.velodb.io/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
+1. Obtain the Filebeat binary file that supports output to Apache Doris. You can [click to download](https://apache-doris-releases.oss-accelerate.aliyuncs.com/extension/filebeat-doris-2.1.1) or compile it from the Apache Doris source code.
 
 2. Configure Filebeat. Specify the filebeat_demo.yml field that is used to configure the specific input path of the collected logs and the settings for output to Apache Doris.
 


### PR DESCRIPTION
Replaces `download.velodb.io` with `apache-doris-releases.oss-accelerate.aliyuncs.com` across the 2.1 and 3.x doc trees.

Follow-up to #4064, which had moved these same links from `download.selectdb.com` to `download.velodb.io`.

## Versions

- [ ] dev
- [ ] 4.x
- [x] 3.x
- [x] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English
- [ ] Japanese candidate translation needed

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

## Scope

Hostname-only change — 23 files, 40 occurrences, no path or content edits.

| Tree | Files |
| --- | --- |
| `versioned_docs/version-2.1` | 6 |
| `versioned_docs/version-3.x` | 6 |
| `i18n/zh-CN/.../version-2.1` | 6 |
| `i18n/zh-CN/.../version-3.x` | 5 |

`ja-source/` is intentionally left untouched, matching the scope of #4064 — it is report-only candidate-translation input per `website-quality-governance/i18n-sync-policy.md`, so its two links still point at the old host.

## Link verification

All 8 distinct URLs were scraped back out of the working tree after the edit and checked live. Every one returns **HTTP 200** with a real `Content-Length` and a sensible `Content-Type`:

| Status | Size | Path |
| --- | --- | --- |
| 200 | 21.9 MB | `/ccr-release/ccr-syncer-2.1.10-rc08-arm64.tar.xz` |
| 200 | 30.7 MB | `/ccr-release/ccr-syncer-2.1.10-rc08-x64.tar.xz` |
| 200 | 28.1 MB | `/ccr-release/ccr-syncer-3.0.6-rc05-x64.tar.xz` |
| 200 | 21.9 MB | `/ccr-release/ccr-syncer-3.0.6-rc07-arm64.tar.xz` |
| 200 | 30.7 MB | `/ccr-release/ccr-syncer-3.0.6-rc07-x64.tar.xz` |
| 200 | 101.7 MB | `/extension/filebeat-doris-2.1.1` |
| 200 | 10.7 KB | `/extension/logstash-output-doris-1.2.0.gem` |
| 200 | 45.8 MB | `/integrations/fluent-bit-doris-3.1.9` |

As a control, a nonexistent path on the same bucket returns 404, so the 200s above are genuine objects rather than a catch-all response.

The diff was additionally normalized line-by-line to confirm every removed line matches an added line once the hostname is masked — i.e. no path was altered in the process.

## Pre-existing inconsistencies (not touched here)

Two discrepancies predate this change and are left alone to keep the diff hostname-only:

1. `admin-manual/data-admin/ccr/quickstart.md` — the English page references `ccr-syncer-3.0.6-rc05-x64` while the Chinese page references `rc07-x64`.
2. `admin-manual/data-admin/ccr/overview.md`, the `3.0 / ARM64` row — the English page lists checksum `dd5f154c…` and the Chinese page lists `bb136f5c…` for the same filename.

Happy to fix either in a separate PR.
