### PR TITLE
[chore](quick-start) start the Docker cluster with a one-line curl command in current / 4.x docs

### DIFF
--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -27,29 +27,21 @@ import TabItem from '@theme/TabItem';
 
 Starting from the latest version, you can use Docker for quick deployment.
 
-### Step 1 (1/3): Download the startup script
+### Step 1 (1/2): Start the cluster
 
-<a target="_blank" download rel="noopener noreferrer" href="/files/start-doris.sh">Download the script</a>, then run the following command to grant execute permission:
-
-```shell
-chmod 755 start-doris.sh
-```
-
-### Step 2 (2/3): Start the cluster
-
-Run the script to start the cluster (the default version is 4.0.1):
+Run the following command to download the startup script and start the cluster in one go. When no version is specified, the latest release (`doris-latest`) is downloaded by default:
 
 ```shell
-bash start-doris.sh
+curl -fsSL https://doris.apache.org/files/start-doris.sh | bash
 ```
 
 To specify a version, use the `-v` parameter:
 
 ```shell
-bash start-doris.sh -v 4.1.0
+curl -fsSL https://doris.apache.org/files/start-doris.sh | bash -s -- -v 4.1.0
 ```
 
-### Step 3 (3/3): Verify cluster status
+### Step 2 (2/2): Verify cluster status
 
 Connect to the cluster with a MySQL client and check the FE and BE status:
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/getting-started/quick-start.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/getting-started/quick-start.mdx
@@ -27,29 +27,21 @@ import TabItem from '@theme/TabItem';
 
 自最新版本起，可以使用 Docker 进行快速部署。
 
-### 第 1 步（1/3）：下载启动脚本
+### 第 1 步（1/2）：启动集群
 
-<a target="_blank" download rel="noopener noreferrer" href="/files/start-doris.sh">下载脚本</a>，运行以下命令赋予执行权限：
-
-```shell
-chmod 755 start-doris.sh
-```
-
-### 第 2 步（2/3）：启动集群
-
-运行脚本启动集群（默认使用 4.0.1 版本）：
+运行以下命令，一步完成启动脚本的下载与集群启动。不指定版本时，默认下载最新版本（`doris-latest`）：
 
 ```shell
-bash start-doris.sh
+curl -fsSL https://doris.apache.org/files/start-doris.sh | bash
 ```
 
 如需指定版本，使用 `-v` 参数：
 
 ```shell
-bash start-doris.sh -v 4.1.0
+curl -fsSL https://doris.apache.org/files/start-doris.sh | bash -s -- -v 4.1.0
 ```
 
-### 第 3 步（3/3）：验证集群状态
+### 第 2 步（2/2）：验证集群状态
 
 使用 MySQL 客户端连接集群，检查 FE 和 BE 状态：
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/getting-started/quick-start.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/getting-started/quick-start.mdx
@@ -27,29 +27,21 @@ import TabItem from '@theme/TabItem';
 
 自最新版本起，可以使用 Docker 进行快速部署。
 
-### 第 1 步（1/3）：下载启动脚本
+### 第 1 步（1/2）：启动集群
 
-<a target="_blank" download rel="noopener noreferrer" href="/files/start-doris.sh">下载脚本</a>，运行以下命令赋予执行权限：
-
-```shell
-chmod 755 start-doris.sh
-```
-
-### 第 2 步（2/3）：启动集群
-
-运行脚本启动集群（默认使用 4.0.1 版本）：
+运行以下命令，一步完成启动脚本的下载与集群启动。不指定版本时，默认下载最新版本（`doris-latest`）：
 
 ```shell
-bash start-doris.sh
+curl -fsSL https://doris.apache.org/files/start-doris.sh | bash
 ```
 
 如需指定版本，使用 `-v` 参数：
 
 ```shell
-bash start-doris.sh -v 4.1.0
+curl -fsSL https://doris.apache.org/files/start-doris.sh | bash -s -- -v 4.1.0
 ```
 
-### 第 3 步（3/3）：验证集群状态
+### 第 2 步（2/2）：验证集群状态
 
 使用 MySQL 客户端连接集群，检查 FE 和 BE 状态：
 

--- a/versioned_docs/version-4.x/getting-started/quick-start.mdx
+++ b/versioned_docs/version-4.x/getting-started/quick-start.mdx
@@ -27,29 +27,21 @@ import TabItem from '@theme/TabItem';
 
 Starting from the latest version, you can use Docker for quick deployment.
 
-### Step 1 (1/3): Download the startup script
+### Step 1 (1/2): Start the cluster
 
-<a target="_blank" download rel="noopener noreferrer" href="/files/start-doris.sh">Download the script</a>, then run the following command to grant execute permission:
-
-```shell
-chmod 755 start-doris.sh
-```
-
-### Step 2 (2/3): Start the cluster
-
-Run the script to start the cluster (the default version is 4.0.1):
+Run the following command to download the startup script and start the cluster in one go. When no version is specified, the latest release (`doris-latest`) is downloaded by default:
 
 ```shell
-bash start-doris.sh
+curl -fsSL https://doris.apache.org/files/start-doris.sh | bash
 ```
 
 To specify a version, use the `-v` parameter:
 
 ```shell
-bash start-doris.sh -v 4.1.0
+curl -fsSL https://doris.apache.org/files/start-doris.sh | bash -s -- -v 4.1.0
 ```
 
-### Step 3 (3/3): Verify cluster status
+### Step 2 (2/2): Verify cluster status
 
 Connect to the cluster with a MySQL client and check the FE and BE status:
 


### PR DESCRIPTION
## What's changed

In the **Quick deployment with Docker** section of the 5-minute quick start, replace the "download the script → `chmod 755` → `bash start-doris.sh`" flow with a single curl one-liner:

```shell
curl -fsSL https://doris.apache.org/files/start-doris.sh | bash
```

And, to pin a version:

```shell
curl -fsSL https://doris.apache.org/files/start-doris.sh | bash -s -- -v 4.1.0
```

Accompanying text changes:

- The section drops from 3 steps to 2 (download + start are now one command), so "Verify cluster status" is renumbered from step 3/3 to 2/2.
- The default-version note no longer hardcodes `4.0.1`; it now says that with no `-v`, the latest release (`doris-latest`) is downloaded.

## Scope

Applied to all four copies, which stay byte-identical per language:

- `docs/getting-started/quick-start.mdx` (EN, current)
- `versioned_docs/version-4.x/getting-started/quick-start.mdx` (EN, 4.x)
- `i18n/zh-CN/.../current/getting-started/quick-start.mdx` (zh-CN, current)
- `i18n/zh-CN/.../version-4.x/getting-started/quick-start.mdx` (zh-CN, 4.x)

The 2.1 and 3.x quick-start pages still use the old download-and-chmod flow and are intentionally left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxrMVy28ehEpxD3hVWhDB
