### PR TITLE
[chore](quick-start) start the Docker cluster with a one-line curl command in 3.x docs

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/gettingStarted/quick-start.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/gettingStarted/quick-start.mdx
@@ -20,24 +20,15 @@
 
 自 Doris 2.1.8 版本后，可以使用 Docker 进行快速部署。
 
-### 第 1 步：下载 Quick-Start 脚本
+### 第 1 步：启动集群
 
-<a target="_blank" download rel="noopener noreferrer" href="/files/start-doris.sh"> 下载脚本 </a>, 运行以下命令，给其赋有相应的执行权限。
-
-```shell
-chmod 755 start-doris.sh
-```
-
-
-### 第 2 步：启动集群
-
-运行脚本，启动集群。使用 `-v` 参数指定 3.x 版本：
+运行以下命令，一步完成启动脚本的下载与集群启动。使用 `-v` 参数指定 3.x 版本：
 
 ```shell
-bash start-doris.sh -v 3.0.8
+curl -fsSL https://doris.apache.org/files/start-doris.sh | bash -s -- -v 3.0.8
 ```
 
-### 第 3 步：使用 MySQL 客户端连接集群，并检查集群状态
+### 第 2 步：使用 MySQL 客户端连接集群，并检查集群状态
 
 ```sql
 ## 检查 FE 状态，确定 Join 与 Alive 列均为 true

--- a/versioned_docs/version-3.x/gettingStarted/quick-start.mdx
+++ b/versioned_docs/version-3.x/gettingStarted/quick-start.mdx
@@ -23,23 +23,15 @@ The following rapid deployment methods are intended solely for local development
 
 Starting from Doris version 2.1.8, Docker can be used for rapid deployment.
 
-### Step 1: Download the Quick-Start script
+### Step 1: Start the cluster
 
-<a target="_blank" download rel="noopener noreferrer" href="/files/start-doris.sh"> Download the script </a>, run the following command to grant it the corresponding execution permissions.
-
-```shell
-chmod 755 start-doris.sh
-```
-
-### Step 2: Start the cluster
-
-Run the script to start the cluster. Use the `-v` parameter to specify a 3.x version:
+Run the following command to download the startup script and start the cluster in one go. Use the `-v` parameter to specify a 3.x version:
 
 ```shell
-bash start-doris.sh -v 3.0.8
+curl -fsSL https://doris.apache.org/files/start-doris.sh | bash -s -- -v 3.0.8
 ```
 
-### Step 3: Connect to the cluster using MySQL client and check the cluster status
+### Step 2: Connect to the cluster using MySQL client and check the cluster status
 
 ```sql
 ## Check the FE status to ensure that both the Join and Alive columns are true.


### PR DESCRIPTION
## Versions 

- [ ] dev
- [ ] 4.x
- [x] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

## What's changed

Mirrors the current / 4.x quick-start change to the 3.x docs. In the "Use Docker for Quick Deployment" section, the *download the script -> `chmod 755` -> `bash start-doris.sh`* flow is replaced by a single curl one-liner:

```shell
curl -fsSL https://doris.apache.org/files/start-doris.sh | bash -s -- -v 3.0.8
```

The `-v` parameter is kept here (unlike in the current / 4.x docs, where it is optional), since 3.x readers still need to pin a 3.x version rather than take the default latest release.

The section drops from 3 steps to 2, so the "connect with MySQL client and check the cluster status" step is renumbered from Step 3 to Step 2.

Applies to both EN (`versioned_docs/version-3.x`) and zh-CN (`i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh5WHTh9uCAf66miXZDEGa
