### PR TITLE
[chore](ci) refresh the docs last-update map on every cron deploy

### DIFF
--- a/.github/workflows/cron-deploy-website.yml
+++ b/.github/workflows/cron-deploy-website.yml
@@ -10,10 +10,16 @@ jobs:
         environment: Production
         steps:
             - name: Checkout
-              uses: actions/checkout@master
+              # v4 (the pinned @master commit predates the `filter` input) with
+              # the full history the last-update map is computed from. Blobless
+              # keeps that affordable: only commit/tree metadata is fetched
+              # (~15MB), not every historical file version (~1.7GB).
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
                   submodules: recursive
+                  fetch-depth: 0
+                  filter: blob:none
 
             - name: Add Chinese Fonts
               run: |
@@ -31,6 +37,18 @@ jobs:
               uses: actions/setup-node@v3
               with:
                   node-version: 20
+
+            - name: Refresh docs last-update map
+              # Recompute scripts/last-update/data.json from the history fetched
+              # above, overwriting the committed copy so every deploy renders
+              # current "last updated" footers instead of waiting for the manual
+              # "Refresh Docs Last-Update Map" PR. Only the build below reads it;
+              # nothing is committed. Non-fatal on purpose - the generator writes
+              # the file only after it succeeds, so a failure leaves the committed
+              # map untouched and the site still ships.
+              run: |
+                  node scripts/last-update/generate.js \
+                    || echo "::warning::last-update refresh failed; deploying with the committed map"
 
             - name: Add Swap Space
               run: |

--- a/.github/workflows/refresh-docs-last-update.yml
+++ b/.github/workflows/refresh-docs-last-update.yml
@@ -1,9 +1,12 @@
 name: Refresh Docs Last-Update Map
 
 # Manually triggered. Recomputes each document's last-update time from the full
-# git history and opens a PR updating scripts/last-update/data.json. The regular
-# Cron Deploy then serves those timestamps (docs/dev + 4.x + community footers)
-# without needing full history itself.
+# git history and opens a PR updating scripts/last-update/data.json.
+#
+# The Cron Deploy regenerates that map on every run, so the published site does
+# not depend on this workflow. It exists to keep the committed copy - what local
+# builds read, and what a deploy falls back to if its own refresh fails - from
+# drifting far behind master.
 #
 # Requires the repo/org setting "Allow GitHub Actions to create and approve pull
 # requests" to be enabled so the default token can open the PR.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,11 +61,12 @@ const COURSE_RAIL_BOOTSTRAP = `(function () {
 }());`;
 
 // Per-document last-update timestamps, generated from git history by
-// scripts/last-update/generate.js and refreshed on demand via the
-// "Refresh Docs Last-Update Map" workflow. markdown.parseFrontMatter (below)
-// injects these as `last_update` front matter so the 2-hourly deploy renders
-// "last updated" without a full-history clone. Missing file / not-yet-generated
-// map → Docusaurus falls back to its own git lookup.
+// scripts/last-update/generate.js. The 2-hourly Cron Deploy regenerates the map
+// before it builds, so published dates are always current; the committed copy
+// is what local builds use, and what a deploy falls back to if that refresh
+// fails. markdown.parseFrontMatter (below) injects the dates as `last_update`
+// front matter, sparing the build a per-file git lookup. Missing file /
+// not-yet-generated map → Docusaurus falls back to its own git lookup.
 let DOCS_LAST_UPDATE = {};
 try {
     DOCS_LAST_UPDATE = require('./scripts/last-update/data.json');

--- a/scripts/last-update/generate.js
+++ b/scripts/last-update/generate.js
@@ -5,10 +5,13 @@
 // derived from this repo's git history.
 //
 // docusaurus.config.js reads this map at build time (markdown.parseFrontMatter)
-// and injects it as each document's `last_update` front matter, so the regular
-// 2-hourly deploy can render "last updated" without a full-history clone or a
-// per-file git lookup. Refreshed on demand by the "Refresh Docs Last-Update
-// Map" workflow (.github/workflows/refresh-docs-last-update.yml).
+// and injects it as each document's `last_update` front matter, so the build
+// never does a per-file git lookup. The 2-hourly Cron Deploy runs this script
+// itself (its checkout uses fetch-depth: 0 + filter: blob:none) and builds from
+// the result, so published dates track master. The committed data.json is the
+// local-build copy and the deploy's fallback; the "Refresh Docs Last-Update
+// Map" workflow (.github/workflows/refresh-docs-last-update.yml) keeps it fresh
+// via PR.
 //
 // Requires full git history to be accurate. In a shallow clone every file
 // resolves to the single HEAD commit, so run this only where the history is


### PR DESCRIPTION
## Problem

`scripts/last-update/generate.js` needs full git history — in a shallow clone every file collapses to the HEAD commit, so it exits 1 rather than write a misleading map.

Cron Deploy checks out shallow, so it could never run the generator. The published "last updated" footers were whatever the last manual **Refresh Docs Last-Update Map** PR had committed into `scripts/last-update/data.json`, and drifted further behind `master` until someone remembered to trigger that workflow again.

## Change

`.github/workflows/cron-deploy-website.yml`:

- Checkout now fetches full history with `filter: blob:none`. `actions/checkout@master` is pinned to a **July 2020** commit (v2.3.1-era) that predates the `filter` input, hence the bump to `v4`.
- A new step regenerates `data.json` before the build. The build is the only consumer — nothing is committed, so the checked-in map stays the local-build copy and the deploy's fallback.

## Cost

Measured against `apache/doris-website`, both over the same link:

| | time | size |
|---|---|---|
| `--filter=blob:none` full history (**added** by this PR) | 12.5s | 21 MB |
| `--depth=1` (what the workflow **already** downloads) | 5m40s | 449 MB |

The expensive part is the HEAD blobs — images and static assets — and this PR does not touch that path. Full commit history is only ~5% more bytes on top, and a GitHub runner is far better connected than the machine those numbers came from. The generator itself runs in ~1s and uses only Node built-ins, so it needs no `yarn install`.

## Failure behavior

The refresh step is deliberately non-fatal. `generate.js` writes `data.json` only after computing everything, so a failure leaves the committed map intact and the deploy still ships with the previous timestamps. A cosmetic footer should not be able to block a release; the step emits a `::warning::` instead.

## Notes

- **Refresh Docs Last-Update Map** is kept. The published site no longer depends on it, but it keeps the committed fallback — what local builds read — from drifting far behind. Comments in both workflows were updated to say so.
- `manual-deploy-website.yml` is **not** changed. It still checks out shallow and will deploy the committed timestamps, which is exactly what it does today, so this is not a regression. Happy to apply the same two changes there if reviewers want them consistent.
- The other edits are comment-only, correcting three places that claimed the deploy renders these dates "without a full-history clone".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013F7zebd8iJKbAJB2RSB8iq
