### PR TITLE
[chore](download) separate maintained and archived releases on the download page

### DIFF
--- a/doc-tools/skills/add-release/SKILL.md
+++ b/doc-tools/skills/add-release/SKILL.md
@@ -21,7 +21,7 @@ Publish release information to /download/ and /releases/ from the doris-website 
 Read these sources before choosing a workflow:
 
 - AGENTS.md
-- src/constant/download.data.ts
+- src/constant/download.data.ts, in particular ACTIVE_CORE_BRANCHES and ACTIVE_TOOL_LINES
 - sidebarsReleases.json
 - releasenotes/all-release.md
 - releasenotes/core.md
@@ -45,7 +45,8 @@ Use this template:
     - Release-note source: <GitHub issue, PR, Markdown, or upstream page>
     - Website scope: </download/, /releases/, or both>
     - Locales: <English, zh-CN, or both>
-    - Position: <Latest, Prev, Earlier, or historical>
+    - Position: <latest, stable, maintained, or historical>
+    - Branch change: <none, promote a new branch, or retire a branch>
     - Source filename version: <plain version or RC-suffixed version>
     - Source directory and binary origin: <URLs, if nonstandard>
 
@@ -78,7 +79,7 @@ Never infer doris-core only because a version has three numeric segments.
 
 Keep these values separate throughout the change:
 
-- Public release version: the version shown in titles, links, VersionEnum, labels, sidebar IDs, binary filenames, and release-note paths, such as 4.1.3.
+- Public release version: the version shown in titles, links, labels, sidebar IDs, binary filenames, and release-note paths, such as 4.1.3.
 - Source filename version: the segment used by the published source tarball, which may include an RC suffix such as 4.1.3-rc02.
 
 The version field inside each architecture row in download.data.ts controls the source filename rendered by the download UI. Never replace an RC-suffixed source filename with the public version unless that exact plain source tarball exists.
@@ -113,27 +114,45 @@ A normal bilingual Core release that updates both website surfaces touches:
     i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/core.md
     sidebarsReleases.json
 
+When the release opens or retires a branch it also changes ACTIVE_CORE_BRANCHES inside src/constant/download.data.ts. See Maintained and Archived Branches below.
+
 releasenotes/all-release.md and its zh-CN mirror are project indexes. They route readers to Doris Core and ecosystem pages. Do not add individual Core versions to them and do not modify them for a routine Core patch release.
+
+### Maintained and Archived Branches
+
+The download page separates maintained releases from archived ones because the ASF security team asked that a page which is still a distribution channel stop presenting unpatched releases beside supported ones. One constant drives the whole split:
+
+    export const ACTIVE_CORE_BRANCHES: string[] = ['4.1', '4.0'];
+
+Read it as an ordered, newest-first list of the branches Apache Doris still maintains.
+
+- A branch in this list appears in the quick download card, in Doris Releases, and nowhere else.
+- A branch missing from this list is archived. It moves behind the archive picker under a notice saying it receives no further security patches.
+- Order determines the label. The first entry renders as Latest, the last as Stable, and anything between them as Maintained. There is no separate Earlier slot any more.
+- ACTIVE_HEADS takes the first child of each maintained branch. A headline release that is not the newest patch of its branch never reaches the quick download card.
+
+This means a release that opens a new branch has one extra, easily forgotten step. Publishing 4.2.0 without adding 4.2 to ACTIVE_CORE_BRANCHES ships a release that never appears on the download page, and the site will not error. The bundled validator checks for exactly this.
+
+Branch changes to confirm with the release manager before editing:
+
+| Situation | ACTIVE_CORE_BRANCHES change |
+| --- | --- |
+| Patch on an existing maintained branch | none |
+| First release of a new minor branch | prepend the new branch, and confirm whether the oldest maintained branch retires in the same change |
+| Retiring a branch | remove it; its releases stay in ALL_VERSIONS and move to the archive picker automatically |
+| Patch on an already archived branch | none; use position historical |
+
+Never delete releases from ALL_VERSIONS to archive them. Archiving is removal from ACTIVE_CORE_BRANCHES, nothing else. The ASF keeps every release it has published, and the archive picker reads straight from ALL_VERSIONS.
 
 ### Update Download Data
 
 Edit src/constant/download.data.ts.
 
-Update VersionEnum only as confirmed:
+ALL_VERSIONS is the single source of core release data. It drives the quick download card, the maintained release form, and the archive picker; ACTIVE_CORE_BRANCHES only decides which side of the split each branch lands on.
 
-- Latest: the headline current release.
-- Prev: the stable previous release line shown beside Latest.
-- Earlier: the older supported line.
-- Historical: no VersionEnum change.
+Add the public version to the matching branch in ALL_VERSIONS with x64, x64-noavx2, and arm64 rows. Each row must contain the binary gz, asc, sha512, source directory, and exact source filename version.
 
-Add the public version to both structures:
-
-- DORIS_VERSIONS drives the quick-download selector.
-- ALL_VERSIONS drives the all-releases form.
-
-In both structures, add x64, x64-noavx2, and arm64 rows. Each row must contain the binary gz, asc, sha512, source directory, and exact source filename version.
-
-Keep patch releases newest-first within their series. Audit the entire target series in both arrays, not only the new entry. Every target-series version in DORIS_VERSIONS must exist in ALL_VERSIONS and vice versa. Fix a discovered omission when it is clearly a data drift in the requested release scope; mention it explicitly in the handoff.
+Keep patch releases newest-first within their branch. A headline release must be the first child of its branch, because that is the entry the quick download card offers. Audit the whole target branch, not only the new entry. Fix a discovered ordering drift when it falls inside the requested release scope; mention it explicitly in the handoff.
 
 Do not broadly reformat download.data.ts.
 
@@ -169,7 +188,7 @@ Edit both Core history pages:
 
 In each file:
 
-- Update the relevant tip entry when the release is Latest, Prev, or Earlier.
+- Update the relevant tip entry when the release is Latest, Stable, or Maintained.
 - Add the dated per-version link to the chronological list.
 - Use the confirmed YYYY-MM-DD release date.
 - Keep the chronological list reverse-sorted by date.
@@ -196,7 +215,7 @@ Most established ecosystem releases update:
 
 Some also update src/constant/download.data.ts. Update sidebarsReleases.json only when adding a new ecosystem page; individual ecosystem versions normally remain sections within one component page.
 
-Do not update Core per-version notes, releasenotes/core.md, its zh-CN mirror, or Core VersionEnum values for an ecosystem release unless the release manager explicitly requests a cross-surface change.
+Do not update Core per-version notes, releasenotes/core.md, its zh-CN mirror, or ACTIVE_CORE_BRANCHES for an ecosystem release unless the release manager explicitly requests a cross-surface change.
 
 Component profiles:
 
@@ -230,7 +249,32 @@ When updating TOOL_VERSIONS:
 - Verify the exact source filename and directory.
 - Preserve the existing Option shape.
 - Keep versions newest-first.
-- Do not add a Core VersionEnum entry.
+- Do not touch ACTIVE_CORE_BRANCHES; that constant is Core-only.
+
+### Maintained and Archived Tool Lines
+
+Ecosystem downloads are split the same way Core downloads are, by ACTIVE_TOOL_LINES:
+
+    export const ACTIVE_TOOL_LINES: Record<ToolsEnum, string[]> = {
+        [ToolsEnum.Kafka]: ['26', '25'],
+        [ToolsEnum.Flink]: ['26'],
+        [ToolsEnum.Spark]: ['26'],
+        [ToolsEnum.StreamLoader]: ['1.0.3'],
+        [ToolsEnum.Operator]: ['26'],
+    };
+
+Each entry is either a major line such as '26', which matches every version beginning with that major, or an exact version such as '1.0.3' for a tool that does not release in lines. A version that matches no entry is archived and moves behind the archive picker.
+
+Consequences for a release:
+
+| Situation | ACTIVE_TOOL_LINES change |
+| --- | --- |
+| New patch inside an already maintained line, for example 26.1.2 | none |
+| First release of a new major line, for example 27.0.0 | add '27', and confirm whether the oldest maintained line retires in the same change |
+| Retiring a line | remove it; its versions stay in TOOL_VERSIONS and move to the archive picker |
+| A tool pinned to an exact version, such as Streamloader | replace the exact version string with the new one, otherwise the new release is archived on arrival |
+
+Streamloader is the easiest one to get wrong: its entry is a full version, so shipping 1.0.4 without editing this constant leaves 1.0.4 archived and 1.0.3 maintained. The bundled validator does not cover ecosystem components, so check this by hand and confirm on the rendered page.
 
 ## Validation
 
@@ -242,7 +286,7 @@ Run the validator tests:
 
 For Doris Core, run the bundled validator with the confirmed values:
 
-    node doc-tools/skills/add-release/scripts/validate-release.mjs --component doris-core --version <public-version> --series <series> --source-version <source-version> --release-date <YYYY-MM-DD> --position <latest|prev|earlier|historical> --source-dir <official-source-directory>
+    node doc-tools/skills/add-release/scripts/validate-release.mjs --component doris-core --version <public-version> --series <series> --source-version <source-version> --release-date <YYYY-MM-DD> --position <latest|stable|maintained|historical> --source-dir <official-source-directory>
 
 The validator checks:
 
@@ -251,9 +295,11 @@ The validator checks:
 - Both core.md indexes, release date, link, and reverse chronology
 - That both all-release.md project indexes still route to core.md and remain untouched
 - sidebarsReleases.json parseability and newest-first placement
-- VersionEnum positioning
-- Target-series ordering and drift between DORIS_VERSIONS and ALL_VERSIONS
-- All six architecture rows, source filename version, source directory, and binary filenames
+- ACTIVE_CORE_BRANCHES lists the target branch, and its index matches the confirmed position
+- Every maintained branch has matching data in ALL_VERSIONS
+- The release is the newest patch of its branch, so ACTIVE_HEADS offers it
+- Target-branch ordering inside ALL_VERSIONS
+- All three architecture rows, source filename version, source directory, and binary filenames
 - The full twelve-artifact URL matrix
 
 Use --skip-links only when external link verification is explicitly out of scope, and disclose the skipped check. --skip-git-routing is intended for isolated test fixtures, not routine release work.
@@ -299,7 +345,9 @@ Before reporting completion:
 - Re-read the request and compare it with the exact changed-file set.
 - Confirm the public version, source filename version, release date, scope, locales, and positioning.
 - Confirm all artifact checks and note any mirror choice.
-- Confirm DORIS_VERSIONS and ALL_VERSIONS are aligned for the target series.
+- Confirm ACTIVE_CORE_BRANCHES matches the intended maintained set, and that any branch it names has data in ALL_VERSIONS.
+- Confirm the new version is the first entry in its branch when the release is a headline one.
+- For ecosystem releases, confirm ACTIVE_TOOL_LINES still covers the new version.
 - Confirm Core history is in core.md, not all-release.md.
 - Confirm no unrelated files were modified.
 

--- a/doc-tools/skills/add-release/scripts/validate-release.mjs
+++ b/doc-tools/skills/add-release/scripts/validate-release.mjs
@@ -6,6 +6,10 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ARCHITECTURES = ['x64', 'x64-noavx2', 'arm64'];
+// Position is now a property of the branch, not of a hand-maintained enum:
+// ACTIVE_CORE_BRANCHES is ordered newest-first, so its first entry is Latest
+// and its last entry is Stable. 'prev' is kept as an alias for 'stable'.
+const POSITIONS = ['latest', 'stable', 'prev', 'maintained', 'historical'];
 const SIDECAR_SUFFIXES = ['', '.asc', '.sha512'];
 
 class ReleaseValidationError extends Error {
@@ -53,14 +57,18 @@ function parseFrontmatter(markdown, relativePath, failures) {
 }
 
 function extractAssignedArray(source, variableName) {
-    const declaration = source.search(new RegExp('\\b' + variableName + '\\b'));
-    if (declaration === -1) {
+    // Anchor on the declaration itself. Matching the bare identifier would also
+    // hit a doc comment that merely names the constant, and then silently
+    // extract the wrong array.
+    const declaration = new RegExp(
+        '(?:export\\s+)?const\\s+' + escapeRegExp(variableName) + '\\b[^=\\n]*=',
+    ).exec(source);
+    if (!declaration) {
         throw new Error(variableName + ' declaration was not found');
     }
 
-    const equals = source.indexOf('=', declaration);
-    const start = source.indexOf('[', equals);
-    if (equals === -1 || start === -1) {
+    const start = source.indexOf('[', declaration.index + declaration[0].length);
+    if (start === -1) {
         throw new Error(variableName + ' array assignment was not found');
     }
 
@@ -125,6 +133,21 @@ function extractAssignedArray(source, variableName) {
     }
 
     throw new Error(variableName + ' array is not balanced');
+}
+
+function parseStringArray(arraySource) {
+    return Array.from(arraySource.matchAll(/['"]([^'"]+)['"]/g)).map(match => match[1]);
+}
+
+function extractBranchValues(arraySource) {
+    const branches = [];
+    for (const match of arraySource.matchAll(/\bvalue\s*:\s*['"]([^'"]+)['"]/g)) {
+        const value = match[1];
+        if ((/^\d+\.\d+$/.test(value) || value === '0.x') && !branches.includes(value)) {
+            branches.push(value);
+        }
+    }
+    return branches;
 }
 
 function extractPatchVersions(arraySource, series) {
@@ -430,8 +453,8 @@ export async function validateCoreRelease(options) {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(releaseDate || '')) {
         throw new Error('releaseDate must use YYYY-MM-DD format');
     }
-    if (!['latest', 'prev', 'earlier', 'historical'].includes(position)) {
-        throw new Error('position must be latest, prev, earlier, or historical');
+    if (!POSITIONS.includes(position)) {
+        throw new Error('position must be ' + POSITIONS.join(', '));
     }
 
     const releasePath = 'releasenotes/v' + series + '/release-' + version + '.md';
@@ -552,37 +575,29 @@ export async function validateCoreRelease(options) {
     const downloadPath = 'src/constant/download.data.ts';
     const downloadSource = readRequired(repoRoot, downloadPath, failures);
     if (downloadSource) {
-        let dorisArray = '';
         let allArray = '';
+        let activeBranches = null;
         try {
-            dorisArray = extractAssignedArray(downloadSource, 'DORIS_VERSIONS');
             allArray = extractAssignedArray(downloadSource, 'ALL_VERSIONS');
-            checks.push('DORIS_VERSIONS and ALL_VERSIONS arrays are readable');
+            checks.push('ALL_VERSIONS array is readable');
+        } catch (error) {
+            failures.push(downloadPath + ': ' + error.message);
+        }
+        try {
+            activeBranches = parseStringArray(
+                extractAssignedArray(downloadSource, 'ACTIVE_CORE_BRANCHES'),
+            );
+            checks.push('ACTIVE_CORE_BRANCHES is readable');
         } catch (error) {
             failures.push(downloadPath + ': ' + error.message);
         }
 
-        if (dorisArray && allArray) {
-            const dorisVersions = extractPatchVersions(dorisArray, series);
+        if (allArray) {
             const allVersions = extractPatchVersions(allArray, series);
-            addResult(
-                dorisVersions.includes(version),
-                'DORIS_VERSIONS includes ' + version,
-                version + ' is missing from DORIS_VERSIONS',
-                checks,
-                failures,
-            );
             addResult(
                 allVersions.includes(version),
                 'ALL_VERSIONS includes ' + version,
                 version + ' is missing from ALL_VERSIONS',
-                checks,
-                failures,
-            );
-            addResult(
-                isNewestFirst(dorisVersions),
-                'DORIS_VERSIONS ' + series + ' entries are newest-first',
-                'DORIS_VERSIONS ' + series + ' entries are not newest-first',
                 checks,
                 failures,
             );
@@ -594,20 +609,17 @@ export async function validateCoreRelease(options) {
                 failures,
             );
 
-            for (const listedVersion of dorisVersions) {
+            // ACTIVE_HEADS takes the first child of each maintained branch, and
+            // that is what the quick download card offers. A new headline patch
+            // that is not first in its series never reaches the top of the page.
+            if (position !== 'historical') {
                 addResult(
-                    allVersions.includes(listedVersion),
-                    listedVersion + ' is mirrored in ALL_VERSIONS',
-                    listedVersion + ' is missing from ALL_VERSIONS',
-                    checks,
-                    failures,
-                );
-            }
-            for (const listedVersion of allVersions) {
-                addResult(
-                    dorisVersions.includes(listedVersion),
-                    listedVersion + ' is mirrored in DORIS_VERSIONS',
-                    listedVersion + ' is missing from DORIS_VERSIONS',
+                    allVersions[0] === version,
+                    version + ' is the newest patch of ' + series + ', so ACTIVE_HEADS picks it up',
+                    version +
+                        ' must be the first ' +
+                        series +
+                        ' entry in ALL_VERSIONS; the quick download card offers the first child of each maintained branch',
                     checks,
                     failures,
                 );
@@ -617,15 +629,13 @@ export async function validateCoreRelease(options) {
                 "version\\s*:\\s*['\"]" + escapeRegExp(sourceVersion) + "['\"]",
                 'g',
             );
-            const sourceVersionCount =
-                countMatches(dorisArray, sourceVersionExpression) +
-                countMatches(allArray, sourceVersionExpression);
+            const sourceVersionCount = countMatches(allArray, sourceVersionExpression);
             addResult(
-                sourceVersionCount === ARCHITECTURES.length * 2,
-                'Source filename version ' + sourceVersion + ' is set for all six package rows',
+                sourceVersionCount === ARCHITECTURES.length,
+                'Source filename version ' + sourceVersion + ' is set for all three package rows',
                 'Expected source filename version ' +
                     sourceVersion +
-                    ' in six package rows, found ' +
+                    ' in three package rows, found ' +
                     sourceVersionCount,
                 checks,
                 failures,
@@ -634,16 +644,11 @@ export async function validateCoreRelease(options) {
             for (const architecture of ARCHITECTURES) {
                 for (const suffix of SIDECAR_SUFFIXES) {
                     const filename =
-                        'apache-doris-' +
-                        version +
-                        '-bin-' +
-                        architecture +
-                        '.tar.gz' +
-                        suffix;
+                        'apache-doris-' + version + '-bin-' + architecture + '.tar.gz' + suffix;
                     addResult(
-                        dorisArray.includes(filename) && allArray.includes(filename),
-                        filename + ' exists in both download data arrays',
-                        filename + ' must exist in both DORIS_VERSIONS and ALL_VERSIONS',
+                        allArray.includes(filename),
+                        filename + ' exists in ALL_VERSIONS',
+                        filename + ' must exist in ALL_VERSIONS',
                         checks,
                         failures,
                     );
@@ -651,38 +656,99 @@ export async function validateCoreRelease(options) {
             }
 
             const normalizedSourceDir = sourceDir.endsWith('/') ? sourceDir : sourceDir + '/';
-            const sourceDirCount =
-                dorisArray.split(normalizedSourceDir).length -
-                1 +
-                (allArray.split(normalizedSourceDir).length - 1);
+            const sourceDirCount = allArray.split(normalizedSourceDir).length - 1;
             addResult(
-                sourceDirCount === ARCHITECTURES.length * 2,
-                'Source directory is set for all six package rows',
+                sourceDirCount === ARCHITECTURES.length,
+                'Source directory is set for all three package rows',
                 'Expected source directory ' +
                     normalizedSourceDir +
-                    ' in six package rows, found ' +
+                    ' in three package rows, found ' +
                     sourceDirCount,
                 checks,
                 failures,
             );
         }
 
-        if (position !== 'historical') {
-            const enumName = {
-                latest: 'Latest',
-                prev: 'Prev',
-                earlier: 'Earlier',
-            }[position];
-            const enumExpression = new RegExp(
-                "\\b" + enumName + "\\s*=\\s*['\"]" + escapeRegExp(version) + "['\"]",
-            );
-            addResult(
-                enumExpression.test(downloadSource),
-                'VersionEnum.' + enumName + ' points to ' + version,
-                'VersionEnum.' + enumName + ' must point to ' + version,
-                checks,
-                failures,
-            );
+        if (activeBranches) {
+            // A branch that is not in this list is archived: it disappears from
+            // the maintained sections of /download and moves behind the archive
+            // picker. Opening a new branch without adding it here ships a
+            // release that never appears on the page.
+            const branchIndex = activeBranches.indexOf(series);
+
+            if (position === 'historical') {
+                addResult(
+                    true,
+                    'Historical release: ' +
+                        series +
+                        ' is ' +
+                        (branchIndex === -1 ? 'archived' : 'still maintained') +
+                        ', no branch-list change required',
+                    '',
+                    checks,
+                    failures,
+                );
+            } else {
+                addResult(
+                    branchIndex !== -1,
+                    'ACTIVE_CORE_BRANCHES lists ' + series + ' as maintained',
+                    'ACTIVE_CORE_BRANCHES must list ' +
+                        series +
+                        '; a branch missing from it is treated as archived and is hidden from the maintained download sections',
+                    checks,
+                    failures,
+                );
+
+                if (branchIndex !== -1) {
+                    const lastIndex = activeBranches.length - 1;
+                    if (position === 'latest') {
+                        addResult(
+                            branchIndex === 0,
+                            series + ' is first in ACTIVE_CORE_BRANCHES, so it renders as Latest',
+                            series +
+                                ' must be first in ACTIVE_CORE_BRANCHES to render as Latest, found index ' +
+                                branchIndex,
+                            checks,
+                            failures,
+                        );
+                    } else if (position === 'stable' || position === 'prev') {
+                        addResult(
+                            branchIndex === lastIndex,
+                            series + ' is last in ACTIVE_CORE_BRANCHES, so it renders as Stable',
+                            series +
+                                ' must be last in ACTIVE_CORE_BRANCHES to render as Stable, found index ' +
+                                branchIndex,
+                            checks,
+                            failures,
+                        );
+                    } else {
+                        addResult(
+                            branchIndex > 0 && branchIndex < lastIndex,
+                            series + ' sits between Latest and Stable in ACTIVE_CORE_BRANCHES',
+                            series +
+                                ' must sit between the first and last ACTIVE_CORE_BRANCHES entries to render as Maintained, found index ' +
+                                branchIndex,
+                            checks,
+                            failures,
+                        );
+                    }
+                }
+            }
+
+            if (allArray) {
+                const branchValues = extractBranchValues(allArray);
+                for (const branch of activeBranches) {
+                    addResult(
+                        branchValues.includes(branch),
+                        'Maintained branch ' + branch + ' has data in ALL_VERSIONS',
+                        'ACTIVE_CORE_BRANCHES lists ' +
+                            branch +
+                            ' but ALL_VERSIONS has no such branch, so its download section renders empty',
+                        checks,
+                        failures,
+                    );
+                }
+            }
         }
 
         const originMatch = downloadSource.match(

--- a/doc-tools/skills/add-release/scripts/validate-release.test.mjs
+++ b/doc-tools/skills/add-release/scripts/validate-release.test.mjs
@@ -21,7 +21,10 @@ function packageRows(version, sourceVersion) {
                 gz: 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-${version}-bin-${arch}.tar.gz',
                 asc: 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-${version}-bin-${arch}.tar.gz.asc',
                 sha512: 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-${version}-bin-${arch}.tar.gz.sha512',
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/${version}/',
+                source: 'https://dist.apache.org/repos/dist/release/doris/${version
+                    .split('.')
+                    .slice(0, 2)
+                    .join('.')}/${version}/',
                 version: '${sourceVersion}',
             }`,
         )
@@ -29,10 +32,11 @@ function packageRows(version, sourceVersion) {
 }
 
 function versionEntry(version, sourceVersion) {
+    const series = version.split('.').slice(0, 2).join('.');
     return `{
         label: '${version}',
         value: '${version}',
-        majorVersion: '4.1',
+        majorVersion: '${series}',
         packages: [
             ${packageRows(version, sourceVersion)}
         ],
@@ -61,35 +65,37 @@ function releaseNote(language, issueRef) {
 `;
 }
 
-function createFixture({ omit412FromAll = false, zhIssueRef = '#10001' } = {}) {
+function createFixture({
+    activeBranches = ['4.1', '4.0'],
+    stalePatchOrder = false,
+    zhIssueRef = '#10001',
+} = {}) {
     const root = mkdtempSync(path.join(tmpdir(), 'add-release-validator-'));
-    const dorisVersions = [
-        versionEntry('4.1.3', '4.1.3-rc02'),
-        versionEntry('4.1.2', '4.1.2'),
-    ].join(',\n');
-    const allVersions = [
-        versionEntry('4.1.3', '4.1.3-rc02'),
-        ...(omit412FromAll ? [] : [versionEntry('4.1.2', '4.1.2')]),
-    ].join(',\n');
+    const entries = [versionEntry('4.1.3', '4.1.3-rc02'), versionEntry('4.1.2', '4.1.2')];
+    const allVersions = (stalePatchOrder ? entries.slice().reverse() : entries).join(',\n');
+    const branchList = activeBranches.map(branch => `'${branch}'`).join(', ');
 
     write(
         root,
         'src/constant/download.data.ts',
         `export const ORIGIN = 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/';
-export enum VersionEnum {
-    Latest = '4.1.3',
-    Prev = '4.0.7',
-    Earlier = '3.1.4',
-}
-export const DORIS_VERSIONS = [
-${dorisVersions}
-];
+
+// A doc comment that names ALL_VERSIONS must not confuse the array extractor.
+export const ACTIVE_CORE_BRANCHES: string[] = [${branchList}];
+
 export const ALL_VERSIONS = [
 {
     label: '4.1',
     value: '4.1',
     children: [
 ${allVersions}
+    ],
+},
+{
+    label: '4.0',
+    value: '4.0',
+    children: [
+${versionEntry('4.0.8', '4.0.8')}
     ],
 }
 ];
@@ -161,6 +167,12 @@ test('skill routes Doris Core history to core.md and uses the bundled validator'
     );
     assert.doesNotMatch(skill, /Update both all-release indexes/);
     assert.match(skill, /scripts\/validate-release\.mjs/);
+    // The download page is driven by ACTIVE_CORE_BRANCHES now, not by a
+    // hand-maintained VersionEnum and a duplicate DORIS_VERSIONS array.
+    assert.match(skill, /ACTIVE_CORE_BRANCHES/);
+    assert.match(skill, /ACTIVE_TOOL_LINES/);
+    assert.doesNotMatch(skill, /DORIS_VERSIONS/);
+    assert.doesNotMatch(skill, /VersionEnum/);
 });
 
 test('validator accepts a complete bilingual Doris Core release', async () => {
@@ -185,8 +197,8 @@ test('validator accepts a complete bilingual Doris Core release', async () => {
     }
 });
 
-test('validator catches versions missing from ALL_VERSIONS', async () => {
-    const root = createFixture({ omit412FromAll: true });
+test('validator rejects a headline release that is not the newest patch of its series', async () => {
+    const root = createFixture({ stalePatchOrder: true });
 
     try {
         const { validateCoreRelease } = await import('./validate-release.mjs');
@@ -201,7 +213,53 @@ test('validator catches versions missing from ALL_VERSIONS', async () => {
                 checkLinks: false,
                 checkGitRouting: false,
             }),
-            /4\.1\.2.*missing from ALL_VERSIONS/,
+            /must be the first 4\.1 entry in ALL_VERSIONS/,
+        );
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('validator rejects a release on a branch that ACTIVE_CORE_BRANCHES does not list', async () => {
+    const root = createFixture({ activeBranches: ['4.0'] });
+
+    try {
+        const { validateCoreRelease } = await import('./validate-release.mjs');
+        await assert.rejects(
+            validateCoreRelease({
+                repoRoot: root,
+                version: '4.1.3',
+                series: '4.1',
+                sourceVersion: '4.1.3-rc02',
+                releaseDate: '2026-07-13',
+                position: 'latest',
+                checkLinks: false,
+                checkGitRouting: false,
+            }),
+            /ACTIVE_CORE_BRANCHES must list 4\.1/,
+        );
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('validator rejects a maintained branch that has no ALL_VERSIONS data', async () => {
+    const root = createFixture({ activeBranches: ['4.1', '4.0', '3.9'] });
+
+    try {
+        const { validateCoreRelease } = await import('./validate-release.mjs');
+        await assert.rejects(
+            validateCoreRelease({
+                repoRoot: root,
+                version: '4.1.3',
+                series: '4.1',
+                sourceVersion: '4.1.3-rc02',
+                releaseDate: '2026-07-13',
+                position: 'latest',
+                checkLinks: false,
+                checkGitRouting: false,
+            }),
+            /ACTIVE_CORE_BRANCHES lists 3\.9 but ALL_VERSIONS has no such branch/,
         );
     } finally {
         rmSync(root, { recursive: true, force: true });

--- a/src/components/download-form-next/DownloadFormNext.tsx
+++ b/src/components/download-form-next/DownloadFormNext.tsx
@@ -1,121 +1,86 @@
 import Translate, { translate } from '@docusaurus/Translate';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import Link from '@docusaurus/Link';
+import clsx from 'clsx';
 import DownloadFormAllRelease from '@site/src/components/download-form/download-form-all-release';
+import DownloadFormArchive from '@site/src/components/download-form/download-form-archive';
 import DownloadFormTools from '@site/src/components/download-form/download-form-tools';
 import {
+    ACTIVE_HEADS,
+    ACTIVE_TOOL_VERSIONS,
+    ACTIVE_VERSIONS,
+    ARCHIVED_TOOL_VERSIONS,
+    ARCHIVED_VERSIONS,
     CPUEnum,
-    DORIS_VERSIONS,
     DownloadTypeEnum,
+    findCoreRelease,
     ORIGIN,
-    VersionEnum,
+    TOOL_RELEASE_NOTES,
+    ToolsEnum,
 } from '@site/src/constant/download.data';
-import Link from '@docusaurus/Link';
 import './download-page.scss';
 import LinkWithArrow from '@site/src/components/link-arrow';
-import clsx from 'clsx';
-import { ALL_VERSIONS, TOOL_RELEASE_NOTES, TOOL_VERSIONS, ToolsEnum } from '@site/src/constant/download.data';
-import * as semver from 'semver';
 import { CheckedIcon } from '@site/src/components/Icons/checked-icon';
 import { LayoutNext } from '@site/src/components/home-next/LayoutNext';
 
-const BINARY_VERSION = [
-    { label: `${VersionEnum.Latest} ( Latest )`, value: VersionEnum.Latest },
-    { label: `${VersionEnum.Prev} ( Stable )`, value: VersionEnum.Prev },
-];
+const KEYS_URL = 'https://downloads.apache.org/doris/KEYS';
+const VERIFY_URL = '/community/release-and-verify/release-verify';
+const VERSIONING_URL = '/community/release-and-verify/release-versioning';
+const SECURITY_URL = '/community/security';
+const ASF_ARCHIVE_URL = 'https://archive.apache.org/dist/doris/';
+
+const CPU_OPTIONS = [CPUEnum.X64, CPUEnum.X64NoAvx2, CPUEnum.ARM64];
+
+/** Canonical release-note route: releasenotes/v4.1/release-4.1.3.md → /releases/v4.1/release-4.1.3 */
+function releaseNotePath(branch: string, version: string) {
+    return `/releases/v${branch}/release-${version}`;
+}
 
 export default function DownloadFormNext(): JSX.Element {
-    const [version, setVersion] = useState<string>(VersionEnum.Latest);
-    const [cpus, setCpus] = useState<any[]>([]);
-    const [cpu, setCPU] = useState<string>(CPUEnum.X64);
-    const [downloadInfo, setDownloadInfo] = useState<any>({});
-    const [releaseFlag, setReleaseFlag] = useState<boolean>(true);
-    const [downloadType, setDownloadType] = useState(DownloadTypeEnum.Binary);
-    const [releaseNote, setReleaseNote] = useState('/docs/dev/releasenotes/v4.0/release-4.0.0');
+    const defaultHead = ACTIVE_HEADS[0];
+    const [version, setVersion] = useState<string>(defaultHead?.version ?? '');
+    const [cpu, setCpu] = useState<string>(CPUEnum.X64);
+    const [downloadType, setDownloadType] = useState<DownloadTypeEnum>(DownloadTypeEnum.Binary);
+    const [releaseNote, setReleaseNote] = useState<string>(
+        defaultHead ? releaseNotePath(defaultHead.branch, defaultHead.version) : '/releases/all-release',
+    );
     const [ecosystemTool, setEcosystemTool] = useState<ToolsEnum>(ToolsEnum.Kafka);
 
-    const changeVersion = (val: string) => {
-        setVersion(val);
-    };
-
-    const changeCPU = (val: string) => {
-        setCPU(val);
-        const nextDownloadInfo = cpus.find(item => item.value === val);
-        if (!nextDownloadInfo || typeof nextDownloadInfo.gz !== 'string') {
-            setDownloadInfo({});
-            return;
-        }
-        const filename = nextDownloadInfo.gz.split(ORIGIN)[1];
-        nextDownloadInfo.filename = filename;
-        setDownloadInfo(nextDownloadInfo);
-    };
-
-    const getIssueCode = (code: string) => {
-        switch (code) {
-            case '1.2.1':
-                return 15508;
-            case '1.2.2':
-                return 16446;
-            case '1.2.3':
-                return 17748;
-            case '1.2.4':
-                return 18762;
-            case '1.2.5':
-                return 20827;
-            case '1.2.6':
-                return 21805;
-            case '1.2.7':
-                return 23711;
-            case '1.2.8':
-                return 31673;
-            default:
-                return null;
-        }
-    };
-
-    function toDocsRelease(version: string) {
-        const SUPPORTED_VERSION = '>=1.1.0';
-        const versionNumber = version.match(/[0-9].[0-9].[0-9]*/)?.[0] || '0.0.0';
-        return semver.satisfies(versionNumber, SUPPORTED_VERSION);
-    }
-
-    function onValuesChange(values: any) {
-        setReleaseFlag(values.version[0] === '1.1' ? false : true);
-        if (!toDocsRelease(values.version[1])) {
-            setReleaseNote('https://github.com/apache/doris/releases');
-        } else if (values.version[0] === '1.2') {
-            setReleaseNote(`https://github.com/apache/doris/issues/${getIssueCode(values.version[1])}`);
-        } else if (['3.0', '2.0', '3.1', '2.1'].includes(values.version[0])) {
-            setReleaseNote(
-                `/docs/${values.version[0] === '3.0' || values.version[0] === '3.1' ? '3.x' : values.version[0]}/releasenotes/v${
-                    values.version[0]
-                }/release-${values.version[1]}`,
-            );
-        } else if (values.version[0] === '4.0') {
-            setReleaseNote(`/docs/dev/releasenotes/v${values.version[0]}/release-${values.version[1]}`);
-        } else {
-            setReleaseNote(`/docs/releasenotes/v${values.version[0]}/release-${values.version[1]}`);
-        }
-    }
+    /** Every CPU build of the release the quick card is currently showing. */
+    const builds = useMemo(() => findCoreRelease(version)?.items ?? [], [version]);
+    const build = useMemo(() => builds.find(item => item.value === cpu) ?? builds[0], [builds, cpu]);
 
     useEffect(() => {
-        const currentVersion = DORIS_VERSIONS.find(doris_version => doris_version.value === version);
-        if (!currentVersion || !Array.isArray(currentVersion.children)) {
-            setCpus([]);
-            setCPU(CPUEnum.X64);
-            setDownloadInfo({});
-            return;
+        if (!builds.some(item => item.value === cpu)) setCpu(CPUEnum.X64);
+    }, [builds]);
+
+    const isSource = downloadType === DownloadTypeEnum.Source;
+
+    const asset = useMemo(() => {
+        if (!build) return null;
+        if (isSource) {
+            const base = `${build.source}apache-doris-${build.version}-src.tar.gz`;
+            return {
+                filename: `apache-doris-${build.version}-src.tar.gz`,
+                gz: base,
+                asc: `${base}.asc`,
+                sha512: `${base}.sha512`,
+            };
         }
-        setCpus(currentVersion.children);
-        setCPU(CPUEnum.X64);
-        const nextDownloadInfo: any = currentVersion.children.find(item => item.value === CPUEnum.X64);
-        if (!nextDownloadInfo || typeof nextDownloadInfo.gz !== 'string') {
-            setDownloadInfo({});
-            return;
-        }
-        const filename = nextDownloadInfo.gz.split(ORIGIN)[1];
-        nextDownloadInfo.filename = filename;
-        setDownloadInfo(nextDownloadInfo);
-    }, [version]);
+        return {
+            filename: typeof build.gz === 'string' ? build.gz.split(ORIGIN)[1] : '',
+            gz: build.gz,
+            asc: build.asc,
+            sha512: build.sha512,
+        };
+    }, [build, isSource]);
+
+    function onCoreVersionChange(values: any) {
+        const [branch, release] = values.version || [];
+        if (branch && release) setReleaseNote(releaseNotePath(branch, release));
+    }
+
+    const maintainedBranches = ACTIVE_VERSIONS.map(branch => branch.value).join(', ');
 
     return (
         <LayoutNext
@@ -136,19 +101,23 @@ export default function DownloadFormNext(): JSX.Element {
                     <div className="download-next__hero-bg-grid" aria-hidden="true" />
                     <div className="download-next__hero-inner">
                         <h1 className="download-next__title">
-                            <span className="download-next__title-line">Quick Download</span>
+                            <span className="download-next__title-line">Download</span>
                             <span className="download-next__title-line">
-                                & <span className="download-next__title-accent">Easy Deployment</span>
+                                Apache <span className="download-next__title-accent">Doris</span>
                             </span>
                         </h1>
                         <p className="download-next__sub">
-                            Download verified binaries or source tarballs of every Apache Doris release, and deploy
-                            anywhere — bare metal, Kubernetes, or cloud.
+                            Verified binaries and source tarballs for the release branches Apache Doris currently
+                            maintains. Every download is signed and checksummed.
                         </p>
+                        <div className="download-next__maintained">
+                            <span className="download-next__maintained-dot" aria-hidden="true" />
+                            Maintained branches — {maintainedBranches}
+                        </div>
                     </div>
                 </section>
 
-                {/* ── Quick download card ─────────────────────────────────────── */}
+                {/* ── Quick download ──────────────────────────────────────────── */}
                 <section className="download-next__quick">
                     <div className="download-next__quick-inner">
                         <div className="download-next__quick-card">
@@ -159,16 +128,18 @@ export default function DownloadFormNext(): JSX.Element {
                                     </Translate>
                                 </label>
                                 <div className="download-next__seg">
-                                    {BINARY_VERSION.map(item => (
+                                    {ACTIVE_HEADS.map(head => (
                                         <button
                                             type="button"
+                                            key={head.version}
+                                            aria-pressed={version === head.version}
                                             className={clsx('download-next__seg-item', {
-                                                'is-checked': version === item.value,
+                                                'is-checked': version === head.version,
                                             })}
-                                            key={item.value}
-                                            onClick={() => changeVersion(item.value)}
+                                            onClick={() => setVersion(head.version)}
                                         >
-                                            {item.label}
+                                            {head.version}
+                                            <span className="download-next__seg-tag">{head.label}</span>
                                         </button>
                                     ))}
                                 </div>
@@ -180,17 +151,23 @@ export default function DownloadFormNext(): JSX.Element {
                                         Architecture
                                     </Translate>
                                 </label>
-                                <div className="download-next__seg">
-                                    {cpus.map(item => (
+                                <div
+                                    className={clsx('download-next__seg', {
+                                        'is-muted': isSource,
+                                    })}
+                                >
+                                    {CPU_OPTIONS.map(option => (
                                         <button
                                             type="button"
+                                            key={option}
+                                            disabled={isSource}
+                                            aria-pressed={cpu === option}
                                             className={clsx('download-next__seg-item', {
-                                                'is-checked': cpu === item.value,
+                                                'is-checked': cpu === option,
                                             })}
-                                            key={item.value}
-                                            onClick={() => changeCPU(item.value)}
+                                            onClick={() => setCpu(option)}
                                         >
-                                            {item.label}
+                                            {option}
                                         </button>
                                     ))}
                                 </div>
@@ -203,160 +180,116 @@ export default function DownloadFormNext(): JSX.Element {
                                     </Translate>
                                 </label>
                                 <div className="download-next__seg">
-                                    <button
-                                        type="button"
-                                        onClick={() => setDownloadType(DownloadTypeEnum.Binary)}
-                                        className={clsx('download-next__seg-item', {
-                                            'is-checked': downloadType === DownloadTypeEnum.Binary,
-                                        })}
-                                    >
-                                        Binary
-                                    </button>
-                                    <button
-                                        type="button"
-                                        onClick={() => setDownloadType(DownloadTypeEnum.Source)}
-                                        className={clsx('download-next__seg-item', {
-                                            'is-checked': downloadType === DownloadTypeEnum.Source,
-                                        })}
-                                    >
-                                        Source
-                                    </button>
+                                    {[DownloadTypeEnum.Binary, DownloadTypeEnum.Source].map(option => (
+                                        <button
+                                            type="button"
+                                            key={option}
+                                            aria-pressed={downloadType === option}
+                                            className={clsx('download-next__seg-item', {
+                                                'is-checked': downloadType === option,
+                                            })}
+                                            onClick={() => setDownloadType(option)}
+                                        >
+                                            {option}
+                                        </button>
+                                    ))}
                                 </div>
                             </div>
 
-                            {downloadInfo && (downloadInfo.filename || downloadInfo.version) && (
-                                <div className="download-next__quick-row download-next__quick-row--file">
-                                    <label className="download-next__quick-label" />
+                            {asset && (
+                                <div className="download-next__file-row">
+                                    <span className="download-next__quick-label" aria-hidden="true" />
                                     <div className="download-next__file">
-                                        {downloadType === DownloadTypeEnum.Binary ? (
-                                            <>
-                                                <Link className="download-next__file-name" to={downloadInfo.gz}>
-                                                    {downloadInfo.filename}
-                                                </Link>
-                                                <span className="download-next__file-meta">
-                                                    (
-                                                    <Link to={downloadInfo.asc}>ASC</Link>
-                                                    {', '}
-                                                    <Link to={downloadInfo.sha512}>SHA-512</Link>
-                                                    )
-                                                </span>
-                                            </>
-                                        ) : (
-                                            <>
-                                                <Link
-                                                    className="download-next__file-name"
-                                                    to={`${downloadInfo.source}apache-doris-${downloadInfo.version}-src.tar.gz`}
-                                                >
-                                                    {`apache-doris-${downloadInfo.version}-src.tar.gz`}
-                                                </Link>
-                                                <span className="download-next__file-meta">
-                                                    (
-                                                    <Link
-                                                        to={`${downloadInfo.source}apache-doris-${downloadInfo.version}-src.tar.gz.asc`}
-                                                    >
-                                                        ASC
-                                                    </Link>
-                                                    {', '}
-                                                    <Link
-                                                        to={`${downloadInfo.source}apache-doris-${downloadInfo.version}-src.tar.gz.sha512`}
-                                                    >
-                                                        SHA-512
-                                                    </Link>
-                                                    )
-                                                </span>
-                                            </>
-                                        )}
+                                        <code className="download-next__file-name">{asset.filename}</code>
+                                        <div className="download-next__file-links">
+                                            <Link to={asset.asc}>ASC</Link>
+                                            <Link to={asset.sha512}>SHA-512</Link>
+                                            <Link to={KEYS_URL}>KEYS</Link>
+                                            <Link to={VERIFY_URL}>How to verify</Link>
+                                        </div>
                                     </div>
+                                    <Link className="download-next__download-btn" to={asset.gz}>
+                                        Download
+                                    </Link>
                                 </div>
                             )}
 
                             <p className="download-next__quick-note">
-                                Note: For Apache Doris version specifics, please refer to the{' '}
-                                <Link to="https://doris.apache.org/community/release-and-verify/release-versioning">
-                                    release versioning.
-                                </Link>
+                                Apache Doris maintains the two most recent minor branches, labelled Latest and Stable —
+                                see <Link to={VERSIONING_URL}>release versioning</Link>. Releases from older branches
+                                are <Link to="#archive">archived</Link>.
                             </p>
                         </div>
                     </div>
                 </section>
 
-                {/* ── All releases ────────────────────────────────────────────── */}
+                {/* ── Maintained core releases ────────────────────────────────── */}
                 <section className="download-next__section">
                     <div className="download-next__section-inner">
-                        <h2 className="download-next__section-title">Doris All Releases</h2>
+                        <span className="download-next__eyebrow">Maintained</span>
+                        <h2 className="download-next__section-title">Doris Releases</h2>
                         <div className="download-next__split">
                             <div className="download-next__split-intro">
                                 <div className="download-next__split-text">
                                     <p>
-                                        Doris is released as source code tarballs with corresponding binary tarballs
-                                        for convenience. The downloads should be verified for tampering using ASC or
-                                        SHA-512.
+                                        Doris is released as source tarballs, with binary tarballs built for
+                                        convenience. Verify every download against its ASC signature or SHA-512 checksum
+                                        before you deploy it.
                                     </p>
-                                    <p>For more information on the latest release, please refer to the Docs.</p>
                                     <p>
-                                        Kindly note that older releases (v1.2, v1.1, v0.x) are provided for archival
-                                        purposes only, and are no longer supported.
+                                        Every patch on a maintained branch is listed here. Patch releases are compatible
+                                        in both directions, so moving to the newest patch on your branch needs no data
+                                        migration.
                                     </p>
                                 </div>
-                                {releaseFlag && (
-                                    <div>
-                                        <LinkWithArrow to="/releases/all-release" text="Release note" />
-                                    </div>
-                                )}
+                                <div>
+                                    <LinkWithArrow to={releaseNote} text="Release note" />
+                                </div>
                                 <p className="download-next__split-note">
-                                    Note: For detailed upgrade precautions, please refer to the{' '}
-                                    <Link to="/docs/dev/install/intro">deployment</Link> manual and cluster{' '}
-                                    <Link to="/docs/dev/admin-manual/cluster-management/upgrade">upgrade</Link>{' '}
-                                    manual.
+                                    For upgrade precautions see the <Link to="/docs/dev/install/intro">deployment</Link>{' '}
+                                    and{' '}
+                                    <Link to="/docs/dev/admin-manual/cluster-management/upgrade">cluster upgrade</Link>{' '}
+                                    manuals.
                                 </p>
                             </div>
                             <div className="download-next__split-card">
                                 <DownloadFormAllRelease
-                                    versions={ALL_VERSIONS}
-                                    onValuesChange={(values: any) => onValuesChange(values)}
+                                    versions={ACTIVE_VERSIONS}
+                                    onValuesChange={onCoreVersionChange}
                                 />
                             </div>
                         </div>
                     </div>
                 </section>
 
-                {/* ── Ecosystem tools ─────────────────────────────────────────── */}
+                {/* ── Maintained ecosystem ────────────────────────────────────── */}
                 <a id="doris-ecosystem" className="scroll-mt-20"></a>
                 <section className="download-next__section">
                     <div className="download-next__section-inner">
+                        <span className="download-next__eyebrow">Maintained</span>
                         <h2 className="download-next__section-title">Doris Ecosystem</h2>
                         <div className="download-next__split">
                             <div className="download-next__split-intro">
                                 <div className="download-next__split-text">
-                                    <p>Streamline integration and data loading with Doris tools.</p>
+                                    <p>
+                                        Connectors and tools for loading into and reading out of Doris. Only maintained
+                                        versions are listed; older connector lines are in the{' '}
+                                        <Link to="#archive">archive</Link>.
+                                    </p>
                                 </div>
                                 <ul className="download-next__tool-list">
-                                    <li>
-                                        <CheckedIcon />
-                                        <span>Kafka Doris Connector</span>
-                                    </li>
-                                    <li>
-                                        <CheckedIcon />
-                                        <span>Flink Doris Connector</span>
-                                    </li>
-                                    <li>
-                                        <CheckedIcon />
-                                        <span>Spark Doris Connector</span>
-                                    </li>
-                                    <li>
-                                        <CheckedIcon />
-                                        <span>Doris Streamloader</span>
-                                    </li>
-                                    <li>
-                                        <CheckedIcon />
-                                        <span>Doris Operator</span>
-                                    </li>
+                                    {ACTIVE_TOOL_VERSIONS.map(tool => (
+                                        <li key={tool.value}>
+                                            <CheckedIcon />
+                                            <span>{tool.label}</span>
+                                            <span className="download-next__tool-version">
+                                                {tool.children[0]?.label}
+                                            </span>
+                                        </li>
+                                    ))}
                                 </ul>
                                 <div className="download-next__ecosystem-links">
-                                    <LinkWithArrow
-                                        to={TOOL_RELEASE_NOTES[ecosystemTool]}
-                                        text="Release Notes"
-                                    />
+                                    <LinkWithArrow to={TOOL_RELEASE_NOTES[ecosystemTool]} text="Release Notes" />
                                     <LinkWithArrow
                                         to="/docs/4.x/connection-integration/data-integration/intro"
                                         text="More Tools"
@@ -364,7 +297,39 @@ export default function DownloadFormNext(): JSX.Element {
                                 </div>
                             </div>
                             <div className="download-next__split-card">
-                                <DownloadFormTools data={TOOL_VERSIONS} onToolChange={setEcosystemTool} />
+                                <DownloadFormTools data={ACTIVE_TOOL_VERSIONS} onToolChange={setEcosystemTool} />
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                {/* ── Archive ─────────────────────────────────────────────────── */}
+                <a id="archive" className="scroll-mt-20"></a>
+                <section className="download-next__archive">
+                    <div className="download-next__section-inner">
+                        <h2 className="download-next__section-title download-next__section-title--archive">
+                            Archived Releases
+                        </h2>
+                        <div className="download-next__split">
+                            <div className="download-next__split-intro">
+                                <p className="download-next__archive-lead">
+                                    <strong>
+                                        These versions receive no further releases of any kind, security patches
+                                        included.
+                                    </strong>{' '}
+                                    A vulnerability found in one of them stays unfixed there, permanently.
+                                </p>
+                                <div className="download-next__archive-links">
+                                    <Link to="/docs/dev/admin-manual/cluster-management/upgrade">Upgrade guide</Link>
+                                    <Link to={SECURITY_URL}>Report a vulnerability to the ASF security team</Link>
+                                    <Link to={ASF_ARCHIVE_URL}>archive.apache.org/dist/doris</Link>
+                                </div>
+                            </div>
+                            <div className="download-next__split-card">
+                                <DownloadFormArchive
+                                    coreVersions={ARCHIVED_VERSIONS}
+                                    toolVersions={ARCHIVED_TOOL_VERSIONS}
+                                />
                             </div>
                         </div>
                     </div>

--- a/src/components/download-form-next/download-page.scss
+++ b/src/components/download-form-next/download-page.scss
@@ -13,19 +13,29 @@
     --dl-yellow-bright: var(--brand-accent-bright);
     --dl-ink: var(--brand-ink);
     --dl-text: #1d1d1d;
-    --dl-text-muted: #4C576C;
-    --dl-text-subtle: #8592A6;
+    --dl-text-muted: #4c576c;
+    --dl-text-subtle: #8592a6;
     --dl-border: #dfe5f0;
-    --dl-bg-soft: #F7FAFC;
+    --dl-bg-soft: #f7fafc;
     --dl-mono: #{type.$font-mono};
     --dl-sans: #{type.$font-sans};
+
+    // Archive tones. Deliberately outside the brand palette and identical in
+    // every brand theme: "no longer maintained" has to read the same way
+    // whichever theme the visitor has picked.
+    --dl-ended: #b4442a;
+    --dl-drained: #767b84;
+    --dl-drained-bg: #f1f2f4;
+    --dl-drained-line: #dcdee2;
 
     font-family: var(--dl-sans);
     color: var(--dl-text);
     background: #ffffff;
 
     a {
-        transition: color 0.18s ease, opacity 0.18s ease;
+        transition:
+            color 0.18s ease,
+            opacity 0.18s ease;
     }
 }
 
@@ -96,6 +106,28 @@
     max-width: 620px;
 }
 
+.download-next__maintained {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 26px;
+    padding: 8px 15px 8px 12px;
+    border: 1px solid rgb(var(--brand-primary-glow-rgb) / 35%);
+    border-radius: 999px;
+    background: rgb(var(--brand-shadow-rgb) / 35%);
+    color: var(--brand-primary-soft);
+    @include type.mono-text(12.5px, 500, 1.4, 0.02em);
+}
+
+.download-next__maintained-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--dl-green-glow);
+    box-shadow: 0 0 0 3px rgb(var(--brand-primary-glow-rgb) / 25%);
+    flex-shrink: 0;
+}
+
 // ─── Quick download card ────────────────────────────────────────────────────
 
 .download-next__quick {
@@ -130,9 +162,56 @@
     & + & {
         margin-top: 18px;
     }
+}
 
-    &--file {
-        align-items: flex-start;
+.download-next__file-row {
+    display: grid;
+    grid-template-columns: 9.0625rem minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 20px;
+    margin-top: 22px;
+}
+
+.download-next__file-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    margin-top: 7px;
+    @include type.mono-text(12px, 500, 1.4, 0.02em);
+
+    a {
+        color: var(--dl-text-muted);
+        border-bottom: 1px solid var(--dl-drained-line);
+
+        &:hover {
+            color: var(--ifm-color-primary);
+            border-bottom-color: var(--ifm-color-primary);
+            text-decoration: none;
+        }
+    }
+}
+
+.download-next__download-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 15px 28px;
+    border-radius: 6px;
+    background: var(--dl-yellow);
+    color: var(--dl-ink) !important;
+    white-space: nowrap;
+    @include type.mono-text(13px, 800, 1, 0.05em, uppercase);
+    box-shadow: 0 2px 0 rgb(var(--brand-ink-rgb) / 18%);
+    transition:
+        transform 0.14s ease,
+        box-shadow 0.18s ease,
+        background 0.18s ease;
+
+    &:hover {
+        background: var(--dl-yellow-bright);
+        transform: translateY(-1px);
+        box-shadow: 0 4px 0 rgb(var(--brand-ink-rgb) / 18%);
+        text-decoration: none !important;
     }
 }
 
@@ -190,6 +269,20 @@
         color: #ffffff;
         z-index: 1;
     }
+
+    &:disabled {
+        cursor: not-allowed;
+    }
+}
+
+.download-next__seg-tag {
+    margin-left: 8px;
+    @include type.mono-text(12px, 700, 1, 0.08em, uppercase);
+    opacity: 0.72;
+}
+
+.download-next__seg.is-muted {
+    opacity: 0.45;
 }
 
 .download-next__file {
@@ -212,7 +305,9 @@
 }
 
 .download-next__file-name {
+    display: block;
     font-weight: 600;
+    word-break: break-all;
 }
 
 .download-next__file-meta {
@@ -248,6 +343,13 @@
     max-width: 1180px;
     margin: 0 auto;
     padding: 0 56px;
+}
+
+.download-next__eyebrow {
+    display: block;
+    margin-bottom: 10px;
+    @include type.mono-text(12px, 700, 1.2, 0.18em, uppercase);
+    color: var(--dl-text-subtle);
 }
 
 .download-next__section-title {
@@ -331,11 +433,161 @@
     }
 }
 
+.download-next__tool-version {
+    margin-left: auto;
+    padding: 3px 9px;
+    border-radius: 5px;
+    background: var(--brand-primary-soft);
+    color: var(--brand-primary-darker);
+    @include type.mono-text(12px, 600, 1.4, 0.01em);
+}
+
 .download-next__ecosystem-links {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 12px;
+}
+
+// ─── Archive ───────────────────────────────────────────────────────────────
+//
+// Everything Apache Doris no longer maintains. The zone is drained rather than
+// alarmed: a decommissioned room with the lights on, not a warning banner. The
+// brand green never appears below this line, so a visitor can tell which half
+// of the page they are in from the colour alone.
+
+.download-next__archive {
+    margin-top: 80px;
+    padding: 46px 0 56px;
+    border-top: 1px solid var(--dl-drained-line);
+    background: var(--dl-drained-bg);
+}
+
+.download-next__section-title--archive {
+    color: #5a5f67;
+}
+
+.download-next__archive .download-next__split {
+    background: #ffffff;
+    border-color: var(--dl-drained-line);
+}
+
+.download-next__archive-lead {
+    margin: 0;
+    color: #3f4652;
+    font-size: 16px;
+    line-height: 1.7;
+
+    strong {
+        color: var(--dl-ended);
+        font-weight: 600;
+    }
+}
+
+.download-next__archive-links {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+    font-size: 14px;
+
+    a {
+        color: #3f4652;
+        border-bottom: 1px solid var(--dl-drained-line);
+
+        &:hover {
+            color: var(--dl-ended);
+            border-bottom-color: var(--dl-ended);
+            text-decoration: none;
+        }
+    }
+}
+
+.download-next__archive-card {
+    border: 1px solid var(--dl-drained-line);
+    border-top: 3px solid var(--dl-ended);
+    border-radius: 8px;
+    background: #ffffff;
+    padding: 32px 32px 30px;
+}
+
+.download-next__archive-card-title {
+    margin-bottom: 32px;
+    color: var(--dl-text);
+    font-size: 20px;
+    font-weight: 500;
+    text-align: left;
+}
+
+.download-next__archive-project {
+    margin-bottom: 24px;
+}
+
+// Matches .button-primary in shape, inverted in tone: the archive download is
+// available, not encouraged.
+.download-next__archive-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 48px;
+    padding: 10px 24px;
+    border: 1.5px solid var(--dl-ended);
+    border-radius: 6px;
+    background: #ffffff;
+    color: var(--dl-ended);
+    cursor: pointer;
+    transition:
+        background 0.18s ease,
+        color 0.18s ease;
+
+    &:hover {
+        background: var(--dl-ended);
+        color: #ffffff;
+    }
+}
+
+// The shared download form is brand-green throughout. Inside the archive card
+// every one of those accents is re-toned, so no green appears past the cut.
+.download-next__archive-card {
+    .ant-select:not(.ant-select-customize-input) {
+        &:hover .ant-select-selector,
+        &.ant-select-focused .ant-select-selector {
+            border-color: var(--dl-ended) !important;
+        }
+    }
+
+    .ant-select-arrow {
+        color: var(--dl-drained);
+    }
+
+    .text-primary {
+        color: var(--dl-ended) !important;
+
+        svg rect {
+            stroke: var(--dl-ended);
+        }
+
+        svg path {
+            fill: var(--dl-ended);
+        }
+    }
+
+    .hover\:text-primary:hover {
+        color: var(--dl-ended) !important;
+    }
+}
+
+// antd renders the popup in a body-level portal, so it cannot be reached from
+// the card. FormSelect forwards this class through `popupExtraClass`.
+.form-select-select--archive {
+    &.ant-select-dropdown .ant-select-item-option-selected:not(.ant-select-item-option-disabled),
+    .ant-cascader-menu li.ant-cascader-menu-item-active {
+        color: var(--dl-ended);
+
+        .ant-cascader-menu-item-expand-icon {
+            color: var(--dl-ended);
+        }
+    }
 }
 
 // ─── Run anywhere (single CTA card) ────────────────────────────────────────
@@ -360,14 +612,16 @@
     border: 1px solid rgb(var(--brand-primary-glow-rgb) / 30%);
     background:
         radial-gradient(ellipse at 78% 20%, rgb(var(--brand-primary-glow-rgb) / 22%), transparent 58%),
-        radial-gradient(ellipse at 6% 100%, rgb(var(--brand-accent-rgb) / 8%), transparent 58%),
-        var(--dl-green);
+        radial-gradient(ellipse at 6% 100%, rgb(var(--brand-accent-rgb) / 8%), transparent 58%), var(--dl-green);
     color: var(--dl-cream-light);
     text-decoration: none !important;
     box-shadow:
         0 30px 60px -32px rgb(var(--brand-shadow-rgb) / 0.35),
         0 8px 24px -12px rgb(var(--brand-ink-rgb) / 0.12);
-    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        border-color 0.2s ease;
 
     &::before {
         content: '';
@@ -426,7 +680,10 @@
     color: var(--dl-ink);
     border-radius: 6px;
     @include type.mono-text(13px, 800, 1, 0.04em);
-    transition: background 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+    transition:
+        background 0.18s ease,
+        transform 0.18s ease,
+        box-shadow 0.18s ease;
 
     svg {
         transition: transform 0.18s ease;
@@ -488,6 +745,29 @@
 
     .download-next__split-card {
         order: -1;
+    }
+
+    .download-next__quick-row,
+    .download-next__file-row {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+
+    .download-next__file-row {
+        gap: 14px;
+    }
+
+    .download-next__quick-label {
+        margin-bottom: 0;
+    }
+
+    .download-next__archive {
+        margin-top: 56px;
+        padding: 36px 0 44px;
+    }
+
+    .download-next__archive-card {
+        padding: 24px 20px 22px;
     }
 
     .download-next__run {

--- a/src/components/download-form/download-form-all-release.tsx
+++ b/src/components/download-form/download-form-all-release.tsx
@@ -8,10 +8,16 @@ import copy from 'copy-to-clipboard';
 
 interface DownloadFormProps {
     versions: Option[];
-    onValuesChange: (values: any) => void;
+    onValuesChange?: (values: any) => void;
+    /** Render only the form, without the card chrome — used inside the archive card. */
+    bare?: boolean;
+    /** 'archive' re-tones the popup and the download button for retired releases. */
+    tone?: 'primary' | 'archive';
 }
 export default function DownloadFormAllRelease(props: DownloadFormProps) {
-    const { versions } = props;
+    const { versions, bare = false, tone = 'primary' } = props;
+    const isArchive = tone === 'archive';
+    const popupExtraClass = isArchive ? 'form-select-select--archive' : '';
     const [form] = useForm();
     const version = useWatch('version', form) || [versions[0].value, versions[0].children[0].value];
     const architecture = useWatch('architecture', form);
@@ -66,154 +72,160 @@ export default function DownloadFormAllRelease(props: DownloadFormProps) {
         }
     }, [version]);
 
-    return (
-        <div className="rounded-lg border border-b-[0.375rem] border-primary px-8 pt-[3.125rem] pb-[2.1875rem]">
-            <div className="mb-8 text-xl font-medium text-left">Downloads</div>
-            <Form
-                form={form}
-                onFinish={val => {
-                    const url = getDownloadLinkByCard({
-                        version: version,
-                        cpu: architecture,
-                        tarBall: tarBall,
-                        type: 'gz',
-                    });
-                    window.open(url, '_blank');
-                    return;
-                }}
-                initialValues={{
-                    version: [versions[0].value, versions[0].children[0].value],
-                    tarBall: DownloadTypeEnum.Binary,
-                }}
-                onValuesChange={(changedValues, values) => props?.onValuesChange(values)}
-            >
-                <Form.Item name="version" rules={[{ required: true }]}>
-                    <FormSelect
-                        placeholder="Version"
-                        label="Version"
-                        isCascader={true}
-                        displayRender={label => {
-                            return label.length > 0 ? label[label.length - 1] : '';
-                        }}
-                        options={versions}
-                    />
+    const formBody = (
+        <Form
+            form={form}
+            onFinish={val => {
+                const url = getDownloadLinkByCard({
+                    version: version,
+                    cpu: architecture,
+                    tarBall: tarBall,
+                    type: 'gz',
+                });
+                window.open(url, '_blank');
+                return;
+            }}
+            initialValues={{
+                version: [versions[0].value, versions[0].children[0].value],
+                tarBall: DownloadTypeEnum.Binary,
+            }}
+            onValuesChange={(changedValues, values) => props.onValuesChange?.(values)}
+        >
+            <Form.Item name="version" rules={[{ required: true }]}>
+                <FormSelect
+                    placeholder="Version"
+                    label="Version"
+                    isCascader={true}
+                    popupExtraClass={popupExtraClass}
+                    displayRender={label => {
+                        return label.length > 0 ? label[label.length - 1] : '';
+                    }}
+                    options={versions}
+                />
+            </Form.Item>
+            {Array.isArray(version) && showArch(version[1]) && (
+                <Form.Item noStyle shouldUpdate>
+                    {({ getFieldValue }) => (
+                        <Form.Item name="architecture" rules={[{ required: true }]}>
+                            <FormSelect
+                                placeholder="Architecture"
+                                label="Architecture"
+                                isCascader={false}
+                                popupExtraClass={popupExtraClass}
+                                options={getOptions(getFieldValue('version'))}
+                            />
+                        </Form.Item>
+                    )}
                 </Form.Item>
-                {Array.isArray(version) && showArch(version[1]) && (
-                    <Form.Item noStyle shouldUpdate>
-                        {({ getFieldValue }) => (
-                            <Form.Item name="architecture" rules={[{ required: true }]}>
-                                <FormSelect
-                                    placeholder="Architecture"
-                                    label="Architecture"
-                                    isCascader={false}
-                                    options={getOptions(getFieldValue('version'))}
-                                />
-                            </Form.Item>
-                        )}
-                    </Form.Item>
-                )}
-                {Array.isArray(version) && showArch(version[1]) && (
-                    <Form.Item noStyle shouldUpdate>
-                        {({ getFieldValue }) => (
-                            <Form.Item name="tarBall" rules={[{ required: true }]}>
-                                <FormSelect
-                                    placeholder="Tarball"
-                                    label="Tarball"
-                                    isCascader={false}
-                                    options={[
-                                        {
-                                            label: DownloadTypeEnum.Binary,
-                                            value: DownloadTypeEnum.Binary,
-                                        },
-                                        {
-                                            label: DownloadTypeEnum.Source,
-                                            value: DownloadTypeEnum.Source,
-                                        },
-                                    ]}
-                                />
-                            </Form.Item>
-                        )}
-                    </Form.Item>
-                )}
+            )}
+            {Array.isArray(version) && showArch(version[1]) && (
+                <Form.Item noStyle shouldUpdate>
+                    {({ getFieldValue }) => (
+                        <Form.Item name="tarBall" rules={[{ required: true }]}>
+                            <FormSelect
+                                placeholder="Tarball"
+                                label="Tarball"
+                                isCascader={false}
+                                popupExtraClass={popupExtraClass}
+                                options={[
+                                    {
+                                        label: DownloadTypeEnum.Binary,
+                                        value: DownloadTypeEnum.Binary,
+                                    },
+                                    {
+                                        label: DownloadTypeEnum.Source,
+                                        value: DownloadTypeEnum.Source,
+                                    },
+                                ]}
+                            />
+                        </Form.Item>
+                    )}
+                </Form.Item>
+            )}
 
-                <Form.Item style={{ marginBottom: 0 }} colon={false}>
-                    <button type="submit" className="button-primary w-full text-lg">
-                        Download
-                    </button>
-                </Form.Item>
-                {Array.isArray(version) && showArch(version[1]) && (
-                    <>
+            <Form.Item style={{ marginBottom: 0 }} colon={false}>
+                <button
+                    type="submit"
+                    className={`w-full text-lg ${isArchive ? 'download-next__archive-button' : 'button-primary'}`}
+                >
+                    Download
+                </button>
+            </Form.Item>
+            {Array.isArray(version) && showArch(version[1]) && (
+                <>
+                    <div
+                        className="flex cursor-pointer text-primary items-center mt-4 justify-center"
+                        onClick={() => {
+                            const url = getDownloadLinkByCard({
+                                version: version,
+                                cpu: architecture,
+                                tarBall: tarBall,
+                                type: 'gz',
+                            });
+                            copy(url);
+                            message.success('Copy Successfully!');
+                        }}
+                    >
+                        <span className="mr-2">Copy link</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+                            <rect
+                                x="2.5"
+                                y="5.5"
+                                width="8"
+                                height="8"
+                                rx="0.564706"
+                                stroke="var(--brand-primary)"
+                                strokeWidth="1.2"
+                            />
+                            <path
+                                fillRule="evenodd"
+                                clipRule="evenodd"
+                                d="M6.0999 1.89996C5.43716 1.89996 4.8999 2.43722 4.8999 3.09996V5.49995H6.0999V3.09996L12.8999 3.09996V9.89996H10.5V11.1H12.8999C13.5626 11.1 14.0999 10.5627 14.0999 9.89996V3.09996C14.0999 2.43722 13.5626 1.89996 12.8999 1.89996H6.0999Z"
+                                fill="var(--brand-primary)"
+                            />
+                        </svg>
+                    </div>
+                    <div className="flex justify-center mt-4">
                         <div
-                            className="flex cursor-pointer text-primary items-center mt-4 justify-center"
+                            className="inline-flex items-center text-[#8592A6] cursor-pointer hover:underline hover:text-primary"
                             onClick={() => {
                                 const url = getDownloadLinkByCard({
                                     version: version,
                                     cpu: architecture,
                                     tarBall: tarBall,
-                                    type: 'gz',
+                                    type: 'asc',
                                 });
-                                copy(url);
-                                message.success('Copy Successfully!');
+                                window.open(url, '_blank');
                             }}
                         >
-                            <span className="mr-2">Copy link</span>
-                            <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                width="16"
-                                height="16"
-                                viewBox="0 0 16 16"
-                                fill="none"
-                            >
-                                <rect
-                                    x="2.5"
-                                    y="5.5"
-                                    width="8"
-                                    height="8"
-                                    rx="0.564706"
-                                    stroke="var(--brand-primary)"
-                                    strokeWidth="1.2"
-                                />
-                                <path
-                                    fillRule="evenodd"
-                                    clipRule="evenodd"
-                                    d="M6.0999 1.89996C5.43716 1.89996 4.8999 2.43722 4.8999 3.09996V5.49995H6.0999V3.09996L12.8999 3.09996V9.89996H10.5V11.1H12.8999C13.5626 11.1 14.0999 10.5627 14.0999 9.89996V3.09996C14.0999 2.43722 13.5626 1.89996 12.8999 1.89996H6.0999Z"
-                                    fill="var(--brand-primary)"
-                                />
-                            </svg>
+                            ASC
                         </div>
-                        <div className="flex justify-center mt-4">
-                            <div
-                                className="inline-flex items-center text-[#8592A6] cursor-pointer hover:underline hover:text-primary"
-                                onClick={() => {
-                                    const url = getDownloadLinkByCard({
-                                        version: version,
-                                        cpu: architecture,
-                                        tarBall: tarBall,
-                                        type: 'asc',
-                                    });
-                                    window.open(url, '_blank');
-                                }}
-                            >
-                                ASC
-                            </div>
-                            <div
-                                className="inline-flex items-center ml-4 text-[#8592A6] hover:text-primary cursor-pointer hover:underline"
-                                onClick={() => {
-                                    const url = getDownloadLinkByCard({
-                                        version: version,
-                                        cpu: architecture,
-                                        tarBall: tarBall,
-                                        type: 'sha512',
-                                    });
-                                    window.open(url, '_blank');
-                                }}
-                            >
-                                SHA-512
-                            </div>
+                        <div
+                            className="inline-flex items-center ml-4 text-[#8592A6] hover:text-primary cursor-pointer hover:underline"
+                            onClick={() => {
+                                const url = getDownloadLinkByCard({
+                                    version: version,
+                                    cpu: architecture,
+                                    tarBall: tarBall,
+                                    type: 'sha512',
+                                });
+                                window.open(url, '_blank');
+                            }}
+                        >
+                            SHA-512
                         </div>
-                    </>
-                )}
-            </Form>
+                    </div>
+                </>
+            )}
+        </Form>
+    );
+
+    if (bare) return formBody;
+
+    return (
+        <div className="rounded-lg border border-b-[0.375rem] border-primary px-8 pt-[3.125rem] pb-[2.1875rem]">
+            <div className="mb-8 text-xl font-medium text-left">Downloads</div>
+            {formBody}
         </div>
     );
 }

--- a/src/components/download-form/download-form-archive.tsx
+++ b/src/components/download-form/download-form-archive.tsx
@@ -1,0 +1,59 @@
+import React, { useMemo, useState } from 'react';
+import { AllVersionOption, Option } from '@site/src/constant/download.data';
+import FormSelect from '../form-select/form-select';
+import DownloadFormAllRelease from './download-form-all-release';
+import DownloadFormTools from './download-form-tools';
+
+const CORE_PROJECT = 'Doris Core';
+const ARCHIVE_POPUP_CLASS = 'form-select-select--archive';
+
+interface DownloadFormArchiveProps {
+    /** Core branches that are no longer maintained. */
+    coreVersions: AllVersionOption[];
+    /** Ecosystem tools, each already reduced to its retired versions. */
+    toolVersions: Option[];
+}
+
+/**
+ * One card for everything Apache Doris no longer maintains.
+ *
+ * A single Project picker sits on top; the rest of the form is the existing
+ * core / tool download form running in `bare` mode, so the archive reuses the
+ * same link-building logic as the maintained sections rather than repeating it.
+ */
+export default function DownloadFormArchive({ coreVersions, toolVersions }: DownloadFormArchiveProps) {
+    const projects = useMemo(
+        () => [
+            ...(coreVersions.length > 0 ? [{ label: CORE_PROJECT, value: CORE_PROJECT }] : []),
+            ...toolVersions.map(tool => ({ label: tool.label, value: tool.value })),
+        ],
+        [coreVersions, toolVersions],
+    );
+
+    const [project, setProject] = useState<string>(projects[0]?.value ?? CORE_PROJECT);
+    const selectedTool = toolVersions.find(tool => tool.value === project);
+
+    if (projects.length === 0) return null;
+
+    return (
+        <div className="download-next__archive-card">
+            <div className="download-next__archive-card-title">Archived download</div>
+            <div className="download-next__archive-project">
+                <FormSelect
+                    placeholder="Project"
+                    label="Project"
+                    isCascader={false}
+                    popupExtraClass={ARCHIVE_POPUP_CLASS}
+                    options={projects}
+                    value={project}
+                    onChange={value => setProject(value as string)}
+                />
+            </div>
+            {selectedTool ? (
+                <DownloadFormTools key={project} bare tone="archive" data={[selectedTool]} />
+            ) : (
+                <DownloadFormAllRelease key={project} bare tone="archive" versions={coreVersions} />
+            )}
+        </div>
+    );
+}

--- a/src/components/download-form/download-form-tools.tsx
+++ b/src/components/download-form/download-form-tools.tsx
@@ -10,9 +10,17 @@ import { DownloadIcon } from '../Icons/download-icon';
 interface DownloadFormToolsProps {
     data: Option[];
     onToolChange?: (tool: ToolsEnum) => void;
+    /** Render only the form, without the card chrome — used inside the archive card. */
+    bare?: boolean;
+    /** 'archive' re-tones the popup and the download button for retired releases. */
+    tone?: 'primary' | 'archive';
 }
 export default function DownloadFormTools(props: DownloadFormToolsProps) {
-    const { data, onToolChange } = props;
+    const { data, onToolChange, bare = false, tone = 'primary' } = props;
+    const isArchive = tone === 'archive';
+    const popupExtraClass = isArchive ? 'form-select-select--archive' : '';
+    // With a single tool the picker is redundant: the parent already chose it.
+    const showToolSelect = data.length > 1;
     const [form] = useForm();
     const tool = useWatch('tool', form);
     const architecture = useWatch('architecture', form);
@@ -99,9 +107,7 @@ export default function DownloadFormTools(props: DownloadFormToolsProps) {
 
     useEffect(() => {
         if (tool !== ToolsEnum.Operator || !tarBall) return;
-        const options = data
-            .find(item => item.value === ToolsEnum.Operator)
-            .children.filter(option => option[tarBall]);
+        const options = data.find(item => item.value === ToolsEnum.Operator).children.filter(option => option[tarBall]);
         const selectedVersion = Array.isArray(version) ? version[0] : version;
         if (!options.some(option => option.value === selectedVersion)) {
             form.setFieldValue('version', options[0].value);
@@ -123,198 +129,221 @@ export default function DownloadFormTools(props: DownloadFormToolsProps) {
           })
         : '';
 
-    return (
-        <div className="rounded-lg border border-b-[0.375rem] border-primary px-8 pt-[3.125rem] pb-[2.1875rem]">
-            <div className="mb-8 text-xl font-medium text-left">Downloads</div>
-            <Form
-                form={form}
-                onFinish={val => {
-                    if (isOperatorBinary) return;
-                    const url = getDownloadLinkByCard({
-                        version: version,
-                        cpu: architecture,
-                        tarBall: tarBall,
-                        type: '',
-                    });
-                    window.open(url, '_blank');
-                }}
-                initialValues={{
-                    tool: data[0]?.value,
-                    version: '',
-                    architecture: '',
-                    tarBall: DownloadTypeEnum.Binary,
-                }}
-            >
-                <Form.Item name="tool" rules={[{ required: true }]}>
-                    <FormSelect placeholder="Tools" label="Tools" isCascader={false} options={data} />
-                </Form.Item>
-                <Form.Item noStyle shouldUpdate>
-                    {({ getFieldValue }) =>
-                        getFieldValue('tool') === ToolsEnum.StreamLoader ? (
-                            <>
-                                <Form.Item name="version" rules={[{ required: true }]}>
-                                    <FormSelect
-                                        placeholder="Version"
-                                        label="Version"
-                                        isCascader={false}
-                                        options={getOptions}
-                                    />
-                                </Form.Item>
-                                <Form.Item name="architecture" rules={[{ required: true }]}>
-                                    <FormSelect
-                                        placeholder="Architecture"
-                                        label="Architecture"
-                                        isCascader={false}
-                                        options={getArchitectureOptions}
-                                    />
-                                </Form.Item>
-                            </>
-                        ) : (
+    const formBody = (
+        <Form
+            form={form}
+            onFinish={val => {
+                if (isOperatorBinary) return;
+                const url = getDownloadLinkByCard({
+                    version: version,
+                    cpu: architecture,
+                    tarBall: tarBall,
+                    type: '',
+                });
+                window.open(url, '_blank');
+            }}
+            initialValues={{
+                tool: data[0]?.value,
+                version: '',
+                architecture: '',
+                tarBall: DownloadTypeEnum.Binary,
+            }}
+        >
+            <Form.Item name="tool" rules={[{ required: true }]} hidden={!showToolSelect}>
+                <FormSelect
+                    placeholder="Tools"
+                    label="Tools"
+                    isCascader={false}
+                    popupExtraClass={popupExtraClass}
+                    options={data}
+                />
+            </Form.Item>
+            <Form.Item noStyle shouldUpdate>
+                {({ getFieldValue }) =>
+                    getFieldValue('tool') === ToolsEnum.StreamLoader ? (
+                        <>
                             <Form.Item name="version" rules={[{ required: true }]}>
                                 <FormSelect
                                     placeholder="Version"
                                     label="Version"
-                                    isCascader={tool !== ToolsEnum.Operator}
+                                    isCascader={false}
+                                    popupExtraClass={popupExtraClass}
                                     options={getOptions}
-                                    displayRender={label => {
-                                        if (label.length > 1) {
-                                            return `${label[0]} (${label[1]})`;
-                                        }
-                                        if (label.length > 0) {
-                                            return label[label.length - 1];
-                                        }
-                                        return '';
-                                    }}
                                 />
                             </Form.Item>
-                        )
-                    }
-                </Form.Item>
-                <Form.Item name="tarBall" rules={[{ required: true }]}>
-                    <FormSelect
-                        placeholder="Tarball"
-                        label="Tarball"
-                        isCascader={false}
-                        options={[
-                            {
-                                label: DownloadTypeEnum.Binary,
-                                value: DownloadTypeEnum.Binary,
-                            },
-                            {
-                                label: DownloadTypeEnum.Source,
-                                value: DownloadTypeEnum.Source,
-                            },
-                        ]}
-                    />
-                </Form.Item>
-                {isOperatorBinary ? (
-                    <Form.Item style={{ marginBottom: 0 }} colon={false}>
-                        <div
-                            className="rounded-lg border border-[var(--brand-terminal)] bg-black p-4"
-                            style={{ backgroundColor: '#000000' }}
-                        >
-                            <div className="mb-3 flex items-center justify-between gap-4 border-b border-[var(--brand-terminal)]/30 pb-3">
-                                <span className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--brand-terminal)]">
-                                    Docker command
-                                </span>
-                                <button
-                                    aria-label="Copy Docker pull command"
-                                    className="shrink-0 rounded-md border border-[var(--brand-terminal)] bg-black px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-[var(--brand-terminal)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-terminal)] focus-visible:ring-offset-2 focus-visible:ring-offset-black disabled:cursor-not-allowed disabled:opacity-50"
-                                    disabled={!operatorBinaryCommand}
-                                    style={{ backgroundColor: '#000000', borderColor: 'var(--brand-terminal)', color: 'var(--brand-terminal)' }}
-                                    type="button"
-                                    onClick={() => {
-                                        copy(operatorBinaryCommand);
-                                        message.success('Copy Successfully!');
-                                    }}
-                                >
-                                    Copy
-                                </button>
-                            </div>
-                            <div className="flex min-w-0 items-start">
-                                <span
-                                    aria-hidden="true"
-                                    className="mr-3 mt-0.5 select-none font-mono text-sm font-semibold text-[var(--brand-terminal)]"
-                                >
-                                    $
-                                </span>
-                                <code
-                                    aria-label="Docker pull command"
-                                    className="min-w-0 flex-1 select-text whitespace-normal break-all !bg-black !p-0 font-mono text-sm leading-6 !text-[var(--brand-terminal)]"
-                                    style={{ backgroundColor: '#000000', color: 'var(--brand-terminal)' }}
-                                >
-                                    {operatorBinaryCommand}
-                                </code>
-                            </div>
-                        </div>
-                    </Form.Item>
-                ) : (
-                    <Form.Item style={{ marginBottom: 0 }} colon={false}>
-                        <button type="submit" className="button-primary w-full text-lg">
-                            Download
-                        </button>
-                    </Form.Item>
-                )}
-                {!isOperatorBinary && (
+                            <Form.Item name="architecture" rules={[{ required: true }]}>
+                                <FormSelect
+                                    placeholder="Architecture"
+                                    label="Architecture"
+                                    isCascader={false}
+                                    popupExtraClass={popupExtraClass}
+                                    options={getArchitectureOptions}
+                                />
+                            </Form.Item>
+                        </>
+                    ) : (
+                        <Form.Item name="version" rules={[{ required: true }]}>
+                            <FormSelect
+                                placeholder="Version"
+                                label="Version"
+                                isCascader={tool !== ToolsEnum.Operator}
+                                popupExtraClass={popupExtraClass}
+                                options={getOptions}
+                                displayRender={label => {
+                                    if (label.length > 1) {
+                                        return `${label[0]} (${label[1]})`;
+                                    }
+                                    if (label.length > 0) {
+                                        return label[label.length - 1];
+                                    }
+                                    return '';
+                                }}
+                            />
+                        </Form.Item>
+                    )
+                }
+            </Form.Item>
+            <Form.Item name="tarBall" rules={[{ required: true }]}>
+                <FormSelect
+                    placeholder="Tarball"
+                    label="Tarball"
+                    isCascader={false}
+                    popupExtraClass={popupExtraClass}
+                    options={[
+                        {
+                            label: DownloadTypeEnum.Binary,
+                            value: DownloadTypeEnum.Binary,
+                        },
+                        {
+                            label: DownloadTypeEnum.Source,
+                            value: DownloadTypeEnum.Source,
+                        },
+                    ]}
+                />
+            </Form.Item>
+            {isOperatorBinary ? (
+                <Form.Item style={{ marginBottom: 0 }} colon={false}>
                     <div
-                        className="flex cursor-pointer text-primary items-center mt-4 justify-center"
+                        className="rounded-lg border border-[var(--brand-terminal)] bg-black p-4"
+                        style={{ backgroundColor: '#000000' }}
+                    >
+                        <div className="mb-3 flex items-center justify-between gap-4 border-b border-[var(--brand-terminal)]/30 pb-3">
+                            <span className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--brand-terminal)]">
+                                Docker command
+                            </span>
+                            <button
+                                aria-label="Copy Docker pull command"
+                                className="shrink-0 rounded-md border border-[var(--brand-terminal)] bg-black px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-[var(--brand-terminal)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-terminal)] focus-visible:ring-offset-2 focus-visible:ring-offset-black disabled:cursor-not-allowed disabled:opacity-50"
+                                disabled={!operatorBinaryCommand}
+                                style={{
+                                    backgroundColor: '#000000',
+                                    borderColor: 'var(--brand-terminal)',
+                                    color: 'var(--brand-terminal)',
+                                }}
+                                type="button"
+                                onClick={() => {
+                                    copy(operatorBinaryCommand);
+                                    message.success('Copy Successfully!');
+                                }}
+                            >
+                                Copy
+                            </button>
+                        </div>
+                        <div className="flex min-w-0 items-start">
+                            <span
+                                aria-hidden="true"
+                                className="mr-3 mt-0.5 select-none font-mono text-sm font-semibold text-[var(--brand-terminal)]"
+                            >
+                                $
+                            </span>
+                            <code
+                                aria-label="Docker pull command"
+                                className="min-w-0 flex-1 select-text whitespace-normal break-all !bg-black !p-0 font-mono text-sm leading-6 !text-[var(--brand-terminal)]"
+                                style={{ backgroundColor: '#000000', color: 'var(--brand-terminal)' }}
+                            >
+                                {operatorBinaryCommand}
+                            </code>
+                        </div>
+                    </div>
+                </Form.Item>
+            ) : (
+                <Form.Item style={{ marginBottom: 0 }} colon={false}>
+                    <button
+                        type="submit"
+                        className={`w-full text-lg ${isArchive ? 'download-next__archive-button' : 'button-primary'}`}
+                    >
+                        Download
+                    </button>
+                </Form.Item>
+            )}
+            {!isOperatorBinary && (
+                <div
+                    className="flex cursor-pointer text-primary items-center mt-4 justify-center"
+                    onClick={() => {
+                        const url = getDownloadLinkByCard({
+                            version: version,
+                            cpu: architecture,
+                            tarBall: tarBall,
+                            type: '',
+                        });
+                        copy(url);
+                        message.success('Copy Successfully!');
+                    }}
+                >
+                    <span className="mr-2">Copy link</span>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+                        <rect
+                            x="2.5"
+                            y="5.5"
+                            width="8"
+                            height="8"
+                            rx="0.564706"
+                            stroke="var(--brand-primary)"
+                            strokeWidth="1.2"
+                        />
+                        <path
+                            fillRule="evenodd"
+                            clipRule="evenodd"
+                            d="M6.0999 1.89996C5.43716 1.89996 4.8999 2.43722 4.8999 3.09996V5.49995H6.0999V3.09996L12.8999 3.09996V9.89996H10.5V11.1H12.8999C13.5626 11.1 14.0999 10.5627 14.0999 9.89996V3.09996C14.0999 2.43722 13.5626 1.89996 12.8999 1.89996H6.0999Z"
+                            fill="var(--brand-primary)"
+                        />
+                    </svg>
+                </div>
+            )}
+            {!isOperatorBinary && (
+                <div className="flex justify-center mt-4">
+                    <div
+                        className="inline-flex items-center text-[#8592A6] cursor-pointer hover:underline hover:text-primary"
                         onClick={() => {
                             const url = getDownloadLinkByCard({
                                 version: version,
                                 cpu: architecture,
                                 tarBall: tarBall,
-                                type: '',
+                                type: 'asc',
                             });
-                            copy(url);
-                            message.success('Copy Successfully!');
+                            window.open(url, '_blank');
                         }}
                     >
-                        <span className="mr-2">Copy link</span>
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-                            <rect x="2.5" y="5.5" width="8" height="8" rx="0.564706" stroke="var(--brand-primary)" strokeWidth="1.2" />
-                            <path
-                                fillRule="evenodd"
-                                clipRule="evenodd"
-                                d="M6.0999 1.89996C5.43716 1.89996 4.8999 2.43722 4.8999 3.09996V5.49995H6.0999V3.09996L12.8999 3.09996V9.89996H10.5V11.1H12.8999C13.5626 11.1 14.0999 10.5627 14.0999 9.89996V3.09996C14.0999 2.43722 13.5626 1.89996 12.8999 1.89996H6.0999Z"
-                                fill="var(--brand-primary)"
-                            />
-                        </svg>
+                        ASC
                     </div>
-                )}
-                {!isOperatorBinary && (
-                    <div className="flex justify-center mt-4">
-                        <div
-                            className="inline-flex items-center text-[#8592A6] cursor-pointer hover:underline hover:text-primary"
-                            onClick={() => {
-                                const url = getDownloadLinkByCard({
-                                    version: version,
-                                    cpu: architecture,
-                                    tarBall: tarBall,
-                                    type: 'asc',
-                                });
-                                window.open(url, '_blank');
-                            }}
-                        >
-                            ASC
-                        </div>
-                        <div
-                            className="inline-flex items-center ml-4 text-[#8592A6] hover:text-primary cursor-pointer hover:underline"
-                            onClick={() => {
-                                const url = getDownloadLinkByCard({
-                                    version: version,
-                                    cpu: architecture,
-                                    tarBall: tarBall,
-                                    type: 'sha512',
-                                });
-                                window.open(url, '_blank');
-                            }}
-                        >
-                            SHA-512
-                        </div>
+                    <div
+                        className="inline-flex items-center ml-4 text-[#8592A6] hover:text-primary cursor-pointer hover:underline"
+                        onClick={() => {
+                            const url = getDownloadLinkByCard({
+                                version: version,
+                                cpu: architecture,
+                                tarBall: tarBall,
+                                type: 'sha512',
+                            });
+                            window.open(url, '_blank');
+                        }}
+                    >
+                        SHA-512
                     </div>
-                )}
-                {/* {tool === ToolsEnum.StreamLoader && ( */}
-                {/* <div className="flex justify-center mt-4 hover:text-primary">
+                </div>
+            )}
+            {/* {tool === ToolsEnum.StreamLoader && ( */}
+            {/* <div className="flex justify-center mt-4 hover:text-primary">
                     <div
                         className="inline-flex items-center text-[#8592A6] cursor-pointer hover:underline hover:text-primary"
                         onClick={() => {
@@ -333,8 +362,16 @@ export default function DownloadFormTools(props: DownloadFormToolsProps) {
                         </div>
                     </div>
                 </div> */}
-                {/* )} */}
-            </Form>
+            {/* )} */}
+        </Form>
+    );
+
+    if (bare) return formBody;
+
+    return (
+        <div className="rounded-lg border border-b-[0.375rem] border-primary px-8 pt-[3.125rem] pb-[2.1875rem]">
+            <div className="mb-8 text-xl font-medium text-left">Downloads</div>
+            {formBody}
         </div>
     );
 }

--- a/src/components/form-select/form-select.tsx
+++ b/src/components/form-select/form-select.tsx
@@ -12,6 +12,12 @@ export interface FormSelectProps {
     options: Option[];
     isCascader?: boolean;
     displayRender?: (label, selectedOptions) => ReactNode;
+    /**
+     * Extra class on the antd popup. The popup renders in a body-level portal,
+     * so a wrapper class cannot reach it — pass one here to re-tone the list
+     * (see `.form-select-select--archive` in download-page.scss).
+     */
+    popupExtraClass?: string;
 }
 
 export default function FormSelect({
@@ -24,6 +30,7 @@ export default function FormSelect({
     displayRender = label => {
         return label.length > 0 ? label[0] : '';
     },
+    popupExtraClass = '',
 }: FormSelectProps) {
     return (
         <div className="group relative z-0 w-full form-select text-left">
@@ -38,12 +45,12 @@ export default function FormSelect({
                     }}
                     options={options}
                     className={`peer block h-[3.5rem] w-full appearance-none rounded-lg  bg-transparent text-sm text-[#1D1D1D] focus:border-blue-600 focus:outline-none focus:ring-0 dark:border-gray-600 dark:text-white dark:focus:border-blue-500`}
-                    popupClassName="form-cascader"
+                    popupClassName={`form-cascader ${popupExtraClass}`}
                 />
             ) : (
                 <Select
                     suffixIcon={<ArrowDownIcon />}
-                    popupClassName="form-select-select"
+                    popupClassName={`form-select-select ${popupExtraClass}`}
                     value={value}
                     onChange={e => onChange && onChange(e || '')}
                     className={`peer block h-[3.5rem] w-full appearance-none rounded-lg  bg-transparent text-sm text-[#1D1D1D] focus:border-blue-600 focus:outline-none focus:ring-0 dark:border-gray-600 dark:text-white dark:focus:border-blue-500`}

--- a/src/constant/download.data.ts
+++ b/src/constant/download.data.ts
@@ -39,530 +39,41 @@ export const TOOL_RELEASE_NOTES: Record<ToolsEnum, string> = {
     [ToolsEnum.Operator]: '/releases/ecosystem/doris-operator',
 };
 
-export const ORIGIN = 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/';
-export enum VersionEnum {
-    Latest = '4.1.3',
-    Prev = '4.0.8',
-    Earlier = '3.1.4',
+/**
+ * Release branches Apache Doris still maintains.
+ *
+ * Anything not listed here is archived: it receives no further releases of any
+ * kind, security patches included. The ASF security team asked that the
+ * download page stop presenting archived releases alongside maintained ones,
+ * so this list is the single switch that drives the split. Adding a branch
+ * here (and to ALL_VERSIONS) is all it takes to promote it.
+ *
+ * See community/release-and-verify/release-versioning: the project maintains
+ * the two most recent minor branches, labelled Latest and Stable.
+ */
+export const ACTIVE_CORE_BRANCHES: string[] = ['4.1', '4.0'];
+
+/**
+ * Maintained lines per ecosystem tool. An entry is either a major line ('26')
+ * or an exact version ('1.0.3') for tools that do not release in lines.
+ */
+export const ACTIVE_TOOL_LINES: Record<ToolsEnum, string[]> = {
+    [ToolsEnum.Kafka]: ['26', '25'],
+    [ToolsEnum.Flink]: ['26'],
+    [ToolsEnum.Spark]: ['26'],
+    [ToolsEnum.StreamLoader]: ['1.0.3'],
+    [ToolsEnum.Operator]: ['26'],
+};
+
+export function isActiveToolVersion(tool: ToolsEnum, version: string): boolean {
+    return (ACTIVE_TOOL_LINES[tool] || []).some(line => version === line || version.split('.')[0] === line);
 }
 
+export const ORIGIN = 'https://apache-doris-releases.oss-accelerate.aliyuncs.com/';
 export enum DownloadTypeEnum {
     Binary = 'Binary',
     Source = 'Source',
 }
-export const DORIS_VERSIONS: Option[] = [
-    {
-        label: '4.1.3',
-        value: '4.1.3',
-        majorVersion: '4.1',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.1.3-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.3-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.3-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.3/',
-                version: '4.1.3-rc02',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.1.3-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.3-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.3-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.3/',
-                version: '4.1.3-rc02',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.1.3-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.3-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.3-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.3/',
-                version: '4.1.3-rc02',
-            },
-        ],
-    },
-    {
-        label: '4.1.2',
-        value: '4.1.2',
-        majorVersion: '4.1',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.1.2-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.2-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.2-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.2/',
-                version: '4.1.2',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.1.2-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.2-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.2-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.2/',
-                version: '4.1.2',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.1.2-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.2-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.2-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.2/',
-                version: '4.1.2',
-            },
-        ],
-    },
-    {
-        label: '4.1.1',
-        value: '4.1.1',
-        majorVersion: '4.1',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.1.1-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.1-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.1-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.1/',
-                version: '4.1.1',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.1.1-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.1-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.1-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.1/',
-                version: '4.1.1',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.1.1-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.1-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.1-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.1/',
-                version: '4.1.1',
-            },
-        ],
-    },
-    {
-        label: '4.1.0',
-        value: '4.1.0',
-        majorVersion: '4.1',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.1.0-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.0-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.0-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.0/',
-                version: '4.1.0',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.1.0-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.0-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.0-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.0/',
-                version: '4.1.0',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.1.0-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.1.0-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.1.0-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.0/',
-                version: '4.1.0',
-            },
-        ],
-    },
-    {
-        label: '4.0.8',
-        value: '4.0.8',
-        majorVersion: '4.0',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.0.8-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.8-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.8-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.8/',
-                version: '4.0.8',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.0.8-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.8-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.8-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.8/',
-                version: '4.0.8',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.0.8-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.8-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.8-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.8/',
-                version: '4.0.8',
-            },
-        ],
-    },
-    {
-        label: '4.0.7',
-        value: '4.0.7',
-        majorVersion: '4.0',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.0.7-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.7-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.7-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.7/',
-                version: '4.0.7',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.0.7-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.7-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.7-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.7/',
-                version: '4.0.7',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.0.7-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.7-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.7-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.7/',
-                version: '4.0.7',
-            },
-        ],
-    },
-    {
-        label: '4.0.6',
-        value: '4.0.6',
-        majorVersion: '4.0',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.0.6-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.6-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.6-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.6/',
-                version: '4.0.6',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.0.6-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.6-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.6-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.6/',
-                version: '4.0.6',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.0.6-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.6-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.6-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.6/',
-                version: '4.0.6',
-            },
-        ],
-    },
-    {
-        label: '4.0.5',
-        value: '4.0.5',
-        majorVersion: '4.0',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.0.5-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.5-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.5-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.5/',
-                version: '4.0.5',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.0.5-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.5-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.5-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.5/',
-                version: '4.0.5',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.0.5-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.5-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.5-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.5/',
-                version: '4.0.5',
-            },
-        ],
-    },
-    {
-        label: '4.0.4',
-        value: '4.0.4',
-        majorVersion: '4.0',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.0.4-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.4-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.4-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.4/',
-                version: '4.0.4',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.0.4-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.4-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.4-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.4/',
-                version: '4.0.4',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.0.4-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.4-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.4-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.4/',
-                version: '4.0.4',
-            },
-        ],
-    },
-    {
-        label: '4.0.3',
-        value: '4.0.3',
-        majorVersion: '4.0',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.0.3-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.3-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.3-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.3/',
-                version: '4.0.3-rc03',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.0.3-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.3-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.3-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.3/',
-                version: '4.0.3-rc03',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.0.3-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.3-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.3-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.3/',
-                version: '4.0.3-rc03',
-            },
-        ],
-    },
-    {
-        label: '4.0.2',
-        value: '4.0.2',
-        majorVersion: '4.0',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.0.2-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.2-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.2-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.2/',
-                version: '4.0.2-rc02',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.0.2-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.2-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.2-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.2/',
-                version: '4.0.2-rc02',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.0.2-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.2-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.2-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.2/',
-                version: '4.0.2-rc02',
-            },
-        ],
-    },
-    {
-        label: '4.0.1',
-        value: '4.0.1',
-        majorVersion: '4.0',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-4.0.1-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.1-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.1-bin-x64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.1/',
-                version: '4.0.1-rc02',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-4.0.1-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.1-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.1-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.1/',
-                version: '4.0.1-rc02',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-4.0.1-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-4.0.1-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-4.0.1-bin-arm64.tar.gz.sha512`,
-                source: 'https://dist.apache.org/repos/dist/release/doris/4.0/4.0.1/',
-                version: '4.0.1-rc02',
-            },
-        ],
-    },
-    {
-        label: '3.1.4',
-        value: '3.1.4',
-        majorVersion: '3.1',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-3.1.4-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-3.1.4-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-3.1.4-bin-x64.tar.gz.sha512`,
-                source: 'https://downloads.apache.org/doris/3.1/3.1.4/',
-                version: '3.1.4',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-3.1.4-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-3.1.4-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-3.1.4-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://downloads.apache.org/doris/3.1/3.1.4/',
-                version: '3.1.4',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-3.1.4-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-3.1.4-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-3.1.4-bin-arm64.tar.gz.sha512`,
-                source: 'https://downloads.apache.org/doris/3.1/3.1.4/',
-                version: '3.1.4',
-            },
-        ],
-    },
-    {
-        label: '3.0.8',
-        value: '3.0.8',
-        majorVersion: '3.0',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-3.0.8-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-3.0.8-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-3.0.8-bin-x64.tar.gz.sha512`,
-                source: 'https://archive.apache.org/dist/doris/3.0/3.0.8-rc01/',
-                version: '3.0.8-rc01',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-3.0.8-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-3.0.8-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-3.0.8-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://archive.apache.org/dist/doris/3.0/3.0.8-rc01/',
-                version: '3.0.8-rc01',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-3.0.8-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-3.0.8-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-3.0.8-bin-arm64.tar.gz.sha512`,
-                source: 'https://archive.apache.org/dist/doris/3.0/3.0.8-rc01/',
-                version: '3.0.8-rc01',
-            },
-        ],
-    },
-    {
-        label: '2.1.11',
-        value: '2.1.11',
-        majorVersion: '2.1',
-        children: [
-            {
-                label: CPUEnum.X64,
-                value: CPUEnum.X64,
-                gz: `${ORIGIN}apache-doris-2.1.11-bin-x64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-2.1.11-bin-x64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-2.1.11-bin-x64.tar.gz.sha512`,
-                source: 'https://downloads.apache.org/doris/2.1/2.1.11/',
-                version: '2.1.11-rc01',
-            },
-            {
-                label: CPUEnum.X64NoAvx2,
-                value: CPUEnum.X64NoAvx2,
-                gz: `${ORIGIN}apache-doris-2.1.11-bin-x64-noavx2.tar.gz`,
-                asc: `${ORIGIN}apache-doris-2.1.11-bin-x64-noavx2.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-2.1.11-bin-x64-noavx2.tar.gz.sha512`,
-                source: 'https://downloads.apache.org/doris/2.1/2.1.11/',
-                version: '2.1.11-rc01',
-            },
-            {
-                label: CPUEnum.ARM64,
-                value: CPUEnum.ARM64,
-                gz: `${ORIGIN}apache-doris-2.1.11-bin-arm64.tar.gz`,
-                asc: `${ORIGIN}apache-doris-2.1.11-bin-arm64.tar.gz.asc`,
-                sha512: `${ORIGIN}apache-doris-2.1.11-bin-arm64.tar.gz.sha512`,
-                source: 'https://downloads.apache.org/doris/2.1/2.1.11/',
-                version: '2.1.11-rc01',
-            },
-        ],
-    },
-];
-
 export type AllVersionOption = {
     label: string;
     value: string;
@@ -3624,6 +3135,54 @@ export const TOOL_VERSIONS = [
         children: DORIS_OPERATOR_VERSIONS,
     },
 ];
+
+/* ── maintained / archived views ───────────────────────────────────────────
+ * Derived from ACTIVE_CORE_BRANCHES and ACTIVE_TOOL_LINES so there is exactly
+ * one place to edit when a branch is promoted or retired.
+ * ------------------------------------------------------------------------ */
+
+export const ACTIVE_VERSIONS: AllVersionOption[] = ALL_VERSIONS.filter(branch =>
+    ACTIVE_CORE_BRANCHES.includes(branch.value),
+);
+
+export const ARCHIVED_VERSIONS: AllVersionOption[] = ALL_VERSIONS.filter(
+    branch => !ACTIVE_CORE_BRANCHES.includes(branch.value),
+);
+
+const splitToolVersions = (keepActive: boolean) =>
+    TOOL_VERSIONS.map(tool => ({
+        ...tool,
+        children: tool.children.filter(
+            version => isActiveToolVersion(tool.value as ToolsEnum, version.value) === keepActive,
+        ),
+    })).filter(tool => tool.children.length > 0);
+
+export const ACTIVE_TOOL_VERSIONS = splitToolVersions(true);
+export const ARCHIVED_TOOL_VERSIONS = splitToolVersions(false);
+
+/**
+ * The head of every maintained branch, newest branch first — what the quick
+ * download card offers. Labelled the way the versioning doc labels them:
+ * the newest branch is Latest, the oldest maintained one is Stable, and any
+ * branch in between is simply maintained.
+ */
+export const ACTIVE_HEADS: { version: string; label: string; branch: string }[] = ACTIVE_VERSIONS.map(
+    (branch, index) => ({
+        branch: branch.value,
+        version: branch.children[0].value,
+        label:
+            index === 0 ? 'Latest' : index === ACTIVE_VERSIONS.length - 1 ? 'Stable' : 'Maintained',
+    }),
+);
+
+/** Every CPU build of one core release, wherever that release lives. */
+export function findCoreRelease(version: string) {
+    for (const branch of ALL_VERSIONS) {
+        const release = branch.children.find(child => child.value === version);
+        if (release) return release;
+    }
+    return undefined;
+}
 
 export const RUN_ANYWHERE = [
     {


### PR DESCRIPTION
## What

Separate maintained releases from archived ones on `/download`, at the request of the ASF security team.

Until now every version from 0.13.0 to 4.1.3 sat in the same dropdown with an identical affordance. The only hint was one buried sentence, which had itself gone stale — it named v1.2 / v1.1 / v0.x as archival, while 3.1, 3.0, 2.1 and 2.0 had since stopped receiving fixes too.

Maintained releases now hold the page. Archived ones stay reachable, behind a plain statement of what archived means, in a zone with no brand green in it.

## How

One constant drives the split:

```ts
export const ACTIVE_CORE_BRANCHES: string[] = ['4.1', '4.0'];

export const ACTIVE_TOOL_LINES: Record<ToolsEnum, string[]> = {
    [ToolsEnum.Kafka]: ['26', '25'],
    [ToolsEnum.Flink]: ['26'],
    [ToolsEnum.Spark]: ['26'],
    [ToolsEnum.StreamLoader]: ['1.0.3'],
    [ToolsEnum.Operator]: ['26'],
};
```

`ACTIVE_VERSIONS`, `ARCHIVED_VERSIONS`, `ACTIVE_TOOL_VERSIONS`, `ARCHIVED_TOOL_VERSIONS` and `ACTIVE_HEADS` are all derived from those two, so promoting or retiring a branch is a one-line edit. This matches the published policy in `community/release-and-verify/release-versioning`: the project maintains the two most recent minor branches, labelled Latest and Stable.

**Nothing is deleted from `ALL_VERSIONS` or `TOOL_VERSIONS`.** Archiving is removal from the maintained lists, so clusters still running an older branch keep a working download path, and the archive picker reads straight from the same data.

## Page changes

- The quick download card keeps its existing segmented **Version / Architecture / Tarball** layout and offers the head of each maintained branch. A third branch adds one more segment rather than breaking the layout — verified by temporarily setting `ACTIVE_CORE_BRANCHES` to three entries.
- **Doris Releases** and **Doris Ecosystem** list maintained versions only.
- A new **Archived Releases** section carries a single Project / Version / Architecture / Tarball picker covering all 91 archived releases, plus links to the upgrade guide, the ASF security reporting page, and `archive.apache.org/dist/doris`.
- The quick card gained `KEYS` and verification links, which [ASF download-page policy](https://infra.apache.org/release-download-pages) asks for and the page did not have.

## Notable removals

`DORIS_VERSIONS` and `VersionEnum` are gone. `DORIS_VERSIONS` duplicated data that already lives in `ALL_VERSIONS` and had drifted: it still offered 3.1.4, 3.0.8 and 2.1.11 as quick downloads — exactly the versions being demoted here. The quick card now reads `ACTIVE_HEADS` and `findCoreRelease()` instead. `VersionEnum.Earlier = '3.1.4'` was the same class of hazard.

## Reuse over reimplementation

The archive reuses the existing core and tool download forms in a new `bare` mode rather than reimplementing link building, so the Flink and Spark cascaders, the Streamloader architecture picker, the Operator `docker pull` command and the pre-1.2.3 no-architecture path all keep working unchanged. Both new props (`bare`, `tone`) are optional and default to current behaviour.

## Why the add-release skill is in the same PR

It was coupled to the removed structures, and its validator did not just fail — **it lost coverage**. The `DORIS_VERSIONS` lookup threw, which skipped the entire block containing the nine binary filename checks, the source filename version, the source directory and the ordering checks. It would have reported 27 PASS / 2 FAIL while silently dropping ~20 real artifact checks.

The validator now checks the branch model, and catches the new failure mode: a release that opens a branch never added to `ACTIVE_CORE_BRANCHES` ships a version that never appears on the page, with no build error. It also verifies the release is the newest patch of its branch, since `ACTIVE_HEADS` takes the first child.

A latent bug in its array extractor is fixed too — it matched the first occurrence of an identifier, so a doc comment merely naming a constant could make it extract the wrong array.

`SKILL.md` gains two sections covering branch promotion/retirement and tool lines. It calls out the easiest trap: Streamloader's entry is an exact version, so shipping 1.0.4 without editing `ACTIVE_TOOL_LINES` leaves the new release archived on arrival.

## Verification

Against a local dev server:

| Check | Result |
| --- | --- |
| Maintained branches offered | `["4.1","4.0"]` |
| Archive branches offered | `["3.1","3.0","2.1","2.0","1.2","1.1","0.x"]` |
| Kafka / Flink / Spark / Streamloader / Operator maintained versions | `26.0.0, 25.0.0` / `26.1.1, 26.0.0` / `26.0.0` / `1.0.3` / `26.0.1, 26.0.0` |
| Pre-1.2.3 releases (0.x) | only Project + Version shown, existing `showArch` guard intact |
| Brand-green elements inside the archive zone | none |
| Filename resolution (4.0.8 + ARM64 + Source) | `apache-doris-4.0.8-src.tar.gz` |
| Release-note link tracks the version picker | `/releases/v4.1/release-4.1.3` → `/releases/v4.0/release-4.0.5` |
| Page errors | none |
| Horizontal scroll at 390px | none (`scrollWidth == 390`) |
| Internal links | all 8 resolve |
| `tsc` | same 179 pre-existing errors as before the change, 0 introduced |
| `node --test .../validate-release.test.mjs` | 6 tests, 6 pass |
| Validator against 4.1.3, incl. the twelve-artifact URL matrix | 65 checks passed |

## Out of scope, worth flagging separately

Core binaries, `.asc` and `.sha512` are served from `apache-doris-releases.oss-accelerate.aliyuncs.com`, and source tarballs deep-link `dist.apache.org`. ASF policy expects signatures, checksums and KEYS to come from the Apache distribution directory, and says not to link `dist.apache.org` directly. Not changed here, but if the security team is already looking at this page it is likely the next question.

The page is English-only: `i18n/zh-CN/code.json` holds only three theme keys and the existing `<Translate>` ids have no zh-CN messages. New copy follows that convention rather than introducing a half-wired i18n layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9C9dPvMXAqhb93sVbeyAN
