### PR TITLE
[Feat](map) Support function map_from_array/entries

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/map-functions/map-from-arrays.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/map-functions/map-from-arrays.md
@@ -1,0 +1,94 @@
+---
+{
+    "title": "MAP_FROM_ARRAYS",
+    "language": "en",
+    "description": "Constructs a MAP from a key array and a value array"
+}
+---
+
+## Description
+
+Constructs a `MAP<K, V>` from a key array and a value array. Elements at the same position form a key-value pair.
+
+## Syntax
+
+```sql
+MAP_FROM_ARRAYS(<keys>, <values>)
+```
+
+## Parameters
+
+| Parameter | Description |
+| -- | -- |
+| `<keys>` | An `ARRAY<K>`. `K` must be a type supported by MAP keys. The array and its elements can be `NULL`. |
+| `<values>` | An `ARRAY<V>`. The array and its elements can be `NULL`. When both arrays are non-`NULL`, it must have the same number of elements as `<keys>`. |
+
+## Return Value
+
+Returns a `MAP<K, V>`.
+
+- If either input array is `NULL`, returns `NULL`.
+- `NULL` elements are retained as `NULL` keys or values in the result.
+- If both arrays are non-`NULL` but have different lengths, an error is reported. The length of the other array is not checked when either array is `NULL`.
+- If a key occurs more than once, the value from the last occurrence is retained.
+- If an argument is not an array, or `K` is not a type supported by MAP keys, an analysis error is reported.
+
+## Examples
+
+```sql
+SELECT map_from_arrays([1, 2], [10, 20]) AS result;
+```
+
+```text
++--------------+
+| result       |
++--------------+
+| {1:10, 2:20} |
++--------------+
+```
+
+```sql
+SELECT map_from_arrays([1, 1], [10, 20]) AS result;
+```
+
+```text
++--------+
+| result |
++--------+
+| {1:20} |
++--------+
+```
+
+```sql
+SELECT map_from_arrays(CAST(NULL AS ARRAY<INT>), [10]);
+```
+
+```text
++-------------------------------------------------+
+| map_from_arrays(CAST(NULL AS ARRAY<INT>), [10]) |
++-------------------------------------------------+
+| NULL                                            |
++-------------------------------------------------+
+```
+
+```sql
+SELECT map_from_arrays(
+    array(CAST(NULL AS INT), 2),
+    array(10, CAST(NULL AS INT))) AS result;
+```
+
+```text
++-------------------+
+| result            |
++-------------------+
+| {null:10, 2:null} |
++-------------------+
+```
+
+```sql
+SELECT map_from_arrays([1, 2], [10]);
+```
+
+```text
+ERROR 1105 (HY000): The key and value array offsets of function map_from_arrays must be identical
+```

--- a/docs/sql-manual/sql-functions/scalar-functions/map-functions/map-from-entries.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/map-functions/map-from-entries.md
@@ -1,0 +1,106 @@
+---
+{
+    "title": "MAP_FROM_ENTRIES",
+    "language": "en",
+    "description": "Constructs a MAP from an array of two-field STRUCT entries"
+}
+---
+
+## Description
+
+Constructs a `MAP<K, V>` from an array whose elements are two-field `STRUCT`s. The first field is used as the key and the second field as the value.
+
+## Syntax
+
+```sql
+MAP_FROM_ENTRIES(<entries>)
+```
+
+## Parameters
+
+| Parameter | Description |
+| -- | -- |
+| `<entries>` | An `ARRAY<STRUCT<K, V>>`. Each STRUCT must contain exactly two fields. The array can be `NULL`, and the two fields inside a STRUCT can be `NULL`, but a STRUCT array element itself cannot be `NULL`. `K` must be a type supported by MAP keys. |
+
+## Return Value
+
+Returns a `MAP<K, V>`.
+
+- If `<entries>` is `NULL`, returns `NULL`.
+- `NULL` fields inside a non-`NULL` STRUCT are retained as `NULL` keys or values.
+- If a STRUCT array element itself is `NULL`, a runtime error is reported.
+- If the input is not an array of STRUCTs, or a STRUCT has fewer or more than two fields, an analysis error is reported.
+- If `K` is not a type supported by MAP keys, an analysis error is reported.
+- If a key occurs more than once, the value from the last occurrence is retained.
+
+## Examples
+
+```sql
+SELECT map_from_entries(array(struct(1, 10), struct(2, 20))) AS result;
+```
+
+```text
++--------------+
+| result       |
++--------------+
+| {1:10, 2:20} |
++--------------+
+```
+
+```sql
+SELECT map_from_entries(array(struct(1, 10), struct(1, 20))) AS result;
+```
+
+```text
++--------+
+| result |
++--------+
+| {1:20} |
++--------+
+```
+
+```sql
+SELECT map_from_entries(CAST(NULL AS ARRAY<STRUCT<k:INT,v:INT>>));
+```
+
+```text
++------------------------------------------------------------+
+| map_from_entries(CAST(NULL AS ARRAY<STRUCT<k:INT,v:INT>>)) |
++------------------------------------------------------------+
+| NULL                                                       |
++------------------------------------------------------------+
+```
+
+```sql
+SELECT map_from_entries(array(
+    struct(CAST(NULL AS INT), 10),
+    struct(2, CAST(NULL AS INT)))) AS result;
+```
+
+```text
++-------------------+
+| result            |
++-------------------+
+| {null:10, 2:null} |
++-------------------+
+```
+
+The following example fails because the array contains a `NULL` STRUCT element:
+
+```sql
+SELECT map_from_entries(array(CAST(NULL AS STRUCT<k:INT,v:INT>)));
+```
+
+```text
+ERROR 1105 (HY000): Map entry of function map_from_entries cannot be null
+```
+
+The following example fails during analysis because the STRUCT has three fields:
+
+```sql
+SELECT map_from_entries(array(struct(1, 2, 3)));
+```
+
+```text
+ERROR 1105 (HY000): map_from_entries requires an array of structs with exactly two fields
+```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/map-functions/map-from-arrays.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/map-functions/map-from-arrays.md
@@ -1,0 +1,94 @@
+---
+{
+    "title": "MAP_FROM_ARRAYS",
+    "language": "zh-CN",
+    "description": "根据键数组和值数组构造 MAP"
+}
+---
+
+## 描述
+
+根据键数组和值数组构造 `MAP<K, V>`。两个数组中相同位置的元素组成一个键值对。
+
+## 语法
+
+```sql
+MAP_FROM_ARRAYS(<keys>, <values>)
+```
+
+## 参数
+
+| 参数 | 描述 |
+| -- | -- |
+| `<keys>` | `ARRAY<K>` 类型。`K` 必须是 MAP 键支持的类型。数组本身及数组元素都可以为 `NULL`。 |
+| `<values>` | `ARRAY<V>` 类型。数组本身及数组元素都可以为 `NULL`。两个数组均非 `NULL` 时，元素数量必须与 `<keys>` 相同。 |
+
+## 返回值
+
+返回 `MAP<K, V>`。
+
+- 任一输入数组为 `NULL` 时，返回 `NULL`。
+- 数组中的 `NULL` 元素会作为 `NULL` 键或值保留在结果中。
+- 两个数组均非 `NULL` 且长度不同时，报错；任一数组为 `NULL` 时，不校验另一个数组的长度。
+- 同一个键出现多次时，保留最后一次出现的值。
+- 参数不是数组，或 `K` 不是 MAP 键支持的类型时，在分析阶段报错。
+
+## 示例
+
+```sql
+SELECT map_from_arrays([1, 2], [10, 20]) AS result;
+```
+
+```text
++--------------+
+| result       |
++--------------+
+| {1:10, 2:20} |
++--------------+
+```
+
+```sql
+SELECT map_from_arrays([1, 1], [10, 20]) AS result;
+```
+
+```text
++--------+
+| result |
++--------+
+| {1:20} |
++--------+
+```
+
+```sql
+SELECT map_from_arrays(CAST(NULL AS ARRAY<INT>), [10]);
+```
+
+```text
++-------------------------------------------------+
+| map_from_arrays(CAST(NULL AS ARRAY<INT>), [10]) |
++-------------------------------------------------+
+| NULL                                            |
++-------------------------------------------------+
+```
+
+```sql
+SELECT map_from_arrays(
+    array(CAST(NULL AS INT), 2),
+    array(10, CAST(NULL AS INT))) AS result;
+```
+
+```text
++-------------------+
+| result            |
++-------------------+
+| {null:10, 2:null} |
++-------------------+
+```
+
+```sql
+SELECT map_from_arrays([1, 2], [10]);
+```
+
+```text
+ERROR 1105 (HY000): The key and value array offsets of function map_from_arrays must be identical
+```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/map-functions/map-from-entries.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/map-functions/map-from-entries.md
@@ -1,0 +1,106 @@
+---
+{
+    "title": "MAP_FROM_ENTRIES",
+    "language": "zh-CN",
+    "description": "根据二字段 STRUCT 数组构造 MAP"
+}
+---
+
+## 描述
+
+根据元素为二字段 `STRUCT` 的数组构造 `MAP<K, V>`。STRUCT 的第一个字段作为键，第二个字段作为值。
+
+## 语法
+
+```sql
+MAP_FROM_ENTRIES(<entries>)
+```
+
+## 参数
+
+| 参数 | 描述 |
+| -- | -- |
+| `<entries>` | `ARRAY<STRUCT<K, V>>` 类型。每个 STRUCT 必须恰好包含两个字段。数组本身可以为 `NULL`，STRUCT 内的两个字段也可以为 `NULL`，但 STRUCT 数组元素本身不能为 `NULL`。`K` 必须是 MAP 键支持的类型。 |
+
+## 返回值
+
+返回 `MAP<K, V>`。
+
+- `<entries>` 为 `NULL` 时，返回 `NULL`。
+- 非 `NULL` STRUCT 内的 `NULL` 字段会作为 `NULL` 键或值保留在结果中。
+- STRUCT 数组元素本身为 `NULL` 时，在运行阶段报错。
+- 输入不是 STRUCT 数组，或 STRUCT 少于或多于两个字段时，在分析阶段报错。
+- `K` 不是 MAP 键支持的类型时，在分析阶段报错。
+- 同一个键出现多次时，保留最后一次出现的值。
+
+## 示例
+
+```sql
+SELECT map_from_entries(array(struct(1, 10), struct(2, 20))) AS result;
+```
+
+```text
++--------------+
+| result       |
++--------------+
+| {1:10, 2:20} |
++--------------+
+```
+
+```sql
+SELECT map_from_entries(array(struct(1, 10), struct(1, 20))) AS result;
+```
+
+```text
++--------+
+| result |
++--------+
+| {1:20} |
++--------+
+```
+
+```sql
+SELECT map_from_entries(CAST(NULL AS ARRAY<STRUCT<k:INT,v:INT>>));
+```
+
+```text
++------------------------------------------------------------+
+| map_from_entries(CAST(NULL AS ARRAY<STRUCT<k:INT,v:INT>>)) |
++------------------------------------------------------------+
+| NULL                                                       |
++------------------------------------------------------------+
+```
+
+```sql
+SELECT map_from_entries(array(
+    struct(CAST(NULL AS INT), 10),
+    struct(2, CAST(NULL AS INT)))) AS result;
+```
+
+```text
++-------------------+
+| result            |
++-------------------+
+| {null:10, 2:null} |
++-------------------+
+```
+
+以下示例因为数组中包含 `NULL` STRUCT 元素而报错：
+
+```sql
+SELECT map_from_entries(array(CAST(NULL AS STRUCT<k:INT,v:INT>)));
+```
+
+```text
+ERROR 1105 (HY000): Map entry of function map_from_entries cannot be null
+```
+
+以下示例因为 STRUCT 包含三个字段而在分析阶段报错：
+
+```sql
+SELECT map_from_entries(array(struct(1, 2, 3)));
+```
+
+```text
+ERROR 1105 (HY000): map_from_entries requires an array of structs with exactly two fields
+```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/map-functions/map-from-arrays.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/map-functions/map-from-arrays.md
@@ -1,0 +1,98 @@
+---
+{
+    "title": "MAP_FROM_ARRAYS",
+    "language": "zh-CN",
+    "description": "根据键数组和值数组构造 MAP"
+}
+---
+
+## 描述
+
+根据键数组和值数组构造 `MAP<K, V>`。两个数组中相同位置的元素组成一个键值对。
+
+:::note
+自 Apache Doris 4.2 起支持该函数。
+:::
+
+## 语法
+
+```sql
+MAP_FROM_ARRAYS(<keys>, <values>)
+```
+
+## 参数
+
+| 参数 | 描述 |
+| -- | -- |
+| `<keys>` | `ARRAY<K>` 类型。`K` 必须是 MAP 键支持的类型。数组本身及数组元素都可以为 `NULL`。 |
+| `<values>` | `ARRAY<V>` 类型。数组本身及数组元素都可以为 `NULL`。两个数组均非 `NULL` 时，元素数量必须与 `<keys>` 相同。 |
+
+## 返回值
+
+返回 `MAP<K, V>`。
+
+- 任一输入数组为 `NULL` 时，返回 `NULL`。
+- 数组中的 `NULL` 元素会作为 `NULL` 键或值保留在结果中。
+- 两个数组均非 `NULL` 且长度不同时，报错；任一数组为 `NULL` 时，不校验另一个数组的长度。
+- 同一个键出现多次时，保留最后一次出现的值。
+- 参数不是数组，或 `K` 不是 MAP 键支持的类型时，在分析阶段报错。
+
+## 示例
+
+```sql
+SELECT map_from_arrays([1, 2], [10, 20]) AS result;
+```
+
+```text
++--------------+
+| result       |
++--------------+
+| {1:10, 2:20} |
++--------------+
+```
+
+```sql
+SELECT map_from_arrays([1, 1], [10, 20]) AS result;
+```
+
+```text
++--------+
+| result |
++--------+
+| {1:20} |
++--------+
+```
+
+```sql
+SELECT map_from_arrays(CAST(NULL AS ARRAY<INT>), [10]);
+```
+
+```text
++-------------------------------------------------+
+| map_from_arrays(CAST(NULL AS ARRAY<INT>), [10]) |
++-------------------------------------------------+
+| NULL                                            |
++-------------------------------------------------+
+```
+
+```sql
+SELECT map_from_arrays(
+    array(CAST(NULL AS INT), 2),
+    array(10, CAST(NULL AS INT))) AS result;
+```
+
+```text
++-------------------+
+| result            |
++-------------------+
+| {null:10, 2:null} |
++-------------------+
+```
+
+```sql
+SELECT map_from_arrays([1, 2], [10]);
+```
+
+```text
+ERROR 1105 (HY000): The key and value array offsets of function map_from_arrays must be identical
+```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/map-functions/map-from-entries.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/sql-manual/sql-functions/scalar-functions/map-functions/map-from-entries.md
@@ -1,0 +1,110 @@
+---
+{
+    "title": "MAP_FROM_ENTRIES",
+    "language": "zh-CN",
+    "description": "根据二字段 STRUCT 数组构造 MAP"
+}
+---
+
+## 描述
+
+根据元素为二字段 `STRUCT` 的数组构造 `MAP<K, V>`。STRUCT 的第一个字段作为键，第二个字段作为值。
+
+:::note
+自 Apache Doris 4.2 起支持该函数。
+:::
+
+## 语法
+
+```sql
+MAP_FROM_ENTRIES(<entries>)
+```
+
+## 参数
+
+| 参数 | 描述 |
+| -- | -- |
+| `<entries>` | `ARRAY<STRUCT<K, V>>` 类型。每个 STRUCT 必须恰好包含两个字段。数组本身可以为 `NULL`，STRUCT 内的两个字段也可以为 `NULL`，但 STRUCT 数组元素本身不能为 `NULL`。`K` 必须是 MAP 键支持的类型。 |
+
+## 返回值
+
+返回 `MAP<K, V>`。
+
+- `<entries>` 为 `NULL` 时，返回 `NULL`。
+- 非 `NULL` STRUCT 内的 `NULL` 字段会作为 `NULL` 键或值保留在结果中。
+- STRUCT 数组元素本身为 `NULL` 时，在运行阶段报错。
+- 输入不是 STRUCT 数组，或 STRUCT 少于或多于两个字段时，在分析阶段报错。
+- `K` 不是 MAP 键支持的类型时，在分析阶段报错。
+- 同一个键出现多次时，保留最后一次出现的值。
+
+## 示例
+
+```sql
+SELECT map_from_entries(array(struct(1, 10), struct(2, 20))) AS result;
+```
+
+```text
++--------------+
+| result       |
++--------------+
+| {1:10, 2:20} |
++--------------+
+```
+
+```sql
+SELECT map_from_entries(array(struct(1, 10), struct(1, 20))) AS result;
+```
+
+```text
++--------+
+| result |
++--------+
+| {1:20} |
++--------+
+```
+
+```sql
+SELECT map_from_entries(CAST(NULL AS ARRAY<STRUCT<k:INT,v:INT>>));
+```
+
+```text
++------------------------------------------------------------+
+| map_from_entries(CAST(NULL AS ARRAY<STRUCT<k:INT,v:INT>>)) |
++------------------------------------------------------------+
+| NULL                                                       |
++------------------------------------------------------------+
+```
+
+```sql
+SELECT map_from_entries(array(
+    struct(CAST(NULL AS INT), 10),
+    struct(2, CAST(NULL AS INT)))) AS result;
+```
+
+```text
++-------------------+
+| result            |
++-------------------+
+| {null:10, 2:null} |
++-------------------+
+```
+
+以下示例因为数组中包含 `NULL` STRUCT 元素而报错：
+
+```sql
+SELECT map_from_entries(array(CAST(NULL AS STRUCT<k:INT,v:INT>)));
+```
+
+```text
+ERROR 1105 (HY000): Map entry of function map_from_entries cannot be null
+```
+
+以下示例因为 STRUCT 包含三个字段而在分析阶段报错：
+
+```sql
+SELECT map_from_entries(array(struct(1, 2, 3)));
+```
+
+```text
+ERROR 1105 (HY000): map_from_entries requires an array of structs with exactly two fields
+```

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1767,6 +1767,8 @@ const sidebars: SidebarsConfig = {
                                         'sql-manual/sql-functions/scalar-functions/map-functions/map-contains-key',
                                         'sql-manual/sql-functions/scalar-functions/map-functions/map-contains-value',
                                         'sql-manual/sql-functions/scalar-functions/map-functions/map-entries',
+                                        'sql-manual/sql-functions/scalar-functions/map-functions/map-from-arrays',
+                                        'sql-manual/sql-functions/scalar-functions/map-functions/map-from-entries',
                                         'sql-manual/sql-functions/scalar-functions/map-functions/map-keys',
                                         'sql-manual/sql-functions/scalar-functions/map-functions/map-size',
                                         'sql-manual/sql-functions/scalar-functions/map-functions/map-values',

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/map-functions/map-from-arrays.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/map-functions/map-from-arrays.md
@@ -1,0 +1,98 @@
+---
+{
+    "title": "MAP_FROM_ARRAYS",
+    "language": "en",
+    "description": "Constructs a MAP from a key array and a value array"
+}
+---
+
+## Description
+
+Constructs a `MAP<K, V>` from a key array and a value array. Elements at the same position form a key-value pair.
+
+:::note
+This function is supported since Apache Doris 4.2.
+:::
+
+## Syntax
+
+```sql
+MAP_FROM_ARRAYS(<keys>, <values>)
+```
+
+## Parameters
+
+| Parameter | Description |
+| -- | -- |
+| `<keys>` | An `ARRAY<K>`. `K` must be a type supported by MAP keys. The array and its elements can be `NULL`. |
+| `<values>` | An `ARRAY<V>`. The array and its elements can be `NULL`. When both arrays are non-`NULL`, it must have the same number of elements as `<keys>`. |
+
+## Return Value
+
+Returns a `MAP<K, V>`.
+
+- If either input array is `NULL`, returns `NULL`.
+- `NULL` elements are retained as `NULL` keys or values in the result.
+- If both arrays are non-`NULL` but have different lengths, an error is reported. The length of the other array is not checked when either array is `NULL`.
+- If a key occurs more than once, the value from the last occurrence is retained.
+- If an argument is not an array, or `K` is not a type supported by MAP keys, an analysis error is reported.
+
+## Examples
+
+```sql
+SELECT map_from_arrays([1, 2], [10, 20]) AS result;
+```
+
+```text
++--------------+
+| result       |
++--------------+
+| {1:10, 2:20} |
++--------------+
+```
+
+```sql
+SELECT map_from_arrays([1, 1], [10, 20]) AS result;
+```
+
+```text
++--------+
+| result |
++--------+
+| {1:20} |
++--------+
+```
+
+```sql
+SELECT map_from_arrays(CAST(NULL AS ARRAY<INT>), [10]);
+```
+
+```text
++-------------------------------------------------+
+| map_from_arrays(CAST(NULL AS ARRAY<INT>), [10]) |
++-------------------------------------------------+
+| NULL                                            |
++-------------------------------------------------+
+```
+
+```sql
+SELECT map_from_arrays(
+    array(CAST(NULL AS INT), 2),
+    array(10, CAST(NULL AS INT))) AS result;
+```
+
+```text
++-------------------+
+| result            |
++-------------------+
+| {null:10, 2:null} |
++-------------------+
+```
+
+```sql
+SELECT map_from_arrays([1, 2], [10]);
+```
+
+```text
+ERROR 1105 (HY000): The key and value array offsets of function map_from_arrays must be identical
+```

--- a/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/map-functions/map-from-entries.md
+++ b/versioned_docs/version-4.x/sql-manual/sql-functions/scalar-functions/map-functions/map-from-entries.md
@@ -1,0 +1,110 @@
+---
+{
+    "title": "MAP_FROM_ENTRIES",
+    "language": "en",
+    "description": "Constructs a MAP from an array of two-field STRUCT entries"
+}
+---
+
+## Description
+
+Constructs a `MAP<K, V>` from an array whose elements are two-field `STRUCT`s. The first field is used as the key and the second field as the value.
+
+:::note
+This function is supported since Apache Doris 4.2.
+:::
+
+## Syntax
+
+```sql
+MAP_FROM_ENTRIES(<entries>)
+```
+
+## Parameters
+
+| Parameter | Description |
+| -- | -- |
+| `<entries>` | An `ARRAY<STRUCT<K, V>>`. Each STRUCT must contain exactly two fields. The array can be `NULL`, and the two fields inside a STRUCT can be `NULL`, but a STRUCT array element itself cannot be `NULL`. `K` must be a type supported by MAP keys. |
+
+## Return Value
+
+Returns a `MAP<K, V>`.
+
+- If `<entries>` is `NULL`, returns `NULL`.
+- `NULL` fields inside a non-`NULL` STRUCT are retained as `NULL` keys or values.
+- If a STRUCT array element itself is `NULL`, a runtime error is reported.
+- If the input is not an array of STRUCTs, or a STRUCT has fewer or more than two fields, an analysis error is reported.
+- If `K` is not a type supported by MAP keys, an analysis error is reported.
+- If a key occurs more than once, the value from the last occurrence is retained.
+
+## Examples
+
+```sql
+SELECT map_from_entries(array(struct(1, 10), struct(2, 20))) AS result;
+```
+
+```text
++--------------+
+| result       |
++--------------+
+| {1:10, 2:20} |
++--------------+
+```
+
+```sql
+SELECT map_from_entries(array(struct(1, 10), struct(1, 20))) AS result;
+```
+
+```text
++--------+
+| result |
++--------+
+| {1:20} |
++--------+
+```
+
+```sql
+SELECT map_from_entries(CAST(NULL AS ARRAY<STRUCT<k:INT,v:INT>>));
+```
+
+```text
++------------------------------------------------------------+
+| map_from_entries(CAST(NULL AS ARRAY<STRUCT<k:INT,v:INT>>)) |
++------------------------------------------------------------+
+| NULL                                                       |
++------------------------------------------------------------+
+```
+
+```sql
+SELECT map_from_entries(array(
+    struct(CAST(NULL AS INT), 10),
+    struct(2, CAST(NULL AS INT)))) AS result;
+```
+
+```text
++-------------------+
+| result            |
++-------------------+
+| {null:10, 2:null} |
++-------------------+
+```
+
+The following example fails because the array contains a `NULL` STRUCT element:
+
+```sql
+SELECT map_from_entries(array(CAST(NULL AS STRUCT<k:INT,v:INT>)));
+```
+
+```text
+ERROR 1105 (HY000): Map entry of function map_from_entries cannot be null
+```
+
+The following example fails during analysis because the STRUCT has three fields:
+
+```sql
+SELECT map_from_entries(array(struct(1, 2, 3)));
+```
+
+```text
+ERROR 1105 (HY000): map_from_entries requires an array of structs with exactly two fields
+```

--- a/versioned_sidebars/version-4.x-sidebars.json
+++ b/versioned_sidebars/version-4.x-sidebars.json
@@ -1938,6 +1938,8 @@
                         "sql-manual/sql-functions/scalar-functions/map-functions/map-contains-key",
                         "sql-manual/sql-functions/scalar-functions/map-functions/map-contains-value",
                         "sql-manual/sql-functions/scalar-functions/map-functions/map-entries",
+                        "sql-manual/sql-functions/scalar-functions/map-functions/map-from-arrays",
+                        "sql-manual/sql-functions/scalar-functions/map-functions/map-from-entries",
                         "sql-manual/sql-functions/scalar-functions/map-functions/map-keys",
                         "sql-manual/sql-functions/scalar-functions/map-functions/map-size",
                         "sql-manual/sql-functions/scalar-functions/map-functions/map-values",


### PR DESCRIPTION
## Versions 

- [x] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [ ] Chinese
- [ ] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
- [ ] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync
