### PR TITLE
[doc](lance) document string predicate pushdown

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/lance-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/lakehouse/catalogs/lance-catalog.mdx
@@ -325,13 +325,17 @@ Doris 会将语义兼容的谓词转换为 Substrait 表达式，并交给 Lance
 | `<=>` | 直接的列与常量 Null-safe 等值比较；在 `NOT`、`AND` 或 `OR` 中仍保持非 `NULL` 的二值逻辑结果 |
 | `IN`、`NOT IN` | 非空常量列表，列表中不能包含 `NULL` |
 | `IS NULL`、`IS NOT NULL` | 直接引用列 |
+| 布尔列、`NOT` 布尔列 | 直接引用布尔列 |
+| `LIKE`、`NOT LIKE` | 直接引用 `utf8` 或 `large_utf8` 列，模式为字符串字面量，且不包含反斜杠转义、显式 `ESCAPE` 子句或 NUL 字符 |
+| `starts_with`、`ends_with` | 使用内置函数，第一个参数直接引用 `utf8` 或 `large_utf8` 列，第二个参数为字符串字面量 |
 | `AND` | 顶层 Conjunct 可以分别下推，不能下推的部分保留在 Doris |
 | `OR` | 两个分支都能完整转换时下推 |
 | `NOT` | 操作数能完整转换时下推 |
 
 以下形式通常不会下推：
 
-- 列上包含函数或算术表达式。
+- 除上述内置字符串函数之外的函数，或列上的算术表达式。名称为 `like`、`starts_with` 或 `ends_with` 的用户自定义函数不会按同名内置函数下推。
+- 模式包含 NUL 字符的字符串谓词。使用反斜杠转义或显式 `ESCAPE` 子句的 `LIKE`、`NOT LIKE` 也保留在 Doris。
 - `IN` 列表为空或包含 `NULL`。
 - `OR` 或 `NOT` 中只有部分表达式可转换。
 - 数据类型或常量值无法无损转换到 Lance。
@@ -342,7 +346,9 @@ Doris 会将语义兼容的谓词转换为 Substrait 表达式，并交给 Lance
 EXPLAIN
 SELECT user_id
 FROM lance_catalog.default.user_profiles
-WHERE age >= 18 AND country IN ('CN', 'US');
+WHERE active
+  AND starts_with(name, 'A')
+  AND country LIKE 'C%';
 ```
 
 ## 使用文件 TVF 查询 Lance

--- a/versioned_docs/version-4.x/lakehouse/catalogs/lance-catalog.mdx
+++ b/versioned_docs/version-4.x/lakehouse/catalogs/lance-catalog.mdx
@@ -325,13 +325,17 @@ Predicates on other readable types, including `float16`, `decimal256`, Binary, `
 | `<=>` | Direct null-safe equality comparison between a column and a constant; preserves a non-`NULL`, two-valued result inside `NOT`, `AND`, or `OR` |
 | `IN`, `NOT IN` | Non-empty constant list that does not contain `NULL` |
 | `IS NULL`, `IS NOT NULL` | Direct column reference |
+| Boolean column, `NOT` Boolean column | Direct Boolean column reference |
+| `LIKE`, `NOT LIKE` | Direct `utf8` or `large_utf8` column and a string literal pattern without backslash escapes, an explicit `ESCAPE` clause, or an embedded NUL character |
+| `starts_with`, `ends_with` | Built-in function with a direct `utf8` or `large_utf8` column and a string literal |
 | `AND` | Top-level conjuncts can be pushed down independently, with unsupported conjuncts retained in Doris |
 | `OR` | Both branches must be fully convertible |
 | `NOT` | The operand must be fully convertible |
 
 The following forms are generally not pushed down:
 
-- Functions or arithmetic expressions applied to a column.
+- Functions other than the supported built-in string functions, or arithmetic expressions applied to a column. A user-defined function named `like`, `starts_with`, or `ends_with` is not treated as the corresponding built-in function.
+- String predicates whose pattern contains an embedded NUL character. `LIKE` and `NOT LIKE` patterns that use a backslash escape or an explicit `ESCAPE` clause also remain in Doris.
 - An empty `IN` list or an `IN` list containing `NULL`.
 - An `OR` or `NOT` expression in which only part of the expression can be converted.
 - A data type or constant value that cannot be converted to Lance without loss.
@@ -342,7 +346,9 @@ Use `lancePushdownPredicate` in `EXPLAIN` to inspect the conditions that are act
 EXPLAIN
 SELECT user_id
 FROM lance_catalog.default.user_profiles
-WHERE age >= 18 AND country IN ('CN', 'US');
+WHERE active
+  AND starts_with(name, 'A')
+  AND country LIKE 'C%';
 ```
 
 ## Query Lance with File TVFs


### PR DESCRIPTION
Documents the string and Boolean predicate pushdown support added by apache/doris#67051.

## What Changed

- Added direct Boolean predicates, `LIKE` / `NOT LIKE`, `starts_with`, and `ends_with` to the supported predicate table.
- Documented the direct-column/literal requirements and the safety fallbacks for escaped or NUL-bearing patterns and same-named UDFs.
- Updated the `EXPLAIN` example to show the new predicate forms.
- Kept the English and Chinese 4.x pages synchronized.

`docs/` (dev) is intentionally untouched because the Lance Catalog page exists only under 4.x; apache/doris master currently has no Lance integration.

## Validation

- `git diff --check`
- `node scripts/docs-governance/report.js --changed --format github` (no new blocking findings; existing SEO and missing-current-page warnings remain)

## Versions 

- [ ] dev
- [x] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [ ] If only one language changed, confirmed whether source/translation counterparts need sync