### PR TITLE
[doc](upgrade) Fix broken zh-CN versioning link in cluster upgrade docs

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/cluster-management/upgrade.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/admin-manual/cluster-management/upgrade.md
@@ -63,7 +63,7 @@ Doris 版本号由三位组成，第一位表示重大里程碑版本，第二�
 | 二位版本 | 不建议跨版本 | 按二位版本号依次升级，如 3.0 → 3.1 → 3.2 → 3.3 |
 | 一位版本 | 不建议跨版本 | 先升至同一位的最新二位版本，再跨大版本升级 |
 
-详细版本说明可参考 [版本规则](https://doris.apache.org/zh-CN/community/release-versioning)。
+详细版本说明可参考 [版本规则](https://doris.apache.org/zh-CN/community/release-and-verify/release-versioning)。
 
 ## 升级注意事项
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/cluster-management/upgrade.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/admin-manual/cluster-management/upgrade.md
@@ -18,7 +18,7 @@ Doris 版本号由三维组成，第一位表示重大里程碑版本，第二�
 
 * 二位版本及一位版本：不建议跨二位版本升级，考虑到兼容性问题，建议按照二位版本号依次升级，如 3.0 版本升级到 3.3 版本，需要按照 3.0 -> 3.1 -> 3.2 -> 3.3 的执行路径升级。
 
-详细版本说明可以参考[版本规则](https://doris.apache.org/zh-CN/community/release-versioning)。
+详细版本说明可以参考[版本规则](https://doris.apache.org/zh-CN/community/release-and-verify/release-versioning)。
 
 ## 升级注意事项
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/cluster-management/upgrade.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/admin-manual/cluster-management/upgrade.md
@@ -18,7 +18,7 @@ Doris 版本号由三位组成，第一位表示重大里程碑版本，第二�
 
 * 二位版本及一位版本：不建议跨二位版本升级，考虑到兼容性问题，建议按照二位版本号依次升级，如 3.0 版本升级到 3.3 版本，需要按照 3.0 -> 3.1 -> 3.2 -> 3.3 的执行路径升级。
 
-详细版本说明可以参考[版本规则](https://doris.apache.org/zh-CN/community/release-versioning)。
+详细版本说明可以参考[版本规则](https://doris.apache.org/zh-CN/community/release-and-verify/release-versioning)。
 
 ## 升级注意事项
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/cluster-management/upgrade.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-4.x/admin-manual/cluster-management/upgrade.md
@@ -63,7 +63,7 @@ Doris 版本号由三位组成，第一位表示重大里程碑版本，第二�
 | 二位版本 | 不建议跨版本 | 按二位版本号依次升级，如 3.0 → 3.1 → 3.2 → 3.3 |
 | 一位版本 | 不建议跨版本 | 先升至同一位的最新二位版本，再跨大版本升级 |
 
-详细版本说明可参考 [版本规则](https://doris.apache.org/zh-CN/community/release-versioning)。
+详细版本说明可参考 [版本规则](https://doris.apache.org/zh-CN/community/release-and-verify/release-versioning)。
 
 ## 升级注意事项
 


### PR DESCRIPTION
## Summary
- Chinese cluster-upgrade pages linked to `/zh-CN/community/release-versioning`, which 404s.
- Point them at `/zh-CN/community/release-and-verify/release-versioning`, matching the English docs.

Fixes #4006

## Test plan
- [ ] Confirm https://doris.apache.org/zh-CN/community/release-versioning still 404s
- [ ] Confirm https://doris.apache.org/zh-CN/community/release-and-verify/release-versioning loads
- [ ] After merge, check the 版本规则 link on 3.x / 4.x / 2.1 / dev Chinese upgrade pages