### PR TITLE
[doc](sql-functions) Sort EXPLODE_SPLIT example output to match ORDER BY

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0/sql-manual/sql-functions/table-functions/explode-split.md
@@ -65,9 +65,9 @@ mysql> select k1, e1 from example1 lateral view explode_split(k2, ',') tmp1 as e
 +------+------+
 | k1   | e1   |
 +------+------+
+|    5 | 1    |
 |    5 | 2    |
 |    5 | 3    |
-|    5 | 1    |
 +------+------+
 
 mysql> select k1, e1 from example1 lateral view explode_split(k2, ',') tmp1 as e1 where k1 = 6 order by k1, e1;

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-functions/table-functions/explode-split.md
@@ -103,9 +103,9 @@ select k1, e1 from example1 lateral view explode_split(k2, ',') tmp1 as e1 where
 +------+------+
 | k1   | e1   |
 +------+------+
+|    5 | 1    |
 |    5 | 2    |
 |    5 | 3    |
-|    5 | 1    |
 +------+------+
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-3.x/sql-manual/sql-functions/table-functions/explode-split.md
@@ -103,9 +103,9 @@ select k1, e1 from example1 lateral view explode_split(k2, ',') tmp1 as e1 where
 +------+------+
 | k1   | e1   |
 +------+------+
+|    5 | 1    |
 |    5 | 2    |
 |    5 | 3    |
-|    5 | 1    |
 +------+------+
 ```
 

--- a/versioned_docs/version-2.0/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/versioned_docs/version-2.0/sql-manual/sql-functions/table-functions/explode-split.md
@@ -71,9 +71,9 @@ mysql> select k1, e1 from example1 lateral view explode_split(k2, ',') tmp1 as e
 +------+------+
 | k1   | e1   |
 +------+------+
+|    5 | 1    |
 |    5 | 2    |
 |    5 | 3    |
-|    5 | 1    |
 +------+------+
 
 mysql> select k1, e1 from example1 lateral view explode_split(k2, ',') tmp1 as e1 where k1 = 6 order by k1, e1;

--- a/versioned_docs/version-2.1/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/versioned_docs/version-2.1/sql-manual/sql-functions/table-functions/explode-split.md
@@ -104,9 +104,9 @@ select k1, e1 from example1 lateral view explode_split(k2, ',') tmp1 as e1 where
 +------+------+
 | k1   | e1   |
 +------+------+
+|    5 | 1    |
 |    5 | 2    |
 |    5 | 3    |
-|    5 | 1    |
 +------+------+
 ```
 

--- a/versioned_docs/version-3.x/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/versioned_docs/version-3.x/sql-manual/sql-functions/table-functions/explode-split.md
@@ -104,9 +104,9 @@ select k1, e1 from example1 lateral view explode_split(k2, ',') tmp1 as e1 where
 +------+------+
 | k1   | e1   |
 +------+------+
+|    5 | 1    |
 |    5 | 2    |
 |    5 | 3    |
-|    5 | 1    |
 +------+------+
 ```
 


### PR DESCRIPTION
## Summary
- The `k1 = 5` example uses `ORDER BY k1, e1` with `k2 = 1,2,3`, but the printed rows were `2, 3, 1`.
- Update the expected output to `1, 2, 3` in the 3.x / 2.1 / 2.0 English and zh-CN pages.

Fixes #3889

## Test plan
- [ ] Compare the `k1 = 5` result table with `ORDER BY k1, e1` on 2.1 / 3.x
- [ ] Confirm 4.x, current, and 1.2 pages were already sorted and were not changed