### PR TITLE
[docs] Add connector release notes and downloads

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/ecosystem/doris-flink-connector.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/ecosystem/doris-flink-connector.md
@@ -10,6 +10,36 @@
 
 本文按版本倒序列出 Doris Flink Connector 的版本发布说明。
 
+## 26.2.0
+
+来源：[Release Note 26.2.0](https://github.com/apache/doris-flink-connector/issues/691)
+
+### 功能与改进
+
+- Doris Source 支持 snapshot、incremental 和 initial 三种扫描模式。[#679](https://github.com/apache/doris-flink-connector/pull/679)
+- 支持通过 HTTP、MySQL/JDBC、Thrift 和 Arrow Flight SQL 与 Doris 建立单向 TLS 连接。[#686](https://github.com/apache/doris-flink-connector/pull/686)
+- 支持 S3 TVF Sink 写入模式。[#688](https://github.com/apache/doris-flink-connector/pull/688)
+- 为 Flink 2.x 增加 JDK 21 构建和 CI 验证。[#678](https://github.com/apache/doris-flink-connector/pull/678)
+- 上报标准 FLIP-33 Sink 指标 `numRecordsSend` 和 `numBytesSend`。[#681](https://github.com/apache/doris-flink-connector/pull/681)
+- CDC 同步支持 PostgreSQL `regclass` 类型。[#658](https://github.com/apache/doris-flink-connector/pull/658)
+- 增加 Doris 回归测试程序。[#687](https://github.com/apache/doris-flink-connector/pull/687)
+
+### Bug 修复
+
+- 修复大表 initial snapshot 的 checkpoint state 过大的问题。[#690](https://github.com/apache/doris-flink-connector/pull/690)
+- 修复 `DorisWriter` abort 错误事务的问题。[#683](https://github.com/apache/doris-flink-connector/pull/683)
+- 修复 `fullDocument` 以 JSON 字符串返回时 MongoDB CDC 的解析问题。[#671](https://github.com/apache/doris-flink-connector/pull/671)
+- 修复 Doris `DATETIME` 和 `TIMESTAMPTZ` 类型的 Arrow timestamp 转换问题。[#676](https://github.com/apache/doris-flink-connector/pull/676)
+
+### 致谢
+
+- @Cq-study
+- @JNSimba
+- @liujiwen-up
+- @Sbaia
+- @Tan-JiaLiang
+- @ziyanTOP
+
 ## 26.1.1
 
 来源：[Release Note 26.1.1](https://github.com/apache/doris-flink-connector/issues/654)

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/ecosystem/doris-kafka-connector.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/ecosystem/doris-kafka-connector.md
@@ -10,6 +10,21 @@
 
 本文按版本倒序列出 Doris Kafka Connector 的版本发布说明。
 
+## 26.1.0
+
+来源：[Release Note 26.1.0](https://github.com/apache/doris-kafka-connector/issues/102)
+
+### 功能与改进
+
+- 缓存可用 BE，避免每次 load 前都执行 HTTP 探测。[#99](https://github.com/apache/doris-kafka-connector/pull/99)
+- 支持与 Doris 建立单向 TLS 连接。[#100](https://github.com/apache/doris-kafka-connector/pull/100)
+- combined at-least-once 写入支持 S3 TVF Sink 模式。[#101](https://github.com/apache/doris-kafka-connector/pull/101)
+
+### 致谢
+
+- @diggle1
+- @JNSimba
+
 ## 26.0.0
 
 来源：[Release Note 26.0.0](https://github.com/apache/doris-kafka-connector/issues/98)

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/ecosystem/doris-spark-connector.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/ecosystem/doris-spark-connector.md
@@ -10,6 +10,33 @@
 
 本文按版本倒序列出 Doris Spark Connector 的版本发布说明。
 
+## 26.1.0
+
+来源：[Spark Doris Connector 26.1.0](https://github.com/apache/doris-spark-connector/issues/372)
+
+### Spark Connector
+
+#### 功能与改进
+
+- 支持将 Doris `ARRAY` 列映射为 Spark `Array[String]`。[#362](https://github.com/apache/doris-spark-connector/pull/362)
+- 支持 Spark 4.1。[#365](https://github.com/apache/doris-spark-connector/pull/365)
+- 支持与 Doris 建立单向 TLS 连接。[#369](https://github.com/apache/doris-spark-connector/pull/369)
+- 增加 Doris 回归测试程序。[#370](https://github.com/apache/doris-spark-connector/pull/370)
+- 支持 S3 TVF batch sink 模式。[#371](https://github.com/apache/doris-spark-connector/pull/371)
+- 默认使用 Arrow Flight SQL 读取，不可用时回退到 Thrift。[#367](https://github.com/apache/doris-spark-connector/pull/367)
+
+#### Bug 修复
+
+- 修复 cloud mode 下指定 compute group 的 backend discovery 问题。[#361](https://github.com/apache/doris-spark-connector/pull/361)
+- 修复 Doris `DATETIME` 和 `TIMESTAMPTZ` 类型的 Arrow timestamp 转换问题。[#366](https://github.com/apache/doris-spark-connector/pull/366)
+
+### 致谢
+
+- @addu390
+- @gnehil
+- @JNSimba
+- @LuciferYang
+
 ## 26.0.0
 
 来源：[Spark Doris Connector 26.0.0](https://github.com/apache/doris-spark-connector/issues/358)

--- a/releasenotes/ecosystem/doris-flink-connector.md
+++ b/releasenotes/ecosystem/doris-flink-connector.md
@@ -10,6 +10,36 @@
 
 This document lists Doris Flink Connector release notes in reverse chronological order.
 
+## 26.2.0
+
+Source: [Release Note 26.2.0](https://github.com/apache/doris-flink-connector/issues/691)
+
+### Features and Improvements
+
+- Supported snapshot, incremental, and initial scan modes for Doris Source. [#679](https://github.com/apache/doris-flink-connector/pull/679)
+- Supported one-way TLS connections to Doris over HTTP, MySQL/JDBC, Thrift, and Arrow Flight SQL. [#686](https://github.com/apache/doris-flink-connector/pull/686)
+- Supported S3 TVF sink write mode. [#688](https://github.com/apache/doris-flink-connector/pull/688)
+- Added JDK 21 build and CI validation for Flink 2.x. [#678](https://github.com/apache/doris-flink-connector/pull/678)
+- Reported the standard FLIP-33 sink metrics `numRecordsSend` and `numBytesSend`. [#681](https://github.com/apache/doris-flink-connector/pull/681)
+- Supported the PostgreSQL `regclass` type in CDC synchronization. [#658](https://github.com/apache/doris-flink-connector/pull/658)
+- Added Doris regression test programs. [#687](https://github.com/apache/doris-flink-connector/pull/687)
+
+### Bug Fixes
+
+- Fixed oversized checkpoint state for initial snapshots of large tables. [#690](https://github.com/apache/doris-flink-connector/pull/690)
+- Fixed an issue where `DorisWriter` aborted the wrong transaction. [#683](https://github.com/apache/doris-flink-connector/pull/683)
+- Fixed MongoDB CDC parsing when `fullDocument` is returned as a JSON string. [#671](https://github.com/apache/doris-flink-connector/pull/671)
+- Fixed Arrow timestamp conversion for Doris `DATETIME` and `TIMESTAMPTZ` types. [#676](https://github.com/apache/doris-flink-connector/pull/676)
+
+### Thanks
+
+- @Cq-study
+- @JNSimba
+- @liujiwen-up
+- @Sbaia
+- @Tan-JiaLiang
+- @ziyanTOP
+
 ## 26.1.1
 
 Source: [Release Note 26.1.1](https://github.com/apache/doris-flink-connector/issues/654)

--- a/releasenotes/ecosystem/doris-kafka-connector.md
+++ b/releasenotes/ecosystem/doris-kafka-connector.md
@@ -10,6 +10,21 @@
 
 This document lists Doris Kafka Connector release notes in reverse chronological order.
 
+## 26.1.0
+
+Source: [Release Note 26.1.0](https://github.com/apache/doris-kafka-connector/issues/102)
+
+### Features and Improvements
+
+- Cached the available BE to avoid an HTTP probe before every load. [#99](https://github.com/apache/doris-kafka-connector/pull/99)
+- Supported one-way TLS connections to Doris. [#100](https://github.com/apache/doris-kafka-connector/pull/100)
+- Supported S3 TVF sink mode for combined at-least-once writes. [#101](https://github.com/apache/doris-kafka-connector/pull/101)
+
+### Thanks
+
+- @diggle1
+- @JNSimba
+
 ## 26.0.0
 
 Source: [Release Note 26.0.0](https://github.com/apache/doris-kafka-connector/issues/98)

--- a/releasenotes/ecosystem/doris-spark-connector.md
+++ b/releasenotes/ecosystem/doris-spark-connector.md
@@ -10,6 +10,33 @@
 
 This document lists Doris Spark Connector release notes in reverse chronological order.
 
+## 26.1.0
+
+Source: [Spark Doris Connector 26.1.0](https://github.com/apache/doris-spark-connector/issues/372)
+
+### Spark Connector
+
+#### Features and Improvements
+
+- Supported exposing Doris `ARRAY` columns as Spark `Array[String]`. [#362](https://github.com/apache/doris-spark-connector/pull/362)
+- Supported Spark 4.1. [#365](https://github.com/apache/doris-spark-connector/pull/365)
+- Supported one-way TLS connections to Doris. [#369](https://github.com/apache/doris-spark-connector/pull/369)
+- Added Doris regression test programs. [#370](https://github.com/apache/doris-spark-connector/pull/370)
+- Supported S3 TVF batch sink mode. [#371](https://github.com/apache/doris-spark-connector/pull/371)
+- Used Arrow Flight SQL as the default read mode, with fallback to Thrift when unavailable. [#367](https://github.com/apache/doris-spark-connector/pull/367)
+
+#### Bug Fixes
+
+- Fixed backend discovery for the specified compute group in cloud mode. [#361](https://github.com/apache/doris-spark-connector/pull/361)
+- Fixed Arrow timestamp conversion for Doris `DATETIME` and `TIMESTAMPTZ` types. [#366](https://github.com/apache/doris-spark-connector/pull/366)
+
+### Thanks
+
+- @addu390
+- @gnehil
+- @JNSimba
+- @LuciferYang
+
 ## 26.0.0
 
 Source: [Spark Doris Connector 26.0.0](https://github.com/apache/doris-spark-connector/issues/358)

--- a/src/constant/download.data.ts
+++ b/src/constant/download.data.ts
@@ -2299,6 +2299,9 @@ const FLINK_SAME_SOURCE_2600 =
 const FLINK_SAME_SOURCE_2611 =
     'https://downloads.apache.org/doris/flink-connector/26.1.1/apache-doris-flink-connector-26.1.1-src.tgz';
 
+const FLINK_SAME_SOURCE_2620 =
+    'https://downloads.apache.org/doris/flink-connector/26.2.0/apache-doris-flink-connector-26.2.0-src.tgz';
+
 const SPARK_SAME_SOURCE_132 =
     'https://downloads.apache.org/doris/spark-connector/1.3.2/apache-doris-spark-connector-1.3.2-src.tar.gz';
 const SPARK_SAME_SOURCE_120 =
@@ -2309,6 +2312,9 @@ const SPARK_SAME_SOURCE_2520 =
 
 const SPARK_SAME_SOURCE_2600 =
     'https://downloads.apache.org/doris/spark-connector/26.0.0/apache-doris-spark-connector-26.0.0-src.tgz';
+
+const SPARK_SAME_SOURCE_2610 =
+    'https://downloads.apache.org/doris/spark-connector/26.1.0/apache-doris-spark-connector-26.1.0-src.tgz';
 
 const DORIS_OPERATOR_SOURCE_VERSIONS = [
     '26.0.1',
@@ -2370,6 +2376,13 @@ export const TOOL_VERSIONS = [
         value: ToolsEnum.Kafka,
         children: [
             {
+                label: '26.1.0',
+                value: '26.1.0',
+                gz: 'https://downloads.apache.org/doris/kafka-connector/26.1.0/apache-doris-kafka-connector-26.1.0-src.tgz',
+                Source: 'https://downloads.apache.org/doris/kafka-connector/26.1.0/apache-doris-kafka-connector-26.1.0-src.tgz',
+                Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/doris-kafka-connector/26.1.0/doris-kafka-connector-26.1.0.jar',
+            },
+            {
                 label: '26.0.0',
                 value: '26.0.0',
                 gz: 'https://downloads.apache.org/doris/kafka-connector/26.0.0/apache-doris-kafka-connector-26.0.0-src.tgz',
@@ -2403,6 +2416,75 @@ export const TOOL_VERSIONS = [
         label: ToolsEnum.Flink,
         value: ToolsEnum.Flink,
         children: [
+            {
+                label: '26.2.0',
+                value: '26.2.0',
+                children: [
+                    {
+                        value: '2.2',
+                        label: 'For Flink 2.2',
+                        gz: FLINK_SAME_SOURCE_2620,
+                        Source: FLINK_SAME_SOURCE_2620,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/flink-doris-connector-2.2/26.2.0/flink-doris-connector-2.2-26.2.0.jar',
+                    },
+                    {
+                        value: '2.1',
+                        label: 'For Flink 2.1',
+                        gz: FLINK_SAME_SOURCE_2620,
+                        Source: FLINK_SAME_SOURCE_2620,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/flink-doris-connector-2.1/26.2.0/flink-doris-connector-2.1-26.2.0.jar',
+                    },
+                    {
+                        value: '2.0',
+                        label: 'For Flink 2.0',
+                        gz: FLINK_SAME_SOURCE_2620,
+                        Source: FLINK_SAME_SOURCE_2620,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/flink-doris-connector-2.0/26.2.0/flink-doris-connector-2.0-26.2.0.jar',
+                    },
+                    {
+                        value: '1.20',
+                        label: 'For Flink 1.20',
+                        gz: FLINK_SAME_SOURCE_2620,
+                        Source: FLINK_SAME_SOURCE_2620,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/flink-doris-connector-1.20/26.2.0/flink-doris-connector-1.20-26.2.0.jar',
+                    },
+                    {
+                        value: '1.19',
+                        label: 'For Flink 1.19',
+                        gz: FLINK_SAME_SOURCE_2620,
+                        Source: FLINK_SAME_SOURCE_2620,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/flink-doris-connector-1.19/26.2.0/flink-doris-connector-1.19-26.2.0.jar',
+                    },
+                    {
+                        value: '1.18',
+                        label: 'For Flink 1.18',
+                        gz: FLINK_SAME_SOURCE_2620,
+                        Source: FLINK_SAME_SOURCE_2620,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/flink-doris-connector-1.18/26.2.0/flink-doris-connector-1.18-26.2.0.jar',
+                    },
+                    {
+                        value: '1.17',
+                        label: 'For Flink 1.17',
+                        gz: FLINK_SAME_SOURCE_2620,
+                        Source: FLINK_SAME_SOURCE_2620,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/flink-doris-connector-1.17/26.2.0/flink-doris-connector-1.17-26.2.0.jar',
+                    },
+                    {
+                        value: '1.16',
+                        label: 'For Flink 1.16',
+                        gz: FLINK_SAME_SOURCE_2620,
+                        Source: FLINK_SAME_SOURCE_2620,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/flink-doris-connector-1.16/26.2.0/flink-doris-connector-1.16-26.2.0.jar',
+                    },
+                    {
+                        value: '1.15',
+                        label: 'For Flink 1.15',
+                        gz: FLINK_SAME_SOURCE_2620,
+                        Source: FLINK_SAME_SOURCE_2620,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/flink-doris-connector-1.15/26.2.0/flink-doris-connector-1.15-26.2.0.jar',
+                    },
+                ],
+            },
             {
                 label: '26.1.1',
                 value: '26.1.1',
@@ -2839,6 +2921,61 @@ export const TOOL_VERSIONS = [
         label: ToolsEnum.Spark,
         value: ToolsEnum.Spark,
         children: [
+            {
+                label: '26.1.0',
+                value: '26.1.0',
+                children: [
+                    {
+                        value: '4.1',
+                        label: 'For Spark 4.1',
+                        gz: SPARK_SAME_SOURCE_2610,
+                        Source: SPARK_SAME_SOURCE_2610,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/spark-doris-connector-spark-4.1/26.1.0/spark-doris-connector-spark-4.1-26.1.0.jar',
+                    },
+                    {
+                        value: '3.5_2.12',
+                        label: 'For Spark 3.5_2.12',
+                        gz: SPARK_SAME_SOURCE_2610,
+                        Source: SPARK_SAME_SOURCE_2610,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/spark-doris-connector-spark-3.5/26.1.0/spark-doris-connector-spark-3.5-26.1.0.jar',
+                    },
+                    {
+                        value: '3.4_2.12',
+                        label: 'For Spark 3.4_2.12',
+                        gz: SPARK_SAME_SOURCE_2610,
+                        Source: SPARK_SAME_SOURCE_2610,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/spark-doris-connector-spark-3.4/26.1.0/spark-doris-connector-spark-3.4-26.1.0.jar',
+                    },
+                    {
+                        value: '3.3_2.12',
+                        label: 'For Spark 3.3_2.12',
+                        gz: SPARK_SAME_SOURCE_2610,
+                        Source: SPARK_SAME_SOURCE_2610,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/spark-doris-connector-spark-3.3/26.1.0/spark-doris-connector-spark-3.3-26.1.0.jar',
+                    },
+                    {
+                        value: '3.2_2.12',
+                        label: 'For Spark 3.2_2.12',
+                        gz: SPARK_SAME_SOURCE_2610,
+                        Source: SPARK_SAME_SOURCE_2610,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/spark-doris-connector-spark-3.2/26.1.0/spark-doris-connector-spark-3.2-26.1.0.jar',
+                    },
+                    {
+                        value: '3.1_2.12',
+                        label: 'For Spark 3.1_2.12',
+                        gz: SPARK_SAME_SOURCE_2610,
+                        Source: SPARK_SAME_SOURCE_2610,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/spark-doris-connector-spark-3.1/26.1.0/spark-doris-connector-spark-3.1-26.1.0.jar',
+                    },
+                    {
+                        value: '2_2.11',
+                        label: 'For Spark 2_2.11',
+                        gz: SPARK_SAME_SOURCE_2610,
+                        Source: SPARK_SAME_SOURCE_2610,
+                        Binary: 'https://repository.apache.org/content/repositories/releases/org/apache/doris/spark-doris-connector-spark-2/26.1.0/spark-doris-connector-spark-2-26.1.0.jar',
+                    },
+                ],
+            },
             {
                 label: '26.0.0',
                 value: '26.0.0',


### PR DESCRIPTION
## Summary

- Add the latest Flink, Spark, and Kafka Connector release notes in English and Chinese.
- Add the corresponding source and binary downloads to the download page.

## Validation

- `yarn typecheck`
- `git diff --check`
- Verified all 20 new download URLs return HTTP 200.
- Full site build was attempted but could not complete because the local dependency installation was incomplete.

## Versions

- [x] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync