### PR TITLE
[docs](function) Add ST_IsClosed documentation

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/spatial-functions/st-isclosed.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/spatial-functions/st-isclosed.md
@@ -1,0 +1,95 @@
+---
+{
+    "title": "ST_ISCLOSED",
+    "language": "en",
+    "description": "Determines whether a LineString is closed by comparing its first and last points."
+}
+---
+
+## Description
+
+Determines whether a `LINESTRING` is closed. A `LINESTRING` is closed when its first and last points are exactly equal. This function does not use a distance tolerance.
+
+## Syntax
+
+```sql
+ST_ISCLOSED( <shape> )
+```
+
+## Parameters
+
+| Parameter | Description |
+| :--- | :--- |
+| `<shape>` | The input geometry, of type GEOMETRY or VARCHAR (in WKT format) that can be converted to GEOMETRY. |
+
+## Return Value
+
+Returns a BOOLEAN value:
+
+- `true` if the input is a valid `LINESTRING` whose first and last points are exactly equal.
+- `false` if the input is a valid `LINESTRING` whose first and last points are different.
+- `NULL` if the input is `NULL`, is not a `LINESTRING`, or cannot be decoded as a valid geometry.
+
+In SQL output, `true` is displayed as `1` and `false` as `0`.
+
+## Example
+
+**Closed LineString**
+
+```sql
+SELECT ST_IsClosed(
+    ST_GeometryFromText('LINESTRING(0 0, 1 1, 0 0)')
+) AS is_closed;
+```
+
+```text
++-----------+
+| is_closed |
++-----------+
+|         1 |
++-----------+
+```
+
+**Open LineString**
+
+```sql
+SELECT ST_IsClosed(
+    ST_GeometryFromText('LINESTRING(0 0, 1 1)')
+) AS is_closed;
+```
+
+```text
++-----------+
+| is_closed |
++-----------+
+|         0 |
++-----------+
+```
+
+**NULL Input**
+
+```sql
+SELECT ST_IsClosed(NULL) AS is_closed;
+```
+
+```text
++-----------+
+| is_closed |
++-----------+
+|      NULL |
++-----------+
+```
+
+**Non-LineString Input**
+
+```sql
+SELECT ST_IsClosed(ST_Point(0, 0)) AS is_closed;
+```
+
+```text
++-----------+
+| is_closed |
++-----------+
+|      NULL |
++-----------+
+```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/spatial-functions/st-isclosed.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/spatial-functions/st-isclosed.md
@@ -1,0 +1,95 @@
+---
+{
+    "title": "ST_ISCLOSED",
+    "language": "zh-CN",
+    "description": "通过比较 LineString 的起点和终点，判断其是否闭合。"
+}
+---
+
+## 描述
+
+判断 `LINESTRING` 是否闭合。当 `LINESTRING` 的起点和终点完全相等时，该线为闭合线。此函数不使用距离容差。
+
+## 语法
+
+```sql
+ST_ISCLOSED( <shape> )
+```
+
+## 参数
+
+| 参数 | 说明 |
+| :--- | :--- |
+| `<shape>` | 输入的几何图形，类型为 GEOMETRY 或可以转换为 GEOMETRY 的 VARCHAR（WKT 格式）。 |
+
+## 返回值
+
+返回 BOOLEAN 值：
+
+- 如果输入是有效的 `LINESTRING`，且其起点和终点完全相等，则返回 `true`。
+- 如果输入是有效的 `LINESTRING`，且其起点和终点不同，则返回 `false`。
+- 如果输入为 `NULL`、不是 `LINESTRING`，或无法解码为有效的几何图形，则返回 `NULL`。
+
+在 SQL 输出中，`true` 显示为 `1`，`false` 显示为 `0`。
+
+## 举例
+
+**闭合的 LINESTRING**
+
+```sql
+SELECT ST_IsClosed(
+    ST_GeometryFromText('LINESTRING(0 0, 1 1, 0 0)')
+) AS is_closed;
+```
+
+```text
++-----------+
+| is_closed |
++-----------+
+|         1 |
++-----------+
+```
+
+**未闭合的 LINESTRING**
+
+```sql
+SELECT ST_IsClosed(
+    ST_GeometryFromText('LINESTRING(0 0, 1 1)')
+) AS is_closed;
+```
+
+```text
++-----------+
+| is_closed |
++-----------+
+|         0 |
++-----------+
+```
+
+**NULL 输入**
+
+```sql
+SELECT ST_IsClosed(NULL) AS is_closed;
+```
+
+```text
++-----------+
+| is_closed |
++-----------+
+|      NULL |
++-----------+
+```
+
+**非 LINESTRING 输入**
+
+```sql
+SELECT ST_IsClosed(ST_Point(0, 0)) AS is_closed;
+```
+
+```text
++-----------+
+| is_closed |
++-----------+
+|      NULL |
++-----------+
+```


### PR DESCRIPTION
## Versions 

- [x] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

## Description

Adds the English dev documentation for `ST_IsClosed`.

The documentation covers closed and open LineStrings, NULL input, non-LineString input, and the exact endpoint comparison semantics without a distance tolerance.

Only the dev English documentation is included because `ST_IsClosed` currently exists only on Doris master.

Related code PR: apache/doris#67350

The SQL examples were checked against the implementation and its tests but were not executed on a local Doris cluster.