### PR TITLE
[doc] Add trim_array function documentation

### DIFF
--- a/docs/sql-manual/sql-functions/scalar-functions/array-functions/trim-array.md
+++ b/docs/sql-manual/sql-functions/scalar-functions/array-functions/trim-array.md
@@ -1,0 +1,106 @@
+---
+{
+    "title": "TRIM_ARRAY Function",
+    "language": "en-US",
+    "description": "TRIM_ARRAY removes a specified number of trailing elements from an array while preserving the order and type of the remaining elements."
+}
+---
+
+## trim_array
+
+<version since="dev">
+
+</version>
+
+## Description
+
+Removes `<size>` elements from the end of `<arr>` while preserving the order of the remaining elements.
+
+## Syntax
+
+```sql
+TRIM_ARRAY(<arr>, <size>)
+```
+
+## Parameters
+
+| Parameter | Description |
+| -- | -- |
+| `<arr>` | The input `ARRAY<T>`. `T` can be a numeric, boolean, string, date/time, IP, or complex type. |
+| `<size>` | A non-negative `BIGINT` specifying how many elements to remove from the end. It cannot exceed the cardinality of `<arr>`. |
+
+## Return Value
+
+Returns an `ARRAY<T>` containing the first `cardinality(<arr>) - <size>` elements of `<arr>`.
+
+- If `<size>` is `0`, returns the input array unchanged.
+- If `<size>` equals the array cardinality, returns an empty array.
+- If either argument is `NULL`, returns `NULL`.
+- `NULL` elements inside the array are preserved.
+- If `<size>` is negative or exceeds the array cardinality, returns an error.
+
+## Examples
+
+Remove two elements from the end:
+
+```sql
+SELECT trim_array([1, 2, 3, 4], 2);
+```
+
+```text
+[1, 2]
+```
+
+A size of zero leaves the array unchanged:
+
+```sql
+SELECT trim_array(['a', 'b', 'c'], 0);
+```
+
+```text
+["a", "b", "c"]
+```
+
+Remove all elements:
+
+```sql
+SELECT trim_array([1, 2, 3], 3);
+```
+
+```text
+[]
+```
+
+`NULL` elements and nested arrays are supported:
+
+```sql
+SELECT trim_array([[1, NULL], [2, 3], [4, 5]], 1);
+```
+
+```text
+[[1, null], [2, 3]]
+```
+
+A `NULL` argument produces `NULL`:
+
+```sql
+SELECT trim_array(CAST(NULL AS ARRAY<INT>), 0);
+```
+
+```text
+NULL
+```
+
+A size larger than the array cardinality produces an error:
+
+```sql
+SELECT trim_array([1, 2, 3], 4);
+```
+
+```text
+ERROR 1105 (HY000): size must not exceed array cardinality 3: 4
+```
+
+### Keywords
+
+ARRAY, TRIM, TRIM_ARRAY

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/array-functions/trim-array.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sql-manual/sql-functions/scalar-functions/array-functions/trim-array.md
@@ -1,0 +1,106 @@
+---
+{
+    "title": "TRIM_ARRAY 函数",
+    "language": "zh-CN",
+    "description": "TRIM_ARRAY 函数从数组末尾移除指定数量的元素，同时保持剩余元素的原有顺序和数组元素类型；支持空数组、NULL 元素、嵌套数组以及多种标量和复杂数据类型。"
+}
+---
+
+## trim_array
+
+<version since="dev">
+
+</version>
+
+## 描述
+
+从 `<arr>` 末尾移除 `<size>` 个元素，并保持其余元素的原有顺序。
+
+## 语法
+
+```sql
+TRIM_ARRAY(<arr>, <size>)
+```
+
+## 参数
+
+| 参数 | 描述 |
+| -- | -- |
+| `<arr>` | 输入的 `ARRAY<T>`。`T` 可以是数值、布尔、字符串、日期时间、IP 或复杂类型。 |
+| `<size>` | 非负 `BIGINT`，指定从末尾移除的元素数量，不能超过 `<arr>` 的元素个数。 |
+
+## 返回值
+
+返回一个 `ARRAY<T>`，包含 `<arr>` 的前 `cardinality(<arr>) - <size>` 个元素。
+
+- `<size>` 为 `0` 时，原样返回输入数组。
+- `<size>` 等于数组元素个数时，返回空数组。
+- 任一参数为 `NULL` 时，返回 `NULL`。
+- 数组内部的 `NULL` 元素会被保留。
+- `<size>` 为负数或超过数组元素个数时，返回错误。
+
+## 示例
+
+从末尾移除两个元素：
+
+```sql
+SELECT trim_array([1, 2, 3, 4], 2);
+```
+
+```text
+[1, 2]
+```
+
+移除数量为零时数组保持不变：
+
+```sql
+SELECT trim_array(['a', 'b', 'c'], 0);
+```
+
+```text
+["a", "b", "c"]
+```
+
+移除全部元素：
+
+```sql
+SELECT trim_array([1, 2, 3], 3);
+```
+
+```text
+[]
+```
+
+支持包含 `NULL` 的数组和嵌套数组：
+
+```sql
+SELECT trim_array([[1, NULL], [2, 3], [4, 5]], 1);
+```
+
+```text
+[[1, null], [2, 3]]
+```
+
+参数为 `NULL` 时返回 `NULL`：
+
+```sql
+SELECT trim_array(CAST(NULL AS ARRAY<INT>), 0);
+```
+
+```text
+NULL
+```
+
+移除数量超过数组元素个数时返回错误：
+
+```sql
+SELECT trim_array([1, 2, 3], 4);
+```
+
+```text
+ERROR 1105 (HY000): size must not exceed array cardinality 3: 4
+```
+
+### Keywords
+
+ARRAY, TRIM, TRIM_ARRAY

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1799,6 +1799,7 @@ const sidebars: SidebarsConfig = {
                                         'sql-manual/sql-functions/scalar-functions/array-functions/array-zip',
                                         'sql-manual/sql-functions/scalar-functions/array-functions/arrays-overlap',
                                         'sql-manual/sql-functions/scalar-functions/array-functions/countequal',
+                                        'sql-manual/sql-functions/scalar-functions/array-functions/trim-array',
                                     ],
                                 },
                                 {


### PR DESCRIPTION
## Summary

Document the new `TRIM_ARRAY` array function in English and Chinese.

Describe its arguments, return value, NULL behavior, boundary errors,
and representative examples. Add the page to the array-function
sidebar.

Related to apache/doris#48203

The companion code PR will link to this documentation PR.

## Validation

- `yarn docs:sql-functions:changed`
- `yarn docs:lint:changed`

The new function is available only in the dev version, so no 4.x
counterpart is required.

## Versions

- [x] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [x] Checked by AI
- [x] Test Cases Built
- [x] Updated required version and language counterparts, or explained
  why not
- [x] If only one language changed, confirmed whether
  source/translation counterparts need sync
