### PR TITLE
[doc](community) use a Chinese sidebar title for the Review and CI guide

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/how-to-contribute/review-and-ci.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/how-to-contribute/review-and-ci.md
@@ -1,5 +1,5 @@
 ---
-title: Review and CI
+title: 代码评审和准入
 language: zh-CN
 description: Apache Doris Pull Request 提交后的 Review、CI 触发、问题修复与合入流程。
 keywords:


### PR DESCRIPTION
The Chinese version of the Review and CI guide (added in #4115) kept the English `title: Review and CI`, so the community sidebar rendered an English entry between 代码提交指南 and 贡献文档.

Rename the zh-CN page title to **代码评审和准入**. The English page is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQtvM8qfP3eegwMhgXBZLf
