### PR TITLE
[doc](catalog) Add read capabilities to catalog matrices

### DIFF
--- a/docs/lakehouse/best-practices/doris-iceberg-capability-matrix.mdx
+++ b/docs/lakehouse/best-practices/doris-iceberg-capability-matrix.mdx
@@ -661,7 +661,7 @@ The following matrix summarizes the Iceberg Catalog capabilities currently avail
       <td align="center">✅</td>
     </tr>
     <tr>
-      <td><code>BRANCH_READ</code></td>
+      <td><code>READ_BY_BRANCH</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -711,7 +711,7 @@ The following matrix summarizes the Iceberg Catalog capabilities currently avail
       <td align="center">✅</td>
     </tr>
     <tr>
-      <td><code>TAG_READ</code></td>
+      <td><code>READ_BY_TAG</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>

--- a/docs/lakehouse/best-practices/doris-iceberg-capability-matrix.mdx
+++ b/docs/lakehouse/best-practices/doris-iceberg-capability-matrix.mdx
@@ -327,7 +327,7 @@ The following matrix summarizes the Iceberg Catalog capabilities currently avail
       <td align="center">❌</td>
     </tr>
     <tr>
-      <td rowSpan={7}>View</td>
+      <td rowSpan={8}>View</td>
       <td><code>LIST_VIEWS</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -339,6 +339,16 @@ The following matrix summarizes the Iceberg Catalog capabilities currently avail
     </tr>
     <tr>
       <td><code>LOAD_VIEW</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+      <td align="center">✅</td>
+    </tr>
+    <tr>
+      <td><code>READ_VIEW</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">❌</td>
@@ -630,7 +640,7 @@ The following matrix summarizes the Iceberg Catalog capabilities currently avail
       <td align="center">❌</td>
     </tr>
     <tr>
-      <td rowSpan={8}>Branch / Tag</td>
+      <td rowSpan={10}>Branch / Tag</td>
       <td><code>BRANCH_CREATE</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -642,6 +652,16 @@ The following matrix summarizes the Iceberg Catalog capabilities currently avail
     </tr>
     <tr>
       <td><code>BRANCH_DROP</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+    </tr>
+    <tr>
+      <td><code>BRANCH_READ</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -682,6 +702,16 @@ The following matrix summarizes the Iceberg Catalog capabilities currently avail
     </tr>
     <tr>
       <td><code>TAG_DROP</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+    </tr>
+    <tr>
+      <td><code>TAG_READ</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -743,6 +773,17 @@ The following matrix summarizes the Iceberg Catalog capabilities currently avail
     </tr>
     <tr>
       <td><code>EXPIRE</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+    </tr>
+    <tr>
+      <td>Metadata Table</td>
+      <td><code>READ_METADATA_TABLE</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>

--- a/docs/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
+++ b/docs/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
@@ -8,6 +8,8 @@
 
 The following matrix summarizes the Paimon Catalog capabilities currently available in Doris. The rows are grouped by capability area, and the backend columns show whether each operation is available when Doris uses the corresponding metadata service. ✅ indicates that Doris supports the operation, and ❌ indicates that the operation is not currently supported.
 
+The DLF column refers to `paimon.catalog.type=dlf`, which uses a Hive-compatible metastore client and requires OSS or OSS-HDFS storage configuration. DLF accessed through `paimon.catalog.type=rest` is covered by the REST column.
+
 <table>
   <thead>
     <tr>
@@ -15,6 +17,7 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <th>Operation</th>
       <th>Filesystem</th>
       <th>HMS</th>
+      <th>DLF</th>
       <th>JDBC</th>
       <th>REST</th>
     </tr>
@@ -27,9 +30,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>LOAD_NAMESPACE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -41,9 +46,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>CREATE_NAMESPACE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -55,9 +62,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>DROP_NAMESPACE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -69,9 +78,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>MULTILEVEL_NAMESPACE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -84,9 +95,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>LOAD_TABLE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -98,9 +111,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>CREATE_TABLE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -112,9 +127,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>CTAS</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -126,9 +143,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>REGISTER_TABLE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -140,9 +159,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>DROP_TABLE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -154,6 +175,7 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>RENAME_TABLE</code></td>
@@ -161,9 +183,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>SET_TABLE_LOCATION</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -176,9 +200,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>DROP_COLUMN</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -190,9 +216,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>ALTER_COLUMN_TYPE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -204,9 +232,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>SET_TABLE_PROPERTIES</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -218,6 +248,7 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>EVOLVE_PARTITION_SPEC</code></td>
@@ -225,9 +256,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>EVOLVE_SORT_ORDER</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -240,9 +273,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>LOAD_VIEW</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -254,9 +289,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>CREATE_VIEW</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -268,9 +305,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>ALTER_VIEW</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -282,9 +321,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>DROP_VIEW</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -297,9 +338,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>OVERWRITE_TABLE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -311,9 +354,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>DYNAMIC_PARTITION_OVERWRITE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -325,9 +370,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>DELETE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -339,9 +386,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>UPSERT</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -353,6 +402,7 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>WRITE_TO_BRANCH</code></td>
@@ -360,9 +410,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>SCHEMA_EVOLUTION_ON_WRITE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -375,9 +427,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>MULTI_TABLE_COMMIT</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -389,9 +443,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>OPTIMISTIC_CONCURRENCY</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -403,9 +459,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>COMMIT_RETRY</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -417,9 +475,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>COMMIT_STATUS_RECOVERY</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -429,11 +489,13 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td><code>LOCK_REQUIRED</code></td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
       <td align="center">✅</td>
       <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>LOCK_CONFIGURED</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">✅</td>
@@ -445,9 +507,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>FAILED_WRITE_CLEANUP</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -460,9 +524,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>BRANCH_DROP</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -474,9 +540,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>BRANCH_WRITE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -488,9 +556,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>TAG_CREATE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -502,9 +572,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>READ_BY_TAG</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -516,9 +588,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>TAG_FAST_FORWARD</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -531,9 +605,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>READ_BY_TIME</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -545,9 +621,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>EXPIRE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -560,9 +638,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>REWRITE_DATA_FILES / COMPACT</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -574,6 +654,7 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>REWRITE_DELETE_FILES</code></td>
@@ -581,9 +662,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>EXPIRE_CHANGELOGS</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -596,6 +679,7 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>MIGRATE_TABLE</code></td>
@@ -603,9 +687,11 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>COMPUTE_TABLE_STATS</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>

--- a/docs/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
+++ b/docs/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
@@ -234,7 +234,7 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
     </tr>
     <tr>
-      <td rowSpan={7}>View</td>
+      <td rowSpan={8}>View</td>
       <td><code>LIST_VIEWS</code></td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -243,6 +243,13 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
     </tr>
     <tr>
       <td><code>LOAD_VIEW</code></td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+    </tr>
+    <tr>
+      <td><code>READ_VIEW</code></td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -447,7 +454,7 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">✅</td>
     </tr>
     <tr>
-      <td rowSpan={8}>Branch / Tag</td>
+      <td rowSpan={10}>Branch / Tag</td>
       <td><code>BRANCH_CREATE</code></td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -460,6 +467,13 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+    </tr>
+    <tr>
+      <td><code>BRANCH_READ</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>BRANCH_WRITE</code></td>
@@ -488,6 +502,13 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+    </tr>
+    <tr>
+      <td><code>TAG_READ</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>TAG_WRITE</code></td>

--- a/docs/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
+++ b/docs/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
@@ -469,7 +469,7 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
     </tr>
     <tr>
-      <td><code>BRANCH_READ</code></td>
+      <td><code>READ_BY_BRANCH</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -504,7 +504,7 @@ The following matrix summarizes the Paimon Catalog capabilities currently availa
       <td align="center">❌</td>
     </tr>
     <tr>
-      <td><code>TAG_READ</code></td>
+      <td><code>READ_BY_TAG</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-iceberg-capability-matrix.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-iceberg-capability-matrix.mdx
@@ -327,7 +327,7 @@
       <td align="center">❌</td>
     </tr>
     <tr>
-      <td rowSpan={7}>View</td>
+      <td rowSpan={8}>View</td>
       <td><code>LIST_VIEWS</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -339,6 +339,16 @@
     </tr>
     <tr>
       <td><code>LOAD_VIEW</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+      <td align="center">✅</td>
+    </tr>
+    <tr>
+      <td><code>READ_VIEW</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">❌</td>
@@ -630,7 +640,7 @@
       <td align="center">❌</td>
     </tr>
     <tr>
-      <td rowSpan={8}>Branch / Tag</td>
+      <td rowSpan={10}>Branch / Tag</td>
       <td><code>BRANCH_CREATE</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -642,6 +652,16 @@
     </tr>
     <tr>
       <td><code>BRANCH_DROP</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+    </tr>
+    <tr>
+      <td><code>BRANCH_READ</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -682,6 +702,16 @@
     </tr>
     <tr>
       <td><code>TAG_DROP</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+    </tr>
+    <tr>
+      <td><code>TAG_READ</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -743,6 +773,17 @@
     </tr>
     <tr>
       <td><code>EXPIRE</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+    </tr>
+    <tr>
+      <td>Metadata Table</td>
+      <td><code>READ_METADATA_TABLE</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-iceberg-capability-matrix.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-iceberg-capability-matrix.mdx
@@ -661,7 +661,7 @@
       <td align="center">✅</td>
     </tr>
     <tr>
-      <td><code>BRANCH_READ</code></td>
+      <td><code>READ_BY_BRANCH</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -711,7 +711,7 @@
       <td align="center">✅</td>
     </tr>
     <tr>
-      <td><code>TAG_READ</code></td>
+      <td><code>READ_BY_TAG</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
@@ -469,7 +469,7 @@
       <td align="center">❌</td>
     </tr>
     <tr>
-      <td><code>BRANCH_READ</code></td>
+      <td><code>READ_BY_BRANCH</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -504,7 +504,7 @@
       <td align="center">❌</td>
     </tr>
     <tr>
-      <td><code>TAG_READ</code></td>
+      <td><code>READ_BY_TAG</code></td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
@@ -8,6 +8,8 @@
 
 下表汇总了 Doris 当前支持的 Paimon Catalog 功能。表格按功能分类组织，不同 Catalog 后端列表示 Doris 使用相应元数据服务时是否支持该操作。✅ 表示 Doris 支持该操作，❌ 表示当前不支持该操作。
 
+DLF 列对应 `paimon.catalog.type=dlf`，使用兼容 Hive 的元数据客户端，并要求配置 OSS 或 OSS-HDFS 存储。通过 `paimon.catalog.type=rest` 接入的 DLF 对应 REST 列。
+
 <table>
   <thead>
     <tr>
@@ -15,6 +17,7 @@
       <th>具体操作</th>
       <th>Filesystem</th>
       <th>HMS</th>
+      <th>DLF</th>
       <th>JDBC</th>
       <th>REST</th>
     </tr>
@@ -27,9 +30,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>LOAD_NAMESPACE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -41,9 +46,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>CREATE_NAMESPACE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -55,9 +62,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>DROP_NAMESPACE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -69,9 +78,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>MULTILEVEL_NAMESPACE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -84,9 +95,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>LOAD_TABLE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -98,9 +111,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>CREATE_TABLE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -112,9 +127,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>CTAS</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -126,9 +143,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>REGISTER_TABLE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -140,9 +159,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>DROP_TABLE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -154,6 +175,7 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>RENAME_TABLE</code></td>
@@ -161,9 +183,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>SET_TABLE_LOCATION</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -176,9 +200,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>DROP_COLUMN</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -190,9 +216,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>ALTER_COLUMN_TYPE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -204,9 +232,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>SET_TABLE_PROPERTIES</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -218,6 +248,7 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>EVOLVE_PARTITION_SPEC</code></td>
@@ -225,9 +256,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>EVOLVE_SORT_ORDER</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -240,9 +273,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>LOAD_VIEW</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -254,9 +289,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>CREATE_VIEW</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -268,9 +305,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>ALTER_VIEW</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -282,9 +321,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>DROP_VIEW</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -297,9 +338,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>OVERWRITE_TABLE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -311,9 +354,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>DYNAMIC_PARTITION_OVERWRITE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -325,9 +370,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>DELETE</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -339,9 +386,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>UPSERT</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -353,6 +402,7 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>WRITE_TO_BRANCH</code></td>
@@ -360,9 +410,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>SCHEMA_EVOLUTION_ON_WRITE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -375,9 +427,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>MULTI_TABLE_COMMIT</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -389,9 +443,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>OPTIMISTIC_CONCURRENCY</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -403,9 +459,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>COMMIT_RETRY</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -417,9 +475,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>COMMIT_STATUS_RECOVERY</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -429,11 +489,13 @@
       <td><code>LOCK_REQUIRED</code></td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
       <td align="center">✅</td>
       <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>LOCK_CONFIGURED</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">✅</td>
@@ -445,9 +507,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>FAILED_WRITE_CLEANUP</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -460,9 +524,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>BRANCH_DROP</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -474,9 +540,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>BRANCH_WRITE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -488,9 +556,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>TAG_CREATE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -502,9 +572,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>READ_BY_TAG</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -516,9 +588,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>TAG_FAST_FORWARD</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -531,9 +605,11 @@
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>READ_BY_TIME</code></td>
+      <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
       <td align="center">✅</td>
@@ -545,9 +621,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>EXPIRE</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -560,9 +638,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>REWRITE_DATA_FILES / COMPACT</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -574,6 +654,7 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>REWRITE_DELETE_FILES</code></td>
@@ -581,9 +662,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>EXPIRE_CHANGELOGS</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -596,6 +679,7 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>MIGRATE_TABLE</code></td>
@@ -603,9 +687,11 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+      <td align="center">❌</td>
     </tr>
     <tr>
       <td><code>COMPUTE_TABLE_STATS</code></td>
+      <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/best-practices/doris-paimon-capability-matrix.mdx
@@ -234,7 +234,7 @@
       <td align="center">❌</td>
     </tr>
     <tr>
-      <td rowSpan={7}>View</td>
+      <td rowSpan={8}>View</td>
       <td><code>LIST_VIEWS</code></td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -243,6 +243,13 @@
     </tr>
     <tr>
       <td><code>LOAD_VIEW</code></td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+      <td align="center">❌</td>
+    </tr>
+    <tr>
+      <td><code>READ_VIEW</code></td>
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -447,7 +454,7 @@
       <td align="center">✅</td>
     </tr>
     <tr>
-      <td rowSpan={8}>Branch / Tag</td>
+      <td rowSpan={10}>Branch / Tag</td>
       <td><code>BRANCH_CREATE</code></td>
       <td align="center">❌</td>
       <td align="center">❌</td>
@@ -460,6 +467,13 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+    </tr>
+    <tr>
+      <td><code>BRANCH_READ</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>BRANCH_WRITE</code></td>
@@ -488,6 +502,13 @@
       <td align="center">❌</td>
       <td align="center">❌</td>
       <td align="center">❌</td>
+    </tr>
+    <tr>
+      <td><code>TAG_READ</code></td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
     </tr>
     <tr>
       <td><code>TAG_WRITE</code></td>


### PR DESCRIPTION
## Versions

- [x] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [x] Checked by AI
- [ ] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

## Summary

- add explicit view read capabilities to the Iceberg and Paimon matrices
- add branch and tag read capabilities based on `table@branch(...)` and `table@tag(...)` queries
- add Iceberg metadata table read capability
- keep the English and Chinese matrices synchronized

This is a follow-up to #4116 and updates the current/dev documentation only.

## Validation

- `git diff --check origin/master`
- verified every table row has the expected number of cells
- verified each `rowSpan` matches its capability group
- verified English and Chinese operation ordering and support statuses are identical
