### PR TITLE
[doc](lakehouse) Document Iceberg and Paimon file metadata columns

### DIFF
--- a/docs/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/docs/lakehouse/catalogs/iceberg-catalog.mdx
@@ -1483,6 +1483,58 @@ SELECT * FROM iceberg_tbl LIMIT 10;
 SELECT * FROM iceberg.iceberg_db.iceberg_tbl LIMIT 10;
 ```
 
+### File Metadata Columns
+
+Doris exposes two hidden metadata columns for Iceberg data tables. You can use them to locate the physical data file and row that produced each query result.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `_file` | `STRING NOT NULL` | The original path recorded for the Iceberg data file. |
+| `_pos` | `BIGINT NOT NULL` | The zero-based physical row position within the complete data file. |
+
+Prerequisites: configure an Iceberg Catalog as described in the preceding examples, and create an Iceberg data table that contains an `id` column and uses Parquet or ORC files. The following query assumes that `iceberg_tbl` already contains rows with `id` values `1` and `2`:
+
+```sql
+SELECT id, `_file`, `_pos`
+FROM iceberg.iceberg_db.iceberg_tbl
+ORDER BY `_file`, `_pos`;
+```
+
+Example result (the file path depends on the table location):
+
+```text
++----+---------------------------------------+------+
+| id | _file                                 | _pos |
++----+---------------------------------------+------+
+|  1 | s3://bucket/warehouse/db/table/a.orc |    0 |
+|  2 | s3://bucket/warehouse/db/table/a.orc |    1 |
++----+---------------------------------------+------+
+```
+
+The columns do not appear in `SELECT *` or `DESC` by default.
+
+To include hidden columns in `SELECT *` and `DESC`, enable `show_hidden_columns` for the session:
+
+```sql
+SET show_hidden_columns = true;
+```
+
+Relevant session variables:
+
+| Variable | Type | Default | Required | Effect |
+| --- | --- | --- | --- | --- |
+| `show_hidden_columns` | `BOOLEAN` | `false` | No | Includes hidden columns in `SELECT *` and `DESC`. It is not needed when the columns are referenced explicitly. |
+| `enable_file_scanner_v2` | `BOOLEAN` | `true` | No | Must remain enabled when a query references these metadata columns. |
+| `force_jni_scanner` | `BOOLEAN` | `false` | No | Must remain disabled because the JNI reader cannot produce these metadata columns. |
+
+The row position is relative to the complete physical file. Predicate filtering, delete processing, and scan splitting do not renumber the remaining rows. Therefore, the combination of `_file` and `_pos` can locate a physical record within the current table snapshot. Data-file rewrites or compaction can change both values, so they must not be used as a stable logical row ID.
+
+:::caution
+These columns are available only when an Iceberg data table is read through the FileScannerV2 native Parquet or ORC reader. A query that references them fails if `enable_file_scanner_v2` is disabled, `force_jni_scanner` is enabled, or the selected data files cannot use the native Parquet/ORC reader.
+
+`_file` and `_pos` are reserved names, compared case-insensitively. Do not use them as physical column names in an Iceberg table.
+:::
+
 ### Time Travel
 
 You can read a specific snapshot of an Iceberg table.

--- a/docs/lakehouse/catalogs/paimon-catalog.mdx
+++ b/docs/lakehouse/catalogs/paimon-catalog.mdx
@@ -980,6 +980,58 @@ SELECT * FROM paimon_tbl LIMIT 10;
 SELECT * FROM paimon_ctl.paimon_db.paimon_tbl LIMIT 10;
 ```
 
+### File Metadata Columns
+
+Doris exposes two hidden metadata columns for Paimon data tables. You can use them to locate the physical data file and row that produced each query result.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `__paimon_file_path` | `STRING NOT NULL` | The original path returned by Paimon for the raw data file. |
+| `__paimon_row_index` | `BIGINT NOT NULL` | The zero-based physical row position within the complete data file. |
+
+Prerequisites: configure a Paimon Catalog as described in the preceding examples, and create a Paimon data table that contains an `id` column and uses Parquet or ORC files. The following query assumes that `paimon_tbl` already contains rows with `id` values `1` and `2`:
+
+```sql
+SELECT id, `__paimon_file_path`, `__paimon_row_index`
+FROM paimon_ctl.paimon_db.paimon_tbl
+ORDER BY `__paimon_file_path`, `__paimon_row_index`;
+```
+
+Example result (the file path depends on the table location):
+
+```text
++----+------------------------------------------+--------------------+
+| id | __paimon_file_path                       | __paimon_row_index |
++----+------------------------------------------+--------------------+
+|  1 | s3://bucket/warehouse/db/table/a.parquet |                  0 |
+|  2 | s3://bucket/warehouse/db/table/a.parquet |                  1 |
++----+------------------------------------------+--------------------+
+```
+
+The columns do not appear in `SELECT *` or `DESC` by default.
+
+To include hidden columns in `SELECT *` and `DESC`, enable `show_hidden_columns` for the session:
+
+```sql
+SET show_hidden_columns = true;
+```
+
+Relevant session variables:
+
+| Variable | Type | Default | Required | Effect |
+| --- | --- | --- | --- | --- |
+| `show_hidden_columns` | `BOOLEAN` | `false` | No | Includes hidden columns in `SELECT *` and `DESC`. It is not needed when the columns are referenced explicitly. |
+| `enable_file_scanner_v2` | `BOOLEAN` | `true` | No | Must remain enabled when a query references these metadata columns. |
+| `force_jni_scanner` | `BOOLEAN` | `false` | No | Must remain disabled because the JNI reader cannot produce these metadata columns. |
+
+The row position is relative to the complete physical file. Predicate filtering, deletion-vector processing, and scan splitting do not renumber the remaining rows. Therefore, the combination of `__paimon_file_path` and `__paimon_row_index` can locate a physical record within the current table snapshot. Data-file rewrites or compaction can change both values, so they must not be used as a stable logical row ID.
+
+:::caution
+These columns are available only when every Paimon split participating in the query can be read as a raw data file through the FileScannerV2 native Parquet or ORC reader. A query that references them fails for JNI or mixed native/JNI scans, when `enable_file_scanner_v2` is disabled, when `force_jni_scanner` is enabled, or when the selected data files cannot use the native Parquet/ORC reader.
+
+`__paimon_file_path` and `__paimon_row_index` are reserved names, compared case-insensitively. Do not use them as physical column names in a Paimon table.
+:::
+
 ### Batch Incremental Query
 
 > Since version 3.1.0

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
@@ -1505,6 +1505,58 @@ SELECT * FROM iceberg_tbl LIMIT 10;
 SELECT * FROM iceberg.iceberg_db.iceberg_tbl LIMIT 10;
 ```
 
+### 文件元数据列
+
+Doris 为 Iceberg 数据表提供两个隐藏元数据列，可用于定位每条查询结果对应的物理数据文件和文件内行位置。
+
+| 列名 | 类型 | 说明 |
+| --- | --- | --- |
+| `_file` | `STRING NOT NULL` | Iceberg 数据文件元数据中记录的原始路径。 |
+| `_pos` | `BIGINT NOT NULL` | 该行在完整数据文件中的物理位置，从 0 开始。 |
+
+前置条件：按照前文示例配置 Iceberg Catalog，并创建一个包含 `id` 列、使用 Parquet 或 ORC 文件的 Iceberg 数据表。以下查询假设 `iceberg_tbl` 中已包含 `id` 为 `1` 和 `2` 的记录：
+
+```sql
+SELECT id, `_file`, `_pos`
+FROM iceberg.iceberg_db.iceberg_tbl
+ORDER BY `_file`, `_pos`;
+```
+
+示例结果（文件路径由实际表位置决定）：
+
+```text
++----+---------------------------------------+------+
+| id | _file                                 | _pos |
++----+---------------------------------------+------+
+|  1 | s3://bucket/warehouse/db/table/a.orc |    0 |
+|  2 | s3://bucket/warehouse/db/table/a.orc |    1 |
++----+---------------------------------------+------+
+```
+
+默认情况下，这些列不会出现在 `SELECT *` 或 `DESC` 的结果中。
+
+如需在 `SELECT *` 和 `DESC` 中显示隐藏列，可以在当前会话开启 `show_hidden_columns`：
+
+```sql
+SET show_hidden_columns = true;
+```
+
+相关会话变量：
+
+| 变量 | 类型 | 默认值 | 是否必需 | 作用 |
+| --- | --- | --- | --- | --- |
+| `show_hidden_columns` | `BOOLEAN` | `false` | 否 | 在 `SELECT *` 和 `DESC` 中显示隐藏列。显式引用列名时无需开启。 |
+| `enable_file_scanner_v2` | `BOOLEAN` | `true` | 否 | 查询引用这些元数据列时必须保持开启。 |
+| `force_jni_scanner` | `BOOLEAN` | `false` | 否 | 必须保持关闭，因为 JNI Reader 无法生成这些元数据列。 |
+
+行位置以完整物理文件为基准。谓词过滤、Delete 处理及扫描切分不会对保留行重新编号。因此，`_file` 和 `_pos` 的组合可以定位当前表快照中的一条物理记录。数据文件重写或 Compaction 后，两列的值可能变化，不能将其作为稳定的逻辑行 ID。
+
+:::caution 注意
+仅当 Iceberg 数据表通过 FileScannerV2 原生 Parquet 或 ORC Reader 读取时，才能使用这些列。如果关闭 `enable_file_scanner_v2`、开启 `force_jni_scanner`，或者所选数据文件无法使用原生 Parquet/ORC Reader，引用这些列的查询会失败。
+
+`_file` 和 `_pos` 是保留列名，名称比较不区分大小写。请勿在 Iceberg 表中使用它们作为物理列名。
+:::
+
 ### 时间旅行
 
 支持读取 Iceberg 表指定的 Snapshot。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/paimon-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/paimon-catalog.mdx
@@ -976,6 +976,58 @@ SELECT * FROM paimon_tbl LIMIT 10;
 SELECT * FROM paimon_ctl.paimon_db.paimon_tbl LIMIT 10;
 ```
 
+### 文件元数据列
+
+Doris 为 Paimon 数据表提供两个隐藏元数据列，可用于定位每条查询结果对应的物理数据文件和文件内行位置。
+
+| 列名 | 类型 | 说明 |
+| --- | --- | --- |
+| `__paimon_file_path` | `STRING NOT NULL` | Paimon 为原始数据文件返回的路径。 |
+| `__paimon_row_index` | `BIGINT NOT NULL` | 该行在完整数据文件中的物理位置，从 0 开始。 |
+
+前置条件：按照前文示例配置 Paimon Catalog，并创建一个包含 `id` 列、使用 Parquet 或 ORC 文件的 Paimon 数据表。以下查询假设 `paimon_tbl` 中已包含 `id` 为 `1` 和 `2` 的记录：
+
+```sql
+SELECT id, `__paimon_file_path`, `__paimon_row_index`
+FROM paimon_ctl.paimon_db.paimon_tbl
+ORDER BY `__paimon_file_path`, `__paimon_row_index`;
+```
+
+示例结果（文件路径由实际表位置决定）：
+
+```text
++----+------------------------------------------+--------------------+
+| id | __paimon_file_path                       | __paimon_row_index |
++----+------------------------------------------+--------------------+
+|  1 | s3://bucket/warehouse/db/table/a.parquet |                  0 |
+|  2 | s3://bucket/warehouse/db/table/a.parquet |                  1 |
++----+------------------------------------------+--------------------+
+```
+
+默认情况下，这些列不会出现在 `SELECT *` 或 `DESC` 的结果中。
+
+如需在 `SELECT *` 和 `DESC` 中显示隐藏列，可以在当前会话开启 `show_hidden_columns`：
+
+```sql
+SET show_hidden_columns = true;
+```
+
+相关会话变量：
+
+| 变量 | 类型 | 默认值 | 是否必需 | 作用 |
+| --- | --- | --- | --- | --- |
+| `show_hidden_columns` | `BOOLEAN` | `false` | 否 | 在 `SELECT *` 和 `DESC` 中显示隐藏列。显式引用列名时无需开启。 |
+| `enable_file_scanner_v2` | `BOOLEAN` | `true` | 否 | 查询引用这些元数据列时必须保持开启。 |
+| `force_jni_scanner` | `BOOLEAN` | `false` | 否 | 必须保持关闭，因为 JNI Reader 无法生成这些元数据列。 |
+
+行位置以完整物理文件为基准。谓词过滤、Deletion Vector 处理及扫描切分不会对保留行重新编号。因此，`__paimon_file_path` 和 `__paimon_row_index` 的组合可以定位当前表快照中的一条物理记录。数据文件重写或 Compaction 后，两列的值可能变化，不能将其作为稳定的逻辑行 ID。
+
+:::caution 注意
+仅当查询涉及的每个 Paimon Split 都能作为原始数据文件，通过 FileScannerV2 原生 Parquet 或 ORC Reader 读取时，才能使用这些列。对于 JNI 或原生/JNI 混合扫描、关闭 `enable_file_scanner_v2`、开启 `force_jni_scanner`，以及所选数据文件无法使用原生 Parquet/ORC Reader 的情况，引用这些列的查询会失败。
+
+`__paimon_file_path` 和 `__paimon_row_index` 是保留列名，名称比较不区分大小写。请勿在 Paimon 表中使用它们作为物理列名。
+:::
+
 ### 增量查询
 
 > 该功能自 3.1.0 版本支持


### PR DESCRIPTION
## Versions

- [x] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [x] Checked by AI
- [x] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

## Summary

- Document the Iceberg `_file` and `_pos` hidden metadata columns.
- Document the Paimon `__paimon_file_path` and `__paimon_row_index` hidden metadata columns.
- Explain physical row-position semantics, examples, session variables, reader compatibility, and reserved-name restrictions.

## Related changes

- Apache Doris PR: apache/doris#67207
- Requirement: apache/doris#66816

## Version and language coverage

The feature was newly merged into the Doris development branch and has not been backported to released 4.x or 3.x branches, so this PR updates only the current/dev English and Chinese documentation.

## Validation

- `git diff --check`
- Docs governance changed-file report
- `DOCS_VERSIONS=current` English and Chinese Docusaurus production build