### PR TITLE
[docs] Add Apache Doris 4.1.4 release info

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/core.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/core.md
@@ -11,7 +11,7 @@
 ## Doris Core 版本发布说明
 
 :::tip 最新发布
-🎉 4.1.3 版本已于 2026 年 07 月 13 日正式发布，详情可查看[版本发布](./v4.1/release-4.1.3.md)。Apache Doris 4.1.3 新增 Python UDF/UDAF/UDTF、工作负载策略增强、表级事件驱动预热和 Stream Load zstd 压缩，并修复查询执行、存储、导入、湖仓一体与安全认证方面的多项问题。
+🎉 4.1.4 版本已于 2026 年 09 月 10 日正式发布，详情可查看[版本发布](./v4.1/release-4.1.4.md)。Apache Doris 4.1.4 新增 Merge-on-Write 表 ANN 索引、多模态文件 Embedding、面向大规模集群的自适应全局 Runtime Filter 下发、OceanBase CDC Streaming Job 以及内部通信 TLS 支持，并修复查询执行、存储、导入、存算分离、湖仓一体与安全认证方面的多项问题。
 <br />
 
 🎉 4.0.8 版本已于 2026 年 08 月 14 日正式发布，详情可查看[版本发布](./v4.0/release-4.0.8.md)。Apache Doris 4.0.8 是 4.0 系列维护版本，聚焦存算分离部署、导入与事务稳定性、File Cache 行为、内部接口安全加固以及湖仓兼容性。建议所有 4.0.x 用户升级。
@@ -29,6 +29,8 @@
 :::
 
 <br />
+
+- [2026-09-10, Apache Doris 4.1.4 版本发布](./v4.1/release-4.1.4.md)
 
 - [2026-08-14, Apache Doris 4.0.8 版本发布](./v4.0/release-4.0.8.md)
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/v4.1/release-4.1.4.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-releases/current/v4.1/release-4.1.4.md
@@ -1,0 +1,249 @@
+---
+{
+    "title": "Release 4.1.4",
+    "language": "zh-CN",
+    "description": "Apache Doris 4.1.4 版本发布说明"
+}
+---
+
+# 新功能
+
+## AI 与搜索
+- 支持在 Merge-on-Write 表上创建 ANN 索引 (#67155)
+- 支持多模态文件 Embedding (#66461)
+
+## 查询与执行
+- 新增自适应的全局 Runtime Filter 树下发机制，以支持大规模集群 (#65599)
+- 支持将 Limit 下推到 CTE Producer (#63675)
+- 新增分区过滤条件的 SQL 拦截规则 (#62196)
+
+## 导入与 Streaming Job
+- 新增自适应随机分桶的导入路由 (#65450)
+- 支持转发 Group Commit 的 Stream Load 请求 (#63594)
+- Stream Load 支持 Compute Group 路由与规划 (#65571)
+- 支持 OceanBase CDC Streaming Job (#65588)
+- 支持从 Relation 事件中识别 PostgreSQL 的 Schema 变更 (#64850)
+- Streaming Job 支持 MySQL 的 `ADD` 和 `DROP` Schema 变更 (#65325)
+
+## 云原生
+- FE 侧新增 MetaService RPC 限流 (#65694)
+- 新增外部元数据缓存的内存治理 (#66717)
+- 存算一体模式下支持 `SHOW COMPUTE GROUPS` (#66697)
+- 支持通过 SQL 触发 Tablet 粒度的 Compaction (#66611)
+- 新增 Resource Group 的成功 Quorum 校验 (#66751)
+
+## 湖仓一体
+- 支持修改 Iceberg 和 Paimon 表属性 (#66428)
+- 支持阿里云 OSS Tables REST Catalog (#66823)
+
+## 安全与认证
+- Doris 内部通信支持 TLS (#64016)
+- 新增 FE 与 MetaService 之间的内部 HTTP 认证 (#66090)
+
+## 其他
+- 审计日志新增 `queue_time_ms` 字段 (#66641)
+
+# 改进
+
+## 查询与执行
+- 使用 AVX2 批量路径优化 MD5 计算 (#63484)
+- 提升 percentile 聚合函数性能 (#62520)
+- 优化 Hash Join 探测侧的输出性能 (#65600)
+- 优化 Repeat 拆解时的 Shuffle Key 选择 (#66532)
+- 对 Repeat Project 中的 grouping 标量函数去重 (#65880)
+- 基于 NDV 统计信息推导集合运算的去重属性 (#64618)
+- 避免低估 `NOT IN` 谓词的行数 (#66632)
+- 在 Hash Join Profile 中增加 Instance ID (#66097)
+- 新增落盘读取的反序列化耗时统计 (#67041)
+- 让随机 Shuffle 优先选择本地通道 (#59431)
+
+## 存储与压缩
+- 为 File Cache 新增远程索引字节数指标 (#65398)
+- 新增 Delete Bitmap 任务的排队耗时指标 (#65523)
+- 加快启动时 File Cache LRU 的恢复速度 (#65174)
+- 限制 File Cache LRU recorder 的影子队列大小 (#64798)
+- 跳过非 TTL Tablet 的冗余 TTL 扫描 (#65434)
+- 新增在 TopN 延迟物化过程中关闭 File Cache 写入的开关 (#66414)
+- 远程扫描量达到阈值后关闭 File Cache 写入 (#66479)
+- 优化 Serverless 模式下 cgroup 配置变更时的内存上限刷新 (#66463)
+- Backport 可空列与 Project 相关的优化 (#66586)
+
+## 导入与 Streaming Job
+- 优化 CSV 与 Text 导入中可空字符串的反序列化 (#64476)
+- 按表级 WAL 数量对异步 Group Commit 进行反压 (#65362)
+
+## 云原生
+- 新增 S3 限流的可观测性 (#64038)
+- BE 侧新增预热任务数量指标 (#66136)
+- 使用 Rendezvous Hashing 进行 Colocate Tablet 的分布 (#64638)
+- 新增 MetaService 限流 dry-run 的可观测性 (#66969)
+- 新增云上 Tablet 均衡器的相关指标 (#66576)
+- 预分配全局云上 Tablet 路由集合的容量 (#66447)
+- 计算 TopN Delete Bitmap 分数时跳过非 MoW Tablet (#65964)
+
+## 湖仓一体
+- 在 Hadoop S3A 适配层缓存凭证 Provider (#65165)
+- 使用包含凭证信息的 Hadoop FileSystem 缓存 Key (#65586)
+- 加速 Parquet 中定长二进制 Decimal 的解码 (#66379)
+- 优化 Parquet 分片批次中可空列的选择规划 (#66397)
+
+# 问题修复
+
+## AI 与搜索
+- 修复空查询的倒排索引谓词导致的崩溃 (#65138)
+- 拆分跨多个 Segment 的倒排索引 Reader (#63138)
+- 修复 CLucene 多 Segment 场景下的 `readBlock` 处理 (#66736)
+- 拒绝包含内嵌 NUL 字节的倒排索引词项 (#67179)
+- 关闭 Score 查询的 DSL 缓存 (#65436)
+- 校验嵌套 Variant 上的 `MATCH` 谓词 (#66207)
+- 修复索引被删除后的索引查找问题 (#66316)
+- 追加嵌套 Variant 值时保持原子性 (#66421)
+- 将可空的数组元素识别为 NestedGroup 类型 (#66196)
+- 优先使用 Variant 的稀疏字段而非根值 (#65660)
+- 无需重建根节点即可读取 shredded Variant 叶子节点 (#66941)
+- 在 `explode` 过程中保留 NestedGroup 的访问路径 (#67022)
+- ANN IVF 列表缓存缺失时避免递归 (#67024)
+
+## 查询与执行
+- 修复分析函数分区键在转换为 64 位列之前溢出的问题 (#65240)
+- 并发销毁期间保护执行 Profile 的访问 (#65442)
+- 修复 `PushDownAggThroughJoinOnPkFk` 产生重复 Join 节点的问题 (#65172)
+- 在 Filter 和 TopN 下推规则中保护 `UniqueFunction` 的处理 (#62742)
+- 输入均为 key 列且去重时，为多参数聚合开启预聚合 (#65846)
+- 修复旧版 Decimal 数据缺失精度和小数位的问题 (#65419)
+- 在 Block 合并前物化常量列 (#65770)
+- 复杂类型使用序列化后的 Hash Key (#66777)
+- 修复阻塞队列的等待者计数 (#65827)
+- 修复 Eager Aggregation 中不安全的可空性转换 (#66208)
+- 修复通过 Project 下推的重复聚合函数 (#66531)
+- 下推的 CHAR 类型 `MIN` 和 `MAX` 保留 `NULL` (#65952)
+- 修复下层 Join 为 Mark Join 时非法的 Semi Join 交换 (#66574)
+- 丢弃 Join 外侧无效的函数依赖 (#65982)
+- 阻止不安全的 CTE Runtime Filter 下推 (#65247)
+- 在 Scan 函数依赖推导中屏蔽无效的唯一性约束 (#66801)
+- 修复 TIMESTAMPTZ 可空类型的相等判断 (#66722)
+- 修复 `COALESCE` 中的 TIMESTAMPTZ 取值 (#66689)
+- 保留用户变量中的 TIMESTAMPTZ 类型 (#66833)
+- 处理时间戳类型转换单调性中的夏令时回拨 (#65903)
+- 支持范围分区边界中带空格的 TIMESTAMPTZ 时区偏移 (#66292)
+- Arrow 和 Thrift 返回 DATETIME 时使用不带时区的时间戳 (#67027, #67232)
+- 修正 Flight SQL `GetTables` 的 Schema 以及 TIMESTAMPTZ 的 Arrow Reader (#66344)
+- 修复 `count_substrings` 尾部过度匹配的问题 (#63215)
+- 避免函数中 ICU 默认 locale 的竞争 (#66440)
+- 保持 multi-match 正则缓存的所有权有效 (#66909)
+- 输出大小超过 `INT_MAX` 时避免 `explode_bitmap` 崩溃 (#66034)
+- `NULL` 行跳过 CHAR 负载校验 (#67043)
+- 恢复 NULL 字面量的返回类型处理 (#66280)
+- 修复严格模式下字符串转换将 `NULL` 行附加到下一个值的问题 (#66952)
+- 缓存前先物化常量虚拟列 (#67112)
+- 处理自动分区函数参数的大小写不敏感问题 (#67121)
+- 延迟按行号取数时保留嵌套路径 (#67205)
+- 处理 TopN 中空的行号取数 RPC 失败 (#66443)
+- 云上模式下按 Function ID 缓存 UDF class 并及时清理 (#67046)
+
+## 存储与压缩
+- FLOAT 和 DOUBLE 的 ZoneMap 保留最短往返表示 (#65302)
+- 修复 Parquet 裁剪时浮点数的相等判断 (#66470)
+- 修复稀疏场景下垂直 Compaction 的目标偏移量 (#66306)
+- 拒绝在正在关闭的 Tablet 上 prepare 事务 (#66448)
+- 查询结束时清理落盘目录 (#66458)
+- 避免 Scan Executor 在关闭过程中的 use-after-free (#65220)
+- 在 File Reader 和 Packed File 缓存上下文中显式传递 Tablet ID (#61683, #65701)
+- 避免将 Segment Cache 的 Block 转换为 Index Cache 的 Block (#65905)
+- 修复 Schema Change 作业失败后的 BE 内存泄漏 (#56207)
+- 修复 `PublishVersionDaemon` 的线程池泄漏 (#60720)
+- 保证可空列 Hash 状态更新的异常安全 (#66517)
+- 同步导入错误日志的访问 (#66250)
+- 修复 OLAP 分区被删除后缓存查找失败的问题 (#65889)
+- HTTP 分块响应的 Reader 跳过 File Cache (#66932)
+
+## 导入与 Streaming Job
+- 导入 Writer 的详细信息遵循 Profile Level 设置 (#64978)
+- 修复 Arrow Stream Load 大写列名的问题 (#65617)
+- INSERT 过程中 BE 重启时快速失败 (#65525)
+- 导入路由时跳过正在下线的 BE (#65406)
+- 修正增量导入流的 Quorum 参与者 (#66016)
+- 修复 Stream Receiver 与 `close_load` 竞争导致的泄漏 (#65584)
+- 修复 Broker Load 挂起重试期间 Label 自冲突的问题 (#66469)
+- 恢复事务已可见的 Broker Load 作业 (#66987)
+- 中止 Broker Load 事务后清理事务 ID (#66884)
+- CDC Stream Load 记录按 UTF-8 编码 (#66771)
+- 避免非 GTID 保活重连时 MySQL CDC 丢数据 (#66998)
+- 隔离 CDC 全量快照各分片之间的 Schema (#65645)
+- 保持 CDC 结束位点与当前进度一致 (#65688)
+- 规范化 Streaming Job 使用的 MySQL JDBC URL (#65647)
+- 避免对 Stream Load 应用全局的 BE 认证前置校验 (#66629)
+- Stream Load 的大小限制以 MiB 为单位上报 (#66224)
+- 移除不支持的、会修改会话变量的 Workload Policy Action (#64856)
+
+## 云原生
+- 对 MetaService 返回的 `too busy` 进行重试 (#65378)
+- 为 Recycler 设置 S3 请求超时，避免 `DeleteObjects` 缓慢失败 (#64758)
+- 回收空 Rowset 时保留 Resource ID (#65862)
+- 回收 Rowset 时跳过 Packed Slice 的删除 (#65533)
+- 修正 Schema 视图中本地与远程 Tablet 大小的语义 (#60887)
+- 规范化 `SHOW PARTITIONS` 中的存储和副本字段 (#60871)
+- 云上模式下对齐 Colocate proc 输出与 Tablet 健康度上报 (#60944)
+- 云上 BE 选择时排除正在下线的 BE (#65221)
+- 避免紧急导入抢占 Schema Change 锁 (#66082)
+- 表属性变更后跳过不必要的 MetaService Tablet 更新 (#65983)
+- 避免旧版客户端把未知的 MetaService 状态码当作成功 (#64148)
+- 遇到未知的 MetaService 响应码时按失败处理 (#66364)
+- 跳过 Lazy Commit 未完成时的 Rowset 提升 (#66253)
+- 记录实例删除的回收状态并保留实例 Tombstone (#66519, #66870)
+- 以正确的 Blob 读取和引用计数回收 Delete Bitmap 的 Packed File (#66728, #66919)
+- 回收前只标记已 prepare 的 Rowset (#65550)
+- 非 MoW Tablet 跳过多版本 Delete Bitmap 的清理 (#67084)
+- 分离 Recycler 作业 Key 与校验 Key 的 HTTP 编码 (#67243)
+- Compute Group 被删除后清理过期的 CloudReplica 路由 (#66984)
+- 修复 FE 响应不完整时 `SchemaVariablesScanner` 的崩溃 (#65994)
+- Tablet Header 锁改用 bthread 友好的共享锁 (#66020)
+- 修复云上模式下 Schema Change 的 alter version 获取 (#62506)
+- 云上模式下将 FE 配置的运行时修改限制为 root 用户 (#66478)
+- 解决默认副本属性冲突的问题 (#65836)
+- BE 均衡时排除大小为 0 的 Tablet (#66499)
+- 云上升级期间检查并中止失败的冲突事务 (#60830)
+- 虚拟 Compute Group 被删除时取消其重建的预热任务 (#65426)
+- 修复添加分区时的回滚处理 (#64650)
+
+## 湖仓一体
+- 修正 MaxCompute `IN` 谓词下推的极性 (#65083)
+- 完善 MaxCompute Catalog 的参数校验 (#64119)
+- 多 Catalog 查询中保留外表分区元数据 (#66012)
+- 分区刷新后失效过期的 Hive 文件缓存 (#65334)
+- 安全地发布 Hadoop Catalog 属性 (#66392)
+- 修复 Schema 查找时远程 JDBC 表名缺失的问题 (#65718)
+- 加强 JDBC 驱动 URL 校验，并移除文件上传 HTTP 接口 (#67149)
+- 通过标准 SerDe 路径解析 ORC 时间戳 (#64807)
+- Parquet 谓词扫描中保留嵌套类型的可空性 (#66799)
+- 使用 Bloom Filter 裁剪嵌套 Parquet 列时保证安全 (#66471)
+- 修复 Iceberg Merge-on-Read 延迟按行号读取时的崩溃 (#66506)
+- 避免计算 Iceberg 分区谓词时 BE 异常退出 (#66835)
+- 扫描 Iceberg 表时使用 Split 的文件格式 (#65760)
+- 写入失败后删除外表数据文件，避免产生孤儿文件 (#64678)
+- 跨 Split 保留 Paimon 分区元数据 (#65581)
+- 处理 Paimon 分区值中的特殊字符 (#65904)
+
+## 安全与认证
+- `_stream_load_forward` 需要鉴权并由显式配置开关控制 (#65377)
+- 脱敏 Kafka Routine Load 的敏感属性 (#64786)
+- 在 BE 信息接口中隐藏 Stream Load Token 和认证数据 (#60656, #59743)
+- 转义审计日志的记录分隔符，防止伪造记录行 (#66580)
+- 脱敏加密密钥相关系统表中的敏感字段 (#66834)
+- 脱敏 BE 配置中的私钥密码 (#66836)
+- 脱敏认证与 Stream Load 日志中的凭证信息 (#66917)
+- 停止将 Arrow Flight 的 Bearer Token 写入 `fe.log` (#67146)
+
+## 物化视图
+- 修复扫描物化的模式上下文校验 (#65414)
+- 区分分区补偿与 `UNION ALL` 改写 (#66445)
+- 降低序列化 MTMV 任务 TVF 信息时 Master FE 的 CPU 占用 (#66792)
+- 优化 MTMV 分区血缘检查 (#63899)
+- 避免物化视图 null-reject 补偿中的非法 Slot 转换 (#66613)
+- 排除的触发表发生变化后刷新 MTMV (#64041)
+
+## 其他
+- 修复 Arrow Flight SQL 预处理语句的直接内存泄漏 (#65311)
+- 修复定时作业失败时的任务结束时间戳 (#66232)
+- Metric 仓库初始化前保护查询 Instance 指标的访问 (#62762)
+- 移除 HDFS File Reader 中的查询 Profile (#67293)

--- a/releasenotes/core.md
+++ b/releasenotes/core.md
@@ -11,7 +11,7 @@ This document presents Apache Doris Core release notes in reverse chronological 
 ## Doris Core Release Notes
 
 :::tip Latest Release
-🎉 Version 4.1.3 is released. Check out the 🔗[Release Notes](./v4.1/release-4.1.3.md) here. Apache Doris 4.1.3 adds Python UDF/UDAF/UDTF support, workload policy enhancements, table-level event-driven warm up, and zstd Stream Load compression. It also includes fixes across query execution, storage, load, lakehouse, and authentication.
+🎉 Version 4.1.4 is released. Check out the 🔗[Release Notes](./v4.1/release-4.1.4.md) here. Apache Doris 4.1.4 adds ANN indexes on Merge-on-Write tables, multimodal file embedding, adaptive global runtime filter publishing for large clusters, OceanBase CDC streaming jobs, and TLS for internal communication. It also includes fixes across query execution, storage, load, cloud-native deployments, lakehouse, and authentication.
 
 <br />
 
@@ -33,6 +33,8 @@ This document presents Apache Doris Core release notes in reverse chronological 
 
 
 <br />
+
+- [2026-09-10, Apache Doris 4.1.4 is released](./v4.1/release-4.1.4.md)
 
 - [2026-08-14, Apache Doris 4.0.8 is released](./v4.0/release-4.0.8.md)
 

--- a/releasenotes/v4.1/release-4.1.4.md
+++ b/releasenotes/v4.1/release-4.1.4.md
@@ -1,0 +1,249 @@
+---
+{
+    "title": "Release 4.1.4",
+    "language": "en",
+    "description": "Here's the Apache Doris 4.1.4 release notes:"
+}
+---
+
+# New Features
+
+## AI & Search
+- Support ANN indexes on Merge-on-Write tables (#67155)
+- Support multimodal file embedding (#66461)
+
+## Query & Execution
+- Add adaptive global runtime filter tree publishing to support large cluster (#65599)
+- Push down limits into CTE producers (#63675)
+- Add partition-filter SQL block rules (#62196)
+
+## Load & Streaming
+- Add adaptive random-bucket load routing (#65450)
+- Support forwarding group-commit Stream Load requests (#63594)
+- Support compute-group routing and planning for Stream Load (#65571)
+- Support OceanBase CDC streaming jobs (#65588)
+- Detect PostgreSQL schema changes from Relation events (#64850)
+- Support MySQL `ADD` and `DROP` schema changes in streaming jobs (#65325)
+
+## Cloud Native
+- Add MetaService RPC rate limiting in FE (#65694)
+- Add memory governance for external metadata caches (#66717)
+- Support `SHOW COMPUTE GROUPS` in non-cloud mode (#66697)
+- Support tablet-level compaction through SQL (#66611)
+- Add resource group success-quorum checks (#66751)
+
+## Lakehouse
+- Support altering Iceberg and Paimon table properties (#66428)
+- Support Alibaba Cloud OSS Tables REST catalog (#66823)
+
+## Security & Authentication
+- Add TLS support for internal Doris communication (#64016)
+- Add internal HTTP authentication between FE and MetaService (#66090)
+
+## Other
+- Add `queue_time_ms` to audit logs (#66641)
+
+# Improvement
+
+## Query & Execution
+- Optimize MD5 with an AVX2 batch path (#63484)
+- Improve percentile aggregate performance (#62520)
+- Optimize hash join probe-side output performance (#65600)
+- Optimize shuffle-key selection for Repeat decomposition (#66532)
+- Deduplicate grouping scalar functions in Repeat projections (#65880)
+- Infer set-operation distinctness from NDV statistics (#64618)
+- Avoid underestimating `NOT IN` predicate row counts (#66632)
+- Add instance IDs to hash join profiles (#66097)
+- Add spill-read deserialization timing (#67041)
+- Make random shuffle prefer local channels (#59431)
+
+## Storage & Compaction
+- Add remote-index byte metrics for the file cache (#65398)
+- Add queue-time metrics for delete-bitmap tasks (#65523)
+- Speed up file-cache LRU restoration at startup (#65174)
+- Limit the file-cache LRU recorder shadow queue (#64798)
+- Skip redundant TTL scans for non-TTL tablets (#65434)
+- Add an option to disable file-cache writes during TopN lazy materialization (#66414)
+- Disable file-cache writes after a remote-scan threshold is reached (#66479)
+- Improve memory-limit refresh when cgroup settings change in serverless mode (#66463)
+- Backport nullable-column and projection optimizations (#66586)
+
+## Load & Streaming
+- Optimize nullable-string deserialization in CSV and text load (#64476)
+- Backpressure asynchronous group commit by per-table WAL count (#65362)
+
+## Cloud Native
+- Add S3 rate-limit observability (#64038)
+- Add warm-up job count metrics on BE (#66136)
+- Use rendezvous hashing for colocate-tablet placement (#64638)
+- Add MetaService rate-limit dry-run observability (#66969)
+- Add cloud-tablet rebalancer metrics (#66576)
+- Presize global cloud-tablet route sets (#66447)
+- Skip non-MoW tablets when calculating TopN delete-bitmap scores (#65964)
+
+## Lakehouse
+- Cache credentials providers in the Hadoop S3A glue layer (#65165)
+- Use credential-aware Hadoop FileSystem cache keys (#65586)
+- Accelerate fixed-binary decimal decoding in Parquet (#66379)
+- Improve nullable selection planning for fragmented Parquet batches (#66397)
+
+# Bugfix
+
+## AI & Search
+- Fix crashes caused by null-query inverted-index predicates (#65138)
+- Split bound multi-segment inverted-index readers (#63138)
+- Fix CLucene multi-segment `readBlock` handling (#66736)
+- Reject inverted-index terms containing embedded NUL bytes (#67179)
+- Disable the DSL cache for score queries (#65436)
+- Validate nested Variant `MATCH` predicates (#66207)
+- Fix index lookup after indexes are removed (#66316)
+- Preserve atomicity when appending nested Variant values (#66421)
+- Recognize nullable array elements as NestedGroup types (#66196)
+- Prefer sparse Variant fields over root values (#65660)
+- Serve shredded Variant leaves without rebuilding the root (#66941)
+- Preserve NestedGroup access paths through `explode` (#67022)
+- Avoid recursion when the ANN IVF-list cache is absent (#67024)
+
+## Query & Execution
+- Fix analytic partition keys overflowing before conversion to 64-bit columns (#65240)
+- Guard execution-profile access during concurrent teardown (#65442)
+- Fix duplicate join nodes produced by `PushDownAggThroughJoinOnPkFk` (#65172)
+- Guard `UniqueFunction` handling in filter and TopN pushdown rules (#62742)
+- Enable pre-aggregation for multi-argument aggregates with all-key distinct inputs (#65846)
+- Fix missing decimal precision and scale for legacy decimal data (#65419)
+- Materialize constant columns before block merge (#65770)
+- Use serialized hash keys for complex types (#66777)
+- Fix blocking-queue waiter accounting (#65827)
+- Fix unsafe eager-aggregation nullability conversions (#66208)
+- Fix duplicate aggregate functions pushed through projects (#66531)
+- Preserve `NULL` in pushed-down CHAR `MIN` and `MAX` (#65952)
+- Fix invalid semi-join transpose when the lower join is a mark join (#66574)
+- Drop invalid functional dependencies from the outer side of joins (#65982)
+- Prevent unsafe CTE runtime-filter pushdown (#65247)
+- Suppress invalid unique constraints in scan functional-dependency derivation (#66801)
+- Fix TIMESTAMPTZ nullable type equality (#66722)
+- Fix TIMESTAMPTZ values in `COALESCE` (#66689)
+- Preserve TIMESTAMPTZ user-variable types (#66833)
+- Handle DST fallback in timestamp-cast monotonicity (#65903)
+- Accept spaced TIMESTAMPTZ offsets in range-partition bounds (#66292)
+- Return Arrow and Thrift DATETIME values as naive timestamps (#67027, #67232)
+- Correct the Flight SQL `GetTables` schema and TIMESTAMPTZ Arrow reader (#66344)
+- Fix `count_substrings` tail overmatching (#63215)
+- Avoid ICU default-locale contention in functions (#66440)
+- Keep multi-match regex cache ownership alive (#66909)
+- Prevent `explode_bitmap` crashes when output size exceeds `INT_MAX` (#66034)
+- Skip CHAR payload checks for `NULL` rows (#67043)
+- Restore null-literal return-type handling (#66280)
+- Stop strict-mode string casts from attaching `NULL` rows to the next value (#66952)
+- Materialize constant virtual columns before caching (#67112)
+- Handle case-insensitive auto-partition function arguments (#67121)
+- Preserve nested paths during lazy row-ID fetch (#67205)
+- Handle empty row-ID fetch RPC failures in TopN (#66443)
+- Key UDF class caches by function ID and clean them up in cloud mode (#67046)
+
+## Storage & Compaction
+- Preserve shortest round-trip representations for FLOAT and DOUBLE ZoneMaps (#65302)
+- Fix floating-point equality during Parquet pruning (#66470)
+- Fix sparse vertical-compaction destination offsets (#66306)
+- Reject transaction preparation on tablets that are shutting down (#66448)
+- Clean up spill directories during query teardown (#66458)
+- Avoid scan-executor use-after-free during shutdown (#65220)
+- Pass tablet IDs explicitly through file-reader and packed-file cache contexts (#61683, #65701)
+- Avoid converting segment-cache blocks to index-cache blocks (#65905)
+- Fix BE memory leaks after failed schema-change jobs (#56207)
+- Fix `PublishVersionDaemon` thread-pool leaks (#60720)
+- Make nullable hash-state updates exception-safe (#66517)
+- Synchronize access to load error logs (#66250)
+- Fix cache lookup failures after an OLAP partition is dropped (#65889)
+- Skip file cache for HTTP chunk-response readers (#66932)
+
+## Load & Streaming
+- Respect profile levels for load-writer details (#64978)
+- Fix Arrow Stream Load with uppercase column names (#65617)
+- Fail fast when a backend restarts during INSERT (#65525)
+- Skip decommissioning backends during load routing (#65406)
+- Correct quorum participants for incremental load streams (#66016)
+- Fix stream-receiver leaks racing with `close_load` (#65584)
+- Fix broker-load label self-conflicts during pending retries (#66469)
+- Recover Broker Load jobs whose transactions are already visible (#66987)
+- Clear transaction IDs after aborting Broker Load transactions (#66884)
+- Encode CDC Stream Load records as UTF-8 (#66771)
+- Prevent MySQL CDC data loss on non-GTID keepalive reconnects (#66998)
+- Isolate schemas across CDC snapshot splits (#65645)
+- Keep CDC end offsets consistent with current progress (#65688)
+- Normalize MySQL JDBC URLs used by streaming jobs (#65647)
+- Avoid applying a global BE authentication precheck to Stream Load (#66629)
+- Report Stream Load size limits in MiB (#66224)
+- Remove the unsupported Workload Policy action that mutates session variables (#64856)
+
+## Cloud Native
+- Retry MetaService `too busy` responses (#65378)
+- Set a recycler S3 request timeout to avoid slow `DeleteObjects` failures (#64758)
+- Preserve resource IDs when recycling empty rowsets (#65862)
+- Skip packed-slice deletion while recycling rowsets (#65533)
+- Fix local and remote tablet-size semantics in schema views (#60887)
+- Normalize storage and replica fields in `SHOW PARTITIONS` (#60871)
+- Align colocate proc output and tablet-health reporting in cloud mode (#60944)
+- Exclude decommissioning backends from cloud backend selection (#65221)
+- Prevent urgent loads from preempting schema-change locks (#66082)
+- Skip unnecessary MetaService tablet updates after table-property changes (#65983)
+- Prevent older clients from treating unknown MetaService status codes as success (#64148)
+- Fail closed on unknown MetaService response codes (#66364)
+- Skip rowset promotion for incomplete lazy commits (#66253)
+- Track deleted-instance recycling status and retain instance tombstones (#66519, #66870)
+- Recycle delete-bitmap packed files with correct blob reads and reference counts (#66728, #66919)
+- Only mark prepared rowsets before recycling (#65550)
+- Skip versioned delete-bitmap cleanup for non-MoW tablets (#67084)
+- Separate HTTP encoding for recycler job and check keys (#67243)
+- Drop stale CloudReplica routes after compute groups are deleted (#66984)
+- Fix `SchemaVariablesScanner` crashes on incomplete FE responses (#65994)
+- Use a bthread-aware shared mutex for tablet-header locks (#66020)
+- Fix schema-change alter-version capture in cloud mode (#62506)
+- Restrict runtime FE configuration updates to root in cloud mode (#66478)
+- Resolve conflicting default replica properties (#65836)
+- Exclude zero-size tablets from backend balancing (#66499)
+- Inspect and abort failed conflicting transactions during cloud upgrades (#60830)
+- Cancel rebuilt virtual-compute-group warm-up jobs when the group is dropped (#65426)
+- Fix rollback handling when adding partitions (#64650)
+
+## Lakehouse
+- Fix MaxCompute `IN` predicate pushdown polarity (#65083)
+- Improve MaxCompute catalog validation (#64119)
+- Preserve external partition metadata in multi-catalog queries (#66012)
+- Invalidate stale Hive file-cache entries after partition refresh (#65334)
+- Safely publish Hadoop catalog properties (#66392)
+- Resolve missing remote JDBC table names during schema lookup (#65718)
+- Harden JDBC driver URL validation and remove the file-upload HTTP API (#67149)
+- Decode ORC timestamps through the standard SerDe path (#64807)
+- Preserve nested nullability in Parquet predicate scans (#66799)
+- Safely prune nested Parquet columns with Bloom filters (#66471)
+- Fix Iceberg Merge-on-Read crashes with row-ID lazy reads (#66506)
+- Avoid BE aborts when evaluating Iceberg partition predicates (#66835)
+- Use the split file format when scanning Iceberg tables (#65760)
+- Delete external data files after failed writes to prevent orphan files (#64678)
+- Preserve Paimon partition metadata across splits (#65581)
+- Handle special characters in Paimon partition values (#65904)
+
+## Security & Authentication
+- Require authorization and an explicit configuration gate for `_stream_load_forward` (#65377)
+- Mask Kafka Routine Load sensitive properties (#64786)
+- Hide Stream Load tokens and authentication data from BE information endpoints (#60656, #59743)
+- Escape audit-log record separators to prevent row forgery (#66580)
+- Mask sensitive fields in encryption-key schema tables (#66834)
+- Mask private-key passwords in backend configuration (#66836)
+- Mask credentials in authentication and Stream Load logs (#66917)
+- Stop writing Arrow Flight bearer tokens to `fe.log` (#67146)
+
+## Materialized Views
+- Fix scan-materialization pattern-context checks (#65414)
+- Distinguish partition compensation from `UNION ALL` rewrite (#66445)
+- Reduce master FE CPU usage when serializing MTMV task TVF information (#66792)
+- Optimize MTMV partition-lineage checks (#63899)
+- Avoid invalid slot casts in MV null-reject compensation (#66613)
+- Refresh MTMVs after excluded trigger tables change (#64041)
+
+## Other
+- Fix Arrow Flight SQL direct-memory leaks in prepared statements (#65311)
+- Fix task finish timestamps when scheduled jobs fail (#66232)
+- Guard query-instance metrics before metric repository initialization (#62762)
+- Remove query profiles from HDFS file readers (#67293)

--- a/sidebarsReleases.json
+++ b/sidebarsReleases.json
@@ -13,6 +13,7 @@
                     "type": "category",
                     "label": "v4.1",
                     "items": [
+                        "v4.1/release-4.1.4",
                         "v4.1/release-4.1.3",
                         "v4.1/release-4.1.2",
                         "v4.1/release-4.1.1",

--- a/src/constant/download.data.ts
+++ b/src/constant/download.data.ts
@@ -91,6 +91,40 @@ export const ALL_VERSIONS: AllVersionOption[] = [
         value: '4.1',
         children: [
             {
+                label: '4.1.4',
+                value: '4.1.4',
+                majorVersion: '4.1',
+                items: [
+                    {
+                        label: CPUEnum.X64,
+                        value: CPUEnum.X64,
+                        gz: `${ORIGIN}apache-doris-4.1.4-bin-x64.tar.gz`,
+                        asc: `${ORIGIN}apache-doris-4.1.4-bin-x64.tar.gz.asc`,
+                        sha512: `${ORIGIN}apache-doris-4.1.4-bin-x64.tar.gz.sha512`,
+                        source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.4/',
+                        version: '4.1.4-rc04',
+                    },
+                    {
+                        label: CPUEnum.X64NoAvx2,
+                        value: CPUEnum.X64NoAvx2,
+                        gz: `${ORIGIN}apache-doris-4.1.4-bin-x64-noavx2.tar.gz`,
+                        asc: `${ORIGIN}apache-doris-4.1.4-bin-x64-noavx2.tar.gz.asc`,
+                        sha512: `${ORIGIN}apache-doris-4.1.4-bin-x64-noavx2.tar.gz.sha512`,
+                        source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.4/',
+                        version: '4.1.4-rc04',
+                    },
+                    {
+                        label: CPUEnum.ARM64,
+                        value: CPUEnum.ARM64,
+                        gz: `${ORIGIN}apache-doris-4.1.4-bin-arm64.tar.gz`,
+                        asc: `${ORIGIN}apache-doris-4.1.4-bin-arm64.tar.gz.asc`,
+                        sha512: `${ORIGIN}apache-doris-4.1.4-bin-arm64.tar.gz.sha512`,
+                        source: 'https://dist.apache.org/repos/dist/release/doris/4.1/4.1.4/',
+                        version: '4.1.4-rc04',
+                    },
+                ],
+            },
+            {
                 label: '4.1.3',
                 value: '4.1.3',
                 majorVersion: '4.1',


### PR DESCRIPTION
## Summary

Publish Apache Doris 4.1.4 as **Latest** on `/download/` and `/releases/`.

- Add 4.1.4 to `ALL_VERSIONS` as the newest patch of the 4.1 branch, with x64, x64-noavx2 and arm64 rows. Source filename version is `4.1.4-rc04`, matching the 4.1.3 precedent (`4.1.3-rc02`).
- Add synchronized English and Chinese release notes, generated from [apache/doris#67355](https://github.com/apache/doris/issues/67355).
- Update both Doris Core indexes (`releasenotes/core.md` and its zh-CN mirror): Latest tip plus the `2026-09-10` chronological entry.
- Add `v4.1/release-4.1.4` to the release sidebar.

`ACTIVE_CORE_BRANCHES` is unchanged — 4.1 is already maintained and first, so `ACTIVE_HEADS` picks 4.1.4 up for the quick download card.

## Release metadata

| | |
|---|---|
| Public version | 4.1.4 |
| Source filename version | `4.1.4-rc04` |
| Source directory | `https://dist.apache.org/repos/dist/release/doris/4.1/4.1.4/` |
| Release date | 2026-09-10 |
| Position | latest |
| Branch change | none |

## Known follow-up: source tarball not yet in the dist release repo

All **nine binary artifacts are live**, but the three source artifacts still return 404:

```
https://dist.apache.org/repos/dist/release/doris/4.1/4.1.4/apache-doris-4.1.4-rc04-src.tar.gz{,.asc,.sha512}
```

`dist/dev/doris/4.1/4.1.4-rc04/` and `downloads.apache.org/doris/4.1/4.1.4/` are also empty. The links start working as soon as the RC is moved into the release repository — no further website change is needed.

## Validation

Bilingual release notes are structurally identical: 24 headings, 194 bullets, 199 issue references in the same order.

- `node --test doc-tools/skills/add-release/scripts/validate-release.test.mjs` — 6/6 passed
- Full validator — 62 checks passed, 3 failed (only the three unpublished source URLs above)
- Same validator with `--skip-links` — 53 checks passed
- `sidebarsReleases.json` JSON parse check
- `git diff --check` — clean

```
node doc-tools/skills/add-release/scripts/validate-release.mjs \
  --component doris-core --version 4.1.4 --series 4.1 \
  --source-version 4.1.4-rc04 --release-date 2026-09-10 --position latest \
  --source-dir https://dist.apache.org/repos/dist/release/doris/4.1/4.1.4/
```

## Build

`yarn build` was not run, per request. `yarn typecheck` reports 179 errors on this branch, but the error set is byte-identical to the `upstream-apache/master` baseline — all pre-existing, none in `src/constant/download.data.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsK6ae9vCwo5pREfu6iMBq
