### PR TITLE
[doc](lakehouse) Note file metadata column version

### DIFF
--- a/docs/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/docs/lakehouse/catalogs/iceberg-catalog.mdx
@@ -1508,6 +1508,8 @@ SELECT * FROM iceberg.iceberg_db.iceberg_tbl LIMIT 10;
 
 ### File Metadata Columns
 
+> Supported since version 4.2.0.
+
 Doris exposes two hidden metadata columns for Iceberg data tables. You can use them to locate the physical data file and row that produced each query result.
 
 | Column | Type | Description |

--- a/docs/lakehouse/catalogs/paimon-catalog.mdx
+++ b/docs/lakehouse/catalogs/paimon-catalog.mdx
@@ -982,6 +982,8 @@ SELECT * FROM paimon_ctl.paimon_db.paimon_tbl LIMIT 10;
 
 ### File Metadata Columns
 
+> Supported since version 4.2.0.
+
 Doris exposes two hidden metadata columns for Paimon data tables. You can use them to locate the physical data file and row that produced each query result.
 
 | Column | Type | Description |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/iceberg-catalog.mdx
@@ -1529,6 +1529,8 @@ SELECT * FROM iceberg.iceberg_db.iceberg_tbl LIMIT 10;
 
 ### 文件元数据列
 
+> 该功能自 4.2.0 版本起支持。
+
 Doris 为 Iceberg 数据表提供两个隐藏元数据列，可用于定位每条查询结果对应的物理数据文件和文件内行位置。
 
 | 列名 | 类型 | 说明 |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/paimon-catalog.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/lakehouse/catalogs/paimon-catalog.mdx
@@ -978,6 +978,8 @@ SELECT * FROM paimon_ctl.paimon_db.paimon_tbl LIMIT 10;
 
 ### 文件元数据列
 
+> 该功能自 4.2.0 版本起支持。
+
 Doris 为 Paimon 数据表提供两个隐藏元数据列，可用于定位每条查询结果对应的物理数据文件和文件内行位置。
 
 | 列名 | 类型 | 说明 |


### PR DESCRIPTION
## Versions

- [x] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [x] Checked by AI
- [x] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

## Summary

Follow up on #4125 by noting that the Iceberg and Paimon file metadata columns are supported since Apache Doris 4.2.0. The version note is added consistently to the current/dev English and Chinese catalog documentation.

## Validation

- `git diff --check`
- Docs governance changed-file report