### PR TITLE
[doc](community) bring the ARM compilation guide in line with the current build switches and the 64 KiB-page startup crash

### DIFF
--- a/community/source-install/compilation-arm.mdx
+++ b/community/source-install/compilation-arm.mdx
@@ -61,6 +61,10 @@ The following environments have been verified by the community:
 | CentOS | 7.9 and above (AltArch) | aarch64 |
 | Ubuntu | 20.04 | aarch64 |
 
+:::info Memory page size
+ARM server distributions ship kernels with either 4 KiB or 64 KiB memory pages (KylinOS V10 and CentOS 7/8 aarch64 are commonly 64 KiB, Ubuntu is 4 KiB); check with `getconf PAGESIZE`. The jemalloc that Doris builds on ARM uses `--with-lg-page=16`, so one binary runs on kernels of either page size, but some third-party libraries bake page-size assumptions in at build time. When you build or validate yourself, cover the kernel you actually deploy on; see item 4 of [FAQ 4.2](#42-startup-issues).
+:::
+
 Reference output:
 
 ```shell
@@ -391,19 +395,17 @@ On the ARM platform, only LDB Toolchain is recommended for compilation. This met
 
 For how to download and install LDB Toolchain, see the section above. For the subsequent build steps, see [Compile with LDB Toolchain](./compilation-with-ldb-toolchain). JDK and NodeJS must be replaced with the aarch64 versions (see the section above).
 
-If you have trouble downloading the prebuilt third-party libraries, use `tools/build_thirdparty.sh` to build them yourself. Use gcc when building third-party libraries:
+If you have trouble downloading the prebuilt third-party libraries, use `thirdparty/build-thirdparty.sh` to build them yourself. Use gcc when building third-party libraries:
 
 ```shell
 export DORIS_TOOLCHAIN=gcc
 ```
 
-When compiling Doris on the ARM platform, **you must disable the AVX2, LIBUNWIND, and AZURE third-party libraries**:
+The following build switches behave differently on ARM than on x86_64:
 
-```shell
-export USE_AVX2=OFF
-export USE_UNWIND=OFF
-export DISABLE_BUILD_AZURE=ON
-```
+- **AVX2**: `USE_AVX2` only applies to x86_64 and does not need to be set on ARM. The ARM instruction set is selected with `ARM_MARCH` (4.0 and later, default `armv8-a+crc`), for example `ARM_MARCH=armv8-a+crc+simd sh build.sh --be`.
+- **libunwind**: On 4.1.3 and earlier (including 3.x and 4.0), libunwind does not work on ARM and you need `export USE_UNWIND=OFF` before building. Starting with master (July 2026) and 4.1.4, the `USE_UNWIND` switch has been removed ([apache/doris#64093](https://github.com/apache/doris/pull/64093)): libunwind is always enabled on every Linux platform and setting the variable no longer has any effect. The bundled libunwind 1.6.2 crashes the BE on startup on kernels with 64 KiB memory pages; see item 4 of [FAQ 4.2](#42-startup-issues).
+- **Azure**: On 4.1 and earlier, `env.sh` sets `DISABLE_BUILD_AZURE=ON` automatically on ARM, so nothing needs to be set. Since August 2026, master ([apache/doris#66908](https://github.com/apache/doris/pull/66908)) builds the Azure libraries on ARM as well and links them into the BE by default. To opt out, set `export DISABLE_BUILD_AZURE=ON` (the BE does not link them); when building the third-party libraries, `export DISABLE_THIRDPARTY_BUILD_AZURE=ON` additionally skips building Azure itself.
 
 If you still encounter issues during compilation or startup, see [FAQ](#4-faq). If no relevant solution is available, you are welcome to [open an issue](https://github.com/apache/doris/issues).
 
@@ -653,6 +655,32 @@ If you still encounter issues during compilation or startup, see [FAQ](#4-faq). 
 ```shell
       export GLIBC_COMPATIBILITY=OFF
 ```
+
+#### 4. BE coredumps immediately on startup on ARM, with `unw_backtrace`, `access_mem`, `is_plt_entry` in the core stack
+
+- Symptom:
+
+    An ARM BE built from 4.1.4 or from master after July 2026 segfaults right after `start_be.sh`, with no BE log lines in `be.out`, and a core stack (innermost frame first) like:
+
+    ```text
+    access_mem
+    is_plt_entry
+    _ULaarch64_step
+    _ULaarch64_tdep_trace
+    unw_backtrace
+    ...
+    __libc_csu_init
+    ```
+
+    and `getconf PAGESIZE` prints 65536.
+
+- Cause:
+
+    These versions statically link GNU libunwind 1.6.2 on ARM ([apache/doris#64093](https://github.com/apache/doris/pull/64093)), whose AArch64 memory validator hard-codes a 4 KiB page size. On a kernel with 64 KiB memory pages every validation fails and libunwind dereferences an uninitialized address before `main()`. Kernels with 4 KiB pages are not affected, which is why this does not reproduce on x86_64 or on Ubuntu ARM.
+
+- Solution:
+
+    Build from code or use a release that includes [apache/doris#67877](https://github.com/apache/doris/pull/67877) (libunwind upgraded to 1.8.3); until then, use 4.1.3 on kernels with 64 KiB pages. The crash happens before `main()`, so no `be.conf` setting can work around it.
 
 ### 4.3 Issues With Other Components
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/source-install/compilation-arm.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/source-install/compilation-arm.mdx
@@ -61,6 +61,10 @@ import TabItem from '@theme/TabItem';
 | CentOS | 7.9 及以上（AltArch） | aarch64 |
 | Ubuntu | 20.04 | aarch64 |
 
+:::info 内存页大小
+ARM 服务器发行版的内核内存页可能是 4 KiB 或 64 KiB（麒麟 V10、CentOS 7/8 aarch64 等常见为 64 KiB，Ubuntu 为 4 KiB），可用 `getconf PAGESIZE` 查看。Doris 在 ARM 上编译的 jemalloc 使用 `--with-lg-page=16`，同一个二进制可以运行在两种页大小的内核上；但部分三方库对页大小有编译期假设，自行编译或验证时请覆盖实际部署的内核，见[常见问题 4.2](#42-启动问题) 第 4 条。
+:::
+
 参考输出：
 
 ```shell
@@ -391,19 +395,17 @@ ARM 平台目前仅推荐使用 LDB Toolchain 进行编译。该方法适用于 
 
 LDB Toolchain 的下载和安装详见上文，之后的编译方式请参阅 [使用 LDB Toolchain 编译](./compilation-with-ldb-toolchain)。其中 JDK 与 NodeJS 需替换为 aarch64 版本（详见上文）。
 
-如果下载预编译三方库遇到问题，请使用 `tools/build_thirdparty.sh` 自行编译。编译三方库时请使用 gcc：
+如果下载预编译三方库遇到问题，请使用 `thirdparty/build-thirdparty.sh` 自行编译。编译三方库时请使用 gcc：
 
 ```shell
 export DORIS_TOOLCHAIN=gcc
 ```
 
-在 ARM 平台编译 Doris 时，**必须关闭 AVX2、LIBUNWIND、AZURE 三方库**：
+ARM 平台上，以下编译开关的行为和 x86_64 不同：
 
-```shell
-export USE_AVX2=OFF
-export USE_UNWIND=OFF
-export DISABLE_BUILD_AZURE=ON
-```
+- **AVX2**：`USE_AVX2` 只对 x86_64 生效，ARM 上无需设置。ARM 指令集由 `ARM_MARCH` 指定（4.0 及之后版本，默认 `armv8-a+crc`），例如 `ARM_MARCH=armv8-a+crc+simd sh build.sh --be`。
+- **libunwind**：4.1.3 及更早版本（含 3.x、4.0）中 libunwind 在 ARM 上不可用，编译前需要 `export USE_UNWIND=OFF`。从 master（2026-07 起）和 4.1.4 开始，`USE_UNWIND` 开关已移除（[apache/doris#64093](https://github.com/apache/doris/pull/64093)），libunwind 在所有 Linux 平台上固定启用，设置该变量不再有任何效果；其中自带的 libunwind 1.6.2 在 64 KiB 内存页的内核上会导致 BE 启动崩溃，见[常见问题 4.2](#42-启动问题) 第 4 条。
+- **Azure**：4.1 及更早版本中 `env.sh` 在 ARM 上自动设置 `DISABLE_BUILD_AZURE=ON`，无需手动设置。master 从 2026-08 起（[apache/doris#66908](https://github.com/apache/doris/pull/66908)）Azure 三方库在 ARM 上也会编译并默认链接进 BE；如需关闭，设置 `export DISABLE_BUILD_AZURE=ON`（BE 不链接），编译三方库时另加 `export DISABLE_THIRDPARTY_BUILD_AZURE=ON` 可跳过 Azure 本身的编译。
 
 如在编译、启动时仍遇到问题，请查阅 [常见问题](#4-常见问题)。如果没有相关解决方案，欢迎 [提出 issue](https://github.com/apache/doris/issues)。
 
@@ -653,6 +655,32 @@ export DISABLE_BUILD_AZURE=ON
 ```shell
       export GLIBC_COMPATIBILITY=OFF
 ```
+
+#### 4. ARM 上 BE 启动即 coredump，core 栈中可见 `unw_backtrace`、`access_mem`、`is_plt_entry`
+
+- 问题描述：
+
+    用 4.1.4 或 2026-07 之后的 master 代码编译出的 ARM BE，执行 `start_be.sh` 后立即段错误，`be.out` 中没有任何 BE 日志，core 栈（由内向外）类似：
+
+    ```text
+    access_mem
+    is_plt_entry
+    _ULaarch64_step
+    _ULaarch64_tdep_trace
+    unw_backtrace
+    ...
+    __libc_csu_init
+    ```
+
+    且 `getconf PAGESIZE` 输出 65536。
+
+- 问题原因：
+
+    这些版本开始在 ARM 上静态链接 GNU libunwind 1.6.2（[apache/doris#64093](https://github.com/apache/doris/pull/64093)），它的 AArch64 内存校验写死了 4 KiB 页大小。在 64 KiB 内存页的内核上校验全部失败，libunwind 在 `main()` 之前就会解引用一个未初始化的地址。4 KiB 页内核不受影响，因此 x86_64 和 Ubuntu ARM 上无法复现。
+
+- 解决方案：
+
+    使用包含 [apache/doris#67877](https://github.com/apache/doris/pull/67877)（libunwind 升级到 1.8.3）的代码或版本编译；在此之前，64 KiB 页内核上请使用 4.1.3 版本。该问题发生在 `main()` 之前，修改 `be.conf` 无法规避。
 
 ### 4.3 其他组件问题
 


### PR DESCRIPTION
## Versions 

- [ ] dev
- [ ] 4.x
- [ ] 3.x
- [ ] 2.1 or older (not covered by version/language sync gate)

`community/source-install/compilation-arm.mdx` is an unversioned community page (no `versioned_docs` copy); the text itself states the version boundary for each switch.

## Languages

- [x] Chinese
- [x] English

## Docs Checklist

- [ ] Checked by AI
- [ ] Test Cases Built
- [x] Updated required version and language counterparts, or explained why not
- [x] If only one language changed, confirmed whether source/translation counterparts need sync

## What changed and why

The ARM guide still tells users to `export USE_AVX2=OFF`, `export USE_UNWIND=OFF`, `export DISABLE_BUILD_AZURE=ON` ("you must disable the AVX2, LIBUNWIND, and AZURE third-party libraries"). Checked against the current `build.sh` / `env.sh` / `be/CMakeLists.txt` / `thirdparty/build-thirdparty.sh`, none of the three does what the page says:

- **`USE_UNWIND`** was removed by apache/doris#64093 (master since July 2026, branch-4.1 since 4.1.4). `build.sh` no longer reads it and `be/CMakeLists.txt` hard-sets `USE_UNWIND ON` on Linux, so the variable is silently ignored. That is how the 4.1.4 arm64 package got GNU libunwind 1.6.2 linked in and crashes before `main()` on 64 KiB-page kernels (Kunpeng 920 with KylinOS/openEuler/CentOS aarch64); the fix is apache/doris#67877 (libunwind 1.6.2 → 1.8.3). On 4.1.3 and earlier the variable is still honored.
- **`USE_AVX2`** has never applied to ARM (`-mavx2` is only added under the x86/x86_64 branch in `be/CMakeLists.txt`); the ARM knob is `ARM_MARCH` (4.0+, default `armv8-a+crc`), which the page did not mention.
- **`DISABLE_BUILD_AZURE`** is set to `ON` automatically on ARM by `env.sh` on 4.1 and earlier, and since apache/doris#66908 master builds and links Azure on ARM by default (`DISABLE_THIRDPARTY_BUILD_AZURE=ON` skips the third-party build itself).

Changes (both languages, identical content):

1. Section 3: replace the "must disable" block with a per-switch description that states the version boundary for each; fix the script path `tools/build_thirdparty.sh` → `thirdparty/build-thirdparty.sh`.
2. Section 1: add an info box about 4 KiB vs 64 KiB kernel pages on ARM distributions (`getconf PAGESIZE`), noting that jemalloc is built with `--with-lg-page=16` so one binary runs on both, and that builds should be validated on the kernel actually deployed.
3. Section 4.2: add FAQ item 4 for the libunwind startup crash (symptom, cause, `getconf PAGESIZE` = 65536, fix via apache/doris#67877, use 4.1.3 on 64 KiB kernels until then; no `be.conf` workaround exists because it happens before `main()`).

Both files compile with the site's `@mdx-js/mdx` (the core stack is in a fenced block rather than `<-` arrows, which MDX would reject as a JSX tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MdauUJh8AtE8SozZ29Dmv
